### PR TITLE
Changed Thread name for AF-Packet in workers mode to AFP.

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -504,7 +504,7 @@ int RunModeIdsAFPSingle(DetectEngineCtx *de_ctx)
                                     ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "AFPacket",
+                                    "DecodeAFP", "AFP",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -552,7 +552,7 @@ int RunModeIdsAFPWorkers(DetectEngineCtx *de_ctx)
                                     ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "AFPacket",
+                                    "DecodeAFP", "AFP",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");


### PR DESCRIPTION
pthread takes a maximum of 15 chars long NIC names. With
names (say ens1f1) combined with the old thread name of
AFPacket it can exceed this pthread limit causing bad
thread names. Changed this to AFP so that longer NIC names
are able to be used in suricata.