### PR TITLE
Remove spinning PacketPoolWait

### DIFF
--- a/src/tmqh-packetpool.h
+++ b/src/tmqh-packetpool.h
@@ -26,11 +26,14 @@
 
 #include "decode.h"
 #include "threads.h"
+#include "util-atomic.h"
 
     /* Return stack, onto which other threads free packets. */
 typedef struct PktPoolLockedStack_{
     /* linked list of free packets. */
     SCMutex mutex;
+    SCCondT cond;
+    SC_ATOMIC_DECLARE(int, sync_now);
     Packet *head;
 } __attribute__((aligned(CLS))) PktPoolLockedStack;
 


### PR DESCRIPTION
PacketPoolWait in autofp can wait for considerable time. Until now
it was essentially spinning, keeping the CPU 100% busy.

This patch introduces a condition to wait in such cases.

Atomically flag pool that consumer is waiting, so that we can sync
the pending pool right away instead of waiting for the
MAX_PENDING_RETURN_PACKETS limit.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/149
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/149