### PR TITLE
List keywords fixes

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -4871,8 +4871,8 @@ static inline void SigMultilinePrint(int i, char *prefix)
 void SigTableList(const char *keyword)
 {
     size_t size = sizeof(sigmatch_table) / sizeof(SigTableElmt);
-
     size_t i;
+    char *proto_name;
 
     if (keyword == NULL) {
         printf("=====Supported keywords=====\n");
@@ -4897,8 +4897,8 @@ void SigTableList(const char *keyword)
                     printf("%s", sigmatch_table[i].desc);
                 }
                 /* Build feature */
-                printf(";%s;",
-                       AppLayerGetProtoName(sigmatch_table[i].alproto));
+                proto_name = AppLayerGetProtoName(sigmatch_table[i].alproto);
+                printf(";%s;", proto_name ? proto_name : "Unset"); 
                 PrintFeatureList(sigmatch_table[i].flags, ':');
                 printf(";");
                 if (sigmatch_table[i].url) {

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -27,9 +27,13 @@
 #include "app-layer-parser.h"
 #include "util-cuda.h"
 #include "util-unittest.h"
+#include "util-debug.h"
+#include "conf-yaml-loader.h"
 
 int ListKeywords(const char *keyword_info)
 {
+    if (ConfYamlLoadFile(DEFAULT_CONF_FILE) != -1)
+        SCLogLoadConfig(0, 0);
     MpmTableSetup();
     AppLayerSetup();
     SigTableSetup(); /* load the rule keywords */
@@ -39,6 +43,8 @@ int ListKeywords(const char *keyword_info)
 
 int ListAppLayerProtocols()
 {
+    if (ConfYamlLoadFile(DEFAULT_CONF_FILE) != -1)
+        SCLogLoadConfig(0, 0);
     MpmTableSetup();
     AppLayerSetup();
     AppLayerListSupportedProtocols();

--- a/src/util-running-modes.c
+++ b/src/util-running-modes.c
@@ -24,11 +24,14 @@
 #include "config.h"
 #include "app-layer-detect-proto.h"
 #include "app-layer.h"
+#include "app-layer-parser.h"
 #include "util-cuda.h"
 #include "util-unittest.h"
 
 int ListKeywords(const char *keyword_info)
 {
+    MpmTableSetup();
+    AppLayerSetup();
     SigTableSetup(); /* load the rule keywords */
     SigTableList(keyword_info);
     exit(EXIT_SUCCESS);


### PR DESCRIPTION
This small patchset fixes the output of list-keywords command. The application layer was not displayed anymore in csv mode due to change in Suricata init. Second issue was some warning message that were displayed. This was preventing user from creating a correct CSV file via shell redirection.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/27
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/25

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1375