### PR TITLE
host-os-policy: display msg about unimplemented OS

### DIFF
--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -344,6 +344,11 @@ void SCHInfoLoadFromConfig(void)
             int is_ipv4 = 1;
             if (index(host->val, ':') != NULL)
                 is_ipv4 = 0;
+            if ((! strcmp(policy->name, "bsd-right")) ||
+                (! strcmp(policy->name, "old-solaris"))) {
+                SCLogWarning(SC_ERR_UNIMPLEMENTED, "bsd-right and old-solaris are unimplemented"
+                             " and default to bsd (resp. solaris)");
+            }
             if (SCHInfoAddHostOSInfo(policy->name, host->val, is_ipv4) == -1) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                     "Failed to add host \"%s\" with policy \"%s\" to host "


### PR DESCRIPTION
'bsd-right' and 'old-solaris' are unimplemented and default to
'bsd' (resp. 'solaris').

This patch adds a message to warn the user if the YAML config uses
one of this two policy.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/28
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/26
