### PR TITLE
Bug #1204: Fix eve-log syslog parameters issue.

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -479,7 +479,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                     exit(EXIT_FAILURE);
                 }
             }
-        } else if (json_out == ALERT_SYSLOG) {
+        } else if (json_ctx->json_out == ALERT_SYSLOG) {
             const char *facility_s = ConfNodeLookupChildValue(conf, "facility");
             if (facility_s == NULL) {
                 facility_s = DEFAULT_ALERT_SYSLOG_FACILITY_STR;


### PR DESCRIPTION
...able. Unveils a different potential issue: if eve syslog output is enabled at the same time that syslog output (for fast-log style alert output) is also enabled, 'openlog' API is called twice. As a result, the eve-log identity and facility settings can potentially be overridden by the identity and facility settings defined in the 'syslog:' section if they differ from those defined in the eve section. I'm not sure that it makes sense to have multiple identities/facilities within the same application anyhow, but it's something to take note of since there are multiple places in the yaml that identity and facility can be defined.