### PR TITLE
ParseSizeString - don't abort on unknown unit type - v1.

### DIFF
--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -125,8 +125,9 @@ static int ParseSizeString(const char *size, double *res)
         } else if (strcasecmp(str2, "gb") == 0) {
             *res *= 1024 * 1024 * 1024;
         } else {
-            /* not possible */
-            BUG_ON(1);
+            /* Bad unit. */
+            retval = -1;
+            goto end;
         }
     }
 
@@ -1115,6 +1116,11 @@ int UtilMiscParseSizeStringTest01(void)
         goto error;
     }
     if (result != 10.5 * 1024 * 1024 * 1024) {
+        goto error;
+    }
+
+    /* Should fail on unknown units. */
+    if (ParseSizeString("32eb", &result) > 0) {
         goto error;
     }
 


### PR DESCRIPTION
When ParseSizeString encounters a unit it does not now, just fail the function, don't abort.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/66
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/67
