### PR TITLE
af-packet: don't unlock twice the bpf mutex

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1637,7 +1637,6 @@ TmEcode AFPSetBPFFilter(AFPThreadVars *ptv)
         return TM_ECODE_FAILED;
     }
 
-    SCMutexUnlock(&afpacket_bpf_set_filter_lock);
     return TM_ECODE_OK;
 }
 


### PR DESCRIPTION
Fix a stupid mistake in lock handling.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/42
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/40