### PR TITLE
[discussion only] App layer renegotiation v1.2

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -232,7 +232,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
                              p->flow->flags & FLOW_NOPACKET_INSPECTION ? "TRUE" : "FALSE",
                              p->flow->flags & FLOW_NOPAYLOAD_INSPECTION ? "TRUE" : "FALSE",
                              p->flow->flags & FLOW_NO_APPLAYER_INSPECTION ? "TRUE" : "FALSE",
-                             (p->flow->alproto != ALPROTO_UNKNOWN) ? "TRUE" : "FALSE", p->flow->alproto);
+                             (FlowGetAppProtocol(p->flow) != ALPROTO_UNKNOWN) ? "TRUE" : "FALSE",
+                             FlowGetAppProtocol(p->flow));
         AlertDebugLogFlowVars(aft, p);
         AlertDebugLogFlowBits(aft, (Packet *)p); /* < no const */
         FLOWLOCK_UNLOCK(p->flow);

--- a/src/app-layer-dcerpc-udp.c
+++ b/src/app-layer-dcerpc-udp.c
@@ -1065,7 +1065,7 @@ int DCERPCUDPParserTest01(void)
 	}
 	SCMutexUnlock(&f.m);
 
-	DCERPCUDPState *dcerpc_state = f.alstate;
+	DCERPCUDPState *dcerpc_state = FlowGetAppState(&f);
 	if (dcerpc_state == NULL) {
 		printf("no dcerpc state: ");
 		result = 0;

--- a/src/app-layer-dcerpc.c
+++ b/src/app-layer-dcerpc.c
@@ -2429,7 +2429,7 @@ int DCERPCParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -2661,7 +2661,7 @@ int DCERPCParserTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -2861,7 +2861,7 @@ int DCERPCParserTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4311,7 +4311,7 @@ int DCERPCParserTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4486,7 +4486,7 @@ int DCERPCParserTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4572,7 +4572,7 @@ int DCERPCParserTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4664,7 +4664,7 @@ int DCERPCParserTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4724,7 +4724,7 @@ int DCERPCParserTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4798,7 +4798,7 @@ int DCERPCParserTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4899,7 +4899,7 @@ int DCERPCParserTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -4998,7 +4998,7 @@ int DCERPCParserTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -5076,7 +5076,7 @@ int DCERPCParserTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -5167,7 +5167,7 @@ int DCERPCParserTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -5229,7 +5229,7 @@ int DCERPCParserTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -5691,7 +5691,7 @@ int DCERPCParserTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -5937,7 +5937,7 @@ int DCERPCParserTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -6082,7 +6082,7 @@ int DCERPCParserTest18(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         result = 0;
@@ -6346,7 +6346,7 @@ int DCERPCParserTest19(void)
     }
     SCMutexUnlock(&f.m);
 
-    DCERPCState *dcerpc_state = f.alstate;
+    DCERPCState *dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         printf("no dcerpc state: ");
         goto end;

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -3300,7 +3300,7 @@ static int AppLayerProtoDetectTest16(void)
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
-    f->alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3330,7 +3330,7 @@ static int AppLayerProtoDetectTest16(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3394,7 +3394,7 @@ static int AppLayerProtoDetectTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3424,7 +3424,7 @@ static int AppLayerProtoDetectTest17(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3490,7 +3490,7 @@ static int AppLayerProtoDetectTest18(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3520,7 +3520,7 @@ static int AppLayerProtoDetectTest18(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3582,7 +3582,7 @@ static int AppLayerProtoDetectTest19(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_FTP;
+    FlowSetAppProtocol(f, ALPROTO_FTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3669,7 +3669,7 @@ static int AppLayerProtoDetectTest20(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f->alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(f, ALPROTO_HTTP);
     f->proto = IPPROTO_TCP;
     p->flags |= PKT_STREAM_ADD;
     p->flags |= PKT_STREAM_EOF;

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -449,10 +449,11 @@ static int DNSUDPParserTest01 (void)
     if (f == NULL)
         goto end;
     f->proto = IPPROTO_UDP;
-    f->alproto = ALPROTO_DNS;
-    f->alstate = DNSStateAlloc();
+    FlowSetAppProtocol(f, ALPROTO_DNS);
+    FlowSetAppState(f, DNSStateAlloc());
 
-    int r = DNSUDPResponseParse(f, f->alstate, NULL, buf, buflen, NULL);
+    int r = DNSUDPResponseParse(f, FlowGetAppState(f),
+                                NULL, buf, buflen, NULL);
     if (r != 1)
         goto end;
 
@@ -484,10 +485,11 @@ static int DNSUDPParserTest02 (void)
     if (f == NULL)
         goto end;
     f->proto = IPPROTO_UDP;
-    f->alproto = ALPROTO_DNS;
-    f->alstate = DNSStateAlloc();
+    FlowSetAppProtocol(f, ALPROTO_DNS);
+    FlowSetAppState(f, DNSStateAlloc());
 
-    int r = DNSUDPResponseParse(f, f->alstate, NULL, buf, buflen, NULL);
+    int r = DNSUDPResponseParse(f, FlowGetAppState(f),
+                                NULL, buf, buflen, NULL);
     if (r != 1)
         goto end;
 
@@ -519,10 +521,11 @@ static int DNSUDPParserTest03 (void)
     if (f == NULL)
         goto end;
     f->proto = IPPROTO_UDP;
-    f->alproto = ALPROTO_DNS;
-    f->alstate = DNSStateAlloc();
+    FlowSetAppProtocol(f, ALPROTO_DNS);
+    FlowSetAppState(f, DNSStateAlloc());
 
-    int r = DNSUDPResponseParse(f, f->alstate, NULL, buf, buflen, NULL);
+    int r = DNSUDPResponseParse(f, FlowGetAppState(f),
+                                NULL, buf, buflen, NULL);
     if (r != 1)
         goto end;
 
@@ -557,10 +560,11 @@ static int DNSUDPParserTest04 (void)
     if (f == NULL)
         goto end;
     f->proto = IPPROTO_UDP;
-    f->alproto = ALPROTO_DNS;
-    f->alstate = DNSStateAlloc();
+    FlowSetAppProtocol(f, ALPROTO_DNS);
+    FlowSetAppState(f, DNSStateAlloc());
 
-    int r = DNSUDPResponseParse(f, f->alstate, NULL, buf, buflen, NULL);
+    int r = DNSUDPResponseParse(f, FlowGetAppState(f),
+                                NULL, buf, buflen, NULL);
     if (r != 1)
         goto end;
 
@@ -595,10 +599,11 @@ static int DNSUDPParserTest05 (void)
     if (f == NULL)
         goto end;
     f->proto = IPPROTO_UDP;
-    f->alproto = ALPROTO_DNS;
-    f->alstate = DNSStateAlloc();
+    FlowSetAppProtocol(f, ALPROTO_DNS);
+    FlowSetAppState(f, DNSStateAlloc());
 
-    int r = DNSUDPResponseParse(f, f->alstate, NULL, buf, buflen, NULL);
+    int r = DNSUDPResponseParse(f, FlowGetAppState(f),
+                                NULL, buf, buflen, NULL);
     if (r != -1)
         goto end;
 

--- a/src/app-layer-events.c
+++ b/src/app-layer-events.c
@@ -111,11 +111,12 @@ void AppLayerDecoderEventsSetEventRaw(AppLayerDecoderEvents **sevents, uint8_t e
  */
 void AppLayerDecoderEventsSetEvent(Flow *f, uint8_t event)
 {
-    AppLayerDecoderEvents *events = AppLayerParserGetDecoderEvents(f->alparser);
+    AppLayerDecoderEvents *events = AppLayerParserGetDecoderEvents(FlowGetAppParser(f));
     AppLayerDecoderEvents *new = events;
     AppLayerDecoderEventsSetEventRaw(&events, event);
     if (events != new)
-        AppLayerParserSetDecoderEvents(f->alparser, events);
+        AppLayerParserSetDecoderEvents(FlowGetAppParser(f),
+                                       events);
 }
 
 void AppLayerDecoderEventsResetEvents(AppLayerDecoderEvents *events)

--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -396,7 +396,7 @@ int FTPParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;
@@ -468,7 +468,7 @@ int FTPParserTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;
@@ -517,7 +517,7 @@ int FTPParserTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;
@@ -579,7 +579,7 @@ int FTPParserTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;
@@ -640,7 +640,7 @@ int FTPParserTest10(void)
         SCMutexUnlock(&f.m);
     }
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -346,7 +346,7 @@ static int HTPFileParserTest01(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -460,7 +460,7 @@ static int HTPFileParserTest02(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -606,7 +606,7 @@ static int HTPFileParserTest03(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -757,7 +757,7 @@ static int HTPFileParserTest04(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -850,7 +850,7 @@ static int HTPFileParserTest05(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -975,7 +975,7 @@ static int HTPFileParserTest06(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1089,7 +1089,7 @@ static int HTPFileParserTest07(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1190,7 +1190,7 @@ static int HTPFileParserTest08(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1198,7 +1198,9 @@ static int HTPFileParserTest08(void)
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,FlowGetAppState(f),
+                                                                        0);
     if (decoder_events == NULL) {
         printf("no app events: ");
         SCMutexUnlock(&f->m);
@@ -1308,7 +1310,7 @@ static int HTPFileParserTest09(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1316,7 +1318,9 @@ static int HTPFileParserTest09(void)
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,FlowGetAppState(f),
+                                                                        0);
     if (decoder_events == NULL) {
         printf("no app events: ");
         SCMutexUnlock(&f->m);
@@ -1424,7 +1428,7 @@ static int HTPFileParserTest10(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1432,7 +1436,9 @@ static int HTPFileParserTest10(void)
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,FlowGetAppState(f),
+                                                                        0);
     if (decoder_events != NULL) {
         printf("app events: ");
         SCMutexUnlock(&f->m);
@@ -1559,14 +1565,16 @@ static int HTPFileParserTest11(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,FlowGetAppState(f),
+                                                                        0);
     if (decoder_events != NULL) {
         printf("app events: ");
         SCMutexUnlock(&f->m);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2841,7 +2841,7 @@ int HTPParserTest01(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2905,7 +2905,7 @@ int HTPParserTest02(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2974,7 +2974,7 @@ int HTPParserTest03(void)
         }
         SCMutexUnlock(&f->m);
     }
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3036,7 +3036,7 @@ int HTPParserTest04(void)
     }
     SCMutexUnlock(&f->m);
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3152,7 +3152,7 @@ int HTPParserTest05(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3271,7 +3271,7 @@ int HTPParserTest06(void)
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3355,7 +3355,7 @@ int HTPParserTest07(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3454,7 +3454,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f->m);
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3541,7 +3541,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f->m);
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3619,7 +3619,7 @@ int HTPParserTest10(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3711,7 +3711,7 @@ static int HTPParserTest11(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3796,7 +3796,7 @@ static int HTPParserTest12(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3884,7 +3884,7 @@ int HTPParserTest13(void)
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -4296,7 +4296,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -4479,7 +4479,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -4650,7 +4650,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -4819,7 +4819,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -4958,7 +4958,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5070,7 +5070,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5182,7 +5182,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5295,7 +5295,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5405,7 +5405,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5516,7 +5516,7 @@ libhtp:\n\
         SCMutexUnlock(&f->m);
     }
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5582,7 +5582,7 @@ static int HTPBodyReassemblyTest01(void)
     memset(&tx, 0, sizeof(tx));
 
     hstate.f = &flow;
-    flow.alparser = parser;
+    FlowSetAppParser(&flow, parser);
 
     uint8_t chunk1[] = "--e5a320f21416a02493a0a6f561b1c494\r\nContent-Disposition: form-data; name=\"uploadfile\"; filename=\"D2GUef.jpg\"\r";
     uint8_t chunk2[] = "POST /uri HTTP/1.1\r\nHost: hostname.com\r\nKeep-Alive: 115\r\nAccept-Charset: utf-8\r\nUser-Agent: Mozilla/5.0 (X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\nConnection: keep-alive\r\nContent-length: 68102\r\nReferer: http://otherhost.com\r\nAccept-Encoding: gzip\r\nContent-Type: multipart/form-data; boundary=e5a320f21416a02493a0a6f561b1c494\r\nCookie: blah\r\nAccept-Language: us\r\n\r\n--e5a320f21416a02493a0a6f561b1c494\r\nContent-Disposition: form-data; name=\"uploadfile\"; filename=\"D2GUef.jpg\"\r";
@@ -5681,7 +5681,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f->m);
 
-    http_state = f->alstate;
+    http_state = FlowGetAppState(f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -5689,7 +5689,7 @@ libhtp:\n\
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetDecoderEvents(f->alparser);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetDecoderEvents(FlowGetAppParser(f));
     if (decoder_events != NULL) {
         printf("app events: ");
         SCMutexUnlock(&f->m);
@@ -5807,7 +5807,7 @@ libhtp:\n\
         }
         SCMutexUnlock(&f->m);
     }
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -5823,7 +5823,10 @@ libhtp:\n\
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,
+                                                                        FlowGetAppState(f),
+                                                                        0);
     if (decoder_events == NULL) {
         printf("no app events: ");
         SCMutexUnlock(&f->m);
@@ -5937,7 +5940,7 @@ libhtp:\n\
         }
         SCMutexUnlock(&f->m);
     }
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -5953,7 +5956,10 @@ libhtp:\n\
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP,
+                                                                        ALPROTO_HTTP,
+                                                                        FlowGetAppState(f),
+                                                                        0);
     if (decoder_events != NULL) {
         printf("app events: ");
         SCMutexUnlock(&f->m);
@@ -6020,7 +6026,7 @@ int HTPParserTest16(void)
     }
     SCMutexUnlock(&f->m);
 
-    htp_state = f->alstate;
+    htp_state = FlowGetAppState(f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -6036,7 +6042,7 @@ int HTPParserTest16(void)
     }
 
     SCMutexLock(&f->m);
-    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP,f->alstate, 0);
+    AppLayerDecoderEvents *decoder_events = AppLayerParserGetEventsByTx(IPPROTO_TCP, ALPROTO_HTTP, FlowGetAppState(f), 0);
     if (decoder_events == NULL) {
         printf("no app events: ");
         SCMutexUnlock(&f->m);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -746,7 +746,8 @@ static int HTPHandleRequestData(Flow *f, void *htp_state,
             hstate->flags |= HTP_FLAG_STATE_DATA;
             break;
         case HTP_STREAM_TUNNEL:
-            break;
+            AppLayerAskReset(hstate->f, 0);
+            SCReturnInt(ret);
         default:
             hstate->flags &= ~HTP_FLAG_STATE_DATA;
             hstate->flags &= ~HTP_FLAG_NEW_BODY_SET;

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1561,7 +1561,7 @@ static int ModbusParserTest01(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1626,7 +1626,7 @@ static int ModbusParserTest02(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1688,7 +1688,7 @@ static int ModbusParserTest03(void) {
     p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -1725,7 +1725,7 @@ static int ModbusParserTest03(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1813,7 +1813,7 @@ static int ModbusParserTest04(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1855,7 +1855,7 @@ static int ModbusParserTest05(void) {
     p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -1892,7 +1892,7 @@ static int ModbusParserTest05(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1941,7 +1941,7 @@ static int ModbusParserTest06(void) {
     p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -1978,7 +1978,7 @@ static int ModbusParserTest06(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -2027,7 +2027,7 @@ static int ModbusParserTest07(void) {
     p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -2065,7 +2065,7 @@ static int ModbusParserTest07(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -2114,7 +2114,7 @@ static int ModbusParserTest08(void) {
     p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -2151,7 +2151,7 @@ static int ModbusParserTest08(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -2242,7 +2242,7 @@ static int ModbusParserTest09(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -2329,7 +2329,7 @@ static int ModbusParserTest10(void) {
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -1610,7 +1610,7 @@ int SMBParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -1687,7 +1687,7 @@ int SMBParserTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -1983,7 +1983,7 @@ int SMBParserTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -2100,7 +2100,7 @@ int SMBParserTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -2355,7 +2355,7 @@ int SMBParserTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -2429,7 +2429,7 @@ int SMBParserTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -2543,7 +2543,7 @@ int SMBParserTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;
@@ -2665,7 +2665,7 @@ int SMBParserTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMBState *smb_state = f.alstate;
+    SMBState *smb_state = FlowGetAppState(&f);
     if (smb_state == NULL) {
         printf("no smb state: ");
         goto end;

--- a/src/app-layer-smb2.c
+++ b/src/app-layer-smb2.c
@@ -644,7 +644,7 @@ int SMB2ParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SMB2State *smb2_state = f.alstate;
+    SMB2State *smb2_state = FlowGetAppState(&f);
     if (smb2_state == NULL) {
         printf("no smb2 state: ");
         result = 0;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -848,9 +848,8 @@ static int SMTPProcessReply(SMTPState *state, Flow *f,
         if (reply_code == SMTP_REPLY_220) {
             /* we are entering STARRTTLS data mode */
             state->parser_state |= SMTP_PARSER_STATE_COMMAND_DATA_MODE;
-            AppLayerParserStateSetFlag(pstate,
-                                             APP_LAYER_PARSER_NO_INSPECTION |
-                                             APP_LAYER_PARSER_NO_REASSEMBLY);
+            /* and we reset the alproto */
+            AppLayerAskReset(f, 1);
         } else {
             /* decoder event */
             SMTPSetEvent(state, SMTP_DECODER_EVENT_TLS_REJECTED);

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2007-2012 Open Information Security Foundation
+ * Copyright (C) 2014 European Commission
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -294,7 +295,7 @@ static int ProcessDataChunk(const uint8_t *chunk, uint32_t len,
 
     int ret = MIME_DEC_OK;
     Flow *flow = (Flow *) state->data;
-    SMTPState *smtp_state = (SMTPState *) flow->alstate;
+    SMTPState *smtp_state = (SMTPState *) FlowGetAppState(flow);
     MimeDecEntity *entity = (MimeDecEntity *) state->stack->top->data;
     FileContainer *files = NULL;
     uint16_t flags = 0;
@@ -1479,7 +1480,7 @@ int SMTPParserTest01(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -1837,7 +1838,7 @@ int SMTPParserTest02(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -2471,7 +2472,7 @@ int SMTPParserTest03(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -2618,7 +2619,7 @@ int SMTPParserTest04(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -2765,7 +2766,7 @@ int SMTPParserTest05(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3061,7 +3062,7 @@ int SMTPParserTest06(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3299,7 +3300,7 @@ int SMTPParserTest07(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3412,7 +3413,7 @@ int SMTPParserTest08(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3525,7 +3526,7 @@ int SMTPParserTest09(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3638,7 +3639,7 @@ int SMTPParserTest10(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3745,7 +3746,7 @@ int SMTPParserTest11(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3830,7 +3831,7 @@ int SMTPParserTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SMTP;
+    FlowSetAppProtocol(&f, ALPROTO_SMTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3860,7 +3861,7 @@ int SMTPParserTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    smtp_state = f.alstate;
+    smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -3969,7 +3970,7 @@ int SMTPParserTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SMTP;
+    FlowSetAppProtocol(&f, ALPROTO_SMTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -4000,7 +4001,7 @@ int SMTPParserTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    smtp_state = f.alstate;
+    smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -4261,7 +4262,7 @@ int SMTPParserTest14(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    SMTPState *smtp_state = f.alstate;
+    SMTPState *smtp_state = FlowGetAppState(&f);
     if (smtp_state == NULL) {
         printf("no smtp state: ");
         goto end;
@@ -4471,7 +4472,7 @@ int SMTPParserTest14(void)
         goto end;
     }
 
-    SMTPState *state = (SMTPState *) f.alstate;
+    SMTPState *state = (SMTPState *) FlowGetAppState(&f);
     FileContainer *files = state->files_ts;
     if (files != NULL && files->head != NULL) {
         File *file = files->head;
@@ -4633,7 +4634,7 @@ int SMTPProcessDataChunkTest02(void){
 
     Flow f;
     FLOW_INITIALIZE(&f);
-    f.alstate = SMTPStateAlloc();
+    FlowSetAppState(&f, SMTPStateAlloc());
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     state->body_begin = 1;
@@ -4662,7 +4663,7 @@ int SMTPProcessDataChunkTest03(void){
 
     Flow f;
     FLOW_INITIALIZE(&f);
-    f.alstate = SMTPStateAlloc();
+    FlowSetAppState(&f, SMTPStateAlloc());
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     int ret;
@@ -4715,7 +4716,7 @@ int SMTPProcessDataChunkTest04(void){
 
     Flow f;
     FLOW_INITIALIZE(&f);
-    f.alstate = SMTPStateAlloc();
+    FlowSetAppState(&f, SMTPStateAlloc());
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     int ret = MIME_DEC_OK;
@@ -4751,7 +4752,7 @@ int SMTPProcessDataChunkTest05(void){
 
     Flow f;
     FLOW_INITIALIZE(&f);
-    f.alstate = SMTPStateAlloc();
+    FlowSetAppState(&f, SMTPStateAlloc());
     MimeDecParseState *state = MimeDecInitParser(&f, NULL);
     ((MimeDecEntity *)state->stack->top->data)->ctnt_flags = CTNT_IS_ATTACHMENT;
     state->body_begin = 1;
@@ -4760,7 +4761,7 @@ int SMTPProcessDataChunkTest05(void){
     ret = ProcessDataChunk((uint8_t *)mimemsg, sizeof(mimemsg), state);
     state->body_begin = 0;
     if(ret){goto end;}
-    SMTPState *smtp_state = (SMTPState *)((Flow *)state->data)->alstate;
+    SMTPState *smtp_state = (SMTPState *)FlowGetAppState(((Flow *)state->data));
     FileContainer *files = smtp_state->files_ts;
     File *file = files->head;
     file_size = file->size;

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1563,13 +1563,6 @@ int SMTPParserTest01(void)
         goto end;
     }
 
-    if (!(f.flags & FLOW_NOPAYLOAD_INSPECTION) ||
-        !(f.flags & FLOW_NO_APPLAYER_INSPECTION) ||
-        !(((TcpSession *)f.protoctx)->server.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) ||
-        !(((TcpSession *)f.protoctx)->client.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY)) {
-        goto end;
-    }
-
     result = 1;
 end:
     if (alp_tctx != NULL)

--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -558,7 +558,7 @@ static int SSHParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -624,7 +624,7 @@ static int SSHParserTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -690,7 +690,7 @@ static int SSHParserTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -742,7 +742,7 @@ static int SSHParserTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -808,7 +808,7 @@ static int SSHParserTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -874,7 +874,7 @@ static int SSHParserTest06(void)
     SCMutexUnlock(&f.m);
     /* Ok, it returned an error. Let's make sure we didn't parse the string at all */
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -936,7 +936,7 @@ static int SSHParserTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1023,7 +1023,7 @@ static int SSHParserTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1097,7 +1097,7 @@ static int SSHParserTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1184,7 +1184,7 @@ static int SSHParserTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1259,7 +1259,7 @@ static int SSHParserTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1350,7 +1350,7 @@ static int SSHParserTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1443,7 +1443,7 @@ static int SSHParserTest13(void)
         }
         SCMutexUnlock(&f.m);
     }
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1555,7 +1555,7 @@ static int SSHParserTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1667,7 +1667,7 @@ static int SSHParserTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1758,7 +1758,7 @@ static int SSHParserTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1860,7 +1860,7 @@ static int SSHParserTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1979,7 +1979,7 @@ static int SSHParserTest18(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -1995,7 +1995,7 @@ static int SSHParserTest18(void)
         goto end;
     }
 
-    if (!(AppLayerParserStateIssetFlag(f.alparser, APP_LAYER_PARSER_NO_INSPECTION))) {
+    if (!(AppLayerParserStateIssetFlag(FlowGetAppParser(&f), APP_LAYER_PARSER_NO_INSPECTION))) {
         printf("detection not disabled: ");
         goto end;
     }
@@ -2076,7 +2076,7 @@ static int SSHParserTest19(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -2197,7 +2197,7 @@ static int SSHParserTest20(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -2304,7 +2304,7 @@ static int SSHParserTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -2439,7 +2439,7 @@ static int SSHParserTest22(void)
     }
     SCMutexUnlock(&f.m);
 #endif
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -2536,7 +2536,7 @@ static int SSHParserTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1427,7 +1427,7 @@ static int SSLParserTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -1493,7 +1493,7 @@ static int SSLParserTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -1571,7 +1571,7 @@ static int SSLParserTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -1661,7 +1661,7 @@ static int SSLParserTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -1975,7 +1975,7 @@ static int SSLParserMultimsgTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2056,7 +2056,7 @@ static int SSLParserMultimsgTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2126,7 +2126,7 @@ static int SSLParserTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2322,7 +2322,7 @@ static int SSLParserTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2410,7 +2410,7 @@ static int SSLParserTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2497,7 +2497,7 @@ static int SSLParserTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2599,7 +2599,7 @@ static int SSLParserTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2716,7 +2716,7 @@ static int SSLParserTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2792,7 +2792,7 @@ static int SSLParserTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -2975,7 +2975,7 @@ static int SSLParserTest18(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -3023,7 +3023,7 @@ static int SSLParserTest19(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -3113,7 +3113,7 @@ static int SSLParserTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         goto end;
@@ -3181,7 +3181,7 @@ static int SSLParserTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         result = 0;
@@ -3486,7 +3486,7 @@ static int SSLParserTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         result = 0;
@@ -3734,7 +3734,7 @@ static int SSLParserTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         result = 0;
@@ -4102,7 +4102,7 @@ static int SSLParserTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         goto end;

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -95,6 +95,15 @@ int AppLayerSetup(void);
 int AppLayerDeSetup(void);
 
 /**
+ * \brief Ask for application layer to restart protocol recognition
+ *
+ * Update the flow to tell the application layer to reset the protocol.
+ * If full is set to 1, then we discard the buffer content.
+ *
+ */
+void AppLayerAskReset(Flow *f, int full);
+
+/**
  * \brief Creates a new app layer thread context.
  *
  * \retval Pointer to the newly create thread context, on success;

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -92,7 +92,7 @@ static int DetectAppLayerEventAppMatch(ThreadVars *t, DetectEngineThreadCtx *det
     DetectAppLayerEventData *aled = (DetectAppLayerEventData *)m->ctx;
 
     if (r == 0) {
-        decoder_events = AppLayerParserGetDecoderEvents(f->alparser);
+        decoder_events = AppLayerParserGetDecoderEvents(FlowGetAppParser(f));
         if (decoder_events != NULL &&
                 AppLayerDecoderEventsIsEventSet(decoder_events, aled->event_id)) {
             r = 1;

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -40,8 +40,8 @@ int DetectAppLayerProtocolMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
     int r = 0;
     DetectAppLayerProtocolData *data = (DetectAppLayerProtocolData *)m->ctx;
 
-    r = (data->negated) ? (f->alproto != data->alproto) :
-        (f->alproto == data->alproto);
+    r = (data->negated) ? (FlowGetAppProtocol(f) != data->alproto) :
+        (FlowGetAppProtocol(f) == data->alproto);
 
     return r;
 }

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -895,7 +895,7 @@ static int DetectDceIfaceTestParse12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -927,7 +927,7 @@ static int DetectDceIfaceTestParse12(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1403,7 +1403,7 @@ static int DetectDceIfaceTestParse14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1433,7 +1433,7 @@ static int DetectDceIfaceTestParse14(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1606,7 +1606,7 @@ static int DetectDceIfaceTestParse15(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1643,7 +1643,7 @@ static int DetectDceIfaceTestParse15(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -1164,7 +1164,7 @@ static int DetectDceOpnumTestParse08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1195,7 +1195,7 @@ static int DetectDceOpnumTestParse08(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1221,7 +1221,7 @@ static int DetectDceOpnumTestParse08(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1703,7 +1703,7 @@ static int DetectDceOpnumTestParse09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1734,7 +1734,7 @@ static int DetectDceOpnumTestParse09(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -600,7 +600,7 @@ static int DetectDceStubDataTestParse02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -631,7 +631,7 @@ static int DetectDceStubDataTestParse02(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1155,7 +1155,7 @@ static int DetectDceStubDataTestParse03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1186,7 +1186,7 @@ static int DetectDceStubDataTestParse03(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1356,7 +1356,7 @@ static int DetectDceStubDataTestParse04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1395,7 +1395,7 @@ static int DetectDceStubDataTestParse04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;
@@ -1657,7 +1657,7 @@ static int DetectDceStubDataTestParse05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1703,7 +1703,7 @@ static int DetectDceStubDataTestParse05(void)
     }
     SCMutexUnlock(&f.m);
 
-    dcerpc_state = f.alstate;
+    dcerpc_state = FlowGetAppState(&f);
     if (dcerpc_state == NULL) {
         SCLogDebug("no dcerpc state: ");
         goto end;

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -167,7 +167,7 @@ static int DetectDnsQueryTest01(void)
     p->flow = &f;
     p->flags |= PKT_HAS_FLOW;
     p->flowflags |= FLOW_PKT_TOSERVER;
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {
@@ -195,7 +195,7 @@ static int DetectDnsQueryTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -284,7 +284,7 @@ static int DetectDnsQueryTest02(void)
     f.flags |= FLOW_IPV4;
     f.proto = IPPROTO_UDP;
     f.protomap = FlowGetProtoMapping(f.proto);
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     p1->flow = &f;
     p1->flags |= PKT_HAS_FLOW;
@@ -333,7 +333,7 @@ static int DetectDnsQueryTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -449,7 +449,7 @@ static int DetectDnsQueryTest03(void)
     p->flow = &f;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER|FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -479,7 +479,7 @@ static int DetectDnsQueryTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -547,7 +547,7 @@ static int DetectDnsQueryTest04(void)
     f.flags |= FLOW_IPV4;
     f.proto = IPPROTO_TCP;
     f.protomap = FlowGetProtoMapping(f.proto);
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     p1->flow = &f;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
@@ -585,7 +585,7 @@ static int DetectDnsQueryTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -703,7 +703,7 @@ static int DetectDnsQueryTest05(void)
     f.flags |= FLOW_IPV4;
     f.proto = IPPROTO_TCP;
     f.protomap = FlowGetProtoMapping(f.proto);
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     p1->flow = &f;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
@@ -755,7 +755,7 @@ static int DetectDnsQueryTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -890,7 +890,7 @@ static int DetectDnsQueryTest06(void)
     p->flow = &f;
     p->flags |= PKT_HAS_FLOW;
     p->flowflags |= FLOW_PKT_TOSERVER;
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {
@@ -927,7 +927,7 @@ static int DetectDnsQueryTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;
@@ -1021,7 +1021,7 @@ static int DetectDnsQueryTest07(void)
     f.flags |= FLOW_IPV4;
     f.proto = IPPROTO_UDP;
     f.protomap = FlowGetProtoMapping(f.proto);
-    f.alproto = ALPROTO_DNS;
+    FlowSetAppProtocol(&f, ALPROTO_DNS);
 
     p1->flow = &f;
     p1->flags |= PKT_HAS_FLOW;
@@ -1076,7 +1076,7 @@ static int DetectDnsQueryTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    dns_state = f.alstate;
+    dns_state = FlowGetAppState(&f);
     if (dns_state == NULL) {
         printf("no dns state: ");
         goto end;

--- a/src/detect-engine-apt-event.c
+++ b/src/detect-engine-apt-event.c
@@ -44,7 +44,7 @@ int DetectEngineAptEventInspect(ThreadVars *tv,
     SigMatch *sm;
     DetectAppLayerEventData *aled = NULL;
 
-    alproto = f->alproto;
+    alproto = FlowGetAppProtocol(f);
     decoder_events = AppLayerParserGetEventsByTx(f->proto, alproto, alstate, tx_id);
     if (decoder_events == NULL)
         goto end;

--- a/src/detect-engine-dcepayload.c
+++ b/src/detect-engine-dcepayload.c
@@ -6517,7 +6517,7 @@ int DcePayloadTest15(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -6633,7 +6633,7 @@ int DcePayloadTest16(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -6749,7 +6749,7 @@ int DcePayloadTest17(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -6865,7 +6865,7 @@ int DcePayloadTest18(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -6981,7 +6981,7 @@ int DcePayloadTest19(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -7097,7 +7097,7 @@ int DcePayloadTest20(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -7205,7 +7205,7 @@ int DcePayloadTest21(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -7306,7 +7306,7 @@ int DcePayloadTest22(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -7408,7 +7408,7 @@ int DcePayloadTest23(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -9624,7 +9624,7 @@ int DcePayloadTest42(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 
@@ -9726,7 +9726,7 @@ int DcePayloadTest43(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_DCERPC;
+    FlowSetAppProtocol(&f, ALPROTO_DCERPC);
 
     StreamTcpInitConfig(TRUE);
 

--- a/src/detect-engine-hcbd.c
+++ b/src/detect-engine-hcbd.c
@@ -338,7 +338,7 @@ static int DetectEngineHttpClientBodyTest01(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -368,7 +368,7 @@ static int DetectEngineHttpClientBodyTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -462,7 +462,7 @@ static int DetectEngineHttpClientBodyTest02(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -492,7 +492,7 @@ static int DetectEngineHttpClientBodyTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -571,7 +571,7 @@ static int DetectEngineHttpClientBodyTest03(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -601,7 +601,7 @@ static int DetectEngineHttpClientBodyTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -698,7 +698,7 @@ static int DetectEngineHttpClientBodyTest04(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -728,7 +728,7 @@ static int DetectEngineHttpClientBodyTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -824,7 +824,7 @@ static int DetectEngineHttpClientBodyTest05(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -854,7 +854,7 @@ static int DetectEngineHttpClientBodyTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -950,7 +950,7 @@ static int DetectEngineHttpClientBodyTest06(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -980,7 +980,7 @@ static int DetectEngineHttpClientBodyTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1076,7 +1076,7 @@ static int DetectEngineHttpClientBodyTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1105,7 +1105,7 @@ static int DetectEngineHttpClientBodyTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         goto end;
@@ -1199,7 +1199,7 @@ static int DetectEngineHttpClientBodyTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1229,7 +1229,7 @@ static int DetectEngineHttpClientBodyTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1325,7 +1325,7 @@ static int DetectEngineHttpClientBodyTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1356,7 +1356,7 @@ static int DetectEngineHttpClientBodyTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1452,7 +1452,7 @@ static int DetectEngineHttpClientBodyTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1483,7 +1483,7 @@ static int DetectEngineHttpClientBodyTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1579,7 +1579,7 @@ static int DetectEngineHttpClientBodyTest11(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1610,7 +1610,7 @@ static int DetectEngineHttpClientBodyTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1706,7 +1706,7 @@ static int DetectEngineHttpClientBodyTest12(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1737,7 +1737,7 @@ static int DetectEngineHttpClientBodyTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1833,7 +1833,7 @@ static int DetectEngineHttpClientBodyTest13(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1864,7 +1864,7 @@ static int DetectEngineHttpClientBodyTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1960,7 +1960,7 @@ static int DetectEngineHttpClientBodyTest14(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1991,7 +1991,7 @@ static int DetectEngineHttpClientBodyTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2087,7 +2087,7 @@ static int DetectEngineHttpClientBodyTest15(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2118,7 +2118,7 @@ static int DetectEngineHttpClientBodyTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2214,7 +2214,7 @@ static int DetectEngineHttpClientBodyTest16(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2245,7 +2245,7 @@ static int DetectEngineHttpClientBodyTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2324,7 +2324,7 @@ static int DetectEngineHttpClientBodyTest17(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2396,7 +2396,7 @@ static int DetectEngineHttpClientBodyTest18(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2468,7 +2468,7 @@ static int DetectEngineHttpClientBodyTest19(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2540,7 +2540,7 @@ static int DetectEngineHttpClientBodyTest20(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2629,7 +2629,7 @@ static int DetectEngineHttpClientBodyTest21(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2660,7 +2660,7 @@ static int DetectEngineHttpClientBodyTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2756,7 +2756,7 @@ static int DetectEngineHttpClientBodyTest22(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2787,7 +2787,7 @@ static int DetectEngineHttpClientBodyTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2883,7 +2883,7 @@ static int DetectEngineHttpClientBodyTest23(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2914,7 +2914,7 @@ static int DetectEngineHttpClientBodyTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3010,7 +3010,7 @@ static int DetectEngineHttpClientBodyTest24(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3041,7 +3041,7 @@ static int DetectEngineHttpClientBodyTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3137,7 +3137,7 @@ static int DetectEngineHttpClientBodyTest25(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3168,7 +3168,7 @@ static int DetectEngineHttpClientBodyTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3264,7 +3264,7 @@ static int DetectEngineHttpClientBodyTest26(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3295,7 +3295,7 @@ static int DetectEngineHttpClientBodyTest26(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3391,7 +3391,7 @@ static int DetectEngineHttpClientBodyTest27(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3422,7 +3422,7 @@ static int DetectEngineHttpClientBodyTest27(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3518,7 +3518,7 @@ static int DetectEngineHttpClientBodyTest28(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3549,7 +3549,7 @@ static int DetectEngineHttpClientBodyTest28(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3634,7 +3634,7 @@ static int DetectEngineHttpClientBodyTest29(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3773,7 +3773,7 @@ libhtp:\n\
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3803,7 +3803,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3925,7 +3925,7 @@ libhtp:\n\
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3955,7 +3955,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hcd.c
+++ b/src/detect-engine-hcd.c
@@ -190,7 +190,7 @@ static int DetectEngineHttpCookieTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -220,7 +220,7 @@ static int DetectEngineHttpCookieTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -288,7 +288,7 @@ static int DetectEngineHttpCookieTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -318,7 +318,7 @@ static int DetectEngineHttpCookieTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -386,7 +386,7 @@ static int DetectEngineHttpCookieTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -416,7 +416,7 @@ static int DetectEngineHttpCookieTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -484,7 +484,7 @@ static int DetectEngineHttpCookieTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -514,7 +514,7 @@ static int DetectEngineHttpCookieTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -582,7 +582,7 @@ static int DetectEngineHttpCookieTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -612,7 +612,7 @@ static int DetectEngineHttpCookieTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -680,7 +680,7 @@ static int DetectEngineHttpCookieTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -710,7 +710,7 @@ static int DetectEngineHttpCookieTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -778,7 +778,7 @@ static int DetectEngineHttpCookieTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -808,7 +808,7 @@ static int DetectEngineHttpCookieTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -876,7 +876,7 @@ static int DetectEngineHttpCookieTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -906,7 +906,7 @@ static int DetectEngineHttpCookieTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -974,7 +974,7 @@ static int DetectEngineHttpCookieTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1004,7 +1004,7 @@ static int DetectEngineHttpCookieTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1072,7 +1072,7 @@ static int DetectEngineHttpCookieTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1103,7 +1103,7 @@ static int DetectEngineHttpCookieTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1171,7 +1171,7 @@ static int DetectEngineHttpCookieTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1202,7 +1202,7 @@ static int DetectEngineHttpCookieTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1270,7 +1270,7 @@ static int DetectEngineHttpCookieTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1301,7 +1301,7 @@ static int DetectEngineHttpCookieTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1369,7 +1369,7 @@ static int DetectEngineHttpCookieTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1400,7 +1400,7 @@ static int DetectEngineHttpCookieTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1468,7 +1468,7 @@ static int DetectEngineHttpCookieTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1499,7 +1499,7 @@ static int DetectEngineHttpCookieTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1567,7 +1567,7 @@ static int DetectEngineHttpCookieTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1598,7 +1598,7 @@ static int DetectEngineHttpCookieTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1666,7 +1666,7 @@ static int DetectEngineHttpCookieTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1697,7 +1697,7 @@ static int DetectEngineHttpCookieTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1765,7 +1765,7 @@ static int DetectEngineHttpCookieTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1796,7 +1796,7 @@ static int DetectEngineHttpCookieTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-engine-hhd.c
+++ b/src/detect-engine-hhd.c
@@ -316,7 +316,7 @@ static int DetectEngineHttpHeaderTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -346,7 +346,7 @@ static int DetectEngineHttpHeaderTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -412,7 +412,7 @@ static int DetectEngineHttpHeaderTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -442,7 +442,7 @@ static int DetectEngineHttpHeaderTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -508,7 +508,7 @@ static int DetectEngineHttpHeaderTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -538,7 +538,7 @@ static int DetectEngineHttpHeaderTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -604,7 +604,7 @@ static int DetectEngineHttpHeaderTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -634,7 +634,7 @@ static int DetectEngineHttpHeaderTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -700,7 +700,7 @@ static int DetectEngineHttpHeaderTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -730,7 +730,7 @@ static int DetectEngineHttpHeaderTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -796,7 +796,7 @@ static int DetectEngineHttpHeaderTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -826,7 +826,7 @@ static int DetectEngineHttpHeaderTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -892,7 +892,7 @@ static int DetectEngineHttpHeaderTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -922,7 +922,7 @@ static int DetectEngineHttpHeaderTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -988,7 +988,7 @@ static int DetectEngineHttpHeaderTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1018,7 +1018,7 @@ static int DetectEngineHttpHeaderTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1084,7 +1084,7 @@ static int DetectEngineHttpHeaderTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1114,7 +1114,7 @@ static int DetectEngineHttpHeaderTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1180,7 +1180,7 @@ static int DetectEngineHttpHeaderTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1210,7 +1210,7 @@ static int DetectEngineHttpHeaderTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1276,7 +1276,7 @@ static int DetectEngineHttpHeaderTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1306,7 +1306,7 @@ static int DetectEngineHttpHeaderTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1372,7 +1372,7 @@ static int DetectEngineHttpHeaderTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1402,7 +1402,7 @@ static int DetectEngineHttpHeaderTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1468,7 +1468,7 @@ static int DetectEngineHttpHeaderTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1498,7 +1498,7 @@ static int DetectEngineHttpHeaderTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1564,7 +1564,7 @@ static int DetectEngineHttpHeaderTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1594,7 +1594,7 @@ static int DetectEngineHttpHeaderTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1660,7 +1660,7 @@ static int DetectEngineHttpHeaderTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1690,7 +1690,7 @@ static int DetectEngineHttpHeaderTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1756,7 +1756,7 @@ static int DetectEngineHttpHeaderTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1786,7 +1786,7 @@ static int DetectEngineHttpHeaderTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1852,7 +1852,7 @@ static int DetectEngineHttpHeaderTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1882,7 +1882,7 @@ static int DetectEngineHttpHeaderTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1945,7 +1945,7 @@ static int DetectEngineHttpHeaderTest18(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2020,7 +2020,7 @@ static int DetectEngineHttpHeaderTest19(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2105,7 +2105,7 @@ static int DetectEngineHttpHeaderTest20(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2136,7 +2136,7 @@ static int DetectEngineHttpHeaderTest20(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2229,7 +2229,7 @@ static int DetectEngineHttpHeaderTest21(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2260,7 +2260,7 @@ static int DetectEngineHttpHeaderTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2353,7 +2353,7 @@ static int DetectEngineHttpHeaderTest22(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2384,7 +2384,7 @@ static int DetectEngineHttpHeaderTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2477,7 +2477,7 @@ static int DetectEngineHttpHeaderTest23(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2508,7 +2508,7 @@ static int DetectEngineHttpHeaderTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2601,7 +2601,7 @@ static int DetectEngineHttpHeaderTest24(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2632,7 +2632,7 @@ static int DetectEngineHttpHeaderTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2725,7 +2725,7 @@ static int DetectEngineHttpHeaderTest25(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2756,7 +2756,7 @@ static int DetectEngineHttpHeaderTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2849,7 +2849,7 @@ static int DetectEngineHttpHeaderTest26(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2880,7 +2880,7 @@ static int DetectEngineHttpHeaderTest26(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2973,7 +2973,7 @@ static int DetectEngineHttpHeaderTest27(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3004,7 +3004,7 @@ static int DetectEngineHttpHeaderTest27(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3102,7 +3102,7 @@ static int DetectEngineHttpHeaderTest28(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3133,7 +3133,7 @@ static int DetectEngineHttpHeaderTest28(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3231,7 +3231,7 @@ static int DetectEngineHttpHeaderTest29(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3262,7 +3262,7 @@ static int DetectEngineHttpHeaderTest29(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3393,7 +3393,7 @@ static int DetectEngineHttpHeaderTest30(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3424,7 +3424,7 @@ static int DetectEngineHttpHeaderTest30(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3513,7 +3513,7 @@ static int DetectEngineHttpHeaderTest31(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3545,7 +3545,7 @@ static int DetectEngineHttpHeaderTest31(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3619,7 +3619,7 @@ static int DetectEngineHttpHeaderTest32(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3648,7 +3648,7 @@ static int DetectEngineHttpHeaderTest32(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3730,7 +3730,7 @@ static int DetectEngineHttpHeaderTest33(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3759,7 +3759,7 @@ static int DetectEngineHttpHeaderTest33(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hhhd.c
+++ b/src/detect-engine-hhhd.c
@@ -163,7 +163,7 @@ static int DetectEngineHttpHHTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -193,7 +193,7 @@ static int DetectEngineHttpHHTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -261,7 +261,7 @@ static int DetectEngineHttpHHTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -291,7 +291,7 @@ static int DetectEngineHttpHHTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -359,7 +359,7 @@ static int DetectEngineHttpHHTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -389,7 +389,7 @@ static int DetectEngineHttpHHTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -457,7 +457,7 @@ static int DetectEngineHttpHHTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -487,7 +487,7 @@ static int DetectEngineHttpHHTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -555,7 +555,7 @@ static int DetectEngineHttpHHTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -585,7 +585,7 @@ static int DetectEngineHttpHHTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -653,7 +653,7 @@ static int DetectEngineHttpHHTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -683,7 +683,7 @@ static int DetectEngineHttpHHTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -751,7 +751,7 @@ static int DetectEngineHttpHHTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -781,7 +781,7 @@ static int DetectEngineHttpHHTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -849,7 +849,7 @@ static int DetectEngineHttpHHTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -879,7 +879,7 @@ static int DetectEngineHttpHHTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -947,7 +947,7 @@ static int DetectEngineHttpHHTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -977,7 +977,7 @@ static int DetectEngineHttpHHTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1045,7 +1045,7 @@ static int DetectEngineHttpHHTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1076,7 +1076,7 @@ static int DetectEngineHttpHHTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1144,7 +1144,7 @@ static int DetectEngineHttpHHTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1175,7 +1175,7 @@ static int DetectEngineHttpHHTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1243,7 +1243,7 @@ static int DetectEngineHttpHHTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1274,7 +1274,7 @@ static int DetectEngineHttpHHTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1342,7 +1342,7 @@ static int DetectEngineHttpHHTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1373,7 +1373,7 @@ static int DetectEngineHttpHHTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1441,7 +1441,7 @@ static int DetectEngineHttpHHTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1472,7 +1472,7 @@ static int DetectEngineHttpHHTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1540,7 +1540,7 @@ static int DetectEngineHttpHHTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1571,7 +1571,7 @@ static int DetectEngineHttpHHTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1639,7 +1639,7 @@ static int DetectEngineHttpHHTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1670,7 +1670,7 @@ static int DetectEngineHttpHHTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1738,7 +1738,7 @@ static int DetectEngineHttpHHTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1769,7 +1769,7 @@ static int DetectEngineHttpHHTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1833,7 +1833,7 @@ static int DetectEngineHttpHHTest18(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1863,7 +1863,7 @@ static int DetectEngineHttpHHTest18(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1927,7 +1927,7 @@ static int DetectEngineHttpHHTest19(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1957,7 +1957,7 @@ static int DetectEngineHttpHHTest19(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2021,7 +2021,7 @@ static int DetectEngineHttpHHTest20(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2051,7 +2051,7 @@ static int DetectEngineHttpHHTest20(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2114,7 +2114,7 @@ static int DetectEngineHttpHHTest21(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2144,7 +2144,7 @@ static int DetectEngineHttpHHTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2207,7 +2207,7 @@ static int DetectEngineHttpHHTest22(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2237,7 +2237,7 @@ static int DetectEngineHttpHHTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2300,7 +2300,7 @@ static int DetectEngineHttpHHTest23(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2330,7 +2330,7 @@ static int DetectEngineHttpHHTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2394,7 +2394,7 @@ static int DetectEngineHttpHHTest24(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2424,7 +2424,7 @@ static int DetectEngineHttpHHTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2488,7 +2488,7 @@ static int DetectEngineHttpHHTest25(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2518,7 +2518,7 @@ static int DetectEngineHttpHHTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-engine-hmd.c
+++ b/src/detect-engine-hmd.c
@@ -155,7 +155,7 @@ static int DetectEngineHttpMethodTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -185,7 +185,7 @@ static int DetectEngineHttpMethodTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -252,7 +252,7 @@ static int DetectEngineHttpMethodTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -282,7 +282,7 @@ static int DetectEngineHttpMethodTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -349,7 +349,7 @@ static int DetectEngineHttpMethodTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -379,7 +379,7 @@ static int DetectEngineHttpMethodTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -446,7 +446,7 @@ static int DetectEngineHttpMethodTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -476,7 +476,7 @@ static int DetectEngineHttpMethodTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -543,7 +543,7 @@ static int DetectEngineHttpMethodTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -573,7 +573,7 @@ static int DetectEngineHttpMethodTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -640,7 +640,7 @@ static int DetectEngineHttpMethodTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -670,7 +670,7 @@ static int DetectEngineHttpMethodTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -737,7 +737,7 @@ static int DetectEngineHttpMethodTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -767,7 +767,7 @@ static int DetectEngineHttpMethodTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -834,7 +834,7 @@ static int DetectEngineHttpMethodTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -864,7 +864,7 @@ static int DetectEngineHttpMethodTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -931,7 +931,7 @@ static int DetectEngineHttpMethodTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -961,7 +961,7 @@ static int DetectEngineHttpMethodTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1028,7 +1028,7 @@ static int DetectEngineHttpMethodTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1059,7 +1059,7 @@ static int DetectEngineHttpMethodTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1126,7 +1126,7 @@ static int DetectEngineHttpMethodTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1157,7 +1157,7 @@ static int DetectEngineHttpMethodTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1224,7 +1224,7 @@ static int DetectEngineHttpMethodTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1255,7 +1255,7 @@ static int DetectEngineHttpMethodTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1322,7 +1322,7 @@ static int DetectEngineHttpMethodTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1353,7 +1353,7 @@ static int DetectEngineHttpMethodTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1420,7 +1420,7 @@ static int DetectEngineHttpMethodTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1451,7 +1451,7 @@ static int DetectEngineHttpMethodTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1518,7 +1518,7 @@ static int DetectEngineHttpMethodTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1549,7 +1549,7 @@ static int DetectEngineHttpMethodTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1616,7 +1616,7 @@ static int DetectEngineHttpMethodTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1647,7 +1647,7 @@ static int DetectEngineHttpMethodTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1714,7 +1714,7 @@ static int DetectEngineHttpMethodTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1745,7 +1745,7 @@ static int DetectEngineHttpMethodTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-engine-hrhd.c
+++ b/src/detect-engine-hrhd.c
@@ -201,7 +201,7 @@ static int DetectEngineHttpRawHeaderTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -231,7 +231,7 @@ static int DetectEngineHttpRawHeaderTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -297,7 +297,7 @@ static int DetectEngineHttpRawHeaderTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -327,7 +327,7 @@ static int DetectEngineHttpRawHeaderTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -393,7 +393,7 @@ static int DetectEngineHttpRawHeaderTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -423,7 +423,7 @@ static int DetectEngineHttpRawHeaderTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -489,7 +489,7 @@ static int DetectEngineHttpRawHeaderTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -519,7 +519,7 @@ static int DetectEngineHttpRawHeaderTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -585,7 +585,7 @@ static int DetectEngineHttpRawHeaderTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -615,7 +615,7 @@ static int DetectEngineHttpRawHeaderTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -681,7 +681,7 @@ static int DetectEngineHttpRawHeaderTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -711,7 +711,7 @@ static int DetectEngineHttpRawHeaderTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -777,7 +777,7 @@ static int DetectEngineHttpRawHeaderTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -807,7 +807,7 @@ static int DetectEngineHttpRawHeaderTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -873,7 +873,7 @@ static int DetectEngineHttpRawHeaderTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -903,7 +903,7 @@ static int DetectEngineHttpRawHeaderTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -969,7 +969,7 @@ static int DetectEngineHttpRawHeaderTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -999,7 +999,7 @@ static int DetectEngineHttpRawHeaderTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1065,7 +1065,7 @@ static int DetectEngineHttpRawHeaderTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1095,7 +1095,7 @@ static int DetectEngineHttpRawHeaderTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1161,7 +1161,7 @@ static int DetectEngineHttpRawHeaderTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1191,7 +1191,7 @@ static int DetectEngineHttpRawHeaderTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1257,7 +1257,7 @@ static int DetectEngineHttpRawHeaderTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1287,7 +1287,7 @@ static int DetectEngineHttpRawHeaderTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1353,7 +1353,7 @@ static int DetectEngineHttpRawHeaderTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1383,7 +1383,7 @@ static int DetectEngineHttpRawHeaderTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1449,7 +1449,7 @@ static int DetectEngineHttpRawHeaderTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1479,7 +1479,7 @@ static int DetectEngineHttpRawHeaderTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1545,7 +1545,7 @@ static int DetectEngineHttpRawHeaderTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1575,7 +1575,7 @@ static int DetectEngineHttpRawHeaderTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1641,7 +1641,7 @@ static int DetectEngineHttpRawHeaderTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1671,7 +1671,7 @@ static int DetectEngineHttpRawHeaderTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1737,7 +1737,7 @@ static int DetectEngineHttpRawHeaderTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1767,7 +1767,7 @@ static int DetectEngineHttpRawHeaderTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1830,7 +1830,7 @@ static int DetectEngineHttpRawHeaderTest18(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1905,7 +1905,7 @@ static int DetectEngineHttpRawHeaderTest19(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1990,7 +1990,7 @@ static int DetectEngineHttpRawHeaderTest20(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2021,7 +2021,7 @@ static int DetectEngineHttpRawHeaderTest20(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2114,7 +2114,7 @@ static int DetectEngineHttpRawHeaderTest21(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2145,7 +2145,7 @@ static int DetectEngineHttpRawHeaderTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2238,7 +2238,7 @@ static int DetectEngineHttpRawHeaderTest22(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2269,7 +2269,7 @@ static int DetectEngineHttpRawHeaderTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2362,7 +2362,7 @@ static int DetectEngineHttpRawHeaderTest23(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2393,7 +2393,7 @@ static int DetectEngineHttpRawHeaderTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2486,7 +2486,7 @@ static int DetectEngineHttpRawHeaderTest24(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2517,7 +2517,7 @@ static int DetectEngineHttpRawHeaderTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2610,7 +2610,7 @@ static int DetectEngineHttpRawHeaderTest25(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2641,7 +2641,7 @@ static int DetectEngineHttpRawHeaderTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2734,7 +2734,7 @@ static int DetectEngineHttpRawHeaderTest26(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2765,7 +2765,7 @@ static int DetectEngineHttpRawHeaderTest26(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2856,7 +2856,7 @@ static int DetectEngineHttpRawHeaderTest27(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2887,7 +2887,7 @@ static int DetectEngineHttpRawHeaderTest27(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2985,7 +2985,7 @@ static int DetectEngineHttpRawHeaderTest28(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3016,7 +3016,7 @@ static int DetectEngineHttpRawHeaderTest28(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3114,7 +3114,7 @@ static int DetectEngineHttpRawHeaderTest29(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3145,7 +3145,7 @@ static int DetectEngineHttpRawHeaderTest29(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3270,7 +3270,7 @@ static int DetectEngineHttpRawHeaderTest31(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3300,7 +3300,7 @@ static int DetectEngineHttpRawHeaderTest31(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3382,7 +3382,7 @@ static int DetectEngineHttpRawHeaderTest32(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3412,7 +3412,7 @@ static int DetectEngineHttpRawHeaderTest32(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hrhhd.c
+++ b/src/detect-engine-hrhhd.c
@@ -190,7 +190,7 @@ static int DetectEngineHttpHRHTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -220,7 +220,7 @@ static int DetectEngineHttpHRHTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -288,7 +288,7 @@ static int DetectEngineHttpHRHTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -318,7 +318,7 @@ static int DetectEngineHttpHRHTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -386,7 +386,7 @@ static int DetectEngineHttpHRHTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -416,7 +416,7 @@ static int DetectEngineHttpHRHTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -484,7 +484,7 @@ static int DetectEngineHttpHRHTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -514,7 +514,7 @@ static int DetectEngineHttpHRHTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -582,7 +582,7 @@ static int DetectEngineHttpHRHTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -612,7 +612,7 @@ static int DetectEngineHttpHRHTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -680,7 +680,7 @@ static int DetectEngineHttpHRHTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -710,7 +710,7 @@ static int DetectEngineHttpHRHTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -778,7 +778,7 @@ static int DetectEngineHttpHRHTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -808,7 +808,7 @@ static int DetectEngineHttpHRHTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -876,7 +876,7 @@ static int DetectEngineHttpHRHTest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -906,7 +906,7 @@ static int DetectEngineHttpHRHTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -974,7 +974,7 @@ static int DetectEngineHttpHRHTest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1004,7 +1004,7 @@ static int DetectEngineHttpHRHTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1072,7 +1072,7 @@ static int DetectEngineHttpHRHTest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1103,7 +1103,7 @@ static int DetectEngineHttpHRHTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1171,7 +1171,7 @@ static int DetectEngineHttpHRHTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1202,7 +1202,7 @@ static int DetectEngineHttpHRHTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1270,7 +1270,7 @@ static int DetectEngineHttpHRHTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1301,7 +1301,7 @@ static int DetectEngineHttpHRHTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1369,7 +1369,7 @@ static int DetectEngineHttpHRHTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1400,7 +1400,7 @@ static int DetectEngineHttpHRHTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1468,7 +1468,7 @@ static int DetectEngineHttpHRHTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1499,7 +1499,7 @@ static int DetectEngineHttpHRHTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1567,7 +1567,7 @@ static int DetectEngineHttpHRHTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1598,7 +1598,7 @@ static int DetectEngineHttpHRHTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1666,7 +1666,7 @@ static int DetectEngineHttpHRHTest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1697,7 +1697,7 @@ static int DetectEngineHttpHRHTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1765,7 +1765,7 @@ static int DetectEngineHttpHRHTest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1796,7 +1796,7 @@ static int DetectEngineHttpHRHTest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1860,7 +1860,7 @@ static int DetectEngineHttpHRHTest18(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1890,7 +1890,7 @@ static int DetectEngineHttpHRHTest18(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1954,7 +1954,7 @@ static int DetectEngineHttpHRHTest19(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1984,7 +1984,7 @@ static int DetectEngineHttpHRHTest19(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2048,7 +2048,7 @@ static int DetectEngineHttpHRHTest20(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2078,7 +2078,7 @@ static int DetectEngineHttpHRHTest20(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2141,7 +2141,7 @@ static int DetectEngineHttpHRHTest21(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2171,7 +2171,7 @@ static int DetectEngineHttpHRHTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2234,7 +2234,7 @@ static int DetectEngineHttpHRHTest22(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2264,7 +2264,7 @@ static int DetectEngineHttpHRHTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2327,7 +2327,7 @@ static int DetectEngineHttpHRHTest23(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2357,7 +2357,7 @@ static int DetectEngineHttpHRHTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2421,7 +2421,7 @@ static int DetectEngineHttpHRHTest24(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2451,7 +2451,7 @@ static int DetectEngineHttpHRHTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2515,7 +2515,7 @@ static int DetectEngineHttpHRHTest25(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2545,7 +2545,7 @@ static int DetectEngineHttpHRHTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-engine-hrud.c
+++ b/src/detect-engine-hrud.c
@@ -175,7 +175,7 @@ static int DetectEngineHttpRawUriTest01(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -205,7 +205,7 @@ static int DetectEngineHttpRawUriTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -299,7 +299,7 @@ static int DetectEngineHttpRawUriTest02(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -329,7 +329,7 @@ static int DetectEngineHttpRawUriTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -409,7 +409,7 @@ static int DetectEngineHttpRawUriTest03(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -439,7 +439,7 @@ static int DetectEngineHttpRawUriTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -537,7 +537,7 @@ static int DetectEngineHttpRawUriTest04(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -567,7 +567,7 @@ static int DetectEngineHttpRawUriTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -664,7 +664,7 @@ static int DetectEngineHttpRawUriTest05(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -694,7 +694,7 @@ static int DetectEngineHttpRawUriTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -791,7 +791,7 @@ static int DetectEngineHttpRawUriTest06(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -821,7 +821,7 @@ static int DetectEngineHttpRawUriTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -918,7 +918,7 @@ static int DetectEngineHttpRawUriTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -948,7 +948,7 @@ static int DetectEngineHttpRawUriTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1045,7 +1045,7 @@ static int DetectEngineHttpRawUriTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1075,7 +1075,7 @@ static int DetectEngineHttpRawUriTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1172,7 +1172,7 @@ static int DetectEngineHttpRawUriTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1203,7 +1203,7 @@ static int DetectEngineHttpRawUriTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1300,7 +1300,7 @@ static int DetectEngineHttpRawUriTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1331,7 +1331,7 @@ static int DetectEngineHttpRawUriTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1428,7 +1428,7 @@ static int DetectEngineHttpRawUriTest11(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1459,7 +1459,7 @@ static int DetectEngineHttpRawUriTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1556,7 +1556,7 @@ static int DetectEngineHttpRawUriTest12(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1587,7 +1587,7 @@ static int DetectEngineHttpRawUriTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1684,7 +1684,7 @@ static int DetectEngineHttpRawUriTest13(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1715,7 +1715,7 @@ static int DetectEngineHttpRawUriTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1812,7 +1812,7 @@ static int DetectEngineHttpRawUriTest14(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1843,7 +1843,7 @@ static int DetectEngineHttpRawUriTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1940,7 +1940,7 @@ static int DetectEngineHttpRawUriTest15(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1971,7 +1971,7 @@ static int DetectEngineHttpRawUriTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2068,7 +2068,7 @@ static int DetectEngineHttpRawUriTest16(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2099,7 +2099,7 @@ static int DetectEngineHttpRawUriTest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2178,7 +2178,7 @@ static int DetectEngineHttpRawUriTest17(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2250,7 +2250,7 @@ static int DetectEngineHttpRawUriTest18(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2322,7 +2322,7 @@ static int DetectEngineHttpRawUriTest19(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2394,7 +2394,7 @@ static int DetectEngineHttpRawUriTest20(void)
     p1->flowflags |= FLOW_PKT_TOSERVER;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2484,7 +2484,7 @@ static int DetectEngineHttpRawUriTest21(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2515,7 +2515,7 @@ static int DetectEngineHttpRawUriTest21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2612,7 +2612,7 @@ static int DetectEngineHttpRawUriTest22(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2643,7 +2643,7 @@ static int DetectEngineHttpRawUriTest22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2740,7 +2740,7 @@ static int DetectEngineHttpRawUriTest23(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2771,7 +2771,7 @@ static int DetectEngineHttpRawUriTest23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2868,7 +2868,7 @@ static int DetectEngineHttpRawUriTest24(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2899,7 +2899,7 @@ static int DetectEngineHttpRawUriTest24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2996,7 +2996,7 @@ static int DetectEngineHttpRawUriTest25(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3027,7 +3027,7 @@ static int DetectEngineHttpRawUriTest25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3124,7 +3124,7 @@ static int DetectEngineHttpRawUriTest26(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3155,7 +3155,7 @@ static int DetectEngineHttpRawUriTest26(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3252,7 +3252,7 @@ static int DetectEngineHttpRawUriTest27(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3283,7 +3283,7 @@ static int DetectEngineHttpRawUriTest27(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3380,7 +3380,7 @@ static int DetectEngineHttpRawUriTest28(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3411,7 +3411,7 @@ static int DetectEngineHttpRawUriTest28(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3495,7 +3495,7 @@ static int DetectEngineHttpRawUriTest29(void)
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3526,7 +3526,7 @@ static int DetectEngineHttpRawUriTest29(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3590,7 +3590,7 @@ static int DetectEngineHttpRawUriTest30(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3620,7 +3620,7 @@ static int DetectEngineHttpRawUriTest30(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -346,7 +346,7 @@ static int DetectEngineHttpServerBodyTest01(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -376,7 +376,7 @@ static int DetectEngineHttpServerBodyTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -468,7 +468,7 @@ static int DetectEngineHttpServerBodyTest02(void)
     p1->flowflags |= FLOW_PKT_TOCLIENT;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -508,7 +508,7 @@ static int DetectEngineHttpServerBodyTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -590,7 +590,7 @@ static int DetectEngineHttpServerBodyTest03(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -620,7 +620,7 @@ static int DetectEngineHttpServerBodyTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -728,7 +728,7 @@ static int DetectEngineHttpServerBodyTest04(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -758,7 +758,7 @@ static int DetectEngineHttpServerBodyTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -856,7 +856,7 @@ static int DetectEngineHttpServerBodyTest05(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -886,7 +886,7 @@ static int DetectEngineHttpServerBodyTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -984,7 +984,7 @@ static int DetectEngineHttpServerBodyTest06(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1014,7 +1014,7 @@ static int DetectEngineHttpServerBodyTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1112,7 +1112,7 @@ static int DetectEngineHttpServerBodyTest07(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1142,7 +1142,7 @@ static int DetectEngineHttpServerBodyTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1240,7 +1240,7 @@ static int DetectEngineHttpServerBodyTest08(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1270,7 +1270,7 @@ static int DetectEngineHttpServerBodyTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1368,7 +1368,7 @@ static int DetectEngineHttpServerBodyTest09(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1399,7 +1399,7 @@ static int DetectEngineHttpServerBodyTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1497,7 +1497,7 @@ static int DetectEngineHttpServerBodyTest10(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1528,7 +1528,7 @@ static int DetectEngineHttpServerBodyTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1626,7 +1626,7 @@ static int DetectEngineHttpServerBodyTest11(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1657,7 +1657,7 @@ static int DetectEngineHttpServerBodyTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1755,7 +1755,7 @@ static int DetectEngineHttpServerBodyTest12(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1786,7 +1786,7 @@ static int DetectEngineHttpServerBodyTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1884,7 +1884,7 @@ static int DetectEngineHttpServerBodyTest13(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1915,7 +1915,7 @@ static int DetectEngineHttpServerBodyTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2013,7 +2013,7 @@ static int DetectEngineHttpServerBodyTest14(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2044,7 +2044,7 @@ static int DetectEngineHttpServerBodyTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2142,7 +2142,7 @@ static int DetectEngineHttpServerBodyTest15(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2173,7 +2173,7 @@ static int DetectEngineHttpServerBodyTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2297,7 +2297,7 @@ libhtp:\n\
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2327,7 +2327,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2473,7 +2473,7 @@ libhtp:\n\
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2503,7 +2503,7 @@ libhtp:\n\
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2633,7 +2633,7 @@ static int DetectEngineHttpServerBodyTest18(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2660,7 +2660,7 @@ static int DetectEngineHttpServerBodyTest18(void)
         goto end;
     }
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2763,7 +2763,7 @@ static int DetectEngineHttpServerBodyTest19(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2790,7 +2790,7 @@ static int DetectEngineHttpServerBodyTest19(void)
         goto end;
     }
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2893,7 +2893,7 @@ static int DetectEngineHttpServerBodyTest20(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2920,7 +2920,7 @@ static int DetectEngineHttpServerBodyTest20(void)
         goto end;
     }
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3025,7 +3025,7 @@ static int DetectEngineHttpServerBodyTest21(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3052,7 +3052,7 @@ static int DetectEngineHttpServerBodyTest21(void)
         goto end;
     }
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3159,7 +3159,7 @@ static int DetectEngineHttpServerBodyTest22(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3186,7 +3186,7 @@ static int DetectEngineHttpServerBodyTest22(void)
         goto end;
     }
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3281,7 +3281,7 @@ static int DetectEngineHttpServerBodyFileDataTest01(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3312,7 +3312,7 @@ static int DetectEngineHttpServerBodyFileDataTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3410,7 +3410,7 @@ static int DetectEngineHttpServerBodyFileDataTest02(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3441,7 +3441,7 @@ static int DetectEngineHttpServerBodyFileDataTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3540,7 +3540,7 @@ static int DetectEngineHttpServerBodyFileDataTest03(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3574,7 +3574,7 @@ static int DetectEngineHttpServerBodyFileDataTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hscd.c
+++ b/src/detect-engine-hscd.c
@@ -172,7 +172,7 @@ static int DetectEngineHttpStatCodeTest01(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -202,7 +202,7 @@ static int DetectEngineHttpStatCodeTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -294,7 +294,7 @@ static int DetectEngineHttpStatCodeTest02(void)
     p1->flowflags |= FLOW_PKT_TOCLIENT;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -334,7 +334,7 @@ static int DetectEngineHttpStatCodeTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -416,7 +416,7 @@ static int DetectEngineHttpStatCodeTest03(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -446,7 +446,7 @@ static int DetectEngineHttpStatCodeTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -554,7 +554,7 @@ static int DetectEngineHttpStatCodeTest04(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -584,7 +584,7 @@ static int DetectEngineHttpStatCodeTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -682,7 +682,7 @@ static int DetectEngineHttpStatCodeTest05(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -712,7 +712,7 @@ static int DetectEngineHttpStatCodeTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -810,7 +810,7 @@ static int DetectEngineHttpStatCodeTest06(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -840,7 +840,7 @@ static int DetectEngineHttpStatCodeTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -938,7 +938,7 @@ static int DetectEngineHttpStatCodeTest07(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -968,7 +968,7 @@ static int DetectEngineHttpStatCodeTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1066,7 +1066,7 @@ static int DetectEngineHttpStatCodeTest08(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1096,7 +1096,7 @@ static int DetectEngineHttpStatCodeTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1194,7 +1194,7 @@ static int DetectEngineHttpStatCodeTest09(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1225,7 +1225,7 @@ static int DetectEngineHttpStatCodeTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1323,7 +1323,7 @@ static int DetectEngineHttpStatCodeTest10(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1354,7 +1354,7 @@ static int DetectEngineHttpStatCodeTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1452,7 +1452,7 @@ static int DetectEngineHttpStatCodeTest11(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1483,7 +1483,7 @@ static int DetectEngineHttpStatCodeTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1581,7 +1581,7 @@ static int DetectEngineHttpStatCodeTest12(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1612,7 +1612,7 @@ static int DetectEngineHttpStatCodeTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1710,7 +1710,7 @@ static int DetectEngineHttpStatCodeTest13(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1741,7 +1741,7 @@ static int DetectEngineHttpStatCodeTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1839,7 +1839,7 @@ static int DetectEngineHttpStatCodeTest14(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1870,7 +1870,7 @@ static int DetectEngineHttpStatCodeTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1968,7 +1968,7 @@ static int DetectEngineHttpStatCodeTest15(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1999,7 +1999,7 @@ static int DetectEngineHttpStatCodeTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hsmd.c
+++ b/src/detect-engine-hsmd.c
@@ -172,7 +172,7 @@ static int DetectEngineHttpStatMsgTest01(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -202,7 +202,7 @@ static int DetectEngineHttpStatMsgTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -294,7 +294,7 @@ static int DetectEngineHttpStatMsgTest02(void)
     p1->flowflags |= FLOW_PKT_TOCLIENT;
     p1->flowflags |= FLOW_PKT_ESTABLISHED;
     p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -334,7 +334,7 @@ static int DetectEngineHttpStatMsgTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -416,7 +416,7 @@ static int DetectEngineHttpStatMsgTest03(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -446,7 +446,7 @@ static int DetectEngineHttpStatMsgTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -554,7 +554,7 @@ static int DetectEngineHttpStatMsgTest04(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -584,7 +584,7 @@ static int DetectEngineHttpStatMsgTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -682,7 +682,7 @@ static int DetectEngineHttpStatMsgTest05(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -712,7 +712,7 @@ static int DetectEngineHttpStatMsgTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -810,7 +810,7 @@ static int DetectEngineHttpStatMsgTest06(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -840,7 +840,7 @@ static int DetectEngineHttpStatMsgTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -938,7 +938,7 @@ static int DetectEngineHttpStatMsgTest07(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -968,7 +968,7 @@ static int DetectEngineHttpStatMsgTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1066,7 +1066,7 @@ static int DetectEngineHttpStatMsgTest08(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1096,7 +1096,7 @@ static int DetectEngineHttpStatMsgTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1194,7 +1194,7 @@ static int DetectEngineHttpStatMsgTest09(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1225,7 +1225,7 @@ static int DetectEngineHttpStatMsgTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1323,7 +1323,7 @@ static int DetectEngineHttpStatMsgTest10(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1354,7 +1354,7 @@ static int DetectEngineHttpStatMsgTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1452,7 +1452,7 @@ static int DetectEngineHttpStatMsgTest11(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1483,7 +1483,7 @@ static int DetectEngineHttpStatMsgTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1581,7 +1581,7 @@ static int DetectEngineHttpStatMsgTest12(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1612,7 +1612,7 @@ static int DetectEngineHttpStatMsgTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1710,7 +1710,7 @@ static int DetectEngineHttpStatMsgTest13(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1741,7 +1741,7 @@ static int DetectEngineHttpStatMsgTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1839,7 +1839,7 @@ static int DetectEngineHttpStatMsgTest14(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1870,7 +1870,7 @@ static int DetectEngineHttpStatMsgTest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1968,7 +1968,7 @@ static int DetectEngineHttpStatMsgTest15(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1999,7 +1999,7 @@ static int DetectEngineHttpStatMsgTest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-engine-hua.c
+++ b/src/detect-engine-hua.c
@@ -167,7 +167,7 @@ static int DetectEngineHttpUATest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -197,7 +197,7 @@ static int DetectEngineHttpUATest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -265,7 +265,7 @@ static int DetectEngineHttpUATest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -295,7 +295,7 @@ static int DetectEngineHttpUATest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -363,7 +363,7 @@ static int DetectEngineHttpUATest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -393,7 +393,7 @@ static int DetectEngineHttpUATest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -461,7 +461,7 @@ static int DetectEngineHttpUATest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -491,7 +491,7 @@ static int DetectEngineHttpUATest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -559,7 +559,7 @@ static int DetectEngineHttpUATest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -589,7 +589,7 @@ static int DetectEngineHttpUATest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -657,7 +657,7 @@ static int DetectEngineHttpUATest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -687,7 +687,7 @@ static int DetectEngineHttpUATest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -755,7 +755,7 @@ static int DetectEngineHttpUATest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -785,7 +785,7 @@ static int DetectEngineHttpUATest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -853,7 +853,7 @@ static int DetectEngineHttpUATest08(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -883,7 +883,7 @@ static int DetectEngineHttpUATest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -951,7 +951,7 @@ static int DetectEngineHttpUATest09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -981,7 +981,7 @@ static int DetectEngineHttpUATest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1049,7 +1049,7 @@ static int DetectEngineHttpUATest10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1080,7 +1080,7 @@ static int DetectEngineHttpUATest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1148,7 +1148,7 @@ static int DetectEngineHttpUATest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1179,7 +1179,7 @@ static int DetectEngineHttpUATest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1247,7 +1247,7 @@ static int DetectEngineHttpUATest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1278,7 +1278,7 @@ static int DetectEngineHttpUATest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1346,7 +1346,7 @@ static int DetectEngineHttpUATest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1377,7 +1377,7 @@ static int DetectEngineHttpUATest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1445,7 +1445,7 @@ static int DetectEngineHttpUATest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1476,7 +1476,7 @@ static int DetectEngineHttpUATest14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1544,7 +1544,7 @@ static int DetectEngineHttpUATest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1575,7 +1575,7 @@ static int DetectEngineHttpUATest15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1643,7 +1643,7 @@ static int DetectEngineHttpUATest16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1674,7 +1674,7 @@ static int DetectEngineHttpUATest16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1742,7 +1742,7 @@ static int DetectEngineHttpUATest17(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1773,7 +1773,7 @@ static int DetectEngineHttpUATest17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -354,7 +354,7 @@ static int DetectEngineInspectModbusTest01(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -390,7 +390,7 @@ static int DetectEngineInspectModbusTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -443,7 +443,7 @@ static int DetectEngineInspectModbusTest02(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -479,7 +479,7 @@ static int DetectEngineInspectModbusTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -532,7 +532,7 @@ static int DetectEngineInspectModbusTest03(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -569,7 +569,7 @@ static int DetectEngineInspectModbusTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -622,7 +622,7 @@ static int DetectEngineInspectModbusTest04(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -658,7 +658,7 @@ static int DetectEngineInspectModbusTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -711,7 +711,7 @@ static int DetectEngineInspectModbusTest05(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -748,7 +748,7 @@ static int DetectEngineInspectModbusTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -801,7 +801,7 @@ static int DetectEngineInspectModbusTest06(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -838,7 +838,7 @@ static int DetectEngineInspectModbusTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState *modbus_state = f.alstate;
+    ModbusState *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -891,7 +891,7 @@ static int DetectEngineInspectModbusTest07(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -927,7 +927,7 @@ static int DetectEngineInspectModbusTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -980,7 +980,7 @@ static int DetectEngineInspectModbusTest08(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -1065,7 +1065,7 @@ static int DetectEngineInspectModbusTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;
@@ -1163,7 +1163,7 @@ static int DetectEngineInspectModbusTest09(void)
     p = UTHBuildPacket(readCoilsReq, sizeof(readCoilsReq), IPPROTO_TCP);
 
     FLOW_INITIALIZE(&f);
-    f.alproto   = ALPROTO_MODBUS;
+    FlowSetAppProtocol(&f, ALPROTO_MODBUS);
     f.protoctx  = (void *)&ssn;
     f.proto     = IPPROTO_TCP;
     f.flags     |= FLOW_IPV4;
@@ -1250,7 +1250,7 @@ static int DetectEngineInspectModbusTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    ModbusState    *modbus_state = f.alstate;
+    ModbusState    *modbus_state = FlowGetAppState(&f);
     if (modbus_state == NULL) {
         printf("no modbus state: ");
         goto end;

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -1939,7 +1939,7 @@ static int SCSigOrderingTest12(void)
 
     FLOW_INITIALIZE(&f);
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_UNKNOWN;
+    FlowSetAppProtocol(&f, ALPROTO_UNKNOWN);
     f.proto = IPPROTO_TCP;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();

--- a/src/detect-engine-uri.c
+++ b/src/detect-engine-uri.c
@@ -142,7 +142,7 @@ static int UriTestSig01(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -172,7 +172,7 @@ static int UriTestSig01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -197,7 +197,7 @@ static int UriTestSig01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -265,7 +265,7 @@ static int UriTestSig02(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -295,7 +295,7 @@ static int UriTestSig02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -320,7 +320,7 @@ static int UriTestSig02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -388,7 +388,7 @@ static int UriTestSig03(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -418,7 +418,7 @@ static int UriTestSig03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -443,7 +443,7 @@ static int UriTestSig03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -511,7 +511,7 @@ static int UriTestSig04(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -541,7 +541,7 @@ static int UriTestSig04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -566,7 +566,7 @@ static int UriTestSig04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -634,7 +634,7 @@ static int UriTestSig05(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -664,7 +664,7 @@ static int UriTestSig05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -689,7 +689,7 @@ static int UriTestSig05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -757,7 +757,7 @@ static int UriTestSig06(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -787,7 +787,7 @@ static int UriTestSig06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -812,7 +812,7 @@ static int UriTestSig06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -880,7 +880,7 @@ static int UriTestSig07(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -910,7 +910,7 @@ static int UriTestSig07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -935,7 +935,7 @@ static int UriTestSig07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1003,7 +1003,7 @@ static int UriTestSig08(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1033,7 +1033,7 @@ static int UriTestSig08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1058,7 +1058,7 @@ static int UriTestSig08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1126,7 +1126,7 @@ static int UriTestSig09(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1156,7 +1156,7 @@ static int UriTestSig09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1181,7 +1181,7 @@ static int UriTestSig09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1249,7 +1249,7 @@ static int UriTestSig10(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1279,7 +1279,7 @@ static int UriTestSig10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1304,7 +1304,7 @@ static int UriTestSig10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1372,7 +1372,7 @@ static int UriTestSig11(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1403,7 +1403,7 @@ static int UriTestSig11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1428,7 +1428,7 @@ static int UriTestSig11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1496,7 +1496,7 @@ static int UriTestSig12(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1527,7 +1527,7 @@ static int UriTestSig12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1552,7 +1552,7 @@ static int UriTestSig12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1620,7 +1620,7 @@ static int UriTestSig13(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1650,7 +1650,7 @@ static int UriTestSig13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1675,7 +1675,7 @@ static int UriTestSig13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1744,7 +1744,7 @@ static int UriTestSig14(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1774,7 +1774,7 @@ static int UriTestSig14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1799,7 +1799,7 @@ static int UriTestSig14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1868,7 +1868,7 @@ static int UriTestSig15(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1898,7 +1898,7 @@ static int UriTestSig15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1923,7 +1923,7 @@ static int UriTestSig15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1992,7 +1992,7 @@ static int UriTestSig16(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2020,7 +2020,7 @@ static int UriTestSig16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2048,7 +2048,7 @@ static int UriTestSig16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2112,7 +2112,7 @@ static int UriTestSig17(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2144,7 +2144,7 @@ static int UriTestSig17(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2208,7 +2208,7 @@ static int UriTestSig18(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2240,7 +2240,7 @@ static int UriTestSig18(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2304,7 +2304,7 @@ static int UriTestSig19(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2337,7 +2337,7 @@ static int UriTestSig19(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2401,7 +2401,7 @@ static int UriTestSig20(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2433,7 +2433,7 @@ static int UriTestSig20(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2497,7 +2497,7 @@ static int UriTestSig21(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2528,7 +2528,7 @@ static int UriTestSig21(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2593,7 +2593,7 @@ static int UriTestSig22(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2623,7 +2623,7 @@ static int UriTestSig22(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2687,7 +2687,7 @@ static int UriTestSig23(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2717,7 +2717,7 @@ static int UriTestSig23(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2781,7 +2781,7 @@ static int UriTestSig24(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2811,7 +2811,7 @@ static int UriTestSig24(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2874,7 +2874,7 @@ static int UriTestSig25(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -2905,7 +2905,7 @@ static int UriTestSig25(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2969,7 +2969,7 @@ static int UriTestSig26(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2999,7 +2999,7 @@ static int UriTestSig26(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3063,7 +3063,7 @@ static int UriTestSig27(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3093,7 +3093,7 @@ static int UriTestSig27(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3189,7 +3189,7 @@ static int UriTestSig28(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3221,7 +3221,7 @@ static int UriTestSig28(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3282,7 +3282,7 @@ static int UriTestSig29(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3314,7 +3314,7 @@ static int UriTestSig29(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3375,7 +3375,7 @@ static int UriTestSig30(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3407,7 +3407,7 @@ static int UriTestSig30(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3468,7 +3468,7 @@ static int UriTestSig31(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3500,7 +3500,7 @@ static int UriTestSig31(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3561,7 +3561,7 @@ static int UriTestSig32(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3593,7 +3593,7 @@ static int UriTestSig32(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3653,7 +3653,7 @@ static int UriTestSig33(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -3684,7 +3684,7 @@ static int UriTestSig33(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3744,7 +3744,7 @@ static int UriTestSig34(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -3775,7 +3775,7 @@ static int UriTestSig34(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3835,7 +3835,7 @@ static int UriTestSig35(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -3866,7 +3866,7 @@ static int UriTestSig35(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3926,7 +3926,7 @@ static int UriTestSig36(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -3957,7 +3957,7 @@ static int UriTestSig36(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -4017,7 +4017,7 @@ static int UriTestSig37(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -4048,7 +4048,7 @@ static int UriTestSig37(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -4108,7 +4108,7 @@ static int UriTestSig38(void)
     p->flow = &f;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
 
     StreamTcpInitConfig(TRUE);
@@ -4139,7 +4139,7 @@ static int UriTestSig38(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -158,8 +158,8 @@ static int FilestorePostMatchWithOptions(Packet *p, Flow *f, DetectFilestoreData
         FileStoreFileById(fc, file_id);
     } else if (this_tx) {
         /* flag tx all files will be stored */
-        if (f->alproto == ALPROTO_HTTP && f->alstate != NULL) {
-            HtpState *htp_state = f->alstate;
+        if (FlowGetAppProtocol(f) == ALPROTO_HTTP && FlowGetAppState(f) != NULL) {
+            HtpState *htp_state = FlowGetAppState(f);
             if (toserver_dir) {
                 htp_state->flags |= HTP_FLAG_STORE_FILES_TX_TS;
                 FileStoreAllFilesForTx(htp_state->files_ts, tx_id);
@@ -172,8 +172,8 @@ static int FilestorePostMatchWithOptions(Packet *p, Flow *f, DetectFilestoreData
         }
     } else if (this_flow) {
         /* flag flow all files will be stored */
-        if (f->alproto == ALPROTO_HTTP && f->alstate != NULL) {
-            HtpState *htp_state = f->alstate;
+        if (FlowGetAppProtocol(f) == ALPROTO_HTTP && FlowGetAppState(f) != NULL) {
+            HtpState *htp_state = FlowGetAppState(f);
             if (toserver_dir) {
                 htp_state->flags |= HTP_FLAG_STORE_FILES_TS;
                 FileStoreAllFiles(htp_state->files_ts);
@@ -226,8 +226,10 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
 
     FLOWLOCK_WRLOCK(p->flow);
 
-    FileContainer *ffc = AppLayerParserGetFiles(p->flow->proto, p->flow->alproto,
-                                                p->flow->alstate, flags);
+    FileContainer *ffc = AppLayerParserGetFiles(p->flow->proto,
+                                                FlowGetAppProtocol(p->flow),
+                                                FlowGetAppState(p->flow),
+                                                flags);
 
     /* filestore for single files only */
     if (s->filestore_sm->ctx == NULL) {

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -310,7 +310,7 @@ static int DetectFtpbounceTestALMatch02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_FTP;
+    FlowSetAppProtocol(&f, ALPROTO_FTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -365,7 +365,7 @@ static int DetectFtpbounceTestALMatch02(void)
 
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;
@@ -451,7 +451,7 @@ static int DetectFtpbounceTestALMatch03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_FTP;
+    FlowSetAppProtocol(&f, ALPROTO_FTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -505,7 +505,7 @@ static int DetectFtpbounceTestALMatch03(void)
     }
     SCMutexUnlock(&f.m);
 
-    FtpState *ftp_state = f.alstate;
+    FtpState *ftp_state = FlowGetAppState(&f);
     if (ftp_state == NULL) {
         SCLogDebug("no ftp state: ");
         result = 0;

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -325,7 +325,7 @@ static int DetectHttpClientBodyTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -355,7 +355,7 @@ static int DetectHttpClientBodyTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -436,7 +436,7 @@ static int DetectHttpClientBodyTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -466,7 +466,7 @@ static int DetectHttpClientBodyTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -563,7 +563,7 @@ static int DetectHttpClientBodyTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -593,7 +593,7 @@ static int DetectHttpClientBodyTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -693,7 +693,7 @@ static int DetectHttpClientBodyTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -723,7 +723,7 @@ static int DetectHttpClientBodyTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -823,7 +823,7 @@ static int DetectHttpClientBodyTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -853,7 +853,7 @@ static int DetectHttpClientBodyTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -944,7 +944,7 @@ static int DetectHttpClientBodyTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -974,7 +974,7 @@ static int DetectHttpClientBodyTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1046,7 +1046,7 @@ static int DetectHttpClientBodyTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1076,7 +1076,7 @@ static int DetectHttpClientBodyTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1148,7 +1148,7 @@ static int DetectHttpClientBodyTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1178,7 +1178,7 @@ static int DetectHttpClientBodyTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1251,7 +1251,7 @@ static int DetectHttpClientBodyTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1399,7 +1399,7 @@ static int DetectHttpClientBodyTest14(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1470,7 +1470,7 @@ static int DetectHttpClientBodyTest15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1617,7 +1617,7 @@ static int DetectHttpClientBodyTest15(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -343,7 +343,7 @@ static int DetectHttpCookieSigTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -381,7 +381,7 @@ static int DetectHttpCookieSigTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -449,7 +449,7 @@ static int DetectHttpCookieSigTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -480,7 +480,7 @@ static int DetectHttpCookieSigTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -542,7 +542,7 @@ static int DetectHttpCookieSigTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -573,7 +573,7 @@ static int DetectHttpCookieSigTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -636,7 +636,7 @@ static int DetectHttpCookieSigTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -667,7 +667,7 @@ static int DetectHttpCookieSigTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -730,7 +730,7 @@ static int DetectHttpCookieSigTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -761,7 +761,7 @@ static int DetectHttpCookieSigTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -824,7 +824,7 @@ static int DetectHttpCookieSigTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -855,7 +855,7 @@ static int DetectHttpCookieSigTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -917,7 +917,7 @@ static int DetectHttpCookieSigTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -948,7 +948,7 @@ static int DetectHttpCookieSigTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1015,7 +1015,7 @@ static int DetectHttpCookieSigTest08(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
     p1->flow = &f;
@@ -1060,7 +1060,7 @@ static int DetectHttpCookieSigTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1146,7 +1146,7 @@ static int DetectHttpCookieSigTest09(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
     p1->flow = &f;
@@ -1197,7 +1197,7 @@ static int DetectHttpCookieSigTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -332,7 +332,7 @@ static int DetectHttpHeaderTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -362,7 +362,7 @@ static int DetectHttpHeaderTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -441,7 +441,7 @@ static int DetectHttpHeaderTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -471,7 +471,7 @@ static int DetectHttpHeaderTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -568,7 +568,7 @@ static int DetectHttpHeaderTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -598,7 +598,7 @@ static int DetectHttpHeaderTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -696,7 +696,7 @@ static int DetectHttpHeaderTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -727,7 +727,7 @@ static int DetectHttpHeaderTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -825,7 +825,7 @@ static int DetectHttpHeaderTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -855,7 +855,7 @@ static int DetectHttpHeaderTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -945,7 +945,7 @@ static int DetectHttpHeaderTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -975,7 +975,7 @@ static int DetectHttpHeaderTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1046,7 +1046,7 @@ static int DetectHttpHeaderTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1076,7 +1076,7 @@ static int DetectHttpHeaderTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1148,7 +1148,7 @@ static int DetectHttpHeaderTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1178,7 +1178,7 @@ static int DetectHttpHeaderTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1556,7 +1556,7 @@ static int DetectHttpHeaderTest28(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1643,7 +1643,7 @@ static int DetectHttpHeaderTest29(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1730,7 +1730,7 @@ static int DetectHttpHeaderTest30(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -310,7 +310,7 @@ static int DetectHttpHHTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -340,7 +340,7 @@ static int DetectHttpHHTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -417,7 +417,7 @@ static int DetectHttpHHTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -447,7 +447,7 @@ static int DetectHttpHHTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -540,7 +540,7 @@ static int DetectHttpHHTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -570,7 +570,7 @@ static int DetectHttpHHTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -670,7 +670,7 @@ static int DetectHttpHHTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -700,7 +700,7 @@ static int DetectHttpHHTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -800,7 +800,7 @@ static int DetectHttpHHTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -830,7 +830,7 @@ static int DetectHttpHHTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -920,7 +920,7 @@ static int DetectHttpHHTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -950,7 +950,7 @@ static int DetectHttpHHTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1019,7 +1019,7 @@ static int DetectHttpHHTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1049,7 +1049,7 @@ static int DetectHttpHHTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1119,7 +1119,7 @@ static int DetectHttpHHTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1149,7 +1149,7 @@ static int DetectHttpHHTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1222,7 +1222,7 @@ static int DetectHttpHHTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1351,7 +1351,7 @@ static int DetectHttpHHTest14(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-http-hrh.c
+++ b/src/detect-http-hrh.c
@@ -310,7 +310,7 @@ static int DetectHttpHRHTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -340,7 +340,7 @@ static int DetectHttpHRHTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -417,7 +417,7 @@ static int DetectHttpHRHTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -447,7 +447,7 @@ static int DetectHttpHRHTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -540,7 +540,7 @@ static int DetectHttpHRHTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -570,7 +570,7 @@ static int DetectHttpHRHTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -670,7 +670,7 @@ static int DetectHttpHRHTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -700,7 +700,7 @@ static int DetectHttpHRHTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -800,7 +800,7 @@ static int DetectHttpHRHTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -830,7 +830,7 @@ static int DetectHttpHRHTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -919,7 +919,7 @@ static int DetectHttpHRHTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -949,7 +949,7 @@ static int DetectHttpHRHTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1018,7 +1018,7 @@ static int DetectHttpHRHTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1048,7 +1048,7 @@ static int DetectHttpHRHTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1118,7 +1118,7 @@ static int DetectHttpHRHTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1148,7 +1148,7 @@ static int DetectHttpHRHTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1221,7 +1221,7 @@ static int DetectHttpHRHTest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1350,7 +1350,7 @@ static int DetectHttpHRHTest14(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2107,7 +2107,7 @@ static int DetectHttpHRHTest37(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2137,7 +2137,7 @@ static int DetectHttpHRHTest37(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -430,7 +430,7 @@ static int DetectHttpMethodSigTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -471,7 +471,7 @@ static int DetectHttpMethodSigTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         SCLogDebug("no http state: ");
         goto end;
@@ -533,7 +533,7 @@ static int DetectHttpMethodSigTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -574,7 +574,7 @@ static int DetectHttpMethodSigTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         SCLogDebug("no http state: ");
         goto end;
@@ -635,7 +635,7 @@ static int DetectHttpMethodSigTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -668,7 +668,7 @@ static int DetectHttpMethodSigTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         SCLogDebug("no http state: ");
         goto end;
@@ -727,7 +727,7 @@ static int DetectHttpMethodSigTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -764,7 +764,7 @@ static int DetectHttpMethodSigTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         SCLogDebug("no http state: ");
         goto end;

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -331,7 +331,7 @@ static int DetectHttpRawHeaderTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -361,7 +361,7 @@ static int DetectHttpRawHeaderTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -440,7 +440,7 @@ static int DetectHttpRawHeaderTest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -470,7 +470,7 @@ static int DetectHttpRawHeaderTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -567,7 +567,7 @@ static int DetectHttpRawHeaderTest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -597,7 +597,7 @@ static int DetectHttpRawHeaderTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -695,7 +695,7 @@ static int DetectHttpRawHeaderTest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -725,7 +725,7 @@ static int DetectHttpRawHeaderTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -823,7 +823,7 @@ static int DetectHttpRawHeaderTest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -853,7 +853,7 @@ static int DetectHttpRawHeaderTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -943,7 +943,7 @@ static int DetectHttpRawHeaderTest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -973,7 +973,7 @@ static int DetectHttpRawHeaderTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1044,7 +1044,7 @@ static int DetectHttpRawHeaderTest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1074,7 +1074,7 @@ static int DetectHttpRawHeaderTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1146,7 +1146,7 @@ static int DetectHttpRawHeaderTest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1176,7 +1176,7 @@ static int DetectHttpRawHeaderTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -346,7 +346,7 @@ static int DetectHttpServerBodyTest06(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -383,7 +383,7 @@ static int DetectHttpServerBodyTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -469,7 +469,7 @@ static int DetectHttpServerBodyTest07(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -505,7 +505,7 @@ static int DetectHttpServerBodyTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -606,7 +606,7 @@ static int DetectHttpServerBodyTest08(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -636,7 +636,7 @@ static int DetectHttpServerBodyTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -753,7 +753,7 @@ static int DetectHttpServerBodyTest09(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -783,7 +783,7 @@ static int DetectHttpServerBodyTest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -908,7 +908,7 @@ static int DetectHttpServerBodyTest10(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -938,7 +938,7 @@ static int DetectHttpServerBodyTest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1059,7 +1059,7 @@ static int DetectHttpServerBodyTest11(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1089,7 +1089,7 @@ static int DetectHttpServerBodyTest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1202,7 +1202,7 @@ static int DetectHttpServerBodyTest12(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1232,7 +1232,7 @@ static int DetectHttpServerBodyTest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1333,7 +1333,7 @@ static int DetectHttpServerBodyTest13(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1370,7 +1370,7 @@ static int DetectHttpServerBodyTest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -1453,7 +1453,7 @@ static int DetectHttpServerBodyTest14(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1542,7 +1542,7 @@ static int DetectHttpServerBodyTest14(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1621,7 +1621,7 @@ static int DetectHttpServerBodyTest15(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1702,7 +1702,7 @@ static int DetectHttpServerBodyTest15(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2446,7 +2446,7 @@ static int DetectHttpServerBodyFileDataTest01(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2483,7 +2483,7 @@ static int DetectHttpServerBodyFileDataTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -2569,7 +2569,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2607,7 +2607,7 @@ static int DetectHttpServerBodyFileDataTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2708,7 +2708,7 @@ static int DetectHttpServerBodyFileDataTest03(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2738,7 +2738,7 @@ static int DetectHttpServerBodyFileDataTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2856,7 +2856,7 @@ static int DetectHttpServerBodyFileDataTest04(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2886,7 +2886,7 @@ static int DetectHttpServerBodyFileDataTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3011,7 +3011,7 @@ static int DetectHttpServerBodyFileDataTest05(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3041,7 +3041,7 @@ static int DetectHttpServerBodyFileDataTest05(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3162,7 +3162,7 @@ static int DetectHttpServerBodyFileDataTest06(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3192,7 +3192,7 @@ static int DetectHttpServerBodyFileDataTest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3305,7 +3305,7 @@ static int DetectHttpServerBodyFileDataTest07(void)
     p2->flowflags |= FLOW_PKT_TOCLIENT;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3335,7 +3335,7 @@ static int DetectHttpServerBodyFileDataTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3436,7 +3436,7 @@ static int DetectHttpServerBodyFileDataTest08(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3473,7 +3473,7 @@ static int DetectHttpServerBodyFileDataTest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -3556,7 +3556,7 @@ static int DetectHttpServerBodyFileDataTest09(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3633,7 +3633,7 @@ static int DetectHttpServerBodyFileDataTest09(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3712,7 +3712,7 @@ static int DetectHttpServerBodyFileDataTest10(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3789,7 +3789,7 @@ static int DetectHttpServerBodyFileDataTest10(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -247,7 +247,7 @@ static int DetectHttpStatCodeSigTest01(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -285,7 +285,7 @@ static int DetectHttpStatCodeSigTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -349,7 +349,7 @@ static int DetectHttpStatCodeSigTest02(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -395,7 +395,7 @@ static int DetectHttpStatCodeSigTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -465,7 +465,7 @@ static int DetectHttpStatCodeSigTest03(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -511,7 +511,7 @@ static int DetectHttpStatCodeSigTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -581,7 +581,7 @@ static int DetectHttpStatCodeSigTest04(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -627,7 +627,7 @@ static int DetectHttpStatCodeSigTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -239,7 +239,7 @@ static int DetectHttpStatMsgSigTest01(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -285,7 +285,7 @@ static int DetectHttpStatMsgSigTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -354,7 +354,7 @@ static int DetectHttpStatMsgSigTest02(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -393,7 +393,7 @@ static int DetectHttpStatMsgSigTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -459,7 +459,7 @@ static int DetectHttpStatMsgSigTest03(void)
     p->flowflags |= FLOW_PKT_TOCLIENT;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -505,7 +505,7 @@ static int DetectHttpStatMsgSigTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -311,7 +311,7 @@ static int DetectHttpUATest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -341,7 +341,7 @@ static int DetectHttpUATest06(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -418,7 +418,7 @@ static int DetectHttpUATest07(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -448,7 +448,7 @@ static int DetectHttpUATest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -541,7 +541,7 @@ static int DetectHttpUATest08(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -571,7 +571,7 @@ static int DetectHttpUATest08(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -671,7 +671,7 @@ static int DetectHttpUATest09(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -701,7 +701,7 @@ static int DetectHttpUATest09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -801,7 +801,7 @@ static int DetectHttpUATest10(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -831,7 +831,7 @@ static int DetectHttpUATest10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: \n");
         result = 0;
@@ -920,7 +920,7 @@ static int DetectHttpUATest11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -950,7 +950,7 @@ static int DetectHttpUATest11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1019,7 +1019,7 @@ static int DetectHttpUATest12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1049,7 +1049,7 @@ static int DetectHttpUATest12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1119,7 +1119,7 @@ static int DetectHttpUATest13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1149,7 +1149,7 @@ static int DetectHttpUATest13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -1222,7 +1222,7 @@ static int DetectHttpUATest14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1351,7 +1351,7 @@ static int DetectHttpUATest14(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;

--- a/src/detect-lua-extensions.c
+++ b/src/detect-lua-extensions.c
@@ -577,8 +577,11 @@ void LuaExtensionsMatchSetup(lua_State *lua_state, DetectLuaData *ld, DetectEngi
     LuaStateSetFlow(lua_state, f, flow_locked);
 
     if (det_ctx->tx_id_set && flow_locked == LUA_FLOW_LOCKED_BY_PARENT) {
-        if (f && f->alstate) {
-            void *txptr = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, det_ctx->tx_id);
+        if (f && FlowGetAppState(f)) {
+            void *txptr = AppLayerParserGetTx(f->proto,
+                                              FlowGetAppProtocol(f),
+                                              FlowGetAppState(f),
+                                              det_ctx->tx_id);
             if (txptr) {
                 LuaStateSetTX(lua_state, txptr);
             }

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -407,7 +407,7 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
             SCReturnInt(0);
 
         FLOWLOCK_RDLOCK(p->flow);
-        int alproto = p->flow->alproto;
+        int alproto = FlowGetAppProtocol(p->flow);
         FLOWLOCK_UNLOCK(p->flow);
 
         if (tluajit->alproto != alproto)
@@ -429,10 +429,10 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
     }
     if (tluajit->alproto == ALPROTO_HTTP) {
         FLOWLOCK_RDLOCK(p->flow);
-        HtpState *htp_state = p->flow->alstate;
+        HtpState *htp_state = FlowGetAppState(p->flow);
         if (htp_state != NULL && htp_state->connp != NULL) {
             htp_tx_t *tx = NULL;
-            uint64_t idx = AppLayerParserGetTransactionInspectId(p->flow->alparser,
+            uint64_t idx = AppLayerParserGetTransactionInspectId(FlowGetAppParser(p->flow),
                                                                  STREAM_TOSERVER);
             uint64_t total_txs= AppLayerParserGetTxCnt(IPPROTO_TCP, ALPROTO_HTTP, htp_state);
             for ( ; idx < total_txs; idx++) {
@@ -539,7 +539,7 @@ static int DetectLuaAppMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx,
             f, /* flow is locked */LUA_FLOW_LOCKED_BY_PARENT, NULL);
 
     if (tluajit->alproto != ALPROTO_UNKNOWN) {
-        int alproto = f->alproto;
+        int alproto = FlowGetAppProtocol(f);
         if (tluajit->alproto != alproto)
             SCReturnInt(0);
     }
@@ -1167,7 +1167,7 @@ static int LuaMatchTest01(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1203,7 +1203,7 @@ static int LuaMatchTest01(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1329,7 +1329,7 @@ static int LuaMatchTest02(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1465,7 +1465,7 @@ static int LuaMatchTest03(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1600,7 +1600,7 @@ static int LuaMatchTest04(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1637,7 +1637,7 @@ static int LuaMatchTest04(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1748,7 +1748,7 @@ static int LuaMatchTest05(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1785,7 +1785,7 @@ static int LuaMatchTest05(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1901,7 +1901,7 @@ static int LuaMatchTest06(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -1938,7 +1938,7 @@ static int LuaMatchTest06(void)
         goto end;
     }
     SCMutexUnlock(&f.m);
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -1703,7 +1703,7 @@ static int DetectPcreTestSig01Real(int mpm_type)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
     p->flow = &f;
@@ -1970,7 +1970,7 @@ static int DetectPcreModifPTest04(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2007,7 +2007,7 @@ static int DetectPcreModifPTest04(void)
     }
     SCMutexUnlock(&f.m);
 
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2105,7 +2105,7 @@ static int DetectPcreModifPTest05(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2145,7 +2145,7 @@ static int DetectPcreModifPTest05(void)
     /* do detect for p1 */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
 
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -2299,7 +2299,7 @@ static int DetectPcreTestSig09(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2330,7 +2330,7 @@ static int DetectPcreTestSig09(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2395,7 +2395,7 @@ static int DetectPcreTestSig10(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2426,7 +2426,7 @@ static int DetectPcreTestSig10(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2491,7 +2491,7 @@ static int DetectPcreTestSig11(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2522,7 +2522,7 @@ static int DetectPcreTestSig11(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2587,7 +2587,7 @@ static int DetectPcreTestSig12(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2618,7 +2618,7 @@ static int DetectPcreTestSig12(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2683,7 +2683,7 @@ static int DetectPcreTestSig13(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2714,7 +2714,7 @@ static int DetectPcreTestSig13(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2779,7 +2779,7 @@ static int DetectPcreTestSig14(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2810,7 +2810,7 @@ static int DetectPcreTestSig14(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2875,7 +2875,7 @@ static int DetectPcreTestSig15(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -2907,7 +2907,7 @@ static int DetectPcreTestSig15(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -2972,7 +2972,7 @@ static int DetectPcreTestSig16(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3004,7 +3004,7 @@ static int DetectPcreTestSig16(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3073,7 +3073,7 @@ static int DetectPcreTxBodyChunksTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3126,7 +3126,7 @@ static int DetectPcreTxBodyChunksTest01(void)
     /* Now we should have 2 transactions, each with it's own list
      * of request body chunks (let's test it) */
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3225,7 +3225,7 @@ static int DetectPcreTxBodyChunksTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3372,7 +3372,7 @@ static int DetectPcreTxBodyChunksTest02(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3473,7 +3473,7 @@ static int DetectPcreTxBodyChunksTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -3620,7 +3620,7 @@ static int DetectPcreTxBodyChunksTest03(void)
     }
     p->alerts.cnt = 0;
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         result = 0;
@@ -3690,7 +3690,7 @@ static int DetectPcreFlowvarCapture01(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -3730,7 +3730,7 @@ static int DetectPcreFlowvarCapture01(void)
     }
     SCMutexUnlock(&f.m);
 
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3816,7 +3816,7 @@ static int DetectPcreFlowvarCapture02(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -3877,7 +3877,7 @@ static int DetectPcreFlowvarCapture02(void)
     }
     SCMutexUnlock(&f.m);
 
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -3962,7 +3962,7 @@ static int DetectPcreFlowvarCapture03(void)
     f.protoctx = (void *)&ssn;
     f.proto = IPPROTO_TCP;
     f.flags |= FLOW_IPV4;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     p1->flow = &f;
     p1->flowflags |= FLOW_PKT_TOSERVER;
@@ -4020,7 +4020,7 @@ static int DetectPcreFlowvarCapture03(void)
     }
     SCMutexUnlock(&f.m);
 
-    HtpState *http_state = f.alstate;
+    HtpState *http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -377,7 +377,7 @@ static int DetectSshVersionTestDetect01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -426,7 +426,7 @@ static int DetectSshVersionTestDetect01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -490,7 +490,7 @@ static int DetectSshVersionTestDetect02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -538,7 +538,7 @@ static int DetectSshVersionTestDetect02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -601,7 +601,7 @@ static int DetectSshVersionTestDetect03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -650,7 +650,7 @@ static int DetectSshVersionTestDetect03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -349,7 +349,7 @@ static int DetectSshSoftwareVersionTestDetect01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -398,7 +398,7 @@ static int DetectSshSoftwareVersionTestDetect01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -462,7 +462,7 @@ static int DetectSshSoftwareVersionTestDetect02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -511,7 +511,7 @@ static int DetectSshSoftwareVersionTestDetect02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;
@@ -574,7 +574,7 @@ static int DetectSshSoftwareVersionTestDetect03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_SSH;
+    FlowSetAppProtocol(&f, ALPROTO_SSH);
 
     StreamTcpInitConfig(TRUE);
 
@@ -623,7 +623,7 @@ static int DetectSshSoftwareVersionTestDetect03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SshState *ssh_state = f.alstate;
+    SshState *ssh_state = FlowGetAppState(&f);
     if (ssh_state == NULL) {
         printf("no ssh state: ");
         goto end;

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -714,7 +714,7 @@ static int DetectSslStateTest07(void)
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -764,7 +764,7 @@ static int DetectSslStateTest07(void)
     }
     SCMutexUnlock(&f.m);
 
-    ssl_state = f.alstate;
+    ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no ssl state: ");
         goto end;

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -434,7 +434,7 @@ static int DetectSslVersionTestDetect01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -483,7 +483,7 @@ static int DetectSslVersionTestDetect01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         goto end;
@@ -559,7 +559,7 @@ static int DetectSslVersionTestDetect02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -608,7 +608,7 @@ static int DetectSslVersionTestDetect02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         goto end;
@@ -680,7 +680,7 @@ static int DetectSslVersionTestDetect03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
     f.proto = p->proto;
 
     StreamTcpInitConfig(TRUE);
@@ -742,7 +742,7 @@ static int DetectSslVersionTestDetect03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *app_state = f.alstate;
+    SSLState *app_state = FlowGetAppState(&f);
     if (app_state == NULL) {
         printf("no ssl state: ");
         goto end;

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -346,7 +346,7 @@ static int DetectTlsVersionTestDetect01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -395,7 +395,7 @@ static int DetectTlsVersionTestDetect01(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         goto end;
@@ -474,7 +474,7 @@ static int DetectTlsVersionTestDetect02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
 
     StreamTcpInitConfig(TRUE);
 
@@ -523,7 +523,7 @@ static int DetectTlsVersionTestDetect02(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         goto end;
@@ -599,7 +599,7 @@ static int DetectTlsVersionTestDetect03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_TLS;
+    FlowSetAppProtocol(&f, ALPROTO_TLS);
     f.proto = p->proto;
 
     StreamTcpInitConfig(TRUE);
@@ -661,7 +661,7 @@ static int DetectTlsVersionTestDetect03(void)
     }
     SCMutexUnlock(&f.m);
 
-    SSLState *ssl_state = f.alstate;
+    SSLState *ssl_state = FlowGetAppState(&f);
     if (ssl_state == NULL) {
         printf("no tls state: ");
         goto end;

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -303,7 +303,7 @@ static int HTTPUriTest01(void)
         goto end;
     }
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -371,7 +371,7 @@ static int HTTPUriTest02(void)
         goto end;
     }
 
-    htp_state = f.alstate;
+    htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -441,7 +441,7 @@ static int HTTPUriTest03(void)
         goto end;
     }
 
-    htp_state = f.alstate;
+    htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -512,7 +512,7 @@ static int HTTPUriTest04(void)
         goto end;
     }
 
-    htp_state = f.alstate;
+    htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -627,7 +627,7 @@ static int DetectUriSigTest02(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -672,7 +672,7 @@ static int DetectUriSigTest02(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -743,7 +743,7 @@ static int DetectUriSigTest03(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -812,7 +812,7 @@ static int DetectUriSigTest03(void)
     }
     SCMutexUnlock(&f.m);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1085,7 +1085,7 @@ static int DetectUriSigTest05(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     f.proto = p->proto;
 
     StreamTcpInitConfig(TRUE);
@@ -1144,7 +1144,7 @@ static int DetectUriSigTest05(void)
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1214,7 +1214,7 @@ static int DetectUriSigTest06(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
     f.proto = p->proto;
 
     StreamTcpInitConfig(TRUE);
@@ -1285,7 +1285,7 @@ static int DetectUriSigTest06(void)
    /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;
@@ -1350,7 +1350,7 @@ static int DetectUriSigTest07(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -1408,7 +1408,7 @@ static int DetectUriSigTest07(void)
     /* do detect */
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
 
-    http_state = f.alstate;
+    http_state = FlowGetAppState(&f);
     if (http_state == NULL) {
         printf("no http state: ");
         goto end;

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -605,7 +605,7 @@ static int DetectUrilenSigTest01(void)
     p->flowflags |= FLOW_PKT_TOSERVER;
     p->flowflags |= FLOW_PKT_ESTABLISHED;
     p->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
-    f.alproto = ALPROTO_HTTP;
+    FlowSetAppProtocol(&f, ALPROTO_HTTP);
 
     StreamTcpInitConfig(TRUE);
 
@@ -644,7 +644,7 @@ static int DetectUrilenSigTest01(void)
     }
     SCMutexUnlock(&f.m);
 
-    HtpState *htp_state = f.alstate;
+    HtpState *htp_state = FlowGetAppState(&f);
     if (htp_state == NULL) {
         SCLogDebug("no http state: ");
         goto end;

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -50,15 +50,18 @@
         FLOWLOCK_INIT((f)); \
         (f)->protoctx = NULL; \
         (f)->flow_end_flags = 0; \
-        (f)->alproto = 0; \
         (f)->alproto_ts = 0; \
         (f)->alproto_tc = 0; \
         (f)->data_al_so_far[0] = 0; \
         (f)->data_al_so_far[1] = 0; \
         (f)->de_ctx_id = 0; \
         (f)->thread_id = 0; \
-        (f)->alparser = NULL; \
-        (f)->alstate = NULL; \
+        (f)->applayer_index = 0; \
+        for (int i = 0; i < FLOW_ALPROTO_CHAINED_MAX; i++) { \
+            (f)->applayer[i].alproto = 0; \
+            (f)->applayer[i].alstate = NULL; \
+            (f)->applayer[i].alparser = NULL; \
+        } \
         (f)->de_state = NULL; \
         (f)->sgh_toserver = NULL; \
         (f)->sgh_toclient = NULL; \
@@ -92,9 +95,12 @@
         (f)->lastts.tv_usec = 0; \
         (f)->protoctx = NULL; \
         (f)->flow_end_flags = 0; \
-        (f)->alparser = NULL; \
-        (f)->alstate = NULL; \
-        (f)->alproto = 0; \
+        (f)->applayer_index = 0; \
+        for (int i = 0; i < FLOW_ALPROTO_CHAINED_MAX; i++) { \
+            (f)->applayer[i].alproto = 0; \
+            (f)->applayer[i].alstate = NULL; \
+            (f)->applayer[i].alparser = NULL; \
+        } \
         (f)->alproto_ts = 0; \
         (f)->alproto_tc = 0; \
         (f)->data_al_so_far[0] = 0; \

--- a/src/flow.c
+++ b/src/flow.c
@@ -860,12 +860,12 @@ int FlowSetProtoEmergencyTimeout(uint8_t proto, uint32_t emerg_new_timeout,
     return 1;
 }
 
-AppProto FlowGetAppProtocol(Flow *f)
+AppProto FlowGetAppProtocol(const Flow *f)
 {
     return f->alproto;
 }
 
-void *FlowGetAppState(Flow *f)
+void *FlowGetAppState(const Flow *f)
 {
     return f->alstate;
 }

--- a/src/flow.c
+++ b/src/flow.c
@@ -93,12 +93,20 @@ extern int run_mode;
 
 void FlowCleanupAppLayer(Flow *f)
 {
+    int i;
+
     if (f == NULL || f->proto == 0)
         return;
 
-    AppLayerParserStateCleanup(f->proto, f->alproto, f->alstate, f->alparser);
-    f->alstate = NULL;
-    f->alparser = NULL;
+    for (i = 0; i < FLOW_ALPROTO_CHAINED_MAX; i++) {
+        if (FLOW_GET_APPLAYER(f, i).alproto == 0)
+            break;
+        AppLayerParserStateCleanup(f->proto, FLOW_GET_APPLAYER(f, i).alproto,
+                FLOW_GET_APPLAYER(f, i).alstate,
+                FLOW_GET_APPLAYER(f, i).alparser);
+        FLOW_GET_APPLAYER(f, i).alstate = NULL;
+        FLOW_GET_APPLAYER(f, i).alparser = NULL;
+    }
     return;
 }
 
@@ -862,12 +870,32 @@ int FlowSetProtoEmergencyTimeout(uint8_t proto, uint32_t emerg_new_timeout,
 
 AppProto FlowGetAppProtocol(const Flow *f)
 {
-    return f->alproto;
+    return FLOW_GET_CURRENT_APPLAYER(f).alproto;
 }
 
 void *FlowGetAppState(const Flow *f)
 {
-    return f->alstate;
+    return FLOW_GET_CURRENT_APPLAYER(f).alstate;
+}
+
+AppLayerParserState *FlowGetAppParser(const Flow *f)
+{
+    return FLOW_GET_CURRENT_APPLAYER(f).alparser;
+}
+
+void FlowSetAppProtocol(Flow *f, AppProto proto)
+{
+    FLOW_GET_CURRENT_APPLAYER(f).alproto = proto;
+}
+
+void FlowSetAppState(Flow *f, void *state)
+{
+    FLOW_GET_CURRENT_APPLAYER(f).alstate = state;
+}
+
+void FlowSetAppParser(Flow *f, void *parser)
+{
+    FLOW_GET_CURRENT_APPLAYER(f).alparser = parser;
 }
 
 /************************************Unittests*******************************/

--- a/src/flow.h
+++ b/src/flow.h
@@ -104,6 +104,9 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_FILE_NO_SIZE_TS              (1 << 27)
 #define FLOW_FILE_NO_SIZE_TC              (1 << 28)
 
+#define FLOW_APPLAYER_RESET               (1 << 29)
+#define FLOW_APPLAYER_ACCOUNT             (1 << 30)
+
 #define FLOW_IS_IPV4(f) \
     (((f)->flags & FLOW_IPV4) == FLOW_IPV4)
 #define FLOW_IS_IPV6(f) \

--- a/src/flow.h
+++ b/src/flow.h
@@ -43,66 +43,66 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /* per flow flags */
 
 /** At least on packet from the source address was seen */
-#define FLOW_TO_SRC_SEEN                  0x00000001
+#define FLOW_TO_SRC_SEEN                  (1 << 0)
 /** At least on packet from the destination address was seen */
-#define FLOW_TO_DST_SEEN                  0x00000002
+#define FLOW_TO_DST_SEEN                  (1 << 1)
 /** Don't return this from the flow hash. It has been replaced. */
-#define FLOW_TCP_REUSED                   0x00000004
+#define FLOW_TCP_REUSED                   (1 << 2)
 /** no magic on files in this flow */
-#define FLOW_FILE_NO_MAGIC_TS             0x00000008
-#define FLOW_FILE_NO_MAGIC_TC             0x00000010
+#define FLOW_FILE_NO_MAGIC_TS             (1 << 3)
+#define FLOW_FILE_NO_MAGIC_TC             (1 << 4)
 
 /** Flow was inspected against IP-Only sigs in the toserver direction */
-#define FLOW_TOSERVER_IPONLY_SET          0x00000020
+#define FLOW_TOSERVER_IPONLY_SET          (1 << 5)
 /** Flow was inspected against IP-Only sigs in the toclient direction */
-#define FLOW_TOCLIENT_IPONLY_SET          0x00000040
+#define FLOW_TOCLIENT_IPONLY_SET          (1 << 6)
 
 /** Packet belonging to this flow should not be inspected at all */
-#define FLOW_NOPACKET_INSPECTION          0x00000080
+#define FLOW_NOPACKET_INSPECTION          (1 << 7)
 /** Packet payloads belonging to this flow should not be inspected */
-#define FLOW_NOPAYLOAD_INSPECTION         0x00000100
+#define FLOW_NOPAYLOAD_INSPECTION         (1 << 8)
 
 /** All packets in this flow should be dropped */
-#define FLOW_ACTION_DROP                  0x00000200
+#define FLOW_ACTION_DROP                  (1 << 9)
 
 /** Sgh for toserver direction set (even if it's NULL) */
-#define FLOW_SGH_TOSERVER                 0x00000800
+#define FLOW_SGH_TOSERVER                 (1 << 10)
 /** Sgh for toclient direction set (even if it's NULL) */
-#define FLOW_SGH_TOCLIENT                 0x00001000
+#define FLOW_SGH_TOCLIENT                 (1 << 11)
 
 /** packet to server direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOSERVER_DROP_LOGGED         0x00002000
+#define FLOW_TOSERVER_DROP_LOGGED         (1 << 12)
 /** packet to client direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOCLIENT_DROP_LOGGED         0x00004000
+#define FLOW_TOCLIENT_DROP_LOGGED         (1 << 13)
 /** alproto detect done.  Right now we need it only for udp */
-#define FLOW_ALPROTO_DETECT_DONE          0x00008000
-#define FLOW_NO_APPLAYER_INSPECTION       0x00010000
+#define FLOW_ALPROTO_DETECT_DONE          (1 << 14)
+#define FLOW_NO_APPLAYER_INSPECTION       (1 << 15)
 
 /** Pattern matcher alproto detection done */
-#define FLOW_TS_PM_ALPROTO_DETECT_DONE    0x00020000
+#define FLOW_TS_PM_ALPROTO_DETECT_DONE    (1 << 16)
 /** Probing parser alproto detection done */
-#define FLOW_TS_PP_ALPROTO_DETECT_DONE    0x00040000
+#define FLOW_TS_PP_ALPROTO_DETECT_DONE    (1 << 17)
 /** Pattern matcher alproto detection done */
-#define FLOW_TC_PM_ALPROTO_DETECT_DONE    0x00100000
+#define FLOW_TC_PM_ALPROTO_DETECT_DONE    (1 << 18)
 /** Probing parser alproto detection done */
-#define FLOW_TC_PP_ALPROTO_DETECT_DONE    0x00200000
-#define FLOW_TIMEOUT_REASSEMBLY_DONE      0x00800000
+#define FLOW_TC_PP_ALPROTO_DETECT_DONE    (1 << 19)
+#define FLOW_TIMEOUT_REASSEMBLY_DONE      (1 << 20)
 /** even if the flow has files, don't store 'm */
-#define FLOW_FILE_NO_STORE_TS             0x01000000
-#define FLOW_FILE_NO_STORE_TC             0x02000000
+#define FLOW_FILE_NO_STORE_TS             (1 << 21)
+#define FLOW_FILE_NO_STORE_TC             (1 << 22)
 
 /** flow is ipv4 */
-#define FLOW_IPV4                         0x04000000
+#define FLOW_IPV4                         (1 << 23)
 /** flow is ipv6 */
-#define FLOW_IPV6                         0x08000000
+#define FLOW_IPV6                         (1 << 24)
 
 /** no md5 on files in this flow */
-#define FLOW_FILE_NO_MD5_TS               0x10000000
-#define FLOW_FILE_NO_MD5_TC               0x20000000
+#define FLOW_FILE_NO_MD5_TS               (1 << 25)
+#define FLOW_FILE_NO_MD5_TC               (1 << 26)
 
 /** no size tracking of files in this flow */
-#define FLOW_FILE_NO_SIZE_TS              0x40000000
-#define FLOW_FILE_NO_SIZE_TC              0x80000000
+#define FLOW_FILE_NO_SIZE_TS              (1 << 27)
+#define FLOW_FILE_NO_SIZE_TC              (1 << 28)
 
 #define FLOW_IS_IPV4(f) \
     (((f)->flags & FLOW_IPV4) == FLOW_IPV4)
@@ -181,6 +181,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_END_FLAG_TIMEOUT           0x10
 #define FLOW_END_FLAG_FORCED            0x20
 #define FLOW_END_FLAG_SHUTDOWN          0x40
+
+#define FLOW_ALPROTO_CHAINED_MAX    3
 
 /** Mutex or RWLocks for the flow. */
 //#define FLOWLOCK_RWLOCK
@@ -278,6 +280,15 @@ typedef unsigned short FlowStateType;
 /** Local Thread ID */
 typedef uint16_t FlowThreadId;
 
+typedef struct FlowAppLayer_ {
+    AppProto alproto;
+    /** application level storage ptrs.
+     *
+     */
+    AppLayerParserState *alparser;     /**< parser internal state */
+    void *alstate;      /**< application layer state */
+} FlowAppLayer;
+
 /**
  *  \brief Flow data structure.
  *
@@ -332,6 +343,7 @@ typedef struct Flow_
     uint32_t probing_parser_toclient_alproto_masks;
 
     uint32_t flags;
+    /* coccinelle: Flow:flags:FLOW_ */
 
     /* time stamp of last update (last packet). Set/updated under the
      * flow and flow hash row locks, safe to read under either the
@@ -356,7 +368,8 @@ typedef struct Flow_
     uint8_t flow_end_flags;
     /* coccinelle: Flow:flow_end_flags:FLOW_END_FLAG_ */
 
-    AppProto alproto; /**< \brief application level protocol */
+    FlowAppLayer applayer[FLOW_ALPROTO_CHAINED_MAX];
+    uint8_t  applayer_index;
     AppProto alproto_ts;
     AppProto alproto_tc;
 
@@ -369,12 +382,6 @@ typedef struct Flow_
 
     /** Thread ID for the stream/detect portion of this flow */
     FlowThreadId thread_id;
-
-    /** application level storage ptrs.
-     *
-     */
-    AppLayerParserState *alparser;     /**< parser internal state */
-    void *alstate;      /**< application layer state */
 
     /** detection engine state */
     struct DetectEngineState_ *de_state;
@@ -412,6 +419,9 @@ enum {
     FLOW_STATE_ESTABLISHED,
     FLOW_STATE_CLOSED,
 };
+
+#define FLOW_GET_APPLAYER(f, i) (f)->applayer[(i)]
+#define FLOW_GET_CURRENT_APPLAYER(f) FLOW_GET_APPLAYER(f,(f)->applayer_index)
 
 typedef struct FlowProto_ {
     uint32_t new_timeout;
@@ -576,6 +586,10 @@ int FlowClearMemory(Flow *,uint8_t );
 
 AppProto FlowGetAppProtocol(const Flow *f);
 void *FlowGetAppState(const Flow *f);
+AppLayerParserState *FlowGetAppParser(const Flow *f);
+void FlowSetAppProtocol(Flow *f, AppProto proto);
+void FlowSetAppState(Flow *f, void *state);
+void FlowSetAppParser(Flow *f, void *parser);
 
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);

--- a/src/flow.h
+++ b/src/flow.h
@@ -574,8 +574,8 @@ static inline void FlowDeReference(Flow **d)
 
 int FlowClearMemory(Flow *,uint8_t );
 
-AppProto FlowGetAppProtocol(Flow *f);
-void *FlowGetAppState(Flow *f);
+AppProto FlowGetAppProtocol(const Flow *f);
+void *FlowGetAppState(const Flow *f);
 
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);

--- a/src/log-file.c
+++ b/src/log-file.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2007-2013 Open Information Security Foundation
+ * Copyright (C) 2014 European Commission
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -72,7 +73,7 @@ typedef struct LogFileLogThread_ {
 
 static void LogFileMetaGetUri(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -93,7 +94,7 @@ static void LogFileMetaGetUri(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFileMetaGetHost(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL && tx->request_hostname != NULL) {
@@ -108,7 +109,7 @@ static void LogFileMetaGetHost(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFileMetaGetReferer(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -128,7 +129,7 @@ static void LogFileMetaGetReferer(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFileMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -148,7 +149,7 @@ static void LogFileMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFileMetaGetSmtp(FILE *fp, const Packet *p, const File *ff)
 {
-    SMTPState *state = (SMTPState *) p->flow->alstate;
+    SMTPState *state = (SMTPState *) FlowGetAppState(p->flow);
     if (state != NULL) {
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, state, ff->txid);
         if (tx == NULL || tx->msg_tail == NULL)
@@ -261,7 +262,7 @@ static void LogFileWriteJsonRecord(LogFileLogThread *aft, const Packet *p, const
         fprintf(fp, "\"http_user_agent\": \"");
         LogFileMetaGetUserAgent(fp, p, ff);
         fprintf(fp, "\", ");
-    } else if (p->flow->alproto == ALPROTO_SMTP) {
+    } else if (FlowGetAppProtocol(p->flow) == ALPROTO_SMTP) {
         /* Only applicable to SMTP */
         LogFileMetaGetSmtp(fp, p, ff);
     }

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2007-2013 Open Information Security Foundation
+ * Copyright (C) 2014 European Commission
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -70,7 +71,7 @@ typedef struct LogFilestoreLogThread_ {
 
 static void LogFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -88,7 +89,7 @@ static void LogFilestoreMetaGetUri(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL && tx->request_hostname != NULL) {
@@ -103,7 +104,7 @@ static void LogFilestoreMetaGetHost(FILE *fp, const Packet *p, const File *ff)
 
 static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -123,7 +124,7 @@ static void LogFilestoreMetaGetReferer(FILE *fp, const Packet *p, const File *ff
 
 static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
         if (tx != NULL) {
@@ -143,7 +144,7 @@ static void LogFilestoreMetaGetUserAgent(FILE *fp, const Packet *p, const File *
 
 static void LogFilestoreMetaGetSmtp(FILE *fp, const Packet *p, const File *ff)
 {
-    SMTPState *state = (SMTPState *) p->flow->alstate;
+    SMTPState *state = (SMTPState *) FlowGetAppState(p->flow);
     if (state != NULL) {
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, state, ff->txid);
         if (tx == NULL || tx->msg_tail == NULL)
@@ -208,7 +209,7 @@ static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char 
         }
 
         /* Only applicable to HTTP traffic */
-        if (p->flow->alproto == ALPROTO_HTTP) {
+        if (FlowGetAppProtocol(p->flow) == ALPROTO_HTTP) {
             fprintf(fp, "HTTP URI:          ");
             LogFilestoreMetaGetUri(fp, p, ff);
             fprintf(fp, "\n");
@@ -221,7 +222,7 @@ static void LogFilestoreLogCreateMetaFile(const Packet *p, const File *ff, char 
             fprintf(fp, "HTTP USER AGENT:   ");
             LogFilestoreMetaGetUserAgent(fp, p, ff);
             fprintf(fp, "\n");
-        } else if (p->flow->alproto == ALPROTO_SMTP) {
+        } else if (FlowGetAppProtocol(p->flow) == ALPROTO_SMTP) {
             /* Only applicable to SMTP */
             LogFilestoreMetaGetSmtp(fp, p, ff);
         }

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -116,8 +116,10 @@ static TmEcode OutputFileLog(ThreadVars *tv, Packet *p, void *thread_data, Packe
     FLOWLOCK_WRLOCK(f); // < need write lock for FilePrune below
     file_trunc = StreamTcpReassembleDepthReached(p);
 
-    FileContainer *ffc = AppLayerParserGetFiles(p->proto, f->alproto,
-                                                f->alstate, flags);
+    FileContainer *ffc = AppLayerParserGetFiles(p->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                flags);
     SCLogDebug("ffc %p", ffc);
     if (ffc != NULL) {
         File *ff;

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -149,8 +149,10 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data, P
     FLOWLOCK_WRLOCK(f); // < need write lock for FiledataPrune below
     file_trunc = StreamTcpReassembleDepthReached(p);
 
-    FileContainer *ffc = AppLayerParserGetFiles(p->proto, f->alproto,
-                                                f->alstate, flags);
+    FileContainer *ffc = AppLayerParserGetFiles(p->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                flags);
     SCLogDebug("ffc %p", ffc);
     if (ffc != NULL) {
         File *ff;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -110,7 +110,7 @@ static void AlertJsonHttp(const Flow *f, json_t *js)
 {
     HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
-        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
+        uint64_t tx_id = AppLayerParserGetTransactionLogId(FlowGetAppParser(f));
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
 
         if (tx) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -108,7 +108,7 @@ static int AlertJsonPrintStreamSegmentCallback(const Packet *p, void *data, uint
  */
 static void AlertJsonHttp(const Flow *f, json_t *js)
 {
-    HtpState *htp_state = (HtpState *)f->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
         uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
@@ -130,7 +130,7 @@ static void AlertJsonHttp(const Flow *f, json_t *js)
 
 static void AlertJsonTls(const Flow *f, json_t *js)
 {
-    SSLState *ssl_state = (SSLState *)f->alstate;
+    SSLState *ssl_state = (SSLState *)FlowGetAppState(f);
     if (ssl_state) {
         json_t *tjs = json_object();
         if (unlikely(tjs == NULL))
@@ -147,7 +147,7 @@ static void AlertJsonTls(const Flow *f, json_t *js)
 
 static void AlertJsonSsh(const Flow *f, json_t *js)
 {
-    SshState *ssh_state = (SshState *)f->alstate;
+    SshState *ssh_state = (SshState *)FlowGetAppState(f);
     if (ssh_state) {
         json_t *tjs = json_object();
         if (unlikely(tjs == NULL))

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -76,7 +76,7 @@ typedef struct JsonFileLogThread_ {
 
 static json_t *LogFileMetaGetUri(const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     json_t *js = NULL;
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
@@ -99,7 +99,7 @@ static json_t *LogFileMetaGetUri(const Packet *p, const File *ff)
 
 static json_t *LogFileMetaGetHost(const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     json_t *js = NULL;
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
@@ -119,7 +119,7 @@ static json_t *LogFileMetaGetHost(const Packet *p, const File *ff)
 
 static json_t *LogFileMetaGetReferer(const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     json_t *js = NULL;
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
@@ -144,7 +144,7 @@ static json_t *LogFileMetaGetReferer(const Packet *p, const File *ff)
 
 static json_t *LogFileMetaGetUserAgent(const Packet *p, const File *ff)
 {
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
+    HtpState *htp_state = (HtpState *)FlowGetAppState(p->flow);
     json_t *js = NULL;
     if (htp_state != NULL) {
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
@@ -187,7 +187,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
         return;
     }
 
-    switch (p->flow->alproto) {
+    switch (FlowGetAppProtocol(p->flow)) {
         case ALPROTO_HTTP:
             json_object_set_new(hjs, "url", LogFileMetaGetUri(p, ff));
             json_object_set_new(hjs, "hostname", LogFileMetaGetHost(p, ff));

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -188,7 +188,8 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
         return;
     }
 
-    json_object_set_new(hjs, "app_proto", json_string(AppProtoToString(f->alproto)));
+    json_object_set_new(hjs, "app_proto",
+                        json_string(AppProtoToString(FlowGetAppProtocol(f))));
 
     json_object_set_new(hjs, "pkts_toserver",
             json_integer(f->todstpktcnt));

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -195,7 +195,7 @@ static void JsonNetFlowLogJSONToServer(JsonNetFlowLogThread *aft, json_t *js, Fl
     }
 
     json_object_set_new(hjs, "app_proto",
-            json_string(AppProtoToString(f->alproto_ts ? f->alproto_ts : f->alproto)));
+            json_string(AppProtoToString(f->alproto_ts ? f->alproto_ts : FlowGetAppProtocol(f))));
 
     json_object_set_new(hjs, "pkts",
             json_integer(f->todstpktcnt));
@@ -244,7 +244,7 @@ static void JsonNetFlowLogJSONToClient(JsonNetFlowLogThread *aft, json_t *js, Fl
     }
 
     json_object_set_new(hjs, "app_proto",
-            json_string(AppProtoToString(f->alproto_tc ? f->alproto_tc : f->alproto)));
+            json_string(AppProtoToString(f->alproto_tc ? f->alproto_tc : FlowGetAppProtocol(f))));
 
     json_object_set_new(hjs, "pkts",
             json_integer(f->tosrcpktcnt));

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -65,6 +65,31 @@ typedef struct JsonSshLogThread_ {
     MemBuffer *buffer;
 } JsonSshLogThread;
 
+
+void JsonSshLogJSON(json_t *tjs, SshState *ssh_state)
+{
+    json_t *cjs = json_object();
+    if (cjs != NULL) {
+        json_object_set_new(cjs, "proto_version",
+                json_string((char *)ssh_state->cli_hdr.proto_version));
+
+        json_object_set_new(cjs, "software_version",
+                json_string((char *)ssh_state->cli_hdr.software_version));
+    }
+    json_object_set_new(tjs, "client", cjs);
+
+    json_t *sjs = json_object();
+    if (sjs != NULL) {
+        json_object_set_new(sjs, "proto_version",
+                json_string((char *)ssh_state->srv_hdr.proto_version));
+
+        json_object_set_new(sjs, "software_version",
+                json_string((char *)ssh_state->srv_hdr.software_version));
+    }
+    json_object_set_new(tjs, "server", sjs);
+
+}
+
 static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 {
     JsonSshLogThread *aft = (JsonSshLogThread *)thread_data;
@@ -102,25 +127,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     /* reset */
     MemBufferReset(buffer);
 
-    json_t *cjs = json_object();
-    if (cjs != NULL) {
-        json_object_set_new(cjs, "proto_version",
-                json_string((char *)ssh_state->cli_hdr.proto_version));
-
-        json_object_set_new(cjs, "software_version",
-                json_string((char *)ssh_state->cli_hdr.software_version));
-    }
-    json_object_set_new(tjs, "client", cjs);
-
-    json_t *sjs = json_object();
-    if (sjs != NULL) {
-        json_object_set_new(sjs, "proto_version",
-                json_string((char *)ssh_state->srv_hdr.proto_version));
-
-        json_object_set_new(sjs, "software_version",
-                json_string((char *)ssh_state->srv_hdr.software_version));
-    }
-    json_object_set_new(tjs, "server", sjs);
+    JsonSshLogJSON(tjs, ssh_state);
 
     json_object_set_new(js, "ssh", tjs);
 

--- a/src/output-json-ssh.h
+++ b/src/output-json-ssh.h
@@ -26,4 +26,10 @@
 
 void TmModuleJsonSshLogRegister (void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-ssh.h"
+
+void JsonSshLogJSON(json_t *js, SshState *tx);
+#endif
+
 #endif /* __OUTPUT_JSON_SSH_H__ */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -72,7 +72,19 @@ typedef struct JsonTlsLogThread_ {
 
 #define SSL_VERSION_LENGTH 13
 
-static void LogTlsLogExtendedJSON(json_t *tjs, SSLState * state)
+void JsonTlsLogJSONBasic(json_t *js, SSLState *ssl_state)
+{
+    /* tls.subject */
+    json_object_set_new(js, "subject",
+                        json_string(ssl_state->server_connp.cert0_subject));
+
+    /* tls.issuerdn */
+    json_object_set_new(js, "issuerdn",
+                        json_string(ssl_state->server_connp.cert0_issuerdn));
+
+}
+
+void JsonTlsLogJSONExtended(json_t *tjs, SSLState * state)
 {
     char ssl_version[SSL_VERSION_LENGTH + 1];
 
@@ -145,16 +157,10 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     /* reset */
     MemBufferReset(buffer);
 
-    /* tls.subject */
-    json_object_set_new(tjs, "subject",
-                        json_string(ssl_state->server_connp.cert0_subject));
-
-    /* tls.issuerdn */
-    json_object_set_new(tjs, "issuerdn",
-                        json_string(ssl_state->server_connp.cert0_issuerdn));
+    JsonTlsLogJSONBasic(tjs, ssl_state);
 
     if (tls_ctx->flags & LOG_TLS_EXTENDED) {
-        LogTlsLogExtendedJSON(tjs, ssl_state);
+        JsonTlsLogJSONExtended(tjs, ssl_state);
     }
 
     json_object_set_new(js, "tls", tjs);

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -26,4 +26,11 @@
 
 void TmModuleJsonTlsLogRegister (void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-ssl.h"
+
+void JsonTlsLogJSONBasic(json_t *js, SSLState *ssl_state);
+void JsonTlsLogJSONExtended(json_t *js, SSLState *ssl_state);
+#endif /* HAVE_LIBJANSSON */
+
 #endif /* __OUTPUT_JSON_TLS_H__ */

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -130,8 +130,11 @@ static int LuaStreamingLogger(ThreadVars *tv, void *thread_data, const Flow *f,
     SCLogDebug("flags %02x", flags);
 
     if (flags & OUTPUT_STREAMING_FLAG_TRANSACTION) {
-        if (f && f->alstate)
-            txptr = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, tx_id);
+        if (f && FlowGetAppState(f))
+            txptr = AppLayerParserGetTx(f->proto,
+                                        FlowGetAppProtocol(f),
+                                        FlowGetAppState(f),
+                                        tx_id);
     }
 
     LogLuaThreadCtx *td = (LogLuaThreadCtx *)thread_data;
@@ -306,8 +309,10 @@ static int LuaFileLogger(ThreadVars *tv, void *thread_data, const Packet *p, con
     /* Get the TX so the script can get more context about it.
      * TODO hardcoded to HTTP currently */
     void *txptr = NULL;
-    if (p && p->flow && p->flow->alstate)
-        txptr = AppLayerParserGetTx(p->proto, ALPROTO_HTTP, p->flow->alstate, ff->txid);
+    if (p && p->flow && FlowGetAppState(p->flow))
+        txptr = AppLayerParserGetTx(p->proto, ALPROTO_HTTP,
+                                    FlowGetAppState(p->flow),
+                                    ff->txid);
 
     SCMutexLock(&td->lua_ctx->m);
 

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -6057,7 +6057,7 @@ static int StreamTcpReassembleTest38 (void)
     ssn.client.ra_raw_base_seq = ssn.client.ra_app_base_seq = 9;
     ssn.client.isn = 9;
     ssn.client.last_ack = 60;
-    f.alproto = ALPROTO_UNKNOWN;
+    FlowSetAppProtocol(&f, ALPROTO_UNKNOWN);
 
     f.flags |= FLOW_IPV4;
     f.sp = sp;
@@ -6167,7 +6167,7 @@ static int StreamTcpReassembleTest39 (void)
 
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6194,7 +6194,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6222,7 +6222,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6251,7 +6251,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6281,7 +6281,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6322,7 +6322,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_UNKNOWN ||
+        FlowGetAppProtocol(&f) != ALPROTO_UNKNOWN ||
         f.alproto_ts != ALPROTO_UNKNOWN ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6394,7 +6394,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_UNKNOWN ||
         f.data_al_so_far[0] != 0 ||
@@ -6423,7 +6423,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6452,7 +6452,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6480,7 +6480,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6508,7 +6508,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6538,7 +6538,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6568,7 +6568,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6597,7 +6597,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6627,7 +6627,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6670,7 +6670,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6697,7 +6697,7 @@ static int StreamTcpReassembleTest39 (void)
         goto end;
     if (!StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->server) ||
         !StreamTcpIsSetStreamFlagAppProtoDetectionCompleted(&ssn->client) ||
-        f.alproto != ALPROTO_HTTP ||
+        FlowGetAppProtocol(&f) != ALPROTO_HTTP ||
         f.alproto_ts != ALPROTO_HTTP ||
         f.alproto_tc != ALPROTO_HTTP ||
         f.data_al_so_far[0] != 0 ||
@@ -6911,7 +6911,7 @@ static int StreamTcpReassembleTest40 (void)
         goto end;
     }
 
-    if (f->alproto != ALPROTO_HTTP) {
+    if (FlowGetAppProtocol(f) != ALPROTO_HTTP) {
         printf("app layer proto has not been detected (18): ");
         goto end;
     }
@@ -7466,7 +7466,7 @@ static int StreamTcpReassembleTest47 (void)
         }
     }
 
-    if (f->alproto != ALPROTO_HTTP) {
+    if (FlowGetAppProtocol(f) != ALPROTO_HTTP) {
         printf("App layer protocol (HTTP) should have been detected\n");
         goto end;
     }

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -3012,6 +3012,11 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
             tmp_seg->flags &= ~SEGMENTTCP_FLAG_APPLAYER_PROCESSED;
             tmp_seg = tmp_seg->next;
         }
+        if (p->flow->flags & FLOW_APPLAYER_ACCOUNT) {
+            SCLogDebug("Updating ra app");
+            stream->ra_app_base_seq = rd.ra_base_seq;
+            p->flow->flags &= ~FLOW_APPLAYER_ACCOUNT;
+        }
     }
     SCLogDebug("stream->ra_app_base_seq %u", stream->ra_app_base_seq);
     SCReturnInt(0);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4453,7 +4453,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         }
 
         if (ssn != NULL)
-            SCLogDebug("ssn->alproto %"PRIu16"", p->flow->alproto);
+            SCLogDebug("ssn->alproto %"PRIu16"",
+                       FlowGetAppProtocol(p->flow));
     } else {
         /* special case for PKT_PSEUDO_STREAM_END packets:
          * bypass the state handling and various packet checks,
@@ -5971,7 +5972,7 @@ static int StreamTcpTest01 (void)
     }
     f.protoctx = ssn;
 
-    if (f.alparser != NULL) {
+    if (FlowGetAppParser(&f) != NULL) {
         printf("AppLayer field not set to NULL: ");
         goto end;
     }

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -689,7 +689,10 @@ void FileDisableStoring(Flow *f, uint8_t direction)
     else
         f->flags |= FLOW_FILE_NO_STORE_TC;
 
-    FileContainer *ffc = AppLayerParserGetFiles(f->proto, f->alproto, f->alstate, direction);
+    FileContainer *ffc = AppLayerParserGetFiles(f->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                direction);
     if (ffc != NULL) {
         for (ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
             /* if we're already storing, we'll continue */
@@ -721,7 +724,10 @@ void FileDisableMagic(Flow *f, uint8_t direction)
     else
         f->flags |= FLOW_FILE_NO_MAGIC_TC;
 
-    FileContainer *ffc = AppLayerParserGetFiles(f->proto, f->alproto, f->alstate, direction);
+    FileContainer *ffc = AppLayerParserGetFiles(f->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                direction);
     if (ffc != NULL) {
         for (ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
             SCLogDebug("disabling magic for file %p from direction %s",
@@ -752,7 +758,10 @@ void FileDisableMd5(Flow *f, uint8_t direction)
     else
         f->flags |= FLOW_FILE_NO_MD5_TC;
 
-    FileContainer *ffc = AppLayerParserGetFiles(f->proto, f->alproto, f->alstate, direction);
+    FileContainer *ffc = AppLayerParserGetFiles(f->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                direction);
     if (ffc != NULL) {
         for (ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
             SCLogDebug("disabling md5 for file %p from direction %s",
@@ -791,7 +800,10 @@ void FileDisableFilesize(Flow *f, uint8_t direction)
     else
         f->flags |= FLOW_FILE_NO_SIZE_TC;
 
-    FileContainer *ffc = AppLayerParserGetFiles(f->proto, f->alproto, f->alstate, direction);
+    FileContainer *ffc = AppLayerParserGetFiles(f->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                direction);
     if (ffc != NULL) {
         for (ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
             SCLogDebug("disabling size tracking for file %p from direction %s",
@@ -841,7 +853,10 @@ void FileDisableStoringForTransaction(Flow *f, uint8_t direction, uint64_t tx_id
 
     SCEnter();
 
-    FileContainer *ffc = AppLayerParserGetFiles(f->proto, f->alproto, f->alstate, direction);
+    FileContainer *ffc = AppLayerParserGetFiles(f->proto,
+                                                FlowGetAppProtocol(f),
+                                                FlowGetAppState(f),
+                                                direction);
     if (ffc != NULL) {
         for (ptr = ffc->head; ptr != NULL; ptr = ptr->next) {
             if (ptr->txid == tx_id) {

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -370,7 +370,7 @@ static int LuaCallbackTupleFlow(lua_State *luastate)
  */
 static int LuaCallbackAppLayerProtoPushToStackFromFlow(lua_State *luastate, const Flow *f)
 {
-    const char *string = AppProtoToString(f->alproto);
+    const char *string = AppProtoToString(FlowGetAppProtocol(f));
     if (string == NULL)
         string = "unknown";
     lua_pushstring(luastate, string);
@@ -759,10 +759,10 @@ int LuaStateNeedProto(lua_State *luastate, AppProto alproto)
 
     if (locked == LUA_FLOW_NOT_LOCKED_BY_PARENT) {
         FLOWLOCK_RDLOCK(flow);
-        flow_alproto = flow->alproto;
+        flow_alproto = FlowGetAppProtocol(flow);
         FLOWLOCK_UNLOCK(flow);
     } else {
-        flow_alproto = flow->alproto;
+        flow_alproto = FlowGetAppProtocol(flow);
     }
 
     return (alproto == flow_alproto);

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -57,8 +57,8 @@
         BUG_ON((f)->flags & FLOW_IPV4 &&            \
                (f)->flags & FLOW_IPV6);             \
         if ((f)->proto == IPPROTO_TCP) {            \
-            BUG_ON((f)->alstate != NULL &&          \
-                   (f)->alparser == NULL);          \
+            BUG_ON((FlowGetAppState(f) != NULL) &&          \
+                   FlowGetAppParser(f) == NULL);          \
         }                                           \
         SCMutexUnlock(&(f)->m);                     \
     }                                               \

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -106,6 +106,7 @@ outputs:
             # packet: yes            # enable dumping of packet (without stream segments)
             # http: yes              # enable dumping of http fields
             # tls: yes               # enable dumping of tls fields
+            # ssh: yes               # enable dumping of ssh fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -105,6 +105,7 @@ outputs:
             # payload-printable: yes # enable dumping payload in printable (lossy) format
             # packet: yes            # enable dumping of packet (without stream segments)
             # http: yes              # enable dumping of http fields
+            # tls: yes               # enable dumping of tls fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)


### PR DESCRIPTION
Here's a PR done to discuss the application layer renegotiation feature.

This code can not currently be merged for legal reason. It is owned by European Commission and the Commission has not yet signed a contribution agreement. This should be done soon but before that Stamus Networks (who wrote the code) has the authorization to make it public.

This code is providing application layer renegotiation. The idea is to be able to detect the protocol change that can occur in HTTP (via CONNECT message on a proxy) or SMTP (via STARTTLS). Currently Suricata is not able to get information on the second protocol. This patchset is implementing a series of mechanisms to permit a new protocol discovery when a CONNECT or a STARTTLS command is seen.

First the application layers information are now stored in an array. The patchset provides accessors and setters to be able to interact easily with the current application layer. Then, a function is provided so an application layer parser can ask for the switch to the next application layer.

This code is done on top of #1356 as this merged on top of this branch has to be done manually. This code is a rebase of #1321.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/46
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/44