### PR TITLE
detect: fix condition for warning message

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -442,7 +442,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     /* now we should have signatures to work with */
-    if (goodsigs <= 0) {
+    if (goodtotal <= 0) {
         if (cntf > 0) {
            SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", cntf);
         } else {


### PR DESCRIPTION
Warning message on no rules loaded from all signatures files was
displayed if the last loaded signature file has no signature.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/29
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/27
