### PR TITLE
flow-timeout: fix init of pseudo packet

### DIFF
--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -108,6 +108,13 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
             p->dp = f->sp;
         }
 
+        /* Check if we have enough room in direct data. We need ipv4 hdr + tcp hdr.
+         * Force an allocation if it is not the case.
+         */
+        if (GET_PKT_DIRECT_MAX_SIZE(p) <  40) {
+            uint8_t header[40];
+            PacketCopyData(p, header, 40);
+        }
         /* set the ip header */
         p->ip4h = (IPV4Hdr *)GET_PKT_DATA(p);
         /* version 4 and length 20 bytes for the tcp header */
@@ -145,6 +152,13 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
             p->dp = f->sp;
         }
 
+        /* Check if we have enough room in direct data. We need ipv6 hdr + tcp hdr.
+         * Force an allocation if it is not the case.
+         */
+        if (GET_PKT_DIRECT_MAX_SIZE(p) <  60) {
+            uint8_t header[60];
+            PacketCopyData(p, header, 60);
+        }
         /* set the ip header */
         p->ip6h = (IPV6Hdr *)GET_PKT_DATA(p);
         /* version 6 */


### PR DESCRIPTION
The code was not checking if we had enough room in the direct
data. In case default_packet_size was set really small, this was
resulting in data being written over the data and causing a crash.

The patch fixes the issue by forcing an allocation if the direct
data size in the Packet is to small.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1366

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/26
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/24
