### PR TITLE
TCP ssn reuse v2.4

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -872,12 +872,19 @@ void AddressDebugPrint(Address *);
         (p)->flags |= PKT_NOPAYLOAD_INSPECTION;  \
     } while (0)
 
+#define DecodeUnsetNoPayloadInspectionFlag(p) do { \
+        (p)->flags &= ~PKT_NOPAYLOAD_INSPECTION;  \
+    } while (0)
+
 /** \brief Set the No packet inspection Flag for the packet.
  *
  * \param p Packet to set the flag in
  */
 #define DecodeSetNoPacketInspectionFlag(p) do { \
         (p)->flags |= PKT_NOPACKET_INSPECTION;  \
+    } while (0)
+#define DecodeUnsetNoPacketInspectionFlag(p) do { \
+        (p)->flags &= ~PKT_NOPACKET_INSPECTION;  \
     } while (0)
 
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -390,7 +390,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
     return 0;
 }
 
-int TcpSessionPacketSsnReuse(const Packet *p, void *tcp_ssn);
+int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, void *tcp_ssn);
 
 static inline int FlowCompare(Flow *f, const Packet *p)
 {
@@ -405,20 +405,13 @@ static inline int FlowCompare(Flow *f, const Packet *p)
         if (f->flags & FLOW_TCP_REUSED)
             return 0;
 
-        /* lets see if we need to consider the existing session for
-         * reuse: only considering SYN packets. */
-        int syn = (p->tcph && ((p->tcph->th_flags & TH_SYN) == TH_SYN));
-        int has_protoctx = ((f->protoctx != NULL));
-
-        /* syn on existing state, need to see if we need to 'reuse' */
-        if (unlikely(syn && has_protoctx && FlowGetPacketDirection(f,p) == TOSERVER)) {
-            if (unlikely(TcpSessionPacketSsnReuse(p, f->protoctx) == 1)) {
-                /* okay, we need to setup a new flow for this packet.
-                 * Flag the flow that it's been replaced by a new one */
-                f->flags |= FLOW_TCP_REUSED;
-                SCLogDebug("flow obsolete: TCP reuse will use a new flow");
-                return 0;
-            }
+        /* lets see if we need to consider the existing session reuse */
+        if (unlikely(TcpSessionPacketSsnReuse(p, f, f->protoctx) == 1)) {
+            /* okay, we need to setup a new flow for this packet.
+             * Flag the flow that it's been replaced by a new one */
+            f->flags |= FLOW_TCP_REUSED;
+            SCLogDebug("flow obsolete: TCP reuse will use a new flow");
+            return 0;
         }
         return 1;
     } else {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -507,6 +507,112 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
     return f;
 }
 
+Flow *FlowGetFlowFromHashByPacket(const Packet *p)
+{
+    Flow *f = NULL;
+
+    /* get the key to our bucket */
+    uint32_t key = FlowGetKey(p);
+    /* get our hash bucket and lock it */
+    FlowBucket *fb = &flow_hash[key];
+    FBLOCK_LOCK(fb);
+
+    SCLogDebug("fb %p fb->head %p", fb, fb->head);
+
+    f = FlowGetNew(NULL, NULL, p);
+    if (f != NULL) {
+        /* flow is locked */
+        if (fb->head == NULL) {
+            fb->head = f;
+            fb->tail = f;
+        } else {
+            f->hprev = fb->tail;
+            fb->tail->hnext = f;
+            fb->tail = f;
+        }
+
+        /* got one, now lock, initialize and return */
+        FlowInit(f, p);
+        f->fb = fb;
+    }
+    FBLOCK_UNLOCK(fb);
+    return f;
+}
+
+/** \brief Lookup flow based on packet
+ *
+ *  Find the flow belonging to this packet. If not found, no new flow
+ *  is set up.
+ *
+ *  \param p packet to lookup the flow for
+ *
+ *  \retval f flow or NULL if not found
+ */
+Flow *FlowLookupFlowFromHash(const Packet *p)
+{
+    Flow *f = NULL;
+
+    /* get the key to our bucket */
+    uint32_t key = FlowGetKey(p);
+    /* get our hash bucket and lock it */
+    FlowBucket *fb = &flow_hash[key];
+    FBLOCK_LOCK(fb);
+
+    SCLogDebug("fb %p fb->head %p", fb, fb->head);
+
+    /* see if the bucket already has a flow */
+    if (fb->head == NULL) {
+        FBLOCK_UNLOCK(fb);
+        return NULL;
+    }
+
+    /* ok, we have a flow in the bucket. Let's find out if it is our flow */
+    f = fb->head;
+
+    /* see if this is the flow we are looking for */
+    if (FlowCompare(f, p) == 0) {
+        while (f) {
+            FlowHashCountIncr;
+
+            f = f->hnext;
+
+            if (f == NULL) {
+                FBLOCK_UNLOCK(fb);
+                return NULL;
+            }
+
+            if (FlowCompare(f, p) != 0) {
+                /* we found our flow, lets put it on top of the
+                 * hash list -- this rewards active flows */
+                if (f->hnext) {
+                    f->hnext->hprev = f->hprev;
+                }
+                if (f->hprev) {
+                    f->hprev->hnext = f->hnext;
+                }
+                if (f == fb->tail) {
+                    fb->tail = f->hprev;
+                }
+
+                f->hnext = fb->head;
+                f->hprev = NULL;
+                fb->head->hprev = f;
+                fb->head = f;
+
+                /* found our flow, lock & return */
+                FLOWLOCK_WRLOCK(f);
+                FBLOCK_UNLOCK(fb);
+                return f;
+            }
+        }
+    }
+
+    /* lock & return */
+    FLOWLOCK_WRLOCK(f);
+    FBLOCK_UNLOCK(fb);
+    return f;
+}
+
 /** \brief Get Flow for packet
  *
  * Hash retrieval function for flows. Looks up the hash bucket containing the

--- a/src/flow.c
+++ b/src/flow.c
@@ -324,7 +324,6 @@ void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
      * a new flow if nescesary. If we get NULL, we're out of flow memory.
      * The returned flow is locked. */
     Flow *f = FlowGetFlowFromHash(tv, dtv, p);
-    SCLogInfo("packet %"PRIu64", f %p", p->pcap_cnt, f);
     if (f == NULL)
         return;
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -178,7 +178,7 @@ void FlowSetIPOnlyFlagNoLock(Flow *f, char direction)
  *  \retval 0 to_server
  *  \retval 1 to_client
  */
-int FlowGetPacketDirection(Flow *f, const Packet *p)
+int FlowGetPacketDirection(const Flow *f, const Packet *p)
 {
     if (p->proto == IPPROTO_TCP || p->proto == IPPROTO_UDP || p->proto == IPPROTO_SCTP) {
         if (!(CMP_PORT(p->sp,p->dp))) {

--- a/src/flow.c
+++ b/src/flow.c
@@ -226,22 +226,16 @@ static inline int FlowUpdateSeenFlag(const Packet *p)
     return 1;
 }
 
-/** \brief Entry point for packet flow handling
+/** \brief Update Packet and Flow
  *
- * This is called for every packet.
+ *  Updates packet and flow based on the new packet.
  *
- *  \param tv threadvars
- *  \param dtv decode thread vars (for flow output api thread data)
- *  \param p packet to handle flow for
+ *  \param f locked flow
+ *  \param p packet
  */
-void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
+void FlowHandlePacketUpdate(Flow *f, Packet *p)
 {
-    /* Get this packet's flow from the hash. FlowHandlePacket() will setup
-     * a new flow if nescesary. If we get NULL, we're out of flow memory.
-     * The returned flow is locked. */
-    Flow *f = FlowGetFlowFromHash(tv, dtv, p);
-    if (f == NULL)
-        return;
+    SCLogDebug("packet %"PRIu64" -- flow %p", p->pcap_cnt, f);
 
     /* Point the Packet at the Flow */
     FlowReference(&p->flow, f);
@@ -263,7 +257,7 @@ void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
         p->flowflags |= FLOW_PKT_TOCLIENT;
     }
 
-    if ((f->flags & FLOW_TO_DST_SEEN) && (f->flags & FLOW_TO_SRC_SEEN)) {
+    if ((f->flags & (FLOW_TO_DST_SEEN|FLOW_TO_SRC_SEEN)) == (FLOW_TO_DST_SEEN|FLOW_TO_SRC_SEEN)) {
         SCLogDebug("pkt %p FLOW_PKT_ESTABLISHED", p);
         p->flowflags |= FLOW_PKT_ESTABLISHED;
 
@@ -281,6 +275,27 @@ void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
         SCLogDebug("setting FLOW_NOPAYLOAD_INSPECTION flag on flow %p", f);
         DecodeSetNoPayloadInspectionFlag(p);
     }
+}
+
+/** \brief Entry point for packet flow handling
+ *
+ * This is called for every packet.
+ *
+ *  \param tv threadvars
+ *  \param dtv decode thread vars (for flow output api thread data)
+ *  \param p packet to handle flow for
+ */
+void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
+{
+    /* Get this packet's flow from the hash. FlowHandlePacket() will setup
+     * a new flow if nescesary. If we get NULL, we're out of flow memory.
+     * The returned flow is locked. */
+    Flow *f = FlowGetFlowFromHash(tv, dtv, p);
+    SCLogInfo("packet %"PRIu64", f %p", p->pcap_cnt, f);
+    if (f == NULL)
+        return;
+
+    FlowHandlePacketUpdate(f, p);
 
     FLOWLOCK_UNLOCK(f);
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -232,6 +232,8 @@ static inline int FlowUpdateSeenFlag(const Packet *p)
  *
  *  \param f locked flow
  *  \param p packet
+ *
+ *  \note overwrites p::flowflags
  */
 void FlowHandlePacketUpdate(Flow *f, Packet *p)
 {
@@ -247,14 +249,14 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
         }
         f->todstpktcnt++;
         f->todstbytecnt += GET_PKT_LEN(p);
-        p->flowflags |= FLOW_PKT_TOSERVER;
+        p->flowflags = FLOW_PKT_TOSERVER;
     } else {
         if (FlowUpdateSeenFlag(p)) {
             f->flags |= FLOW_TO_SRC_SEEN;
         }
         f->tosrcpktcnt++;
         f->tosrcbytecnt += GET_PKT_LEN(p);
-        p->flowflags |= FLOW_PKT_TOCLIENT;
+        p->flowflags = FLOW_PKT_TOCLIENT;
     }
 
     if ((f->flags & (FLOW_TO_DST_SEEN|FLOW_TO_SRC_SEEN)) == (FLOW_TO_DST_SEEN|FLOW_TO_SRC_SEEN)) {

--- a/src/flow.c
+++ b/src/flow.c
@@ -226,6 +226,37 @@ static inline int FlowUpdateSeenFlag(const Packet *p)
     return 1;
 }
 
+/**
+ *
+ *  Remove packet from flow. This assumes this happens *before* the packet
+ *  is added to the stream engine and other higher state.
+ *
+ *  \todo we can't restore the lastts
+ */
+void FlowHandlePacketUpdateRemove(Flow *f, Packet *p)
+{
+    if (p->flowflags & FLOW_PKT_TOSERVER) {
+        f->todstpktcnt--;
+        f->todstbytecnt -= GET_PKT_LEN(p);
+        p->flowflags &= ~FLOW_PKT_TOSERVER;
+    } else {
+        f->tosrcpktcnt--;
+        f->tosrcbytecnt -= GET_PKT_LEN(p);
+        p->flowflags &= ~FLOW_PKT_TOCLIENT;
+    }
+    p->flowflags &= ~FLOW_PKT_ESTABLISHED;
+
+    /*set the detection bypass flags*/
+    if (f->flags & FLOW_NOPACKET_INSPECTION) {
+        SCLogDebug("unsetting FLOW_NOPACKET_INSPECTION flag on flow %p", f);
+        DecodeUnsetNoPacketInspectionFlag(p);
+    }
+    if (f->flags & FLOW_NOPAYLOAD_INSPECTION) {
+        SCLogDebug("unsetting FLOW_NOPAYLOAD_INSPECTION flag on flow %p", f);
+        DecodeUnsetNoPayloadInspectionFlag(p);
+    }
+}
+
 /** \brief Update Packet and Flow
  *
  *  Updates packet and flow based on the new packet.

--- a/src/flow.h
+++ b/src/flow.h
@@ -580,7 +580,7 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
-
+void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -46,9 +46,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_TO_SRC_SEEN                  0x00000001
 /** At least on packet from the destination address was seen */
 #define FLOW_TO_DST_SEEN                  0x00000002
-
-// vacany 1x
-
+/** Don't return this from the flow hash. It has been replaced. */
+#define FLOW_TCP_REUSED                   0x00000004
 /** no magic on files in this flow */
 #define FLOW_FILE_NO_MAGIC_TS             0x00000008
 #define FLOW_FILE_NO_MAGIC_TC             0x00000010

--- a/src/flow.h
+++ b/src/flow.h
@@ -449,7 +449,7 @@ static inline void FlowLockSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetSessionNoApplayerInspectionFlag(Flow *);
 
-int FlowGetPacketDirection(Flow *, const Packet *);
+int FlowGetPacketDirection(const Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -580,9 +580,11 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
-
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
+
+Flow *FlowGetFlowFromHashByPacket(const Packet *p);
+Flow *FlowLookupFlowFromHash(const Packet *p);
 
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -580,6 +580,8 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
+
+void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
 #endif /* __FLOW_H__ */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -982,11 +982,16 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
         ssn->flags = STREAMTCP_FLAG_MIDSTREAM;
         ssn->flags |= STREAMTCP_FLAG_MIDSTREAM_ESTABLISHED;
 
+        /** window scaling for midstream pickups, we can't do much other
+         *  than assume that it's set to the max value: 14 */
+        ssn->client.wscale = TCP_WSCALE_MAX;
+        ssn->server.wscale = TCP_WSCALE_MAX;
+
         /* set the sequence numbers and window */
         ssn->client.isn = TCP_GET_SEQ(p) - 1;
         STREAMTCP_SET_RA_BASE_SEQ(&ssn->client, ssn->client.isn);
         ssn->client.next_seq = TCP_GET_SEQ(p) + p->payload_len;
-        ssn->client.window = TCP_GET_WINDOW(p);
+        ssn->client.window = TCP_GET_WINDOW(p) << ssn->client.wscale;
         ssn->client.last_ack = TCP_GET_SEQ(p);
         ssn->client.next_win = ssn->client.last_ack + ssn->client.window;
         SCLogDebug("ssn %p: ssn->client.isn %u, ssn->client.next_seq %u",
@@ -1004,11 +1009,6 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
         SCLogDebug("ssn %p: ssn->client.last_ack %"PRIu32", "
                 "ssn->server.last_ack %"PRIu32"", ssn,
                 ssn->client.last_ack, ssn->server.last_ack);
-
-        /** window scaling for midstream pickups, we can't do much other
-         *  than assume that it's set to the max value: 14 */
-        ssn->client.wscale = TCP_WSCALE_MAX;
-        ssn->server.wscale = TCP_WSCALE_MAX;
 
         /* Set the timestamp value for both streams, if packet has timestamp
          * option enabled.*/

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4386,6 +4386,17 @@ static int StreamTcpPacketIsBadWindowUpdate(TcpSession *ssn, Packet *p)
     return 0;
 }
 
+int TcpSessionPacketSsnReuse(const Packet *p, void *tcp_ssn)
+{
+    TcpSession *ssn = tcp_ssn;
+    if (ssn->state == TCP_CLOSED) {
+        if(!(SEQ_EQ(ssn->client.isn, TCP_GET_SEQ(p))))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
 
 /* flow is and stays locked */
 int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4751,9 +4751,6 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_no_flow = SCPerfTVRegisterCounter("tcp.no_flow", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");
-    stt->counter_tcp_reused_ssn = SCPerfTVRegisterCounter("tcp.reused_ssn", tv,
-                                                        SC_PERF_TYPE_UINT64,
-                                                        "NULL");
     stt->counter_tcp_memuse = SCPerfTVRegisterCounter("tcp.memuse", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4551,60 +4551,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
                 }
                 break;
             case TCP_CLOSED:
-                /* TCP session memory is not returned to pool until timeout.
-                 * If in the mean time we receive any other session from
-                 * the same client reusing same port then we switch back to
-                 * tcp state none, but only on a valid SYN that is not a
-                 * resend from our previous session.
-                 *
-                 * We also check it's not a SYN/ACK, all other SYN pkt
-                 * validation is done at StreamTcpPacketStateNone();
-                 */
-                if (PKT_IS_TOSERVER(p) && (p->tcph->th_flags & TH_SYN) &&
-                    !(p->tcph->th_flags & TH_ACK) &&
-                    !(SEQ_EQ(ssn->client.isn, TCP_GET_SEQ(p))))
-                {
-                    SCLogDebug("reusing closed TCP session");
-
-                    /* return segments */
-                    StreamTcpReturnStreamSegments(&ssn->client);
-                    StreamTcpReturnStreamSegments(&ssn->server);
-                    /* free SACK list */
-                    StreamTcpSackFreeList(&ssn->client);
-                    StreamTcpSackFreeList(&ssn->server);
-                    /* reset the app layer state */
-                    FlowCleanupAppLayer(p->flow);
-
-                    ssn->state = 0;
-                    ssn->flags = 0;
-                    ssn->client.flags = 0;
-                    ssn->server.flags = 0;
-
-                    /* set state the NONE, also pulls flow out of closed queue */
-                    StreamTcpPacketSetState(p, ssn, TCP_NONE);
-
-                    p->flow->alproto_ts = p->flow->alproto_tc = p->flow->alproto = ALPROTO_UNKNOWN;
-                    p->flow->data_al_so_far[0] = p->flow->data_al_so_far[1] = 0;
-                    ssn->data_first_seen_dir = 0;
-                    p->flow->flags &= (~FLOW_TS_PM_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TS_PP_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TC_PM_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TC_PP_ALPROTO_DETECT_DONE);
-                    p->flow->flags &= ~ FLOW_NO_APPLAYER_INSPECTION;
-                    if (p->flow->de_state != NULL) {
-                        SCMutexLock(&p->flow->de_state_m);
-                        DetectEngineStateReset(p->flow->de_state, (STREAM_TOSERVER | STREAM_TOCLIENT));
-                        SCMutexUnlock(&p->flow->de_state_m);
-                    }
-
-                    if (StreamTcpPacketStateNone(tv,p,stt,ssn, &stt->pseudo_queue)) {
-                        goto error;
-                    }
-
-                    SCPerfCounterIncr(stt->counter_tcp_reused_ssn, tv->sc_perf_pca);
-                } else {
-                    SCLogDebug("packet received on closed state");
-                }
+                /* TCP session memory is not returned to pool until timeout. */
+                SCLogDebug("packet received on closed state");
                 break;
             default:
                 SCLogDebug("packet received on default state");


### PR DESCRIPTION
Rebased https://github.com/inliniac/suricata/pull/1326, adds midstream (SYN/ACK) reuse support and fixes a midstream issue (https://redmine.openinfosecfoundation.org/issues/1384)

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/142
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/142