### PR TITLE
Bug #1441: add timezone to timestamp in JSON logs v4

### DIFF
--- a/src/util-time.c
+++ b/src/util-time.c
@@ -128,10 +128,10 @@ void CreateIsoTimeString (const struct timeval *ts, char *str, size_t size)
     time_t time = ts->tv_sec;
     struct tm local_tm;
     struct tm *t = (struct tm*)SCLocalTime(time, &local_tm);
+    char time_fmt[64] = { 0 };
 
-    snprintf(str, size, "%04d-%02d-%02dT%02d:%02d:%02d.%06u",
-             t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour,
-             t->tm_min, t->tm_sec, (uint32_t) ts->tv_usec);
+    strftime(time_fmt, sizeof(time_fmt), "%Y-%m-%dT%H:%M:%S.%%06u%z", t);
+    snprintf(str, size, time_fmt, ts->tv_usec);
 }
 
 /*


### PR DESCRIPTION
Fixed #1439 - that one was not fully ISO conformant (missed 'T' between date and time).