### PR TITLE
bug_1318, init: Setup stream config, before spawning threads.

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2294,6 +2294,9 @@ int main(int argc, char **argv)
         exit(EXIT_SUCCESS);
     }
 
+    if (suri.run_mode != RUNMODE_UNIX_SOCKET)
+        StreamTcpInitConfig(STREAM_VERBOSE);
+
     RunModeDispatch(suri.run_mode, suri.runmode_custom_mode, de_ctx);
 
     /* In Unix socket runmode, Flow manager is started on demand */
@@ -2313,7 +2316,6 @@ int main(int argc, char **argv)
         /* Spawn the flow manager thread */
         FlowManagerThreadSpawn();
         FlowRecyclerThreadSpawn();
-        StreamTcpInitConfig(STREAM_VERBOSE);
 
         SCPerfSpawnThreads();
     }


### PR DESCRIPTION
During the setup/boot phase, we would spawn threads first and then
initialize stream tcp config using StreamTcpInitConfig(), which can lead
to cases where the stream module thread init function would access stream
variables that aren't initialized yet.

This commit moves the StreamTcpInitConfig() function before we dispatch
the runmode.  We also make sure that we do this conditionally on the
current runmode being unix_socket or not.

Buildbot:
- PR build: https://buildbot.openinfosecfoundation.org/builders/poona/builds/0
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/poona-pcap/builds/0
