### PR TITLE
suricatasc: implement autoreconnect

### DIFF
--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -221,7 +221,17 @@ class SuricataSC:
                 except SuricataCommandException as err:
                     print(err)
                     continue
-                cmdret = self.send_command(cmd, arguments)
+                try:
+                    cmdret = self.send_command(cmd, arguments)
+                except IOError, err:
+                    # try to reconnect and resend command
+                    print "Connection lost, trying to reconnect"
+                    try:
+                        self.connect()
+                    except SuricataNetException, err:
+                        print "Can't reconnect to suricata socket, discarding command"
+                        continue
+                    cmdret = self.send_command(cmd, arguments)
                 #decode json message
                 if cmdret["return"] == "NOK":
                     print("Error:")


### PR DESCRIPTION
Implement a basic autoreconnect support. It tries to reconnect once
when connection has been lost. If it fails, it discards the command
and try again to connect at next command.

This is the same code as #1232 rebased on current code.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/30
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/28
