### PR TITLE
build: don't link with libnfnetlink

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -656,44 +656,51 @@
 
     AS_IF([test "x$enable_unixsocket" = "xyes"], [AC_DEFINE([BUILD_UNIX_SOCKET], [1], [Unix socket support enabled])])
 
+    AC_ARG_ENABLE(nflog,
+            AS_HELP_STRING([--enable-nflog],[Enable libnetfilter_log support]),
+                           [ enable_nflog="yes"],
+                           [ enable_nflog="no"])
+    AC_ARG_ENABLE(nfqueue,
+           AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),[enable_nfqueue=yes],[enable_nfqueue=no])
+
+    if test "x$enable_nflog" = "xyes" || test  "x$enable_nfqueue" = "xyes"; then
   # libnfnetlink
-    case $host in
-    *-*-mingw32*)
-        ;;
-    *)
-        AC_ARG_WITH(libnfnetlink_includes,
-                [  --with-libnfnetlink-includes=DIR  libnfnetlink include directory],
-                [with_libnfnetlink_includes="$withval"],[with_libnfnetlink_includes=no])
-        AC_ARG_WITH(libnfnetlink_libraries,
-                [  --with-libnfnetlink-libraries=DIR    libnfnetlink library directory],
-                [with_libnfnetlink_libraries="$withval"],[with_libnfnetlink_libraries="no"])
+        case $host in
+        *-*-mingw32*)
+            ;;
+        *)
+            AC_ARG_WITH(libnfnetlink_includes,
+                    [  --with-libnfnetlink-includes=DIR  libnfnetlink include directory],
+                    [with_libnfnetlink_includes="$withval"],[with_libnfnetlink_includes=no])
+            AC_ARG_WITH(libnfnetlink_libraries,
+                    [  --with-libnfnetlink-libraries=DIR    libnfnetlink library directory],
+                    [with_libnfnetlink_libraries="$withval"],[with_libnfnetlink_libraries="no"])
 
-        if test "$with_libnfnetlink_includes" != "no"; then
-            CPPFLAGS="${CPPFLAGS} -I${with_libnfnetlink_includes}"
-        fi
+            if test "$with_libnfnetlink_includes" != "no"; then
+                CPPFLAGS="${CPPFLAGS} -I${with_libnfnetlink_includes}"
+            fi
 
-        if test "$with_libnfnetlink_libraries" != "no"; then
-            LDFLAGS="${LDFLAGS}  -L${with_libnfnetlink_libraries}"
-        fi
+            if test "$with_libnfnetlink_libraries" != "no"; then
+                LDFLAGS="${LDFLAGS}  -L${with_libnfnetlink_libraries}"
+            fi
 
-        NFNL=""
-        AC_CHECK_LIB(nfnetlink, nfnl_fd,, NFNL="no")
+            NFNL=""
+            AC_CHECK_LIB(nfnetlink, nfnl_fd,, NFNL="no")
 
-        if test "$NFNL" = "no"; then
-            echo
-            echo "   ERROR!  nfnetlink library not found, go get it"
-            echo "   from www.netfilter.org."
-            echo "   we automatically append libnetfilter_queue/ when searching"
-            echo "   for headers etc. when the --with-libnfnetlink-includes directive"
-            echo "   is used"
-            echo
-        fi
-        ;;
-    esac
+            if test "$NFNL" = "no"; then
+                echo
+                echo "   ERROR!  nfnetlink library not found, go get it"
+                echo "   from www.netfilter.org."
+                echo "   we automatically append libnetfilter_queue/ when searching"
+                echo "   for headers etc. when the --with-libnfnetlink-includes directive"
+                echo "   is used"
+                echo
+            fi
+            ;;
+        esac
+    fi
 
     #enable support for NFQUEUE
-    AC_ARG_ENABLE(nfqueue,
-           AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),,[enable_nfqueue=no])
     AS_IF([test "x$enable_nfqueue" = "xyes"], [
         CFLAGS="$CFLAGS -DNFQ"
 
@@ -780,10 +787,6 @@
   ])
 
   # libnetfilter_log
-    AC_ARG_ENABLE(nflog,
-            AS_HELP_STRING([--enable-nflog],[Enable libnetfilter_log support]),
-                           [ enable_nflog="yes"],
-                           [ enable_nflog="no"])
     AC_ARG_WITH(libnetfilter_log_includes,
             [  --with-libnetfilter_log-includes=DIR  libnetfilter_log include directory],
             [with_libnetfilter_log_includes="$withval"],[with_libnetfilter_log_includes="no"])


### PR DESCRIPTION
Don't link suricata with libnfnetlink when we don't have support
for NFQUEUE or NFLOG. Previously, suricata was linked with this
library without reason.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/38
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/36