### PR TITLE
Bug 1401: on midstream pickup, fix packet direction

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -913,6 +913,9 @@ static int StreamTcpPacketStateNone(ThreadVars *tv, Packet *p,
                     "SACK permitted for both sides", ssn);
         }
 
+        /* packet thinks it is in the wrong direction, flip it */
+        StreamTcpPacketSwitchDir(ssn, p);
+
     } else if (p->tcph->th_flags & TH_SYN) {
         if (ssn == NULL) {
             ssn = StreamTcpNewSession(p, stt->ssn_pool_id);


### PR DESCRIPTION
On midstream SYN/ACK pickups, we would flip the direction of packets
after the first. This meant the first (pickup) packet's direction
was wrong.

This patch fixes that.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/165
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/165

Ticket: https://redmine.openinfosecfoundation.org/issues/1401