### PR TITLE
Duplicate rule ID.

### DIFF
--- a/rules/files.rules
+++ b/rules/files.rules
@@ -26,7 +26,7 @@
 
 # Store all JPG files, don't alert.
 #alert http any any -> any any (msg:"FILE magic"; filemagic:"JFIF"; filestore; noalert; sid:16; rev:1;)
-#alert http any any -> any any (msg:"FILE magic"; filemagic:"GIF"; filestore; noalert; sid:16; rev:1;)
+#alert http any any -> any any (msg:"FILE magic"; filemagic:"GIF"; filestore; noalert; sid:23; rev:1;)
 #alert http any any -> any any (msg:"FILE magic"; filemagic:"PNG"; filestore; noalert; sid:17; rev:1;)
 
 # Store all Windows executables


### PR DESCRIPTION
2 rules in file.rules were using sid 16.  Giving the second sid 16 a new SID of 23 which doesn't appear to conflict with anything included in Suricata and ET open.