### PR TITLE
Make sure rule-files configuration node is a sequence - v1.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -840,6 +840,19 @@ ConfNodePrune(ConfNode *node)
     }
 }
 
+/**
+ * \brief Check if a node is a sequence or node.
+ *
+ * \param node the node to check.
+ *
+ * \return 1 if node is a seuence, otherwise 0.
+ */
+int
+ConfNodeIsSequence(ConfNode *node)
+{
+    return node->is_seq == 0 ? 0 : 1;
+}
+
 #ifdef UNITTESTS
 
 /**
@@ -1398,6 +1411,23 @@ end:
     return ret;
 }
 
+int
+ConfNodeIsSequenceTest(void)
+{
+    ConfNode *node = ConfNodeNew();
+    if (node == NULL) {
+        return 0;
+    }
+    if (ConfNodeIsSequence(node)) {
+        return 0;
+    }
+    node->is_seq = 1;
+    if (!ConfNodeIsSequence(node)) {
+        return 0;
+    }
+    return 1;
+}
+
 void
 ConfRegisterTests(void)
 {
@@ -1416,6 +1446,7 @@ ConfRegisterTests(void)
     UtRegisterTest("ConfGetChildValueBoolWithDefaultTest", ConfGetChildValueBoolWithDefaultTest, 1);
     UtRegisterTest("ConfGetNodeOrCreateTest", ConfGetNodeOrCreateTest, 1);
     UtRegisterTest("ConfNodePruneTest", ConfNodePruneTest, 1);
+    UtRegisterTest("ConfNodeIsSequenceTest", ConfNodeIsSequenceTest, 1);
 }
 
 #endif /* UNITTESTS */

--- a/src/conf.c
+++ b/src/conf.c
@@ -1414,18 +1414,26 @@ end:
 int
 ConfNodeIsSequenceTest(void)
 {
+    int retval = 0;
     ConfNode *node = ConfNodeNew();
     if (node == NULL) {
-        return 0;
+        goto end;
     }
     if (ConfNodeIsSequence(node)) {
-        return 0;
+        goto end;
     }
     node->is_seq = 1;
     if (!ConfNodeIsSequence(node)) {
-        return 0;
+        goto end;
     }
-    return 1;
+
+    retval = 1;
+
+end:
+    if (node != NULL) {
+        ConfNodeFree(node);
+    }
+    return retval;
 }
 
 void

--- a/src/conf.h
+++ b/src/conf.h
@@ -87,5 +87,6 @@ int ConfGetChildValueWithDefault(ConfNode *base, ConfNode *dflt, char *name, cha
 int ConfGetChildValueIntWithDefault(ConfNode *base, ConfNode *dflt, char *name, intmax_t *val);
 int ConfGetChildValueBoolWithDefault(ConfNode *base, ConfNode *dflt, char *name, int *val);
 char *ConfLoadCompleteIncludePath(char *);
+int ConfNodeIsSequence(ConfNode *node);
 
 #endif /* ! __CONF_H__ */

--- a/src/detect.c
+++ b/src/detect.c
@@ -405,22 +405,30 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     if (!(sig_file != NULL && sig_file_exclusive == TRUE)) {
         rule_files = ConfGetNode("rule-files");
         if (rule_files != NULL) {
-            TAILQ_FOREACH(file, &rule_files->head, next) {
-                sfile = DetectLoadCompleteSigPath(file->val);
-                SCLogDebug("Loading rule file: %s", sfile);
+            if (!ConfNodeIsSequence(rule_files)) {
+                SCLogWarning(SC_ERR_INVALID_ARGUMENT,
+                    "Invalid rule-files configuration section: "
+                    "expected sequence.");
+            }
+            else {
+                TAILQ_FOREACH(file, &rule_files->head, next) {
+                    sfile = DetectLoadCompleteSigPath(file->val);
+                    SCLogDebug("Loading rule file: %s", sfile);
 
-                cntf++;
-                r = DetectLoadSigFile(de_ctx, sfile, &goodsigs, &badsigs);
-                if (r < 0) {
-                    badfiles++;
-                }
-                if (goodsigs == 0) {
-                    SCLogWarning(SC_ERR_NO_RULES, "No rules loaded from %s", sfile);
-                }
-                SCFree(sfile);
+                    cntf++;
+                    r = DetectLoadSigFile(de_ctx, sfile, &goodsigs, &badsigs);
+                    if (r < 0) {
+                        badfiles++;
+                    }
+                    if (goodsigs == 0) {
+                        SCLogWarning(SC_ERR_NO_RULES,
+                            "No rules loaded from %s", sfile);
+                    }
+                    SCFree(sfile);
 
-                goodtotal += goodsigs;
-                badtotal += badsigs;
+                    goodtotal += goodsigs;
+                    badtotal += badsigs;
+                }
             }
         }
     }


### PR DESCRIPTION
A configuration error could lead to a rule-files section that is not is not a map, which will cause a segfault in detect.c.  This patch adds a function to test if the node is a sequence, and displays a warning if its not a map.

It currently does not exit with an error in case there is a reload where the configuration went bad.  But for such an error it might make sense to exit.

- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/26
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/26
