### PR TITLE
Flow timeout fix v1.4

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -171,6 +171,18 @@ Packet *PacketGetFromQueueOrAlloc(void)
     return p;
 }
 
+inline int PacketCallocExtPkt(Packet *p, int datalen)
+{
+    if (! p->ext_pkt) {
+        p->ext_pkt = SCCalloc(1, datalen);
+        if (unlikely(p->ext_pkt == NULL)) {
+            SET_PKT_LEN(p, 0);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 /**
  *  \brief Copy data to Packet payload at given offset
  *

--- a/src/decode.h
+++ b/src/decode.h
@@ -835,6 +835,7 @@ Packet *PacketGetFromAlloc(void);
 void PacketDecodeFinalize(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p);
 void PacketFree(Packet *p);
 void PacketFreeOrRelease(Packet *p);
+int PacketCallocExtPkt(Packet *p, int datalen);
 int PacketCopyData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketSetData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datalen);

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -108,6 +108,14 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
             p->dp = f->sp;
         }
 
+        /* Check if we have enough room in direct data. We need ipv4 hdr + tcp hdr.
+         * Force an allocation if it is not the case.
+         */
+        if (GET_PKT_DIRECT_MAX_SIZE(p) <  40) {
+            if (PacketCallocExtPkt(p, 40) == -1) {
+                return NULL;
+            }
+        }
         /* set the ip header */
         p->ip4h = (IPV4Hdr *)GET_PKT_DATA(p);
         /* version 4 and length 20 bytes for the tcp header */
@@ -145,6 +153,14 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
             p->dp = f->sp;
         }
 
+        /* Check if we have enough room in direct data. We need ipv6 hdr + tcp hdr.
+         * Force an allocation if it is not the case.
+         */
+        if (GET_PKT_DIRECT_MAX_SIZE(p) <  60) {
+            if (PacketCallocExtPkt(p, 60) == -1) {
+                return NULL;
+            }
+        }
         /* set the ip header */
         p->ip6h = (IPV6Hdr *)GET_PKT_DATA(p);
         /* version 6 */


### PR DESCRIPTION
The code was not checking if we had enough room in the direct
data. In case default_packet_size was set really small, this was
resulting in data being written over the data and causing a crash.

The patch fixes the issue by forcing an allocation if the direct
data size in the Packet is to small.

New version of #1334 with change being a new allocation function that make us avoid to do some memory copy. Also rebased on latest code.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1366

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/43
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/41
