### PR TITLE
optimization, buffer api: Reduce the size of the MemBuffer structure.

### DIFF
--- a/src/util-buffer.c
+++ b/src/util-buffer.c
@@ -46,7 +46,6 @@ MemBuffer *MemBufferCreateNew(uint32_t size)
     memset(buffer, 0, total_size);
 
     buffer->size = size;
-    buffer->buffer = (uint8_t *)buffer + sizeof(MemBuffer);
 
     return buffer;
 }

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -25,9 +25,9 @@
 #define __UTIL_BUFFER_H__
 
 typedef struct MemBuffer_ {
-   uint8_t *buffer;
    uint32_t size;
    uint32_t offset;
+   uint8_t buffer[0];
 } MemBuffer;
 
 MemBuffer *MemBufferCreateNew(uint32_t size);


### PR DESCRIPTION
Minor optimization to reduce the size of the MemBuffer structure in the
buffering api.

- PR build: https://buildbot.openinfosecfoundation.org/builders/poona/builds/1
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/poona-pcap/builds/1