### PR TITLE
Define _DEFAULT_SOURCE. v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -887,7 +887,7 @@
             LLIBNET=""
             AC_CHECK_LIB(net, libnet_write,, LLIBNET="no")
             if test "$LLIBNET" != "no"; then
-                CFLAGS="${CFLAGS} -DHAVE_LIBNET11 -D_BSD_SOURCE -D__BSD_SOURCE -D__FAVOR_BSD -DHAVE_NET_ETHERNET_H"
+                CFLAGS="${CFLAGS} -DHAVE_LIBNET11 -D_DEFAULT_SOURCE -D_BSD_SOURCE -D__BSD_SOURCE -D__FAVOR_BSD -DHAVE_NET_ETHERNET_H"
             else
             #if we displayed a warning already no reason to do it again.
                 if test "$LIBNET_DETECT_FAIL" = "no"; then


### PR DESCRIPTION
As of glibc 2.20, _BSD_SOURCE is deprecated in favour of _DEFAULT_SOURCE.  This patch will suppress the warning on systems that use glibc 2.20+ like Fedora 21.

- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/24
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/24
