### PR TITLE
suricatasc: fix dump-counters command

### DIFF
--- a/scripts/suricatasc/src/suricatasc.py
+++ b/scripts/suricatasc/src/suricatasc.py
@@ -87,7 +87,7 @@ class SuricataSC:
         cmdret = None
         i = 0
         data = ""
-        while i < 5:
+        while i < 20:
             i += 1
             if sys.version < '3':
                 data += self.socket.recv(SIZE)


### PR DESCRIPTION
As the exit of dump-counters command is really long and takes time
to get it can take more 5 iterations to get the complete message.
Increasing to 20 seems to fix the issue (10 was ok too).

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/40
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/38