### PR TITLE
tcp ssn reuse v3.0 20x v1.1

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -842,12 +842,19 @@ void AddressDebugPrint(Address *);
         (p)->flags |= PKT_NOPAYLOAD_INSPECTION;  \
     } while (0)
 
+#define DecodeUnsetNoPayloadInspectionFlag(p) do { \
+        (p)->flags &= ~PKT_NOPAYLOAD_INSPECTION;  \
+    } while (0)
+
 /** \brief Set the No packet inspection Flag for the packet.
  *
  * \param p Packet to set the flag in
  */
 #define DecodeSetNoPacketInspectionFlag(p) do { \
         (p)->flags |= PKT_NOPACKET_INSPECTION;  \
+    } while (0)
+#define DecodeUnsetNoPacketInspectionFlag(p) do { \
+        (p)->flags &= ~PKT_NOPACKET_INSPECTION;  \
     } while (0)
 
 

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -667,7 +667,8 @@ void EngineAnalysisRules(Signature *s, char *line)
                 }
                 DetectFlowData *fd = (DetectFlowData *)sm->ctx;
                 if (fd != NULL) {
-                    if (fd->flags & FLOW_PKT_NOSTREAM) rule_flow_nostream = 1;
+                    if (fd->flags & DETECT_FLOW_FLAG_NOSTREAM)
+                        rule_flow_nostream = 1;
                 }
             }
             else if (sm->type == DETECT_FLOWBITS) {

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -120,30 +120,28 @@ int DetectFlowMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, S
 
     if (p->flowflags & FLOW_PKT_ESTABLISHED) {
         SCLogDebug("FLOW_PKT_ESTABLISHED");
-    } else if (p->flowflags & FLOW_PKT_STATELESS) {
-        SCLogDebug("FLOW_PKT_STATELESS");
     }
 
     uint8_t cnt = 0;
     DetectFlowData *fd = (DetectFlowData *)m->ctx;
 
-    if ((fd->flags & FLOW_PKT_TOSERVER) && (p->flowflags & FLOW_PKT_TOSERVER)) {
+    if ((fd->flags & DETECT_FLOW_FLAG_TOSERVER) && (p->flowflags & FLOW_PKT_TOSERVER)) {
         cnt++;
-    } else if ((fd->flags & FLOW_PKT_TOCLIENT) && (p->flowflags & FLOW_PKT_TOCLIENT)) {
+    } else if ((fd->flags & DETECT_FLOW_FLAG_TOCLIENT) && (p->flowflags & FLOW_PKT_TOCLIENT)) {
         cnt++;
     }
 
-    if ((fd->flags & FLOW_PKT_ESTABLISHED) && (p->flowflags & FLOW_PKT_ESTABLISHED)) {
+    if ((fd->flags & DETECT_FLOW_FLAG_ESTABLISHED) && (p->flowflags & FLOW_PKT_ESTABLISHED)) {
         cnt++;
-    } else if (fd->flags & FLOW_PKT_STATELESS) {
+    } else if (fd->flags & DETECT_FLOW_FLAG_STATELESS) {
         cnt++;
     }
 
     if (det_ctx->flags & DETECT_ENGINE_THREAD_CTX_STREAM_CONTENT_MATCH) {
-        if (fd->flags & FLOW_PKT_ONLYSTREAM)
+        if (fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM)
             cnt++;
     } else {
-        if (fd->flags & FLOW_PKT_NOSTREAM)
+        if (fd->flags & DETECT_FLOW_FLAG_NOSTREAM)
             cnt++;
     }
 
@@ -213,59 +211,59 @@ DetectFlowData *DetectFlowParse (char *flowstr)
         if (args[i]) {
             /* inspect our options and set the flags */
             if (strcasecmp(args[i], "established") == 0) {
-                if (fd->flags & FLOW_PKT_ESTABLISHED) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "FLOW_PKT_ESTABLISHED flag is already set");
+                if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "DETECT_FLOW_FLAG_ESTABLISHED flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_STATELESS) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "FLOW_PKT_STATELESS already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_STATELESS) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "DETECT_FLOW_FLAG_STATELESS already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_ESTABLISHED;
+                fd->flags |= DETECT_FLOW_FLAG_ESTABLISHED;
             } else if (strcasecmp(args[i], "stateless") == 0) {
-                if (fd->flags & FLOW_PKT_STATELESS) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "FLOW_PKT_STATELESS flag is already set");
+                if (fd->flags & DETECT_FLOW_FLAG_STATELESS) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "DETECT_FLOW_FLAG_STATELESS flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_ESTABLISHED) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set FLOW_PKT_STATELESS, FLOW_PKT_ESTABLISHED already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set DETECT_FLOW_FLAG_STATELESS, DETECT_FLOW_FLAG_ESTABLISHED already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_STATELESS;
+                fd->flags |= DETECT_FLOW_FLAG_STATELESS;
             } else if (strcasecmp(args[i], "to_client") == 0 || strcasecmp(args[i], "from_server") == 0) {
-                if (fd->flags & FLOW_PKT_TOCLIENT) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set FLOW_PKT_TOCLIENT flag is already set");
+                if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set DETECT_FLOW_FLAG_TOCLIENT flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_TOSERVER) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set to_client, FLOW_PKT_TOSERVER already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set to_client, DETECT_FLOW_FLAG_TOSERVER already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_TOCLIENT;
+                fd->flags |= DETECT_FLOW_FLAG_TOCLIENT;
             } else if (strcasecmp(args[i], "to_server") == 0 || strcasecmp(args[i], "from_client") == 0){
-                if (fd->flags & FLOW_PKT_TOSERVER) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set FLOW_PKT_TOSERVER flag is already set");
+                if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set DETECT_FLOW_FLAG_TOSERVER flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_TOCLIENT) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set to_server, FLOW_PKT_TO_CLIENT flag already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set to_server, DETECT_FLOW_FLAG_TO_CLIENT flag already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_TOSERVER;
+                fd->flags |= DETECT_FLOW_FLAG_TOSERVER;
             } else if (strcasecmp(args[i], "only_stream") == 0) {
-                if (fd->flags & FLOW_PKT_ONLYSTREAM) {
+                if (fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM) {
                     SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set only_stream flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_NOSTREAM) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set only_stream flag, FLOW_PKT_NOSTREAM already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_NOSTREAM) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set only_stream flag, DETECT_FLOW_FLAG_NOSTREAM already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_ONLYSTREAM;
+                fd->flags |= DETECT_FLOW_FLAG_ONLYSTREAM;
             } else if (strcasecmp(args[i], "no_stream") == 0) {
-                if (fd->flags & FLOW_PKT_NOSTREAM) {
+                if (fd->flags & DETECT_FLOW_FLAG_NOSTREAM) {
                     SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set no_stream flag is already set");
                     goto error;
-                } else if (fd->flags & FLOW_PKT_ONLYSTREAM) {
-                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set no_stream flag, FLOW_PKT_ONLYSTREAM already set");
+                } else if (fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set no_stream flag, DETECT_FLOW_FLAG_ONLYSTREAM already set");
                     goto error;
                 }
-                fd->flags |= FLOW_PKT_NOSTREAM;
+                fd->flags |= DETECT_FLOW_FLAG_NOSTREAM;
             } else {
                 SCLogError(SC_ERR_INVALID_VALUE, "invalid flow option \"%s\"", args[i]);
                 goto error;
@@ -321,18 +319,18 @@ int DetectFlowSetup (DetectEngineCtx *de_ctx, Signature *s, char *flowstr)
     SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
 
     /* set the signature direction flags */
-    if (fd->flags & FLOW_PKT_TOSERVER) {
+    if (fd->flags & DETECT_FLOW_FLAG_TOSERVER) {
         s->flags |= SIG_FLAG_TOSERVER;
-    } else if (fd->flags & FLOW_PKT_TOCLIENT) {
+    } else if (fd->flags & DETECT_FLOW_FLAG_TOCLIENT) {
         s->flags |= SIG_FLAG_TOCLIENT;
     } else {
         s->flags |= SIG_FLAG_TOSERVER;
         s->flags |= SIG_FLAG_TOCLIENT;
     }
-    if (fd->flags & FLOW_PKT_ONLYSTREAM) {
+    if (fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM) {
         s->flags |= SIG_FLAG_REQUIRE_STREAM;
     }
-    if (fd->flags & FLOW_PKT_NOSTREAM) {
+    if (fd->flags & DETECT_FLOW_FLAG_NOSTREAM) {
         s->flags |= SIG_FLAG_REQUIRE_PACKET;
     } else {
         s->init_flags |= SIG_FLAG_INIT_FLOW;
@@ -385,10 +383,10 @@ int DetectFlowTestParse02 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_ESTABLISHED && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_ESTABLISHED && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -404,10 +402,10 @@ int DetectFlowTestParse03 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("stateless");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_STATELESS && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -423,10 +421,10 @@ int DetectFlowTestParse04 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOCLIENT && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOCLIENT, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -442,10 +440,10 @@ int DetectFlowTestParse05 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_server");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOSERVER && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOSERVER, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -461,10 +459,10 @@ int DetectFlowTestParse06 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOCLIENT && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOCLIENT, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -480,10 +478,10 @@ int DetectFlowTestParse07 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_client");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOSERVER && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOSERVER, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -499,10 +497,10 @@ int DetectFlowTestParse08 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established,to_client");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -518,10 +516,10 @@ int DetectFlowTestParse09 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client,stateless");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2) {
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -537,10 +535,10 @@ int DetectFlowTestParse10 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,stateless");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS  && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2){
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -556,10 +554,10 @@ int DetectFlowTestParse11 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse(" from_server , stateless ");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS  && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2){
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -591,10 +589,10 @@ int DetectFlowTestParseNocase02 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("ESTABLISHED");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_ESTABLISHED && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_ESTABLISHED && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -610,10 +608,10 @@ int DetectFlowTestParseNocase03 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("STATELESS");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_STATELESS && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -629,10 +627,10 @@ int DetectFlowTestParseNocase04 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_CLIENT");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOCLIENT && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOCLIENT, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -648,10 +646,10 @@ int DetectFlowTestParseNocase05 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_SERVER");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOSERVER && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOSERVER, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -667,10 +665,10 @@ int DetectFlowTestParseNocase06 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOCLIENT && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOCLIENT, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -686,10 +684,10 @@ int DetectFlowTestParseNocase07 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_CLIENT");
     if (fd != NULL) {
-        if (fd->flags == FLOW_PKT_TOSERVER && fd->match_cnt == 1) {
+        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_TOSERVER, 1, fd->flags, fd->match_cnt);
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -705,10 +703,10 @@ int DetectFlowTestParseNocase08 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("ESTABLISHED,TO_CLIENT");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -724,10 +722,10 @@ int DetectFlowTestParseNocase09 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_CLIENT,STATELESS");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2) {
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -743,10 +741,10 @@ int DetectFlowTestParseNocase10 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,STATELESS");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS  && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2){
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -762,10 +760,10 @@ int DetectFlowTestParseNocase11 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse(" FROM_SERVER , STATELESS ");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_STATELESS  && fd->flags & FLOW_PKT_TOCLIENT && fd->match_cnt == 2){
+        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
             result = 1;
         } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_STATELESS + FLOW_PKT_TOCLIENT, 2, fd->flags, fd->match_cnt);
+            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
     }
@@ -878,10 +876,10 @@ int DetectFlowTestParse18 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,established,only_stream");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->flags & FLOW_PKT_ONLYSTREAM && fd->match_cnt == 3) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM && fd->match_cnt == 3) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT + FLOW_PKT_ONLYSTREAM, 3,
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_ONLYSTREAM, 3,
                     fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
@@ -898,10 +896,10 @@ int DetectFlowTestParseNocase18 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,ESTABLISHED,ONLY_STREAM");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->flags & FLOW_PKT_ONLYSTREAM && fd->match_cnt == 3) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM && fd->match_cnt == 3) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT + FLOW_PKT_ONLYSTREAM, 3,
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_ONLYSTREAM, 3,
                     fd->flags, fd->match_cnt);
         }
         DetectFlowFree(fd);
@@ -935,10 +933,10 @@ int DetectFlowTestParse20 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,established,no_stream");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->flags & FLOW_PKT_NOSTREAM && fd->match_cnt == 3) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_NOSTREAM && fd->match_cnt == 3) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT + FLOW_PKT_NOSTREAM, 3,
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_NOSTREAM, 3,
                     fd->flags, fd->match_cnt);
         }
 
@@ -956,10 +954,10 @@ int DetectFlowTestParseNocase20 (void) {
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,ESTABLISHED,NO_STREAM");
     if (fd != NULL) {
-        if (fd->flags & FLOW_PKT_ESTABLISHED && fd->flags & FLOW_PKT_TOCLIENT && fd->flags & FLOW_PKT_NOSTREAM && fd->match_cnt == 3) {
+        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_NOSTREAM && fd->match_cnt == 3) {
             result = 1;
         } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", FLOW_PKT_ESTABLISHED + FLOW_PKT_TOCLIENT + FLOW_PKT_NOSTREAM, 3,
+            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_NOSTREAM, 3,
                     fd->flags, fd->match_cnt);
         }
 

--- a/src/detect-flow.h
+++ b/src/detect-flow.h
@@ -24,6 +24,13 @@
 #ifndef __DETECT_FLOW_H__
 #define __DETECT_FLOW_H__
 
+#define DETECT_FLOW_FLAG_TOSERVER       0x01
+#define DETECT_FLOW_FLAG_TOCLIENT       0x02
+#define DETECT_FLOW_FLAG_ESTABLISHED    0x04
+#define DETECT_FLOW_FLAG_STATELESS      0x08
+#define DETECT_FLOW_FLAG_ONLYSTREAM     0x10
+#define DETECT_FLOW_FLAG_NOSTREAM       0x20
+
 typedef struct DetectFlowData_ {
     uint8_t flags;     /* flags to match */
     uint8_t match_cnt; /* number of matches we need */

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -48,6 +48,7 @@ SC_ATOMIC_EXTERN(unsigned int, flow_prune_idx);
 SC_ATOMIC_EXTERN(unsigned int, flow_flags);
 
 static Flow *FlowGetUsedFlow(void);
+static int handle_tcp_reuse = 1;
 
 #ifdef FLOW_DEBUG_STATS
 #define FLOW_DEBUG_STATS_PROTO_ALL      0
@@ -143,6 +144,11 @@ void FlowHashDebugDeinit(void)
 #define FlowHashCountIncr
 
 #endif /* FLOW_DEBUG_STATS */
+
+void FlowDisableTcpReuseHandling(void)
+{
+    handle_tcp_reuse = 0;
+}
 
 /** \brief compare two raw ipv6 addrs
  *
@@ -401,14 +407,16 @@ static inline int FlowCompare(Flow *f, const Packet *p)
         if (f->flags & FLOW_TCP_REUSED)
             return 0;
 
-        /* lets see if we need to consider the existing session reuse */
-        if (unlikely(TcpSessionPacketSsnReuse(p, f, f->protoctx) == 1)) {
-            /* okay, we need to setup a new flow for this packet.
-             * Flag the flow that it's been replaced by a new one */
-            f->flags |= FLOW_TCP_REUSED;
-            SCLogDebug("flow obsolete: TCP reuse will use a new flow "
-                    "starting with packet %"PRIu64, p->pcap_cnt);
-            return 0;
+        if (handle_tcp_reuse == 1) {
+            /* lets see if we need to consider the existing session reuse */
+            if (unlikely(TcpSessionPacketSsnReuse(p, f, f->protoctx) == 1)) {
+                /* okay, we need to setup a new flow for this packet.
+                 * Flag the flow that it's been replaced by a new one */
+                f->flags |= FLOW_TCP_REUSED;
+                SCLogDebug("flow obsolete: TCP reuse will use a new flow "
+                        "starting with packet %"PRIu64, p->pcap_cnt);
+                return 0;
+            }
         }
         return 1;
     } else {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -386,10 +386,37 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
     return 0;
 }
 
+int TcpSessionPacketSsnReuse(const Packet *p, void *tcp_ssn);
+
 static inline int FlowCompare(Flow *f, const Packet *p)
 {
     if (p->proto == IPPROTO_ICMP) {
         return FlowCompareICMPv4(f, p);
+    } else if (p->proto == IPPROTO_TCP) {
+        if (CMP_FLOW(f, p) == 0)
+            return 0;
+
+        /* if this session is 'reused', we don't return it anymore,
+         * so return false on the compare */
+        if (f->flags & FLOW_TCP_REUSED)
+            return 0;
+
+        /* lets see if we need to consider the existing session for
+         * reuse: only considering SYN packets. */
+        int syn = (p->tcph && ((p->tcph->th_flags & TH_SYN) == TH_SYN));
+        int has_protoctx = ((f->protoctx != NULL));
+
+        /* syn on existing state, need to see if we need to 'reuse' */
+        if (unlikely(syn && has_protoctx && FlowGetPacketDirection(f,p) == TOSERVER)) {
+            if (unlikely(TcpSessionPacketSsnReuse(p, f->protoctx) == 1)) {
+                /* okay, we need to setup a new flow for this packet.
+                 * Flag the flow that it's been replaced by a new one */
+                f->flags |= FLOW_TCP_REUSED;
+                SCLogDebug("flow obsolete: TCP reuse will use a new flow");
+                return 0;
+            }
+        }
+        return 1;
     } else {
         return CMP_FLOW(f, p);
     }

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -386,7 +386,7 @@ static inline int FlowCompareICMPv4(Flow *f, const Packet *p)
     return 0;
 }
 
-int TcpSessionPacketSsnReuse(const Packet *p, void *tcp_ssn);
+int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, void *tcp_ssn);
 
 static inline int FlowCompare(Flow *f, const Packet *p)
 {
@@ -401,20 +401,13 @@ static inline int FlowCompare(Flow *f, const Packet *p)
         if (f->flags & FLOW_TCP_REUSED)
             return 0;
 
-        /* lets see if we need to consider the existing session for
-         * reuse: only considering SYN packets. */
-        int syn = (p->tcph && ((p->tcph->th_flags & TH_SYN) == TH_SYN));
-        int has_protoctx = ((f->protoctx != NULL));
-
-        /* syn on existing state, need to see if we need to 'reuse' */
-        if (unlikely(syn && has_protoctx && FlowGetPacketDirection(f,p) == TOSERVER)) {
-            if (unlikely(TcpSessionPacketSsnReuse(p, f->protoctx) == 1)) {
-                /* okay, we need to setup a new flow for this packet.
-                 * Flag the flow that it's been replaced by a new one */
-                f->flags |= FLOW_TCP_REUSED;
-                SCLogDebug("flow obsolete: TCP reuse will use a new flow");
-                return 0;
-            }
+        /* lets see if we need to consider the existing session reuse */
+        if (unlikely(TcpSessionPacketSsnReuse(p, f, f->protoctx) == 1)) {
+            /* okay, we need to setup a new flow for this packet.
+             * Flag the flow that it's been replaced by a new one */
+            f->flags |= FLOW_TCP_REUSED;
+            SCLogDebug("flow obsolete: TCP reuse will use a new flow");
+            return 0;
         }
         return 1;
     } else {

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -406,7 +406,8 @@ static inline int FlowCompare(Flow *f, const Packet *p)
             /* okay, we need to setup a new flow for this packet.
              * Flag the flow that it's been replaced by a new one */
             f->flags |= FLOW_TCP_REUSED;
-            SCLogDebug("flow obsolete: TCP reuse will use a new flow");
+            SCLogDebug("flow obsolete: TCP reuse will use a new flow "
+                    "starting with packet %"PRIu64, p->pcap_cnt);
             return 0;
         }
         return 1;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -500,7 +500,115 @@ static Flow *FlowGetNew(const Packet *p)
     return f;
 }
 
-/* FlowGetFlowFromHash
+Flow *FlowGetFlowFromHashByPacket(const Packet *p)
+{
+    Flow *f = NULL;
+
+    /* get the key to our bucket */
+    uint32_t key = FlowGetKey(p);
+    /* get our hash bucket and lock it */
+    FlowBucket *fb = &flow_hash[key];
+    FBLOCK_LOCK(fb);
+
+    SCLogDebug("fb %p fb->head %p", fb, fb->head);
+
+    f = FlowGetNew(p);
+    if (f != NULL) {
+        /* flow is locked */
+        if (fb->head == NULL) {
+            fb->head = f;
+            fb->tail = f;
+        } else {
+            f->hprev = fb->tail;
+            fb->tail->hnext = f;
+            fb->tail = f;
+        }
+
+        /* got one, now lock, initialize and return */
+        FlowInit(f, p);
+        f->fb = fb;
+    }
+    FBLOCK_UNLOCK(fb);
+    return f;
+}
+
+/** \brief Lookup flow based on packet
+ *
+ *  Find the flow belonging to this packet. If not found, no new flow
+ *  is set up.
+ *
+ *  \param p packet to lookup the flow for
+ *
+ *  \retval f flow or NULL if not found
+ */
+Flow *FlowLookupFlowFromHash(const Packet *p)
+{
+    Flow *f = NULL;
+
+    /* get the key to our bucket */
+    uint32_t key = FlowGetKey(p);
+    /* get our hash bucket and lock it */
+    FlowBucket *fb = &flow_hash[key];
+    FBLOCK_LOCK(fb);
+
+    SCLogDebug("fb %p fb->head %p", fb, fb->head);
+
+    /* see if the bucket already has a flow */
+    if (fb->head == NULL) {
+        FBLOCK_UNLOCK(fb);
+        return NULL;
+    }
+
+    /* ok, we have a flow in the bucket. Let's find out if it is our flow */
+    f = fb->head;
+
+    /* see if this is the flow we are looking for */
+    if (FlowCompare(f, p) == 0) {
+        while (f) {
+            FlowHashCountIncr;
+
+            f = f->hnext;
+
+            if (f == NULL) {
+                FBLOCK_UNLOCK(fb);
+                return NULL;
+            }
+
+            if (FlowCompare(f, p) != 0) {
+                /* we found our flow, lets put it on top of the
+                 * hash list -- this rewards active flows */
+                if (f->hnext) {
+                    f->hnext->hprev = f->hprev;
+                }
+                if (f->hprev) {
+                    f->hprev->hnext = f->hnext;
+                }
+                if (f == fb->tail) {
+                    fb->tail = f->hprev;
+                }
+
+                f->hnext = fb->head;
+                f->hprev = NULL;
+                fb->head->hprev = f;
+                fb->head = f;
+
+                /* found our flow, lock & return */
+                FLOWLOCK_WRLOCK(f);
+
+                FBLOCK_UNLOCK(fb);
+                return f;
+            }
+        }
+    }
+
+    /* lock & return */
+    FLOWLOCK_WRLOCK(f);
+
+    FBLOCK_UNLOCK(fb);
+    return f;
+}
+
+/** \brief Get Flow for packet
  *
  * Hash retrieval function for flows. Looks up the hash bucket containing the
  * flow pointer. Then compares the packet with the found flow to see if it is

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -70,6 +70,8 @@ typedef struct FlowBucket_ {
 
 Flow *FlowGetFlowFromHash(const Packet *);
 
+void FlowDisableTcpReuseHandling(void);
+
 /** enable to print stats on hash lookups in flow-debug.log */
 //#define FLOW_DEBUG_STATS
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -179,7 +179,7 @@ void FlowSetIPOnlyFlagNoLock(Flow *f, char direction)
  *  \retval 0 to_server
  *  \retval 1 to_client
  */
-int FlowGetPacketDirection(Flow *f, const Packet *p)
+int FlowGetPacketDirection(const Flow *f, const Packet *p)
 {
     if (p->proto == IPPROTO_TCP || p->proto == IPPROTO_UDP || p->proto == IPPROTO_SCTP) {
         if (!(CMP_PORT(p->sp,p->dp))) {

--- a/src/flow.c
+++ b/src/flow.c
@@ -233,6 +233,8 @@ static inline int FlowUpdateSeenFlag(const Packet *p)
  *
  *  \param f locked flow
  *  \param p packet
+ *
+ *  \note overwrites p::flowflags
  */
 void FlowHandlePacketUpdate(Flow *f, Packet *p)
 {
@@ -252,7 +254,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
 #ifdef DEBUG
         f->todstpktcnt++;
 #endif
-        p->flowflags |= FLOW_PKT_TOSERVER;
+        p->flowflags = FLOW_PKT_TOSERVER;
     } else {
         if (FlowUpdateSeenFlag(p)) {
             f->flags |= FLOW_TO_SRC_SEEN;
@@ -260,7 +262,7 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
 #ifdef DEBUG
         f->tosrcpktcnt++;
 #endif
-        p->flowflags |= FLOW_PKT_TOCLIENT;
+        p->flowflags = FLOW_PKT_TOCLIENT;
     }
 #ifdef DEBUG
     f->bytecnt += GET_PKT_LEN(p);

--- a/src/flow.h
+++ b/src/flow.h
@@ -419,7 +419,7 @@ static inline void FlowLockSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetSessionNoApplayerInspectionFlag(Flow *);
 
-int FlowGetPacketDirection(Flow *, const Packet *);
+int FlowGetPacketDirection(const Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -543,9 +543,11 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
-
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
+
+Flow *FlowGetFlowFromHashByPacket(const Packet *p);
+Flow *FlowLookupFlowFromHash(const Packet *p);
 
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -46,9 +46,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_TO_SRC_SEEN                  0x00000001
 /** At least on packet from the destination address was seen */
 #define FLOW_TO_DST_SEEN                  0x00000002
-
-// vacany 1x
-
+/** Don't return this from the flow hash. It has been replaced. */
+#define FLOW_TCP_REUSED                   0x00000004
 /** no magic on files in this flow */
 #define FLOW_FILE_NO_MAGIC_TS             0x00000008
 #define FLOW_FILE_NO_MAGIC_TC             0x00000010

--- a/src/flow.h
+++ b/src/flow.h
@@ -170,13 +170,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_PKT_TOSERVER               0x01
 #define FLOW_PKT_TOCLIENT               0x02
 #define FLOW_PKT_ESTABLISHED            0x04
-#define FLOW_PKT_STATELESS              0x08
-#define FLOW_PKT_TOSERVER_IPONLY_SET    0x10
-#define FLOW_PKT_TOCLIENT_IPONLY_SET    0x20
-/** \todo only used by flow keyword internally. */
-#define FLOW_PKT_NOSTREAM               0x40
-/** \todo only used by flow keyword internally. */
-#define FLOW_PKT_ONLYSTREAM             0x80
+#define FLOW_PKT_TOSERVER_IPONLY_SET    0x08
+#define FLOW_PKT_TOCLIENT_IPONLY_SET    0x10
 
 /** Mutex or RWLocks for the flow. */
 //#define FLOWLOCK_RWLOCK

--- a/src/flow.h
+++ b/src/flow.h
@@ -543,6 +543,8 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
+
+void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
 #endif /* __FLOW_H__ */

--- a/src/flow.h
+++ b/src/flow.h
@@ -543,7 +543,7 @@ int FlowClearMemory(Flow *,uint8_t );
 AppProto FlowGetAppProtocol(Flow *f);
 void *FlowGetAppState(Flow *f);
 
-
+void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -171,6 +171,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_PKT_ESTABLISHED            0x04
 #define FLOW_PKT_TOSERVER_IPONLY_SET    0x08
 #define FLOW_PKT_TOCLIENT_IPONLY_SET    0x10
+#define FLOW_PKT_TOSERVER_FIRST         0x20
+#define FLOW_PKT_TOCLIENT_FIRST         0x40
 
 /** Mutex or RWLocks for the flow. */
 //#define FLOWLOCK_RWLOCK

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -137,6 +137,7 @@ int RunModeErfFileAutoFp(DetectEngineCtx *de_ctx)
     int thread;
 
     RunModeInitialize();
+    RunmodeSetFlowStreamAsync();
 
     char *file = NULL;
     if (ConfGet("erf-file.file", &file) == 0) {

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -321,6 +321,7 @@ int RunModeFilePcapAutoFp(DetectEngineCtx *de_ctx)
     int thread;
 
     RunModeInitialize();
+    RunmodeSetFlowStreamAsync();
 
     char *file = NULL;
     if (ConfGet("pcap-file.file", &file) == 0) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4929,10 +4929,12 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
             if (p->flow == NULL)
                 return ret;
 
-            /* after that, check for 'new' reuse */
-            TcpSessionReuseHandle(p);
-            if (p->flow == NULL)
-                return ret;
+            if (!(p->flowflags & FLOW_PKT_TOSERVER_FIRST)) {
+                /* after that, check for 'new' reuse */
+                TcpSessionReuseHandle(p);
+                if (p->flow == NULL)
+                    return ret;
+            }
         }
     }
     AppLayerProfilingReset(stt->ra_ctx->app_tctx);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4680,9 +4680,6 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_no_flow = SCPerfTVRegisterCounter("tcp.no_flow", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");
-    stt->counter_tcp_reused_ssn = SCPerfTVRegisterCounter("tcp.reused_ssn", tv,
-                                                        SC_PERF_TYPE_UINT64,
-                                                        "NULL");
     stt->counter_tcp_memuse = SCPerfTVRegisterCounter("tcp.memuse", tv,
                                                         SC_PERF_TYPE_UINT64,
                                                         "NULL");

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4483,60 +4483,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
                 }
                 break;
             case TCP_CLOSED:
-                /* TCP session memory is not returned to pool until timeout.
-                 * If in the mean time we receive any other session from
-                 * the same client reusing same port then we switch back to
-                 * tcp state none, but only on a valid SYN that is not a
-                 * resend from our previous session.
-                 *
-                 * We also check it's not a SYN/ACK, all other SYN pkt
-                 * validation is done at StreamTcpPacketStateNone();
-                 */
-                if (PKT_IS_TOSERVER(p) && (p->tcph->th_flags & TH_SYN) &&
-                    !(p->tcph->th_flags & TH_ACK) &&
-                    !(SEQ_EQ(ssn->client.isn, TCP_GET_SEQ(p))))
-                {
-                    SCLogDebug("reusing closed TCP session");
-
-                    /* return segments */
-                    StreamTcpReturnStreamSegments(&ssn->client);
-                    StreamTcpReturnStreamSegments(&ssn->server);
-                    /* free SACK list */
-                    StreamTcpSackFreeList(&ssn->client);
-                    StreamTcpSackFreeList(&ssn->server);
-                    /* reset the app layer state */
-                    FlowCleanupAppLayer(p->flow);
-
-                    ssn->state = 0;
-                    ssn->flags = 0;
-                    ssn->client.flags = 0;
-                    ssn->server.flags = 0;
-
-                    /* set state the NONE, also pulls flow out of closed queue */
-                    StreamTcpPacketSetState(p, ssn, TCP_NONE);
-
-                    p->flow->alproto_ts = p->flow->alproto_tc = p->flow->alproto = ALPROTO_UNKNOWN;
-                    p->flow->data_al_so_far[0] = p->flow->data_al_so_far[1] = 0;
-                    ssn->data_first_seen_dir = 0;
-                    p->flow->flags &= (~FLOW_TS_PM_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TS_PP_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TC_PM_ALPROTO_DETECT_DONE &
-                                       ~FLOW_TC_PP_ALPROTO_DETECT_DONE);
-                    p->flow->flags &= ~ FLOW_NO_APPLAYER_INSPECTION;
-                    if (p->flow->de_state != NULL) {
-                        SCMutexLock(&p->flow->de_state_m);
-                        DetectEngineStateReset(p->flow->de_state, (STREAM_TOSERVER | STREAM_TOCLIENT));
-                        SCMutexUnlock(&p->flow->de_state_m);
-                    }
-
-                    if (StreamTcpPacketStateNone(tv,p,stt,ssn, &stt->pseudo_queue)) {
-                        goto error;
-                    }
-
-                    SCPerfCounterIncr(stt->counter_tcp_reused_ssn, tv->sc_perf_pca);
-                } else {
-                    SCLogDebug("packet received on closed state");
-                }
+                /* TCP session memory is not returned to pool until timeout. */
+                SCLogDebug("packet received on closed state");
                 break;
             default:
                 SCLogDebug("packet received on default state");

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4353,6 +4353,17 @@ static int StreamTcpPacketIsBadWindowUpdate(TcpSession *ssn, Packet *p)
     return 0;
 }
 
+int TcpSessionPacketSsnReuse(const Packet *p, void *tcp_ssn)
+{
+    TcpSession *ssn = tcp_ssn;
+    if (ssn->state == TCP_CLOSED) {
+        if(!(SEQ_EQ(ssn->client.isn, TCP_GET_SEQ(p))))
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
 
 /* flow is and stays locked */
 int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4619,6 +4619,209 @@ static inline int StreamTcpValidateChecksum(Packet *p)
     return ret;
 }
 
+/** \internal
+ *  \brief check if a packet is a valid stream started
+ *  \retval bool true/false */
+static int TcpSessionPacketIsStreamStarter(const Packet *p)
+{
+    uint8_t flag = TH_SYN;
+
+    //SCLogInfo("Want: %02x, have %02x", flag, p->tcph->th_flags);
+
+    if (p->tcph->th_flags == flag) {
+        SCLogDebug("packet %"PRIu64" is a stream starter: %02x", p->pcap_cnt, p->tcph->th_flags);
+        return 1;
+    }
+    return 0;
+}
+
+/** \internal
+ *  \brief Check if Flow and TCP SSN allow this flow/tuple to be reused
+ *  \retval bool true yes reuse, false no keep tracking old ssn */
+int TcpSessionReuseDoneEnough(Packet *p, const TcpSession *ssn)
+{
+    if (FlowGetPacketDirection(p->flow, p) == TOSERVER) {
+        if (ssn == NULL) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p null. No reuse.", p->pcap_cnt, ssn);
+            return 0;
+        }
+        if (SEQ_EQ(ssn->client.isn, TCP_GET_SEQ(p))) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p. Packet SEQ == Stream ISN. Retransmission. Don't reuse.", p->pcap_cnt, ssn);
+            return 0;
+        }
+        if (ssn->state >= TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state >= TCP_LAST_ACK (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state == TCP_NONE) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state == TCP_NONE (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state < TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state < TCP_LAST_ACK (%u). Don't reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 0;
+        }
+
+    } else {
+        if (ssn == NULL) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p null. Reuse.", p->pcap_cnt, ssn);
+            return 1;
+        }
+        if (ssn->state >= TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state >= TCP_LAST_ACK (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state == TCP_NONE) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state == TCP_NONE (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state < TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state < TCP_LAST_ACK (%u). Don't reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 0;
+        }
+    }
+
+
+    SCLogDebug("default: how did we get here?");
+    return 0;
+}
+
+/** \brief Handle TCP reuse of tuple
+ *
+ *  Logic:
+ *  1. see if packet could trigger a new session
+ *  2. see if the flow/ssn is in a state where we want to support the reuse
+ *  3. disconnect packet from the old flow
+ *  -> at this point new packets can still find the old flow
+ *  -> as the flow's reference count != 0, it can't disappear
+ *  4. setup a new flow unconditionally
+ *  5. attach packet to new flow
+ *  6. tag old flow as FLOW_TCP_REUSED
+ *  -> NEW packets won't find it
+ *  -> existing packets in our queues may still reference it
+ *  7. dereference the old flow (reference cnt *may* now be 0,
+ *     if no other packets reference it)
+ *
+ *  The packets that still hold a reference to the old flow are updated
+ *  by HandleFlowReuseApplyToPacket()
+ */
+static void TcpSessionReuseHandle(Packet *p) {
+    if (likely(TcpSessionPacketIsStreamStarter(p) == 0))
+        return;
+
+    int reuse = 0;
+    FLOWLOCK_RDLOCK(p->flow);
+    reuse = TcpSessionReuseDoneEnough(p, p->flow->protoctx);
+    if (!reuse) {
+        SCLogDebug("steam starter packet %"PRIu64", but state not "
+                   "ready to be reused", p->pcap_cnt);
+        FLOWLOCK_UNLOCK(p->flow);
+        return;
+    }
+
+    /* ok, this packet needs a new flow */
+
+    /* first, get a reference to the old flow */
+    Flow *old_f = NULL;
+    FlowReference(&old_f, p->flow);
+
+    /* get some settings that we move over to the new flow */
+    int autofp_tmqh_flow_qid = SC_ATOMIC_GET(old_f->autofp_tmqh_flow_qid);
+
+    /* disconnect the packet from the old flow */
+    FlowHandlePacketUpdateRemove(p->flow, p);
+    FLOWLOCK_UNLOCK(p->flow);
+    FlowDeReference(&p->flow); // < can't disappear while usecnt >0
+
+    /* Can't tag flow as reused yet, would be a race condition:
+     * new packets will not get old flow because of FLOW_TCP_REUSED,
+     * so new flow may be created. This new flow could be handled in
+     * a different thread. */
+
+    /* Get a flow. It will be either a locked flow or NULL */
+    Flow *new_f = FlowGetFlowFromHashByPacket(p);
+    if (new_f == NULL) {
+        FlowDeReference(&old_f); // < can't disappear while usecnt >0
+        return;
+    }
+
+    /* update flow and packet */
+    FlowHandlePacketUpdate(new_f, p);
+    BUG_ON(new_f != p->flow);
+
+    /* copy flow balancing settings */
+    SC_ATOMIC_SET(new_f->autofp_tmqh_flow_qid, autofp_tmqh_flow_qid);
+
+    FLOWLOCK_UNLOCK(new_f);
+
+    /* tag original flow that it's now unused */
+    FLOWLOCK_WRLOCK(old_f);
+    SCLogDebug("old flow %p tagged with FLOW_TCP_REUSED by packet %"PRIu64"!", old_f, p->pcap_cnt);
+    old_f->flags |= FLOW_TCP_REUSED;
+    FLOWLOCK_UNLOCK(old_f);
+    FlowDeReference(&old_f); // < can't disappear while usecnt >0
+
+    SCLogDebug("new flow %p set up for packet %"PRIu64"!", p->flow, p->pcap_cnt);
+}
+
+/** \brief Handle packets that reference the wrong flow because of TCP reuse
+ *
+ *  In the case of TCP reuse we can have many packets that were assigned
+ *  a flow by the capture/decode threads before the stream engine decided
+ *  that a new flow was needed for these packets.
+ *  When HandleFlowReuse creates a new flow, the packets already processed
+ *  by the flow engine will still reference the old flow.
+ *
+ *  This function detects this case and replaces the flow for those packets.
+ *  It's a fairly expensive operation, but it should be rare as it's only
+ *  done for packets that were already in the engine when the TCP reuse
+ *  case was handled. New packets are assigned the correct flow by the
+ *  flow engine.
+ */
+static void TcpSessionReuseHandleApplyToPacket(Packet *p)
+{
+    int need_flow_replace = 0;
+
+    FLOWLOCK_WRLOCK(p->flow);
+    if (p->flow->flags & FLOW_TCP_REUSED) {
+        SCLogDebug("packet %"PRIu64" attached to outdated flow and ssn", p->pcap_cnt);
+        need_flow_replace = 1;
+    }
+
+    if (likely(need_flow_replace == 0)) {
+        /* Work around a race condition: if HandleFlowReuse has inserted a new flow,
+         * it will not have seen both sides of the session yet. The packet we have here
+         * may be the first that got the flow directly from the hash right after the
+         * flow was added. In this case it won't have FLOW_PKT_ESTABLISHED flag set. */
+        if ((p->flow->flags & FLOW_TO_DST_SEEN) && (p->flow->flags & FLOW_TO_SRC_SEEN)) {
+            p->flowflags |= FLOW_PKT_ESTABLISHED;
+            SCLogDebug("packet %"PRIu64" / flow %p: p->flowflags |= FLOW_PKT_ESTABLISHED (%u/%u)", p->pcap_cnt, p->flow, p->flow->todstpktcnt, p->flow->tosrcpktcnt);
+        } else {
+            SCLogDebug("packet %"PRIu64" / flow %p: p->flowflags NOT FLOW_PKT_ESTABLISHED (%u/%u)", p->pcap_cnt, p->flow, p->flow->todstpktcnt, p->flow->tosrcpktcnt);
+        }
+        SCLogDebug("packet %"PRIu64" attached to regular flow %p and ssn", p->pcap_cnt, p->flow);
+        FLOWLOCK_UNLOCK(p->flow);
+        return;
+    }
+
+    /* disconnect packet from old flow */
+    FlowHandlePacketUpdateRemove(p->flow, p);
+    FLOWLOCK_UNLOCK(p->flow);
+    FlowDeReference(&p->flow); // < can't disappear while usecnt >0
+
+    /* find the new flow that does belong to this packet */
+    Flow *new_f = FlowLookupFlowFromHash(p);
+    if (new_f == NULL) {
+        // TODO reset packet flag wrt flow: direction, HAS_FLOW etc
+        p->flags &= ~PKT_HAS_FLOW;
+        return;
+    }
+    FlowHandlePacketUpdate(new_f, p);
+    BUG_ON(new_f != p->flow);
+    FLOWLOCK_UNLOCK(new_f);
+    SCLogDebug("packet %"PRIu64" switched over to new flow %p!", p->pcap_cnt, p->flow);
+}
+
 TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq)
 {
     StreamTcpThread *stt = (StreamTcpThread *)data;
@@ -4639,6 +4842,20 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
         }
     } else {
         p->flags |= PKT_IGNORE_CHECKSUM;
+    }
+
+// TODO autofp only somehow
+    /* "autofp" handling of TCP session/flow reuse */
+    if (!(p->flags & PKT_PSEUDO_STREAM_END)) {
+        /* apply previous reuses to this packet */
+        TcpSessionReuseHandleApplyToPacket(p);
+        if (p->flow == NULL)
+            return ret;
+
+        /* after that, check for 'new' reuse */
+        TcpSessionReuseHandle(p);
+        if (p->flow == NULL)
+            return ret;
     }
 
     AppLayerProfilingReset(stt->ra_ctx->app_tctx);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4612,13 +4612,16 @@ static inline int StreamTcpValidateChecksum(Packet *p)
  *  \retval bool true/false */
 static int TcpSessionPacketIsStreamStarter(const Packet *p)
 {
-    uint8_t flag = TH_SYN;
-
-    //SCLogInfo("Want: %02x, have %02x", flag, p->tcph->th_flags);
-
-    if (p->tcph->th_flags == flag) {
+    if (p->tcph->th_flags == TH_SYN) {
         SCLogDebug("packet %"PRIu64" is a stream starter: %02x", p->pcap_cnt, p->tcph->th_flags);
         return 1;
+    }
+
+    if (stream_config.midstream == TRUE || stream_config.async_oneside == TRUE) {
+        if (p->tcph->th_flags == (TH_SYN|TH_ACK)) {
+            SCLogDebug("packet %"PRIu64" is a midstream stream starter: %02x", p->pcap_cnt, p->tcph->th_flags);
+            return 1;
+        }
     }
     return 0;
 }
@@ -4626,7 +4629,7 @@ static int TcpSessionPacketIsStreamStarter(const Packet *p)
 /** \internal
  *  \brief Check if Flow and TCP SSN allow this flow/tuple to be reused
  *  \retval bool true yes reuse, false no keep tracking old ssn */
-int TcpSessionReuseDoneEnough(const Packet *p, const Flow *f, const TcpSession *ssn)
+static int TcpSessionReuseDoneEnoughSyn(const Packet *p, const Flow *f, const TcpSession *ssn)
 {
     if (FlowGetPacketDirection(f, p) == TOSERVER) {
         if (ssn == NULL) {
@@ -4670,6 +4673,77 @@ int TcpSessionReuseDoneEnough(const Packet *p, const Flow *f, const TcpSession *
     }
 
     SCLogDebug("default: how did we get here?");
+    return 0;
+}
+
+/** \internal
+ *  \brief check if ssn is done enough for reuse by syn/ack
+ *  \note should only be called if midstream is enabled
+ */
+static int TcpSessionReuseDoneEnoughSynAck(const Packet *p, const Flow *f, const TcpSession *ssn)
+{
+    if (FlowGetPacketDirection(f, p) == TOCLIENT) {
+        if (ssn == NULL) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p null. No reuse.", p->pcap_cnt, ssn);
+            return 0;
+        }
+        if (SEQ_EQ(ssn->server.isn, TCP_GET_SEQ(p))) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p. Packet SEQ == Stream ISN. Retransmission. Don't reuse.", p->pcap_cnt, ssn);
+            return 0;
+        }
+        if (ssn->state >= TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state >= TCP_LAST_ACK (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state == TCP_NONE) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state == TCP_NONE (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state < TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state < TCP_LAST_ACK (%u). Don't reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 0;
+        }
+
+    } else {
+        if (ssn == NULL) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p null. Reuse.", p->pcap_cnt, ssn);
+            return 1;
+        }
+        if (ssn->state >= TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state >= TCP_LAST_ACK (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state == TCP_NONE) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state == TCP_NONE (%u). Reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 1;
+        }
+        if (ssn->state < TCP_LAST_ACK) {
+            SCLogDebug("steam starter packet %"PRIu64", ssn %p state < TCP_LAST_ACK (%u). Don't reuse.", p->pcap_cnt, ssn, ssn->state);
+            return 0;
+        }
+    }
+
+    SCLogDebug("default: how did we get here?");
+    return 0;
+}
+
+/** \brief Check if SSN is done enough for reuse
+ *
+ *  Reuse means a new TCP session reuses the tuple (flow in suri)
+ *
+ *  \retval bool true if ssn can be reused, false if not */
+int TcpSessionReuseDoneEnough(const Packet *p, const Flow *f, const TcpSession *ssn)
+{
+    if (p->tcph->th_flags == TH_SYN) {
+        return TcpSessionReuseDoneEnoughSyn(p, f, ssn);
+    }
+
+    if (stream_config.midstream == TRUE || stream_config.async_oneside == TRUE) {
+        if (p->tcph->th_flags == (TH_SYN|TH_ACK)) {
+            return TcpSessionReuseDoneEnoughSynAck(p, f, ssn);
+        }
+    }
+
     return 0;
 }
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -73,6 +73,10 @@ typedef struct TcpStreamCnf_ {
 typedef struct StreamTcpThread_ {
     int ssn_pool_id;
 
+    /** if set to true, we activate the TCP tuple reuse code in the
+     *  stream engine. */
+    int runmode_flow_stream_async;
+
     uint64_t pkts;
 
     /** queue for pseudo packet(s) that were created in the stream

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -165,9 +165,19 @@ static inline void StreamTcpPacketSwitchDir(TcpSession *ssn, Packet *p)
     if (PKT_IS_TOSERVER(p)) {
         p->flowflags &= ~FLOW_PKT_TOSERVER;
         p->flowflags |= FLOW_PKT_TOCLIENT;
+
+        if (p->flowflags & FLOW_PKT_TOSERVER_FIRST) {
+            p->flowflags &= ~FLOW_PKT_TOSERVER_FIRST;
+            p->flowflags |= FLOW_PKT_TOCLIENT_FIRST;
+        }
     } else {
         p->flowflags &= ~FLOW_PKT_TOCLIENT;
         p->flowflags |= FLOW_PKT_TOSERVER;
+
+        if (p->flowflags & FLOW_PKT_TOCLIENT_FIRST) {
+            p->flowflags &= ~FLOW_PKT_TOCLIENT_FIRST;
+            p->flowflags |= FLOW_PKT_TOSERVER_FIRST;
+        }
     }
 }
 

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -47,6 +47,20 @@
 
 #include "util-runmodes.h"
 
+/** set to true if flow engine and stream engine run in different
+ *  threads. */
+static int runmode_flow_stream_async = 0;
+
+void RunmodeSetFlowStreamAsync(void)
+{
+    runmode_flow_stream_async = 1;
+}
+
+int RunmodeGetFlowStreamAsync(void)
+{
+    return runmode_flow_stream_async;
+}
+
 int RunModeSetLiveCaptureAuto(DetectEngineCtx *de_ctx,
                               ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
@@ -65,6 +79,8 @@ int RunModeSetLiveCaptureAuto(DetectEngineCtx *de_ctx,
         SCLogError(SC_ERR_RUNMODE, "can't use runmode 'auto' when detection is disabled");
         return -1;
     }
+
+    RunmodeSetFlowStreamAsync();
 
     if ((nlive <= 1) && (live_dev != NULL)) {
         void *aconf;
@@ -345,6 +361,8 @@ int RunModeSetLiveCaptureAutoFp(DetectEngineCtx *de_ctx,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+
+    RunmodeSetFlowStreamAsync();
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -941,6 +959,8 @@ int RunModeSetIPSAutoFp(DetectEngineCtx *de_ctx,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+
+    RunmodeSetFlowStreamAsync();
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -47,6 +47,8 @@
 
 #include "util-runmodes.h"
 
+#include "flow-hash.h"
+
 /** set to true if flow engine and stream engine run in different
  *  threads. */
 static int runmode_flow_stream_async = 0;
@@ -54,6 +56,7 @@ static int runmode_flow_stream_async = 0;
 void RunmodeSetFlowStreamAsync(void)
 {
     runmode_flow_stream_async = 1;
+    FlowDisableTcpReuseHandling();
 }
 
 int RunmodeGetFlowStreamAsync(void)

--- a/src/util-runmodes.h
+++ b/src/util-runmodes.h
@@ -23,6 +23,8 @@
 #ifndef __UTIL_RUNMODES_H__
 #define __UTIL_RUNMODES_H__
 
+void RunmodeSetFlowStreamAsync(void);
+int RunmodeGetFlowStreamAsync(void);
 
 typedef void *(*ConfigIfaceParserFunc) (const char *);
 typedef void *(*ConfigIPSParserFunc) (int);


### PR DESCRIPTION
Backport of https://github.com/inliniac/suricata/pull/1342

Not entirely sure if I want this to go into 2.0.x. It's an intrusive branch, but it does improve accuracy for TCP reuse cases significantly.

Prscript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/167
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/167