### PR TITLE
Fix compilation on OS X Yosemite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@
     AC_FUNC_MALLOC
     AC_FUNC_REALLOC
     AC_CHECK_FUNCS([gettimeofday memset strcasecmp strchr strdup strerror strncasecmp strtol strtoul memchr memrchr])
+    AC_CHECK_FUNCS([strlcpy strlcat])
 
     # Add large file support
     AC_SYS_LARGEFILE

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -323,8 +323,12 @@ typedef enum PacketProfileDetectId_ {
 #include "util-path.h"
 #include "util-conf.h"
 
+#ifndef HAVE_STRLCAT
 size_t strlcat(char *, const char *src, size_t siz);
+#endif
+#ifndef HAVE_STRLCPY
 size_t strlcpy(char *dst, const char *src, size_t siz);
+#endif
 
 extern int coverage_unittests;
 extern int g_ut_modules;


### PR DESCRIPTION
Due to our unconditional declaration of the strlcat and strlcpy
functions, compilation failed on OS X Yosemite.

Bug #1192: https://redmine.openinfosecfoundation.org/issues/1192

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/111
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/111