### PR TITLE
Address sanitizer fixups - v2.

### DIFF
--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -69,7 +69,7 @@ void DetectGidRegister (void)
 static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
 {
     char *str = rawstr;
-    char dubbed = 0;
+    char duped = 0;
 
     /* Strip leading and trailing "s. */
     if (rawstr[0] == '\"') {
@@ -80,7 +80,7 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
         if (strlen(str) && str[strlen(str) - 1] == '\"') {
             str[strlen(str) - 1] = '\"';
         }
-        dubbed = 1;
+        duped = 1;
     }
 
     unsigned long gid = 0;
@@ -98,12 +98,12 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
 
     s->gid = (uint32_t)gid;
 
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return 0;
 
  error:
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return -1;
 }

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -48,7 +48,7 @@ void DetectSidRegister (void)
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
 {
     char *str = sidstr;
-    char dubbed = 0;
+    char duped = 0;
 
     /* Strip leading and trailing "s. */
     if (sidstr[0] == '\"') {
@@ -59,7 +59,7 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
         if (strlen(str) && str[strlen(str) - 1] == '\"') {
             str[strlen(str) - 1] = '\0';
         }
-        dubbed = 1;
+        duped = 1;
     }
 
     unsigned long id = 0;
@@ -77,12 +77,12 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
 
     s->id = (uint32_t)id;
 
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return 0;
 
  error:
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return -1;
 }

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -25,10 +25,14 @@
 
 #include "suricata-common.h"
 #include "detect.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
 #include "util-debug.h"
 #include "util-error.h"
+#include "util-unittest.h"
 
 static int DetectSidSetup (DetectEngineCtx *, Signature *, char *);
+static void DetectSidRegisterTests(void);
 
 void DetectSidRegister (void)
 {
@@ -38,7 +42,7 @@ void DetectSidRegister (void)
     sigmatch_table[DETECT_SID].Match = NULL;
     sigmatch_table[DETECT_SID].Setup = DetectSidSetup;
     sigmatch_table[DETECT_SID].Free = NULL;
-    sigmatch_table[DETECT_SID].RegisterTests = NULL;
+    sigmatch_table[DETECT_SID].RegisterTests = DetectSidRegisterTests;
 }
 
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
@@ -46,13 +50,15 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
     char *str = sidstr;
     char dubbed = 0;
 
-    /* strip "'s */
-    if (sidstr[0] == '\"' && sidstr[strlen(sidstr)-1] == '\"') {
-        str = SCStrdup(sidstr+1);
-        if (unlikely(str == NULL))
+    /* Strip leading and trailing "s. */
+    if (sidstr[0] == '\"') {
+        str = SCStrdup(sidstr + 1);
+        if (unlikely(str == NULL)) {
             return -1;
-
-        str[strlen(sidstr)-2] = '\0';
+        }
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 
@@ -81,3 +87,79 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
     return -1;
 }
 
+#ifdef UNITTESTS
+
+static int SidTestParse01(void)
+{
+    int result = 0;
+    Signature *s = NULL;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    s = DetectEngineAppendSig(de_ctx,
+        "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
+    if (s == NULL || s->id != 1)
+        goto end;
+
+    result = 1;
+
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+static int SidTestParse02(void)
+{
+    int result = 0;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    if (DetectEngineAppendSig(de_ctx,
+            "alert tcp 1.2.3.4 any -> any any (sid:a; gid:1;)") != NULL)
+        goto end;
+
+    result = 1;
+
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+static int SidTestParse03(void)
+{
+    int result = 0;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    if (DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any (content:\"ABC\"; sid:\";)") != NULL)
+        goto end;
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+#endif
+
+/**
+ * \brief Register DetectSid unit tests.
+ */
+static void DetectSidRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("SidTestParse01", SidTestParse01, 1);
+    UtRegisterTest("SidTestParse02", SidTestParse02, 1);
+    UtRegisterTest("SidTestParse03", SidTestParse03, 1);
+#endif /* UNITTESTS */
+}

--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -125,8 +125,9 @@ static int ParseSizeString(const char *size, double *res)
         } else if (strcasecmp(str2, "gb") == 0) {
             *res *= 1024 * 1024 * 1024;
         } else {
-            /* not possible */
-            BUG_ON(1);
+            /* Bad unit. */
+            retval = -1;
+            goto end;
         }
     }
 
@@ -1115,6 +1116,11 @@ int UtilMiscParseSizeStringTest01(void)
         goto error;
     }
     if (result != 10.5 * 1024 * 1024 * 1024) {
+        goto error;
+    }
+
+    /* Should fail on unknown units. */
+    if (ParseSizeString("32eb", &result) > 0) {
         goto error;
     }
 


### PR DESCRIPTION
Fixes some memory issues found by @inliniac while testing Suricata with AFL and -fsanitize=address.

Includes contents of PR #1428 .

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/68
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/69
