### PR TITLE
util-ioctl: don't build code RX ring on old system

### DIFF
--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -212,7 +212,7 @@ int GetIfaceOffloading(const char *pcap_dev)
 
 int GetIfaceRSSQueuesNum(const char *pcap_dev)
 {
-#ifdef HAVE_LINUX_ETHTOOL_H
+#if defined HAVE_LINUX_ETHTOOL_H && defined ETHTOOL_GRXRINGS
     struct ifreq ifr;
     struct ethtool_rxnfc nfccmd;
     int fd;


### PR DESCRIPTION
If ETHTOOL_GRXRINGS is undefined we will not be able to build the
RX rings code. So we can make the build conditional to the
definition of ETHTOOL_GRXRINGS.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1393

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/39
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/37