### PR TITLE
More fixes for issues found with AFL - v3

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1630,16 +1630,19 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
         }
     }
 
-    if (strcasecmp(node->val, "yes") == 0) {
-        goto enabled;
-    } else if (strcasecmp(node->val, "no") == 0) {
-        goto disabled;
-    } else if (strcasecmp(node->val, "detection-only") == 0) {
-        goto enabled;
-    } else {
-        SCLogError(SC_ERR_FATAL, "Invalid value found for %s.", param);
-        exit(EXIT_FAILURE);
+    if (node->val) {
+        if (ConfValIsTrue(node->val)) {
+            goto enabled;
+        } else if (ConfValIsFalse(node->val)) {
+            goto disabled;
+        } else if (strcasecmp(node->val, "detection-only") == 0) {
+            goto enabled;
+        }
     }
+
+    /* Invalid or null value. */
+    SCLogError(SC_ERR_FATAL, "Invalid value found for %s.", param);
+    exit(EXIT_FAILURE);
 
  disabled:
     enabled = 0;

--- a/src/conf.c
+++ b/src/conf.c
@@ -271,20 +271,18 @@ ConfSetFinal(const char *name, char *val)
 }
 
 /**
- * \brief Retrieve the value of a configuration node.
+ * \brief Get the value of a configuration node.
  *
- * This function will return the value for a configuration node based
- * on the full name of the node.  It is possible that the value
- * returned could be NULL, this could happen if the requested node
- * does exist but is not a node that contains a value, but contains
- * children ConfNodes instead.
+ * Note on failure: This function will return for failure if the named
+ * configuration node does not exist, or if it does exist and its
+ * value is 0.
  *
  * \param name Name of configuration parameter to get.
  * \param vptr Pointer that will be set to the configuration value parameter.
  *   Note that this is just a reference to the actual value, not a copy.
  *
- * \retval 1 will be returned if the name is found, otherwise 0 will
- *   be returned.
+ * \retval 1 will be returned if the name is found and the value is not NULL,
+ *   otherwise 0 will be returned.
  */
 int
 ConfGet(const char *name, char **vptr)
@@ -294,10 +292,9 @@ ConfGet(const char *name, char **vptr)
         SCLogDebug("failed to lookup configuration parameter '%s'", name);
         return 0;
     }
-    else {
-        *vptr = node->val;
-        return 1;
-    }
+
+    *vptr = node->val;
+    return *vptr == NULL ? 0 : 1;
 }
 
 int ConfGetChildValue(const ConfNode *base, const char *name, char **vptr)

--- a/src/util-host-os-info.c
+++ b/src/util-host-os-info.c
@@ -342,7 +342,7 @@ void SCHInfoLoadFromConfig(void)
         ConfNode *host;
         TAILQ_FOREACH(host, &policy->head, next) {
             int is_ipv4 = 1;
-            if (index(host->val, ':') != NULL)
+            if (host->val != NULL && index(host->val, ':') != NULL)
                 is_ipv4 = 0;
             if (SCHInfoAddHostOSInfo(policy->name, host->val, is_ipv4) == -1) {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,


### PR DESCRIPTION
These are cases where the configuration value is NULL, but not checked.

The 3rd commit fixes one case of the errors at the source, by not returning true if the value is NULL.  Unit tests, and a quick scan of the code shows that this is likely OK for all uses of ConfGet.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/75
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/76
