### PR TITLE
When re-opening a log file on HUP, always append - v1.

### DIFF
--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -251,9 +251,10 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
 
     fclose(log_ctx->fp);
 
-    /* Reopen the file.  In this case do not append like may have been
-     * done on the initial opening of the file. */
-    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "no");
+    /* Reopen the file. Append is forced in case the file was not
+     * moved as part of a rotation process. */
+    SCLogDebug("Reopening log file %s.", log_ctx->filename);
+    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "yes");
     if (log_ctx->fp == NULL) {
         return -1; // Already logged by Open..Fp routine.
     }


### PR DESCRIPTION
This will prevent log files that have not been rotated by some
external tool from being deleted, but log files that were
rotated (moved out of the way) will be re-opened.

This is a better default behaviour, especially when not all
log files are rotated at the same time.

Thanks to iro on IRC.

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/30
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/30

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1402
