### PR TITLE
Jurassic fix

### DIFF
--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -22,7 +22,6 @@
 #include "runmode-pcap-file.h"
 #include "log-httplog.h"
 #include "output.h"
-#include "source-pfring.h"
 #include "detect-engine-mpm.h"
 
 #include "alert-fastlog.h"

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -24,6 +24,8 @@
 #include "output.h"
 #include "detect-engine-mpm.h"
 
+#include "source-pcap-file.h"
+
 #include "alert-fastlog.h"
 #include "alert-prelude.h"
 #include "alert-unified2-alert.h"
@@ -73,6 +75,8 @@ int RunModeFilePcapSingle(DetectEngineCtx *de_ctx)
 
     RunModeInitialize();
     TimeModeSetOffline();
+
+    PcapFileGlobalInit();
 
     /* create the threads */
     ThreadVars *tv = TmThreadCreatePacketHandler("PcapFile",
@@ -162,6 +166,8 @@ int RunModeFilePcapAutoFp(DetectEngineCtx *de_ctx)
     SCLogDebug("file %s", file);
 
     TimeModeSetOffline();
+
+    PcapFileGlobalInit();
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -131,6 +131,11 @@ void TmModuleDecodePcapFileRegister (void)
     tmm_modules[TMM_DECODEPCAPFILE].flags = TM_FLAG_DECODE_TM;
 }
 
+void PcapFileGlobalInit()
+{
+    SC_ATOMIC_INIT(pcap_g.invalid_checksums);
+}
+
 void PcapFileCallbackLoop(char *user, struct pcap_pkthdr *h, u_char *pkt)
 {
     SCEnter();

--- a/src/source-pcap-file.h
+++ b/src/source-pcap-file.h
@@ -29,5 +29,7 @@ void TmModuleDecodePcapFileRegister (void);
 
 void PcapIncreaseInvalidChecksum();
 
+void PcapFileGlobalInit();
+
 #endif /* __SOURCE_PCAP_FILE_H__ */
 


### PR DESCRIPTION
Here's a fix on invalid_checksum counter that was not init in pcap-file mode. It needs to be tested as I don't have an old distribution at home.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1388

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/37
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/35
