### PR TITLE
L7 alert

### DIFF
--- a/src/flow.c
+++ b/src/flow.c
@@ -860,12 +860,12 @@ int FlowSetProtoEmergencyTimeout(uint8_t proto, uint32_t emerg_new_timeout,
     return 1;
 }
 
-AppProto FlowGetAppProtocol(Flow *f)
+AppProto FlowGetAppProtocol(const Flow *f)
 {
     return f->alproto;
 }
 
-void *FlowGetAppState(Flow *f)
+void *FlowGetAppState(const Flow *f)
 {
     return f->alstate;
 }

--- a/src/flow.h
+++ b/src/flow.h
@@ -574,8 +574,8 @@ static inline void FlowDeReference(Flow **d)
 
 int FlowClearMemory(Flow *,uint8_t );
 
-AppProto FlowGetAppProtocol(Flow *f);
-void *FlowGetAppState(Flow *f);
+AppProto FlowGetAppProtocol(const Flow *f);
+void *FlowGetAppState(const Flow *f);
 
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -108,7 +108,7 @@ static int AlertJsonPrintStreamSegmentCallback(const Packet *p, void *data, uint
  */
 static void AlertJsonHttp(const Flow *f, json_t *js)
 {
-    HtpState *htp_state = (HtpState *)f->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
         uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
@@ -130,7 +130,7 @@ static void AlertJsonHttp(const Flow *f, json_t *js)
 
 static void AlertJsonTls(const Flow *f, json_t *js)
 {
-    SSLState *ssl_state = (SSLState *)f->alstate;
+    SSLState *ssl_state = (SSLState *)FlowGetAppState(f);
     if (ssl_state) {
         json_t *tjs = json_object();
         if (unlikely(tjs == NULL))
@@ -147,7 +147,7 @@ static void AlertJsonTls(const Flow *f, json_t *js)
 
 static void AlertJsonSsh(const Flow *f, json_t *js)
 {
-    SshState *ssh_state = (SshState *)f->alstate;
+    SshState *ssh_state = (SshState *)FlowGetAppState(f);
     if (ssh_state) {
         json_t *tjs = json_object();
         if (unlikely(tjs == NULL))

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -65,6 +65,31 @@ typedef struct JsonSshLogThread_ {
     MemBuffer *buffer;
 } JsonSshLogThread;
 
+
+void JsonSshLogJSON(json_t *tjs, SshState *ssh_state)
+{
+    json_t *cjs = json_object();
+    if (cjs != NULL) {
+        json_object_set_new(cjs, "proto_version",
+                json_string((char *)ssh_state->cli_hdr.proto_version));
+
+        json_object_set_new(cjs, "software_version",
+                json_string((char *)ssh_state->cli_hdr.software_version));
+    }
+    json_object_set_new(tjs, "client", cjs);
+
+    json_t *sjs = json_object();
+    if (sjs != NULL) {
+        json_object_set_new(sjs, "proto_version",
+                json_string((char *)ssh_state->srv_hdr.proto_version));
+
+        json_object_set_new(sjs, "software_version",
+                json_string((char *)ssh_state->srv_hdr.software_version));
+    }
+    json_object_set_new(tjs, "server", sjs);
+
+}
+
 static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonSshLogThread *aft = (JsonSshLogThread *)thread_data;
@@ -102,25 +127,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     /* reset */
     MemBufferReset(buffer);
 
-    json_t *cjs = json_object();
-    if (cjs != NULL) {
-        json_object_set_new(cjs, "proto_version",
-                json_string((char *)ssh_state->cli_hdr.proto_version));
-
-        json_object_set_new(cjs, "software_version",
-                json_string((char *)ssh_state->cli_hdr.software_version));
-    }
-    json_object_set_new(tjs, "client", cjs);
-
-    json_t *sjs = json_object();
-    if (sjs != NULL) {
-        json_object_set_new(sjs, "proto_version",
-                json_string((char *)ssh_state->srv_hdr.proto_version));
-
-        json_object_set_new(sjs, "software_version",
-                json_string((char *)ssh_state->srv_hdr.software_version));
-    }
-    json_object_set_new(tjs, "server", sjs);
+    JsonSshLogJSON(tjs, ssh_state);
 
     json_object_set_new(js, "ssh", tjs);
 

--- a/src/output-json-ssh.h
+++ b/src/output-json-ssh.h
@@ -26,4 +26,10 @@
 
 void TmModuleJsonSshLogRegister (void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-ssh.h"
+
+void JsonSshLogJSON(json_t *js, SshState *tx);
+#endif
+
 #endif /* __OUTPUT_JSON_SSH_H__ */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -72,7 +72,19 @@ typedef struct JsonTlsLogThread_ {
 
 #define SSL_VERSION_LENGTH 13
 
-static void LogTlsLogExtendedJSON(json_t *tjs, SSLState * state)
+void JsonTlsLogJSONBasic(json_t *js, SSLState *ssl_state)
+{
+    /* tls.subject */
+    json_object_set_new(js, "subject",
+                        json_string(ssl_state->server_connp.cert0_subject));
+
+    /* tls.issuerdn */
+    json_object_set_new(js, "issuerdn",
+                        json_string(ssl_state->server_connp.cert0_issuerdn));
+
+}
+
+void JsonTlsLogJSONExtended(json_t *tjs, SSLState * state)
 {
     char ssl_version[SSL_VERSION_LENGTH + 1];
 
@@ -145,16 +157,10 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     /* reset */
     MemBufferReset(buffer);
 
-    /* tls.subject */
-    json_object_set_new(tjs, "subject",
-                        json_string(ssl_state->server_connp.cert0_subject));
-
-    /* tls.issuerdn */
-    json_object_set_new(tjs, "issuerdn",
-                        json_string(ssl_state->server_connp.cert0_issuerdn));
+    JsonTlsLogJSONBasic(tjs, ssl_state);
 
     if (tls_ctx->flags & LOG_TLS_EXTENDED) {
-        LogTlsLogExtendedJSON(tjs, ssl_state);
+        JsonTlsLogJSONExtended(tjs, ssl_state);
     }
 
     json_object_set_new(js, "tls", tjs);

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -26,4 +26,11 @@
 
 void TmModuleJsonTlsLogRegister (void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-ssl.h"
+
+void JsonTlsLogJSONBasic(json_t *js, SSLState *ssl_state);
+void JsonTlsLogJSONExtended(json_t *js, SSLState *ssl_state);
+#endif /* HAVE_LIBJANSSON */
+
 #endif /* __OUTPUT_JSON_TLS_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -106,6 +106,7 @@ outputs:
             # packet: yes            # enable dumping of packet (without stream segments)
             # http: yes              # enable dumping of http fields
             # tls: yes               # enable dumping of tls fields
+            # ssh: yes               # enable dumping of ssh fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -105,6 +105,7 @@ outputs:
             # payload-printable: yes # enable dumping payload in printable (lossy) format
             # packet: yes            # enable dumping of packet (without stream segments)
             # http: yes              # enable dumping of http fields
+            # tls: yes               # enable dumping of tls fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)


### PR DESCRIPTION
EVE format allows us to get rich alerts. But currently we only have Suricata generated information for alerts on HTTP protocol. This patchset does the same for TLS and SSH.

This way we can have alerts looking like:
```JSON
{"timestamp":"2015-03-06T20:12:25.792723","flow_id":50932816,"pcap_cnt":49,"event_type":"alert","src_ip":"192.168.56.101","src_port":443,"dest_ip":"192.168.56.1","dest_port":49368,"proto":"TCP","alert":{"action":"allowed","gid":1,"signature_id":1,"rev":1,"signature":"SELKS powa","category":"","severity":3},"tls":{"subject":"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS","issuerdn":"C=FR, ST=IDF, L=Paris, O=Stamus, CN=SELKS","fingerprint":"3a:0b:3b:23:15:2c:44:5c:27:ac:6a:0c:41:d6:fa:74:af:b4:09:5b","version":"TLS 1.2"}}
{"timestamp":"2015-03-06T21:14:21.643871","flow_id":23025888,"pcap_cnt":7,"event_type":"alert","src_ip":"0000:0000:0000:0000:0000:0000:0000:0001","src_port":45379,"dest_ip":"0000:0000:0000:0000:0000:0000:0000:0001","dest_port":22,"proto":"TCP","alert":{"action":"allowed","gid":1,"signature_id":1,"rev":1,"signature":"SSH powa","category":"","severity":3},"ssh":{"client":{"proto_version":"2.0","software_version":"OpenSSH_6.7p1 Debian-3"},"server":{"proto_version":"2.0","software_version":"OpenSSH_6.7p1 Debian-3"}}}
```

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/41
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/39
