### PR TITLE
(2.0.x) Fix alert-debuglog file rotation - v1

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -319,8 +319,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     }
 
     SCMutexLock(&aft->file_ctx->fp_mutex);
-    (void)MemBufferPrintToFPAsString(aft->buffer, aft->file_ctx->fp);
-    fflush(aft->file_ctx->fp);
+    aft->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
+        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx);
     aft->file_ctx->alerts += p->alerts.cnt;
     SCMutexUnlock(&aft->file_ctx->fp_mutex);
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -246,9 +246,10 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
 
     fclose(log_ctx->fp);
 
-    /* Reopen the file.  In this case do not append like may have been
-     * done on the initial opening of the file. */
-    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "no");
+    /* Reopen the file. Append is forced in case the file was not
+     * moved as part of a rotation process. */
+    SCLogDebug("Reopening log file %s.", log_ctx->filename);
+    log_ctx->fp = SCLogOpenFileFp(log_ctx->filename, "yes");
     if (log_ctx->fp == NULL) {
         return -1; // Already logged by Open..Fp routine.
     }


### PR DESCRIPTION
As found by @norg:

The alert-debuglog writer for non-decoder events was writing directly to the log file so the write wrapper was not checking for file rotation like it would in the decoder event case.

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/45
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/44

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1404