### PR TITLE
2.0.x - Address sanitizer fixups - v2.

### DIFF
--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -68,7 +68,7 @@ void DetectGidRegister (void) {
 static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
 {
     char *str = rawstr;
-    char dubbed = 0;
+    char duped = 0;
 
     /* Strip leading and trailing "s. */
     if (rawstr[0] == '\"') {
@@ -79,7 +79,7 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
         if (strlen(str) && str[strlen(str) - 1] == '\"') {
             str[strlen(str) - 1] = '\"';
         }
-        dubbed = 1;
+        duped = 1;
     }
 
     unsigned long gid = 0;
@@ -97,12 +97,12 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
 
     s->gid = (uint32_t)gid;
 
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return 0;
 
  error:
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return -1;
 }

--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -70,13 +70,15 @@ static int DetectGidSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
     char *str = rawstr;
     char dubbed = 0;
 
-    /* strip "'s */
-    if (rawstr[0] == '\"' && rawstr[strlen(rawstr)-1] == '\"') {
-        str = SCStrdup(rawstr+1);
-        if (unlikely(str == NULL))
+    /* Strip leading and trailing "s. */
+    if (rawstr[0] == '\"') {
+        str = SCStrdup(rawstr + 1);
+        if (unlikely(str == NULL)) {
             return -1;
-
-        str[strlen(rawstr)-2] = '\0';
+        }
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\"';
+        }
         dubbed = 1;
     }
 
@@ -157,6 +159,31 @@ end:
         DetectEngineCtxFree(de_ctx);
     return result;
 }
+
+/**
+ * \test Test a gid consisting of a single quote.
+ *
+ * \retval 1 on succces
+ * \retval 0 on failure
+ */
+static int GidTestParse03 (void)
+{
+    int result = 0;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    if (DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any (content:\"ABC\"; gid:\";)") != NULL)
+        goto end;
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
 #endif /* UNITTESTS */
 
 /**
@@ -166,5 +193,6 @@ void GidRegisterTests(void) {
 #ifdef UNITTESTS
     UtRegisterTest("GidTestParse01", GidTestParse01, 1);
     UtRegisterTest("GidTestParse02", GidTestParse02, 1);
+    UtRegisterTest("GidTestParse03", GidTestParse03, 1);
 #endif /* UNITTESTS */
 }

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -25,10 +25,14 @@
 
 #include "suricata-common.h"
 #include "detect.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
 #include "util-debug.h"
 #include "util-error.h"
+#include "util-unittest.h"
 
 static int DetectSidSetup (DetectEngineCtx *, Signature *, char *);
+static void DetectSidRegisterTests(void);
 
 void DetectSidRegister (void) {
     sigmatch_table[DETECT_SID].name = "sid";
@@ -37,7 +41,7 @@ void DetectSidRegister (void) {
     sigmatch_table[DETECT_SID].Match = NULL;
     sigmatch_table[DETECT_SID].Setup = DetectSidSetup;
     sigmatch_table[DETECT_SID].Free = NULL;
-    sigmatch_table[DETECT_SID].RegisterTests = NULL;
+    sigmatch_table[DETECT_SID].RegisterTests = DetectSidRegisterTests;
 }
 
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
@@ -45,13 +49,15 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
     char *str = sidstr;
     char dubbed = 0;
 
-    /* strip "'s */
-    if (sidstr[0] == '\"' && sidstr[strlen(sidstr)-1] == '\"') {
-        str = SCStrdup(sidstr+1);
-        if (unlikely(str == NULL))
+    /* Strip leading and trailing "s. */
+    if (sidstr[0] == '\"') {
+        str = SCStrdup(sidstr + 1);
+        if (unlikely(str == NULL)) {
             return -1;
-
-        str[strlen(sidstr)-2] = '\0';
+        }
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 
@@ -80,3 +86,79 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
     return -1;
 }
 
+#ifdef UNITTESTS
+
+static int SidTestParse01(void)
+{
+    int result = 0;
+    Signature *s = NULL;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    s = DetectEngineAppendSig(de_ctx,
+        "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
+    if (s == NULL || s->id != 1)
+        goto end;
+
+    result = 1;
+
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+static int SidTestParse02(void)
+{
+    int result = 0;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    if (DetectEngineAppendSig(de_ctx,
+            "alert tcp 1.2.3.4 any -> any any (sid:a; gid:1;)") != NULL)
+        goto end;
+
+    result = 1;
+
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+static int SidTestParse03(void)
+{
+    int result = 0;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    if (DetectEngineAppendSig(de_ctx,
+            "alert tcp any any -> any any (content:\"ABC\"; sid:\";)") != NULL)
+        goto end;
+
+    result = 1;
+end:
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+    return result;
+}
+
+#endif
+
+/**
+ * \brief Register DetectSid unit tests.
+ */
+static void DetectSidRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("SidTestParse01", SidTestParse01, 1);
+    UtRegisterTest("SidTestParse02", SidTestParse02, 1);
+    UtRegisterTest("SidTestParse03", SidTestParse03, 1);
+#endif /* UNITTESTS */
+}

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -47,7 +47,7 @@ void DetectSidRegister (void) {
 static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
 {
     char *str = sidstr;
-    char dubbed = 0;
+    char duped = 0;
 
     /* Strip leading and trailing "s. */
     if (sidstr[0] == '\"') {
@@ -58,7 +58,7 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
         if (strlen(str) && str[strlen(str) - 1] == '\"') {
             str[strlen(str) - 1] = '\0';
         }
-        dubbed = 1;
+        duped = 1;
     }
 
     unsigned long id = 0;
@@ -76,12 +76,12 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, char *sidstr)
 
     s->id = (uint32_t)id;
 
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return 0;
 
  error:
-    if (dubbed)
+    if (duped)
         SCFree(str);
     return -1;
 }

--- a/src/util-misc.c
+++ b/src/util-misc.c
@@ -123,8 +123,9 @@ static int ParseSizeString(const char *size, double *res)
         } else if (strcasecmp(str2, "gb") == 0) {
             *res *= 1024 * 1024 * 1024;
         } else {
-            /* not possible */
-            BUG_ON(1);
+            /* Bad unit. */
+            retval = -1;
+            goto end;
         }
     }
 
@@ -1113,6 +1114,11 @@ int UtilMiscParseSizeStringTest01(void)
         goto error;
     }
     if (result != 10.5 * 1024 * 1024 * 1024) {
+        goto error;
+    }
+
+    /* Should fail on unknown units. */
+    if (ParseSizeString("32eb", &result) > 0) {
         goto error;
     }
 


### PR DESCRIPTION
Backport of PR #1429 to the 2.0 branch:

Fixes some memory issues found by @inliniac while testing Suricata with AFL and -fsanitize=address.
Includes contents of PR #1428 .

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/70
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/69
