### PR TITLE
Add Alerts to EVE's drop logs v8

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -255,7 +255,6 @@ typedef uint16_t Port;
  * found in this packet */
 typedef struct PacketAlert_ {
     SigIntId num; /* Internal num, used for sorting */
-    SigIntId order_id; /* Internal num, used for sorting */
     uint8_t action; /* Internal num, used for sorting */
     uint8_t flags;
     struct Signature_ *s;

--- a/src/decode.h
+++ b/src/decode.h
@@ -723,6 +723,7 @@ typedef struct DecodeThreadVars_
         (p)->payload_len = 0;                   \
         (p)->pktlen = 0;                        \
         (p)->alerts.cnt = 0;                    \
+        (p)->alerts.drop.num = 0;               \
         (p)->pcap_cnt = 0;                      \
         (p)->tunnel_rtv_cnt = 0;                \
         (p)->tunnel_tpr_cnt = 0;                \

--- a/src/decode.h
+++ b/src/decode.h
@@ -277,6 +277,9 @@ typedef struct PacketAlert_ {
 typedef struct PacketAlerts_ {
     uint16_t cnt;
     PacketAlert alerts[PACKET_ALERT_MAX];
+    /* single pa used when we're dropping,
+     * so we can log it out in the drop log. */
+    PacketAlert drop;
 } PacketAlerts;
 
 /** number of decoder events we support per packet. Power of 2 minus 1

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -286,8 +286,8 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                 }
             }
 
-            /* set verdict on packet */
-            PACKET_UPDATE_ACTION(p, p->alerts.alerts[i].action);
+            /* set actions on packet */
+            DetectSignatureApplyActions(p, p->alerts.alerts[i].s);
 
             if (PACKET_TEST_ACTION(p, ACTION_PASS)) {
                 /* Ok, reset the alert cnt to end in the previous of pass

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -46,7 +46,6 @@ void PacketAlertTagInit(void)
 
     memset(&g_tag_pa, 0x00, sizeof(g_tag_pa));
 
-    g_tag_pa.order_id = 1000;
     g_tag_pa.action = ACTION_ALERT;
     g_tag_pa.s = &g_tag_signature;
 }

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1081,7 +1081,7 @@ void IPOnlyMatchPacket(ThreadVars *tv,
                             PacketAlertAppend(det_ctx, s, p, 0, 0);
                     } else {
                         /* apply actions for noalert/rule suppressed as well */
-                        PACKET_UPDATE_ACTION(p, s->action);
+                        DetectSignatureApplyActions(p, s);
                     }
                 }
             }

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -331,7 +331,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
                     PacketAlertAppend(det_ctx, s, p, tx_id,
                             PACKET_ALERT_FLAG_STATE_MATCH|PACKET_ALERT_FLAG_TX);
                 } else {
-                    PACKET_UPDATE_ACTION(p, s->action);
+                    DetectSignatureApplyActions(p, s);
                 }
 
                 alert_cnt = 1;
@@ -373,7 +373,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
                     PacketAlertAppend(det_ctx, s, p, 0,
                             PACKET_ALERT_FLAG_STATE_MATCH);
                 } else {
-                    PACKET_UPDATE_ACTION(p, s->action);
+                    DetectSignatureApplyActions(p, s);
                 }
 
                 alert_cnt = 1;
@@ -387,7 +387,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
                     PacketAlertAppend(det_ctx, s, p, 0,
                             PACKET_ALERT_FLAG_STATE_MATCH);
                 } else {
-                    PACKET_UPDATE_ACTION(p, s->action);
+                    DetectSignatureApplyActions(p, s);
                 }
 
             }
@@ -442,7 +442,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
                     PacketAlertAppend(det_ctx, s, p, 0,
                             PACKET_ALERT_FLAG_STATE_MATCH);
                 } else {
-                    PACKET_UPDATE_ACTION(p, s->action);
+                    DetectSignatureApplyActions(p, s);
                 }
                 alert_cnt = 1;
             }
@@ -736,7 +736,7 @@ void DeStateDetectContinueDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
                         PacketAlertAppend(det_ctx, s, p, 0,
                                 PACKET_ALERT_FLAG_STATE_MATCH);
                 } else {
-                    PACKET_UPDATE_ACTION(p, s->action);
+                    DetectSignatureApplyActions(p, s);
                 }
             }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1197,6 +1197,7 @@ void *DetectThreadCtxGetKeywordThreadCtx(DetectEngineThreadCtx *, int);
 int SigMatchSignaturesRunPostMatch(ThreadVars *tv,
                                    DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx, Packet *p,
                                    Signature *s);
+void DetectSignatureApplyActions(Packet *p, const Signature *s);
 
 #endif /* __DETECT_H__ */
 

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -28,6 +28,9 @@
 #define __OUTPUT_JSON_ALERT_H__
 
 void TmModuleJsonAlertLogRegister (void);
+#ifdef HAVE_LIBJANSSON
+void AlertJsonHeader(const PacketAlert *pa, json_t *js);
+#endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_ALERT_H__ */
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -61,9 +61,15 @@
 #ifdef HAVE_LIBJANSSON
 #include <jansson.h>
 
+#define LOG_DROP_ALERTS 1
+
+typedef struct JsonDropOutputCtx_ {
+    LogFileCtx *file_ctx;
+    uint8_t flags;
+} JsonDropOutputCtx;
+
 typedef struct JsonDropLogThread_ {
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx* file_ctx;
+    JsonDropOutputCtx *drop_ctx;
     MemBuffer *buffer;
 } JsonDropLogThread;
 
@@ -135,20 +141,22 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
     }
     json_object_set_new(js, "drop", djs);
 
-    int i;
-    for (i = 0; i < p->alerts.cnt; i++) {
-        const PacketAlert *pa = &p->alerts.alerts[i];
-        if (unlikely(pa->s == NULL)) {
-            continue;
-        }
-        if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
-           ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
-        {
-            AlertJsonHeader(pa, js);
+    if (aft->drop_ctx->flags & LOG_DROP_ALERTS) {
+        int i;
+        for (i = 0; i < p->alerts.cnt; i++) {
+            const PacketAlert *pa = &p->alerts.alerts[i];
+            if (unlikely(pa->s == NULL)) {
+                continue;
+            }
+            if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
+               ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
+            {
+                AlertJsonHeader(pa, js);
+            }
         }
     }
 
-    OutputJSONBuffer(js, aft->file_ctx, buffer);
+    OutputJSONBuffer(js, aft->drop_ctx->file_ctx, buffer);
     json_object_del(js, "drop");
     json_object_clear(js);
     json_decref(js);
@@ -163,6 +171,7 @@ static TmEcode JsonDropLogThreadInit(ThreadVars *t, void *initdata, void **data)
     if (unlikely(aft == NULL))
         return TM_ECODE_FAILED;
     memset(aft, 0, sizeof(*aft));
+
     if(initdata == NULL)
     {
         SCLogDebug("Error getting context for AlertFastLog.  \"initdata\" argument NULL");
@@ -177,7 +186,7 @@ static TmEcode JsonDropLogThreadInit(ThreadVars *t, void *initdata, void **data)
     }
 
     /** Use the Ouptut Context (file pointer and mutex) */
-    aft->file_ctx = ((OutputCtx *)initdata)->data;
+    aft->drop_ctx = ((OutputCtx *)initdata)->data;
 
     *data = (void *)aft;
     return TM_ECODE_OK;
@@ -216,6 +225,15 @@ static void JsonDropLogDeInitCtxSub(OutputCtx *output_ctx)
     SCFree(output_ctx);
 }
 
+static void JsonDropOutputCtxFree(JsonDropOutputCtx *drop_ctx)
+{
+    if (drop_ctx != NULL) {
+        if (drop_ctx->file_ctx != NULL)
+            LogFileFreeCtx(drop_ctx->file_ctx);
+        SCFree(drop_ctx);
+    }
+}
+
 #define DEFAULT_LOG_FILENAME "drop.json"
 static OutputCtx *JsonDropLogInitCtx(ConfNode *conf)
 {
@@ -225,22 +243,37 @@ static OutputCtx *JsonDropLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    LogFileCtx *logfile_ctx = LogFileNewCtx();
-    if (logfile_ctx == NULL) {
+    JsonDropOutputCtx *drop_ctx = SCCalloc(1, sizeof(*drop_ctx));
+    if (drop_ctx == NULL)
+        return NULL;
+
+    drop_ctx->file_ctx = LogFileNewCtx();
+    if (drop_ctx->file_ctx == NULL) {
+        JsonDropOutputCtxFree(drop_ctx);
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
-        LogFileFreeCtx(logfile_ctx);
+    if (SCConfLogOpenGeneric(conf, drop_ctx->file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+        JsonDropOutputCtxFree(drop_ctx);
         return NULL;
     }
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
+        JsonDropOutputCtxFree(drop_ctx);
         return NULL;
     }
 
-    output_ctx->data = logfile_ctx;
+    if (conf) {
+        const char *extended = ConfNodeLookupChildValue(conf, "alerts");
+        if (extended != NULL) {
+            if (ConfValIsTrue(extended)) {
+                drop_ctx->flags = LOG_DROP_ALERTS;
+            }
+        }
+    }
+
+    output_ctx->data = drop_ctx;
     output_ctx->DeInit = JsonDropLogDeInitCtx;
     return output_ctx;
 }
@@ -255,12 +288,28 @@ static OutputCtx *JsonDropLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 
     AlertJsonThread *ajt = parent_ctx->data;
 
+    JsonDropOutputCtx *drop_ctx = SCCalloc(1, sizeof(*drop_ctx));
+    if (drop_ctx == NULL)
+        return NULL;
+
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
+        JsonDropOutputCtxFree(drop_ctx);
         return NULL;
     }
 
-    output_ctx->data = ajt->file_ctx;
+    if (conf) {
+        const char *extended = ConfNodeLookupChildValue(conf, "alerts");
+        if (extended != NULL) {
+            if (ConfValIsTrue(extended)) {
+                drop_ctx->flags = LOG_DROP_ALERTS;
+            }
+        }
+    }
+
+    drop_ctx->file_ctx = ajt->file_ctx;
+
+    output_ctx->data = drop_ctx;
     output_ctx->DeInit = JsonDropLogDeInitCtxSub;
     return output_ctx;
 }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -110,6 +110,7 @@ outputs:
             force-magic: no   # force logging magic on all logged files
             force-md5: no     # force logging of md5 checksums
         #- drop
+        #    alerts: no       # log alerts that caused drops
         - ssh
         # bi-directional flows
         #- flow


### PR DESCRIPTION
Add sig(s) that caused a drop to the drop log, even if the sig is 'noalert'.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/39                 
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/39