### PR TITLE
Bypass libnss for MD5 calculations.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -344,6 +344,7 @@ util-lua-common.c util-lua-common.h \
 util-lua-dns.c util-lua-dns.h \
 util-lua-http.c util-lua-http.h \
 util-magic.c util-magic.h \
+util-md5.c util-md5.h \
 util-memcmp.c util-memcmp.h \
 util-memcpy.h \
 util-mem.h \

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -36,6 +36,14 @@
 #include "app-layer-parser.h"
 #include "util-validate.h"
 
+#define HASH_Create MD5_NewContext
+#define HASH_Destroy MD5_DestroyContext
+#define HASH_Begin MD5_Begin
+#define HASH_End MD5_End
+#define HASH_Update MD5_Update
+
+extern int g_detect_disabled;
+
 /** \brief switch to force magic checks on all files
  *         regardless of the rules.
  */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -541,6 +541,10 @@ File *FileOpenFile(FileContainer *ffc, uint8_t *name,
         SCLogDebug("not doing md5 for this file");
         ff->flags |= FILE_NOMD5;
     }
+    if (g_detect_disabled && (g_file_force_md5 == 0)) {
+        SCLogDebug("not doing md5 for this file");
+        ff->flags |= FILE_NOMD5;
+    }
 
 #ifdef HAVE_NSS
     if (!(ff->flags & FILE_NOMD5) || g_file_force_md5) {

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -29,6 +29,8 @@
 #include <sechash.h>
 #endif
 
+#include "util-md5.h"
+
 #define FILE_TRUNCATED  0x0001
 #define FILE_NOMAGIC    0x0002
 #define FILE_NOMD5      0x0004
@@ -71,7 +73,7 @@ typedef struct File_ {
     FileData *chunks_tail;
     struct File_ *next;
 #ifdef HAVE_NSS
-    HASHContext *md5_ctx;
+    SCMD5Context *md5_ctx;
     uint8_t md5[MD5_LENGTH];
 #endif
 #ifdef DEBUG

--- a/src/util-md5.c
+++ b/src/util-md5.c
@@ -9,6 +9,9 @@
 #include "suricata-common.h"
 #include "suricata.h"
 
+/* require NSS to utilize this */
+#ifdef HAVE_NSS 
+
 #include "prerr.h"
 #include "secerr.h"
 
@@ -606,3 +609,5 @@ MD5_TraceState(SCMD5Context *cx)
 	PORT_SetError(PR_NOT_IMPLEMENTED_ERROR);
 }
 #endif
+
+#endif /* HAVE_NSS */

--- a/src/util-md5.c
+++ b/src/util-md5.c
@@ -1,0 +1,608 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifdef FREEBL_NO_DEPEND
+#include "stubs.h"
+#endif
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "prerr.h"
+#include "secerr.h"
+
+#include "prtypes.h"
+#include "prlong.h"
+
+#include <sechash.h>
+
+#include "util-mem.h"
+#include "util-md5.h"
+
+//#include "blapi.h"
+
+#define MD5_HASH_LEN 16
+#define MD5_BUFFER_SIZE 64
+#define MD5_END_BUFFER (MD5_BUFFER_SIZE - 8)
+
+#define CV0_1 0x67452301
+#define CV0_2 0xefcdab89
+#define CV0_3 0x98badcfe
+#define CV0_4 0x10325476
+
+#define T1_0  0xd76aa478
+#define T1_1  0xe8c7b756
+#define T1_2  0x242070db
+#define T1_3  0xc1bdceee
+#define T1_4  0xf57c0faf
+#define T1_5  0x4787c62a
+#define T1_6  0xa8304613
+#define T1_7  0xfd469501
+#define T1_8  0x698098d8
+#define T1_9  0x8b44f7af
+#define T1_10 0xffff5bb1
+#define T1_11 0x895cd7be
+#define T1_12 0x6b901122
+#define T1_13 0xfd987193
+#define T1_14 0xa679438e
+#define T1_15 0x49b40821
+
+#define T2_0  0xf61e2562
+#define T2_1  0xc040b340
+#define T2_2  0x265e5a51
+#define T2_3  0xe9b6c7aa
+#define T2_4  0xd62f105d
+#define T2_5  0x02441453
+#define T2_6  0xd8a1e681
+#define T2_7  0xe7d3fbc8
+#define T2_8  0x21e1cde6
+#define T2_9  0xc33707d6
+#define T2_10 0xf4d50d87
+#define T2_11 0x455a14ed
+#define T2_12 0xa9e3e905
+#define T2_13 0xfcefa3f8
+#define T2_14 0x676f02d9
+#define T2_15 0x8d2a4c8a
+
+#define T3_0  0xfffa3942
+#define T3_1  0x8771f681
+#define T3_2  0x6d9d6122
+#define T3_3  0xfde5380c
+#define T3_4  0xa4beea44
+#define T3_5  0x4bdecfa9
+#define T3_6  0xf6bb4b60
+#define T3_7  0xbebfbc70
+#define T3_8  0x289b7ec6
+#define T3_9  0xeaa127fa
+#define T3_10 0xd4ef3085
+#define T3_11 0x04881d05
+#define T3_12 0xd9d4d039
+#define T3_13 0xe6db99e5
+#define T3_14 0x1fa27cf8
+#define T3_15 0xc4ac5665
+
+#define T4_0  0xf4292244
+#define T4_1  0x432aff97
+#define T4_2  0xab9423a7
+#define T4_3  0xfc93a039
+#define T4_4  0x655b59c3
+#define T4_5  0x8f0ccc92
+#define T4_6  0xffeff47d
+#define T4_7  0x85845dd1
+#define T4_8  0x6fa87e4f
+#define T4_9  0xfe2ce6e0
+#define T4_10 0xa3014314
+#define T4_11 0x4e0811a1
+#define T4_12 0xf7537e82
+#define T4_13 0xbd3af235
+#define T4_14 0x2ad7d2bb
+#define T4_15 0xeb86d391
+
+#define R1B0  0
+#define R1B1  1
+#define R1B2  2
+#define R1B3  3
+#define R1B4  4
+#define R1B5  5
+#define R1B6  6
+#define R1B7  7
+#define R1B8  8
+#define R1B9  9
+#define R1B10 10
+#define R1B11 11
+#define R1B12 12
+#define R1B13 13
+#define R1B14 14
+#define R1B15 15
+
+#define R2B0  1
+#define R2B1  6
+#define R2B2  11
+#define R2B3  0
+#define R2B4  5
+#define R2B5  10
+#define R2B6  15
+#define R2B7  4
+#define R2B8  9
+#define R2B9  14
+#define R2B10 3 
+#define R2B11 8 
+#define R2B12 13
+#define R2B13 2 
+#define R2B14 7 
+#define R2B15 12
+
+#define R3B0  5
+#define R3B1  8
+#define R3B2  11
+#define R3B3  14
+#define R3B4  1
+#define R3B5  4
+#define R3B6  7
+#define R3B7  10
+#define R3B8  13
+#define R3B9  0
+#define R3B10 3 
+#define R3B11 6 
+#define R3B12 9 
+#define R3B13 12
+#define R3B14 15
+#define R3B15 2 
+
+#define R4B0  0
+#define R4B1  7
+#define R4B2  14
+#define R4B3  5
+#define R4B4  12
+#define R4B5  3
+#define R4B6  10
+#define R4B7  1
+#define R4B8  8
+#define R4B9  15
+#define R4B10 6 
+#define R4B11 13
+#define R4B12 4 
+#define R4B13 11
+#define R4B14 2 
+#define R4B15 9 
+
+#define S1_0 7
+#define S1_1 12
+#define S1_2 17
+#define S1_3 22
+
+#define S2_0 5
+#define S2_1 9
+#define S2_2 14
+#define S2_3 20
+
+#define S3_0 4
+#define S3_1 11
+#define S3_2 16
+#define S3_3 23
+
+#define S4_0 6
+#define S4_1 10
+#define S4_2 15
+#define S4_3 21
+
+struct MD5ContextStr {
+	PRUint32      lsbInput;
+	PRUint32      msbInput;
+	PRUint32      cv[4];
+	union {
+		PRUint8 b[64];
+		PRUint32 w[16];
+	} u;
+};
+
+#define inBuf u.b
+
+#if 0
+SECStatus 
+MD5_Hash(unsigned char *dest, const char *src)
+{
+	return MD5_HashBuf(dest, (const unsigned char *)src, PORT_Strlen(src));
+}
+
+SECStatus 
+MD5_HashBuf(unsigned char *dest, const unsigned char *src, PRUint32 src_length)
+{
+	unsigned int len;
+	SCMD5Context cx;
+
+	MD5_Begin(&cx);
+	MD5_Update(&cx, src, src_length);
+	MD5_End(&cx, dest, &len, MD5_HASH_LEN);
+	memset(&cx, 0, sizeof cx);
+	return SECSuccess;
+}
+#endif
+
+SCMD5Context *
+MD5_NewContext(HASH_HashType type)
+{
+    if (type != HASH_AlgMD5) {
+        return NULL;
+    }
+	/* no need to ZAlloc, MD5_Begin will init the context */
+	//MD5Context *cx = (MD5Context *)PORT_Alloc(sizeof(MD5Context));
+	SCMD5Context *cx = (SCMD5Context *)SCCalloc(1, sizeof(SCMD5Context));
+	if (cx == NULL) {
+		PORT_SetError(PR_OUT_OF_MEMORY_ERROR);
+		return NULL;
+	}
+	return cx;
+}
+
+void 
+MD5_DestroyContext(SCMD5Context *cx)
+{
+	memset(cx, 0, sizeof *cx);
+    SCFree(cx);
+}
+
+void 
+MD5_Begin(SCMD5Context *cx)
+{
+	cx->lsbInput = 0;
+	cx->msbInput = 0;
+/*	memset(cx->inBuf, 0, sizeof(cx->inBuf)); */
+	cx->cv[0] = CV0_1;
+	cx->cv[1] = CV0_2;
+	cx->cv[2] = CV0_3;
+	cx->cv[3] = CV0_4;
+}
+
+#define cls(i32, s) (tmp = i32, tmp << s | tmp >> (32 - s))
+
+#if defined(SOLARIS) || defined(HPUX)
+#define addto64(sumhigh, sumlow, addend) \
+	sumlow += addend; sumhigh += (sumlow < addend);
+#else
+#define addto64(sumhigh, sumlow, addend) \
+	sumlow += addend; if (sumlow < addend) ++sumhigh;
+#endif
+
+#define MASK 0x00ff00ff
+#ifdef IS_LITTLE_ENDIAN
+#define lendian(i32) \
+	(i32)
+#else
+#define lendian(i32) \
+	(tmp = i32 >> 16 | i32 << 16, (tmp & MASK) << 8 | tmp >> 8 & MASK)
+#endif
+
+#ifndef IS_LITTLE_ENDIAN
+
+#define lebytes(b4) \
+	((b4)[3] << 24 | (b4)[2] << 16 | (b4)[1] << 8 | (b4)[0])
+
+static void
+md5_prep_state_le(SCMD5Context *cx)
+{
+	PRUint32 tmp;
+	cx->u.w[0] = lendian(cx->u.w[0]);
+	cx->u.w[1] = lendian(cx->u.w[1]);
+	cx->u.w[2] = lendian(cx->u.w[2]);
+	cx->u.w[3] = lendian(cx->u.w[3]);
+	cx->u.w[4] = lendian(cx->u.w[4]);
+	cx->u.w[5] = lendian(cx->u.w[5]);
+	cx->u.w[6] = lendian(cx->u.w[6]);
+	cx->u.w[7] = lendian(cx->u.w[7]);
+	cx->u.w[8] = lendian(cx->u.w[8]);
+	cx->u.w[9] = lendian(cx->u.w[9]);
+	cx->u.w[10] = lendian(cx->u.w[10]);
+	cx->u.w[11] = lendian(cx->u.w[11]);
+	cx->u.w[12] = lendian(cx->u.w[12]);
+	cx->u.w[13] = lendian(cx->u.w[13]);
+	cx->u.w[14] = lendian(cx->u.w[14]);
+	cx->u.w[15] = lendian(cx->u.w[15]);
+}
+
+static void
+md5_prep_buffer_le(SCMD5Context *cx, const PRUint8 *beBuf)
+{
+	cx->u.w[0] = lebytes(&beBuf[0]);
+	cx->u.w[1] = lebytes(&beBuf[4]);
+	cx->u.w[2] = lebytes(&beBuf[8]);
+	cx->u.w[3] = lebytes(&beBuf[12]);
+	cx->u.w[4] = lebytes(&beBuf[16]);
+	cx->u.w[5] = lebytes(&beBuf[20]);
+	cx->u.w[6] = lebytes(&beBuf[24]);
+	cx->u.w[7] = lebytes(&beBuf[28]);
+	cx->u.w[8] = lebytes(&beBuf[32]);
+	cx->u.w[9] = lebytes(&beBuf[36]);
+	cx->u.w[10] = lebytes(&beBuf[40]);
+	cx->u.w[11] = lebytes(&beBuf[44]);
+	cx->u.w[12] = lebytes(&beBuf[48]);
+	cx->u.w[13] = lebytes(&beBuf[52]);
+	cx->u.w[14] = lebytes(&beBuf[56]);
+	cx->u.w[15] = lebytes(&beBuf[60]);
+}
+#endif
+
+
+#define F(X, Y, Z) \
+	((X & Y) | ((~X) & Z))
+
+#define G(X, Y, Z) \
+	((X & Z) | (Y & (~Z)))
+
+#define H(X, Y, Z) \
+	(X ^ Y ^ Z)
+
+#define I(X, Y, Z) \
+	(Y ^ (X | (~Z)))
+
+#define FF(a, b, c, d, bufint, s, ti) \
+	a = b + cls(a + F(b, c, d) + bufint + ti, s)
+
+#define GG(a, b, c, d, bufint, s, ti) \
+	a = b + cls(a + G(b, c, d) + bufint + ti, s)
+
+#define HH(a, b, c, d, bufint, s, ti) \
+	a = b + cls(a + H(b, c, d) + bufint + ti, s)
+
+#define II(a, b, c, d, bufint, s, ti) \
+	a = b + cls(a + I(b, c, d) + bufint + ti, s)
+
+static void
+md5_compress(SCMD5Context *cx, const PRUint32 *wBuf)
+{
+	PRUint32 a, b, c, d;
+	PRUint32 tmp;
+	a = cx->cv[0];
+	b = cx->cv[1];
+	c = cx->cv[2];
+	d = cx->cv[3];
+	FF(a, b, c, d, wBuf[R1B0 ], S1_0, T1_0);
+	FF(d, a, b, c, wBuf[R1B1 ], S1_1, T1_1);
+	FF(c, d, a, b, wBuf[R1B2 ], S1_2, T1_2);
+	FF(b, c, d, a, wBuf[R1B3 ], S1_3, T1_3);
+	FF(a, b, c, d, wBuf[R1B4 ], S1_0, T1_4);
+	FF(d, a, b, c, wBuf[R1B5 ], S1_1, T1_5);
+	FF(c, d, a, b, wBuf[R1B6 ], S1_2, T1_6);
+	FF(b, c, d, a, wBuf[R1B7 ], S1_3, T1_7);
+	FF(a, b, c, d, wBuf[R1B8 ], S1_0, T1_8);
+	FF(d, a, b, c, wBuf[R1B9 ], S1_1, T1_9);
+	FF(c, d, a, b, wBuf[R1B10], S1_2, T1_10);
+	FF(b, c, d, a, wBuf[R1B11], S1_3, T1_11);
+	FF(a, b, c, d, wBuf[R1B12], S1_0, T1_12);
+	FF(d, a, b, c, wBuf[R1B13], S1_1, T1_13);
+	FF(c, d, a, b, wBuf[R1B14], S1_2, T1_14);
+	FF(b, c, d, a, wBuf[R1B15], S1_3, T1_15);
+	GG(a, b, c, d, wBuf[R2B0 ], S2_0, T2_0);
+	GG(d, a, b, c, wBuf[R2B1 ], S2_1, T2_1);
+	GG(c, d, a, b, wBuf[R2B2 ], S2_2, T2_2);
+	GG(b, c, d, a, wBuf[R2B3 ], S2_3, T2_3);
+	GG(a, b, c, d, wBuf[R2B4 ], S2_0, T2_4);
+	GG(d, a, b, c, wBuf[R2B5 ], S2_1, T2_5);
+	GG(c, d, a, b, wBuf[R2B6 ], S2_2, T2_6);
+	GG(b, c, d, a, wBuf[R2B7 ], S2_3, T2_7);
+	GG(a, b, c, d, wBuf[R2B8 ], S2_0, T2_8);
+	GG(d, a, b, c, wBuf[R2B9 ], S2_1, T2_9);
+	GG(c, d, a, b, wBuf[R2B10], S2_2, T2_10);
+	GG(b, c, d, a, wBuf[R2B11], S2_3, T2_11);
+	GG(a, b, c, d, wBuf[R2B12], S2_0, T2_12);
+	GG(d, a, b, c, wBuf[R2B13], S2_1, T2_13);
+	GG(c, d, a, b, wBuf[R2B14], S2_2, T2_14);
+	GG(b, c, d, a, wBuf[R2B15], S2_3, T2_15);
+	HH(a, b, c, d, wBuf[R3B0 ], S3_0, T3_0);
+	HH(d, a, b, c, wBuf[R3B1 ], S3_1, T3_1);
+	HH(c, d, a, b, wBuf[R3B2 ], S3_2, T3_2);
+	HH(b, c, d, a, wBuf[R3B3 ], S3_3, T3_3);
+	HH(a, b, c, d, wBuf[R3B4 ], S3_0, T3_4);
+	HH(d, a, b, c, wBuf[R3B5 ], S3_1, T3_5);
+	HH(c, d, a, b, wBuf[R3B6 ], S3_2, T3_6);
+	HH(b, c, d, a, wBuf[R3B7 ], S3_3, T3_7);
+	HH(a, b, c, d, wBuf[R3B8 ], S3_0, T3_8);
+	HH(d, a, b, c, wBuf[R3B9 ], S3_1, T3_9);
+	HH(c, d, a, b, wBuf[R3B10], S3_2, T3_10);
+	HH(b, c, d, a, wBuf[R3B11], S3_3, T3_11);
+	HH(a, b, c, d, wBuf[R3B12], S3_0, T3_12);
+	HH(d, a, b, c, wBuf[R3B13], S3_1, T3_13);
+	HH(c, d, a, b, wBuf[R3B14], S3_2, T3_14);
+	HH(b, c, d, a, wBuf[R3B15], S3_3, T3_15);
+	II(a, b, c, d, wBuf[R4B0 ], S4_0, T4_0);
+	II(d, a, b, c, wBuf[R4B1 ], S4_1, T4_1);
+	II(c, d, a, b, wBuf[R4B2 ], S4_2, T4_2);
+	II(b, c, d, a, wBuf[R4B3 ], S4_3, T4_3);
+	II(a, b, c, d, wBuf[R4B4 ], S4_0, T4_4);
+	II(d, a, b, c, wBuf[R4B5 ], S4_1, T4_5);
+	II(c, d, a, b, wBuf[R4B6 ], S4_2, T4_6);
+	II(b, c, d, a, wBuf[R4B7 ], S4_3, T4_7);
+	II(a, b, c, d, wBuf[R4B8 ], S4_0, T4_8);
+	II(d, a, b, c, wBuf[R4B9 ], S4_1, T4_9);
+	II(c, d, a, b, wBuf[R4B10], S4_2, T4_10);
+	II(b, c, d, a, wBuf[R4B11], S4_3, T4_11);
+	II(a, b, c, d, wBuf[R4B12], S4_0, T4_12);
+	II(d, a, b, c, wBuf[R4B13], S4_1, T4_13);
+	II(c, d, a, b, wBuf[R4B14], S4_2, T4_14);
+	II(b, c, d, a, wBuf[R4B15], S4_3, T4_15);
+	cx->cv[0] += a;
+	cx->cv[1] += b;
+	cx->cv[2] += c;
+	cx->cv[3] += d;
+}
+
+void 
+MD5_Update(SCMD5Context *cx, const unsigned char *input, unsigned int inputLen)
+{
+	PRUint32 bytesToConsume;
+	PRUint32 inBufIndex = cx->lsbInput & 63;
+	const PRUint32 *wBuf;
+
+	/* Add the number of input bytes to the 64-bit input counter. */
+	addto64(cx->msbInput, cx->lsbInput, inputLen);
+	if (inBufIndex) {
+		/* There is already data in the buffer.  Fill with input. */
+		bytesToConsume = PR_MIN(inputLen, MD5_BUFFER_SIZE - inBufIndex);
+		memcpy(&cx->inBuf[inBufIndex], input, bytesToConsume);
+		if (inBufIndex + bytesToConsume >= MD5_BUFFER_SIZE) {
+			/* The buffer is filled.  Run the compression function. */
+#ifndef IS_LITTLE_ENDIAN
+			md5_prep_state_le(cx);
+#endif
+			md5_compress(cx, cx->u.w);
+		}
+		/* Remaining input. */
+		inputLen -= bytesToConsume;
+		input += bytesToConsume;
+	}
+
+	/* Iterate over 64-byte chunks of the message. */
+	while (inputLen >= MD5_BUFFER_SIZE) {
+#ifdef IS_LITTLE_ENDIAN
+#ifdef NSS_X86_OR_X64
+		/* x86 can handle arithmetic on non-word-aligned buffers */
+		wBuf = (PRUint32 *)input;
+#else
+		if ((ptrdiff_t)input & 0x3) {
+			/* buffer not aligned, copy it to force alignment */
+			memcpy(cx->inBuf, input, MD5_BUFFER_SIZE);
+			wBuf = cx->u.w;
+		} else {
+			/* buffer is aligned */
+			wBuf = (PRUint32 *)input;
+		}
+#endif
+#else
+		md5_prep_buffer_le(cx, input);
+		wBuf = cx->u.w;
+#endif
+		md5_compress(cx, wBuf);
+		inputLen -= MD5_BUFFER_SIZE;
+		input += MD5_BUFFER_SIZE;
+	}
+
+	/* Tail of message (message bytes mod 64). */
+	if (inputLen)
+		memcpy(cx->inBuf, input, inputLen);
+}
+
+static const unsigned char padbytes[] = {
+	0x80, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,
+	0x00, 0x00, 0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00,  0x00
+};
+
+void 
+MD5_End(SCMD5Context *cx, unsigned char *digest,
+        unsigned int *digestLen, unsigned int maxDigestLen)
+{
+#ifndef IS_LITTLE_ENDIAN
+	PRUint32 tmp;
+#endif
+	PRUint32 lowInput, highInput;
+	PRUint32 inBufIndex = cx->lsbInput & 63;
+
+	if (maxDigestLen < MD5_HASH_LEN) {
+		PORT_SetError(SEC_ERROR_INVALID_ARGS);
+		return;
+	}
+
+	/* Copy out the length of bits input before padding. */
+	lowInput = cx->lsbInput; 
+	highInput = (cx->msbInput << 3) | (lowInput >> 29);
+	lowInput <<= 3;
+
+	if (inBufIndex < MD5_END_BUFFER) {
+		MD5_Update(cx, padbytes, MD5_END_BUFFER - inBufIndex);
+	} else {
+		MD5_Update(cx, padbytes, 
+		           MD5_END_BUFFER + MD5_BUFFER_SIZE - inBufIndex);
+	}
+
+	/* Store the number of bytes input (before padding) in final 64 bits. */
+	cx->u.w[14] = lendian(lowInput);
+	cx->u.w[15] = lendian(highInput);
+
+	/* Final call to compress. */
+#ifndef IS_LITTLE_ENDIAN
+	md5_prep_state_le(cx);
+#endif
+	md5_compress(cx, cx->u.w);
+
+	/* Copy the resulting values out of the chain variables into return buf. */
+	if (digestLen)
+		*digestLen = MD5_HASH_LEN;
+#ifndef IS_LITTLE_ENDIAN
+	cx->cv[0] = lendian(cx->cv[0]);
+	cx->cv[1] = lendian(cx->cv[1]);
+	cx->cv[2] = lendian(cx->cv[2]);
+	cx->cv[3] = lendian(cx->cv[3]);
+#endif
+	memcpy(digest, cx->cv, MD5_HASH_LEN);
+}
+
+void
+MD5_EndRaw(SCMD5Context *cx, unsigned char *digest,
+           unsigned int *digestLen, unsigned int maxDigestLen)
+{
+#ifndef IS_LITTLE_ENDIAN
+	PRUint32 tmp;
+#endif
+	PRUint32 cv[4];
+
+	if (maxDigestLen < MD5_HASH_LEN) {
+		PORT_SetError(SEC_ERROR_INVALID_ARGS);
+		return;
+	}
+
+	memcpy(cv, cx->cv, sizeof(cv));
+#ifndef IS_LITTLE_ENDIAN
+	cv[0] = lendian(cv[0]);
+	cv[1] = lendian(cv[1]);
+	cv[2] = lendian(cv[2]);
+	cv[3] = lendian(cv[3]);
+#endif
+	memcpy(digest, cv, MD5_HASH_LEN);
+	if (digestLen)
+		*digestLen = MD5_HASH_LEN;
+}
+
+#if 0
+unsigned int 
+MD5_FlattenSize(SCMD5Context *cx)
+{
+	return sizeof(*cx);
+}
+
+SECStatus 
+MD5_Flatten(SCMD5Context *cx, unsigned char *space)
+{
+	memcpy(space, cx, sizeof(*cx));
+	return SECSuccess;
+}
+
+SCMD5Context * 
+MD5_Resurrect(unsigned char *space, void *arg)
+{
+	SCMD5Context *cx = MD5_NewContext();
+	if (cx)
+		memcpy(cx, space, sizeof(*cx));
+	return cx;
+}
+
+void MD5_Clone(SCMD5Context *dest, SCMD5Context *src) 
+{
+	memcpy(dest, src, sizeof *dest);
+}
+
+void 
+MD5_TraceState(SCMD5Context *cx)
+{
+	PORT_SetError(PR_NOT_IMPLEMENTED_ERROR);
+}
+#endif

--- a/src/util-md5.h
+++ b/src/util-md5.h
@@ -8,6 +8,9 @@
 #ifndef _UTIL_MD5_H_
 #define _UTIL_MD5_H_
 
+/* require NSS to utilize this */
+#ifdef HAVE_NSS
+
 #if 0
 #include "blapit.h"
 #include "hasht.h"
@@ -1595,5 +1598,7 @@ extern SECStatus EC_CopyParams(PLArenaPool *arena, ECParams *dstParams,
 SEC_END_PROTOS
 
 #endif
+
+#endif /* HAVE_NSS */
 
 #endif /* _UTIL_MD5_H_ */

--- a/src/util-md5.h
+++ b/src/util-md5.h
@@ -1,0 +1,1599 @@
+/*
+ * blapi.h - public prototypes for the freebl library
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef _UTIL_MD5_H_
+#define _UTIL_MD5_H_
+
+#if 0
+#include "blapit.h"
+#include "hasht.h"
+#include "alghmac.h"
+
+SEC_BEGIN_PROTOS
+
+/*
+** RSA encryption/decryption. When encrypting/decrypting the output
+** buffer must be at least the size of the public key modulus.
+*/
+
+extern SECStatus BL_Init(void);
+
+/*
+** Generate and return a new RSA public and private key.
+**	Both keys are encoded in a single RSAPrivateKey structure.
+**	"cx" is the random number generator context
+**	"keySizeInBits" is the size of the key to be generated, in bits.
+**	   512, 1024, etc.
+**	"publicExponent" when not NULL is a pointer to some data that
+**	   represents the public exponent to use. The data is a byte
+**	   encoded integer, in "big endian" order.
+*/
+extern RSAPrivateKey *RSA_NewKey(int         keySizeInBits,
+				 SECItem *   publicExponent);
+
+/*
+** Perform a raw public-key operation 
+**	Length of input and output buffers are equal to key's modulus len.
+*/
+extern SECStatus RSA_PublicKeyOp(RSAPublicKey *   key,
+				 unsigned char *  output,
+				 const unsigned char *  input);
+
+/*
+** Perform a raw private-key operation 
+**	Length of input and output buffers are equal to key's modulus len.
+*/
+extern SECStatus RSA_PrivateKeyOp(RSAPrivateKey *  key,
+				  unsigned char *  output,
+				  const unsigned char *  input);
+
+/*
+** Perform a raw private-key operation, and check the parameters used in
+** the operation for validity by performing a test operation first.
+**	Length of input and output buffers are equal to key's modulus len.
+*/
+extern SECStatus RSA_PrivateKeyOpDoubleChecked(RSAPrivateKey *  key,
+				               unsigned char *  output,
+				               const unsigned char *  input);
+
+/*
+** Perform a check of private key parameters for consistency.
+*/
+extern SECStatus RSA_PrivateKeyCheck(const RSAPrivateKey *key);
+
+/*
+** Given only minimal private key parameters, fill in the rest of the
+** parameters.
+**
+**
+** All the entries, including those supplied by the caller, will be 
+** overwritten with data alocated out of the arena.
+**
+** If no arena is supplied, one will be created.
+**
+** The following fields must be supplied in order for this function
+** to succeed:
+**   one of either publicExponent or privateExponent
+**   two more of the following 5 parameters (not counting the above).
+**      modulus (n)
+**      prime1  (p)
+**      prime2  (q)
+**      publicExponent (e)
+**      privateExponent (d)
+**
+** NOTE: if only the publicExponent, privateExponent, and one prime is given,
+** then there may be more than one RSA key that matches that combination. If
+** we find 2 possible valid keys that meet this criteria, we return an error.
+** If we return the wrong key, and the original modulus is compared to the
+** new modulus, both can be factored by calculateing gcd(n_old,n_new) to get
+** the common prime.
+**
+** NOTE: in some cases the publicExponent must be less than 2^23 for this
+** function to work correctly. (The case where we have only one of: modulus
+** prime1 and prime2).
+**
+** All parameters will be replaced in the key structure with new parameters
+** allocated out of the arena. There is no attempt to free the old structures.
+** prime1 will always be greater than prime2 (even if the caller supplies the
+** smaller prime as prime1 or the larger prime as prime2). The parameters are
+** not overwritten on failure.
+**
+** While the remaining Chinese remainder theorem parameters (dp,dp, and qinv)
+** can also be used in reconstructing the private key, they are currently
+** ignored in this implementation.
+*/
+extern SECStatus RSA_PopulatePrivateKey(RSAPrivateKey *key);
+
+/********************************************************************
+** RSA algorithm
+*/
+
+/********************************************************************
+** Raw signing/encryption/decryption operations.
+**
+** No padding or formatting will be applied.
+** inputLen MUST be equivalent to the modulus size (in bytes).
+*/
+extern SECStatus
+RSA_SignRaw(RSAPrivateKey       * key,
+            unsigned char       * output,
+            unsigned int        * outputLen,
+            unsigned int          maxOutputLen,
+            const unsigned char * input,
+            unsigned int          inputLen);
+
+extern SECStatus
+RSA_CheckSignRaw(RSAPublicKey        * key,
+                 const unsigned char * sig,
+                 unsigned int          sigLen,
+                 const unsigned char * hash,
+                 unsigned int          hashLen);
+
+extern SECStatus
+RSA_CheckSignRecoverRaw(RSAPublicKey        * key,
+                        unsigned char       * data,
+                        unsigned int        * dataLen,
+                        unsigned int          maxDataLen,
+                        const unsigned char * sig,
+                        unsigned int          sigLen);
+
+extern SECStatus
+RSA_EncryptRaw(RSAPublicKey        * key,
+               unsigned char       * output,
+               unsigned int        * outputLen,
+               unsigned int          maxOutputLen,
+               const unsigned char * input,
+               unsigned int          inputLen);
+
+extern SECStatus
+RSA_DecryptRaw(RSAPrivateKey       * key,
+               unsigned char       * output,
+               unsigned int        * outputLen,
+               unsigned int          maxOutputLen,
+               const unsigned char * input,
+               unsigned int          inputLen);
+
+/********************************************************************
+** RSAES-OAEP encryption/decryption, as defined in RFC 3447, Section 7.1.
+**
+** Note: Only MGF1 is supported as the mask generation function. It will be
+** used with maskHashAlg as the inner hash function.
+**
+** Unless performing Known Answer Tests, "seed" should be NULL, indicating that
+** freebl should generate a random value. Otherwise, it should be an octet
+** string of seedLen bytes, which should be the same size as the output of
+** hashAlg.
+*/
+extern SECStatus
+RSA_EncryptOAEP(RSAPublicKey        * key,
+                HASH_HashType         hashAlg,
+                HASH_HashType         maskHashAlg,
+                const unsigned char * label,
+                unsigned int          labelLen,
+                const unsigned char * seed,
+                unsigned int          seedLen,
+                unsigned char       * output,
+                unsigned int        * outputLen,
+                unsigned int          maxOutputLen,
+                const unsigned char * input,
+                unsigned int          inputLen);
+
+extern SECStatus
+RSA_DecryptOAEP(RSAPrivateKey       * key,
+                HASH_HashType         hashAlg,
+                HASH_HashType         maskHashAlg,
+                const unsigned char * label,
+                unsigned int          labelLen,
+                unsigned char       * output,
+                unsigned int        * outputLen,
+                unsigned int          maxOutputLen,
+                const unsigned char * input,
+                unsigned int          inputLen);
+
+/********************************************************************
+** RSAES-PKCS1-v1_5 encryption/decryption, as defined in RFC 3447, Section 7.2.
+*/
+extern SECStatus
+RSA_EncryptBlock(RSAPublicKey        * key,
+                 unsigned char       * output,
+                 unsigned int        * outputLen,
+                 unsigned int          maxOutputLen,
+                 const unsigned char * input,
+                 unsigned int          inputLen);
+
+extern SECStatus
+RSA_DecryptBlock(RSAPrivateKey       * key,
+                 unsigned char       * output,
+                 unsigned int        * outputLen,
+                 unsigned int          maxOutputLen,
+                 const unsigned char * input,
+                 unsigned int          inputLen);
+
+/********************************************************************
+** RSASSA-PSS signing/verifying, as defined in RFC 3447, Section 8.1.
+**
+** Note: Only MGF1 is supported as the mask generation function. It will be
+** used with maskHashAlg as the inner hash function.
+**
+** Unless performing Known Answer Tests, "salt" should be NULL, indicating that
+** freebl should generate a random value.
+*/
+extern SECStatus
+RSA_SignPSS(RSAPrivateKey       * key,
+            HASH_HashType         hashAlg,
+            HASH_HashType         maskHashAlg,
+            const unsigned char * salt,
+            unsigned int          saltLen,
+            unsigned char       * output,
+            unsigned int        * outputLen,
+            unsigned int          maxOutputLen,
+            const unsigned char * input,
+            unsigned int          inputLen);
+
+extern SECStatus
+RSA_CheckSignPSS(RSAPublicKey        * key,
+                 HASH_HashType         hashAlg,
+                 HASH_HashType         maskHashAlg,
+                 unsigned int          saltLen,
+                 const unsigned char * sig,
+                 unsigned int          sigLen,
+                 const unsigned char * hash,
+                 unsigned int          hashLen);
+
+/********************************************************************
+** RSASSA-PKCS1-v1_5 signing/verifying, as defined in RFC 3447, Section 8.2.
+**
+** These functions expect as input to be the raw value to be signed. For most
+** cases using PKCS1-v1_5, this should be the value of T, the DER-encoded
+** DigestInfo structure defined in Section 9.2, Step 2.
+** Note: This can also be used for signatures that use PKCS1-v1_5 padding, such
+** as the signatures used in SSL/TLS, which sign a raw hash.
+*/
+extern SECStatus
+RSA_Sign(RSAPrivateKey       * key,
+         unsigned char       * output,
+         unsigned int        * outputLen,
+         unsigned int          maxOutputLen,
+         const unsigned char * data,
+         unsigned int          dataLen);
+
+extern SECStatus
+RSA_CheckSign(RSAPublicKey        * key,
+              const unsigned char * sig,
+              unsigned int          sigLen,
+              const unsigned char * data,
+              unsigned int          dataLen);
+
+extern SECStatus
+RSA_CheckSignRecover(RSAPublicKey        * key,
+                     unsigned char       * output,
+                     unsigned int        * outputLen,
+                     unsigned int          maxOutputLen,
+                     const unsigned char * sig,
+                     unsigned int          sigLen);
+
+/********************************************************************
+** DSA signing algorithm
+*/
+
+/* Generate a new random value within the interval [2, q-1].
+*/
+extern SECStatus DSA_NewRandom(PLArenaPool * arena, const SECItem * q,
+                               SECItem * random);
+
+/*
+** Generate and return a new DSA public and private key pair,
+**	both of which are encoded into a single DSAPrivateKey struct.
+**	"params" is a pointer to the PQG parameters for the domain
+**	Uses a random seed.
+*/
+extern SECStatus DSA_NewKey(const PQGParams *     params, 
+		            DSAPrivateKey **      privKey);
+
+/* signature is caller-supplied buffer of at least 20 bytes.
+** On input,  signature->len == size of buffer to hold signature.
+**            digest->len    == size of digest.
+** On output, signature->len == size of signature in buffer.
+** Uses a random seed.
+*/
+extern SECStatus DSA_SignDigest(DSAPrivateKey *   key,
+				SECItem *         signature,
+				const SECItem *   digest);
+
+/* signature is caller-supplied buffer of at least 20 bytes.
+** On input,  signature->len == size of buffer to hold signature.
+**            digest->len    == size of digest.
+*/
+extern SECStatus DSA_VerifyDigest(DSAPublicKey *  key,
+				  const SECItem * signature,
+				  const SECItem * digest);
+
+/* For FIPS compliance testing. Seed must be exactly 20 bytes long */
+extern SECStatus DSA_NewKeyFromSeed(const PQGParams *params, 
+                                    const unsigned char * seed,
+                                    DSAPrivateKey **privKey);
+
+/* For FIPS compliance testing. Seed must be exactly 20 bytes. */
+extern SECStatus DSA_SignDigestWithSeed(DSAPrivateKey * key,
+                                        SECItem *       signature,
+                                        const SECItem * digest,
+                                        const unsigned char * seed);
+
+/******************************************************
+** Diffie Helman key exchange algorithm 
+*/
+
+/* Generates parameters for Diffie-Helman key generation.
+**	primeLen is the length in bytes of prime P to be generated.
+*/
+extern SECStatus DH_GenParam(int primeLen, DHParams ** params);
+
+/* Generates a public and private key, both of which are encoded in a single
+**	DHPrivateKey struct. Params is input, privKey are output.  
+**	This is Phase 1 of Diffie Hellman.
+*/
+extern SECStatus DH_NewKey(DHParams *           params, 
+                           DHPrivateKey **	privKey);
+
+/* 
+** DH_Derive does the Diffie-Hellman phase 2 calculation, using the 
+** other party's publicValue, and the prime and our privateValue.
+** maxOutBytes is the requested length of the generated secret in bytes.  
+** A zero value means produce a value of any length up to the size of 
+** the prime.   If successful, derivedSecret->data is set 
+** to the address of the newly allocated buffer containing the derived 
+** secret, and derivedSecret->len is the size of the secret produced.
+** The size of the secret produced will depend on the value of outBytes.
+** If outBytes is 0, the key length will be all the significant bytes of
+** the derived secret (leading zeros are dropped). This length could be less
+** than the length of the prime. If outBytes is nonzero, the length of the
+** produced key will be outBytes long. If the key is truncated, the most
+** significant bytes are truncated. If it is expanded, zero bytes are added
+** at the beginning.
+** It is the caller's responsibility to free the allocated buffer 
+** containing the derived secret.
+*/
+extern SECStatus DH_Derive(SECItem *    publicValue, 
+		           SECItem *    prime, 
+			   SECItem *    privateValue, 
+			   SECItem *    derivedSecret,
+			   unsigned int outBytes);
+
+/* 
+** KEA_CalcKey returns octet string with the private key for a dual
+** Diffie-Helman  key generation as specified for government key exchange.
+*/
+extern SECStatus KEA_Derive(SECItem *prime, 
+                            SECItem *public1, 
+                            SECItem *public2, 
+			    SECItem *private1, 
+			    SECItem *private2,
+			    SECItem *derivedSecret);
+
+/*
+ * verify that a KEA or DSA public key is a valid key for this prime and
+ * subprime domain.
+ */
+extern PRBool KEA_Verify(SECItem *Y, SECItem *prime, SECItem *subPrime);
+
+/****************************************
+ * J-PAKE key transport
+ */
+
+/* Given gx == g^x, create a Schnorr zero-knowledge proof for the value x
+ * using the specified hash algorithm and signer ID. The signature is
+ * returned in the values gv and r. testRandom must be NULL for a PRNG
+ * generated random committment to be used in the sigature. When testRandom
+ * is non-NULL, that value must contain a value in the subgroup q; that
+ * value will be used instead of a PRNG-generated committment in order to
+ * facilitate known-answer tests.
+ *
+ * If gxIn is non-NULL then it must contain a pre-computed value of g^x that
+ * will be used by the function; in this case, the gxOut parameter must be NULL.
+ * If the gxIn parameter is NULL then gxOut must be non-NULL; in this case
+ * gxOut will contain the value g^x on output.
+ *
+ * gx (if not supplied by the caller), gv, and r will be allocated in the arena.
+ * The arena is *not* optional so do not pass NULL for the arena parameter.
+ * The arena should be zeroed when it is freed.
+ */
+SECStatus
+JPAKE_Sign(PLArenaPool * arena, const PQGParams * pqg, HASH_HashType hashType,
+           const SECItem * signerID, const SECItem * x,
+           const SECItem * testRandom, const SECItem * gxIn, SECItem * gxOut,
+           SECItem * gv, SECItem * r);
+
+/* Given gx == g^x, verify the Schnorr zero-knowledge proof (gv, r) for the
+ * value x using the specified hash algorithm and signer ID.
+ *
+ * The arena is *not* optional so do not pass NULL for the arena parameter. 
+ */
+SECStatus
+JPAKE_Verify(PLArenaPool * arena, const PQGParams * pqg,
+             HASH_HashType hashType, const SECItem * signerID,
+             const SECItem * peerID, const SECItem * gx,
+             const SECItem * gv, const SECItem * r);
+
+/* Call before round 2 with x2, s, and x2s all non-NULL. This will calculate
+ * base = g^(x1+x3+x4) (mod p) and x2s = x2*s (mod q). The values to send in 
+ * round 2 (A and the proof of knowledge of x2s) can then be calculated with
+ * JPAKE_Sign using pqg->base = base and x = x2s.
+ *
+ * Call after round 2 with x2, s, and x2s all NULL, and passing (gx1, gx2, gx3)
+ * instead of (gx1, gx3, gx4). This will calculate base = g^(x1+x2+x3). Then call
+ * JPAKE_Verify with pqg->base = base and then JPAKE_Final.
+ *
+ * base and x2s will be allocated in the arena. The arena is *not* optional so
+ * do not pass NULL for the arena parameter. The arena should be zeroed when it
+ * is freed.
+*/
+SECStatus
+JPAKE_Round2(PLArenaPool * arena, const SECItem * p, const SECItem  *q,
+             const SECItem * gx1, const SECItem * gx3, const SECItem * gx4,
+             SECItem * base, const SECItem * x2, const SECItem * s, SECItem * x2s);
+
+/* K = (B/g^(x2*x4*s))^x2 (mod p)
+ *
+ * K will be allocated in the arena. The arena is *not* optional so do not pass
+ * NULL for the arena parameter. The arena should be zeroed when it is freed.
+ */
+SECStatus
+JPAKE_Final(PLArenaPool * arena, const SECItem * p, const SECItem  *q,
+            const SECItem * x2, const SECItem * gx4, const SECItem * x2s,
+            const SECItem * B, SECItem * K);
+
+/******************************************************
+** Elliptic Curve algorithms
+*/
+
+/* Generates a public and private key, both of which are encoded 
+** in a single ECPrivateKey struct. Params is input, privKey are
+** output.
+*/
+extern SECStatus EC_NewKey(ECParams *          params, 
+                           ECPrivateKey **     privKey);
+
+extern SECStatus EC_NewKeyFromSeed(ECParams *  params, 
+                           ECPrivateKey **     privKey,
+                           const unsigned char* seed,
+                           int                 seedlen);
+
+/* Validates an EC public key as described in Section 5.2.2 of
+ * X9.62. Such validation prevents against small subgroup attacks
+ * when the ECDH primitive is used with the cofactor.
+ */
+extern SECStatus EC_ValidatePublicKey(ECParams * params, 
+                           SECItem *           publicValue);
+
+/* 
+** ECDH_Derive performs a scalar point multiplication of a point
+** representing a (peer's) public key and a large integer representing
+** a private key (its own). Both keys must use the same elliptic curve
+** parameters. If the withCofactor parameter is true, the
+** multiplication also uses the cofactor associated with the curve
+** parameters.  The output of this scheme is the x-coordinate of the
+** resulting point. If successful, derivedSecret->data is set to the
+** address of the newly allocated buffer containing the derived
+** secret, and derivedSecret->len is the size of the secret
+** produced. It is the caller's responsibility to free the allocated
+** buffer containing the derived secret.
+*/
+extern SECStatus ECDH_Derive(SECItem *       publicValue,
+                             ECParams *      params,
+                             SECItem *       privateValue,
+                             PRBool          withCofactor,
+                             SECItem *       derivedSecret);
+
+/* On input,  signature->len == size of buffer to hold signature.
+**            digest->len    == size of digest.
+** On output, signature->len == size of signature in buffer.
+** Uses a random seed.
+*/
+extern SECStatus ECDSA_SignDigest(ECPrivateKey  *key, 
+                                  SECItem       *signature, 
+                                  const SECItem *digest);
+
+/* On input,  signature->len == size of buffer to hold signature.
+**            digest->len    == size of digest.
+*/
+extern SECStatus ECDSA_VerifyDigest(ECPublicKey   *key, 
+                                    const SECItem *signature, 
+                                    const SECItem *digest);
+
+/* Uses the provided seed. */
+extern SECStatus ECDSA_SignDigestWithSeed(ECPrivateKey        *key,
+                                          SECItem             *signature,
+                                          const SECItem       *digest,
+                                          const unsigned char *seed, 
+                                          const int           seedlen);
+
+/******************************************/
+/*
+** RC4 symmetric stream cypher
+*/
+
+/*
+** Create a new RC4 context suitable for RC4 encryption/decryption.
+**	"key" raw key data
+**	"len" the number of bytes of key data
+*/
+extern RC4Context *RC4_CreateContext(const unsigned char *key, int len);
+
+extern RC4Context *RC4_AllocateContext(void);
+extern SECStatus   RC4_InitContext(RC4Context *cx, 
+				   const unsigned char *key, 
+				   unsigned int keylen,
+				   const unsigned char *, 
+				   int, 
+				   unsigned int ,
+				   unsigned int );
+
+/*
+** Destroy an RC4 encryption/decryption context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void RC4_DestroyContext(RC4Context *cx, PRBool freeit);
+
+/*
+** Perform RC4 encryption.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus RC4_Encrypt(RC4Context *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform RC4 decryption.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus RC4_Decrypt(RC4Context *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/******************************************/
+/*
+** RC2 symmetric block cypher
+*/
+
+/*
+** Create a new RC2 context suitable for RC2 encryption/decryption.
+** 	"key" raw key data
+** 	"len" the number of bytes of key data
+** 	"iv" is the CBC initialization vector (if mode is NSS_RC2_CBC)
+** 	"mode" one of NSS_RC2 or NSS_RC2_CBC
+**	"effectiveKeyLen" is the effective key length (as specified in 
+**	    RFC 2268) in bytes (not bits).
+**
+** When mode is set to NSS_RC2_CBC the RC2 cipher is run in "cipher block
+** chaining" mode.
+*/
+extern RC2Context *RC2_CreateContext(const unsigned char *key, unsigned int len,
+				     const unsigned char *iv, int mode, 
+				     unsigned effectiveKeyLen);
+extern RC2Context *RC2_AllocateContext(void);
+extern SECStatus   RC2_InitContext(RC2Context *cx,
+				   const unsigned char *key, 
+				   unsigned int keylen,
+				   const unsigned char *iv, 
+				   int mode, 
+				   unsigned int effectiveKeyLen,
+				   unsigned int );
+
+/*
+** Destroy an RC2 encryption/decryption context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void RC2_DestroyContext(RC2Context *cx, PRBool freeit);
+
+/*
+** Perform RC2 encryption.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus RC2_Encrypt(RC2Context *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform RC2 decryption.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus RC2_Decrypt(RC2Context *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/******************************************/
+/*
+** RC5 symmetric block cypher -- 64-bit block size
+*/
+
+/*
+** Create a new RC5 context suitable for RC5 encryption/decryption.
+**      "key" raw key data
+**      "len" the number of bytes of key data
+**      "iv" is the CBC initialization vector (if mode is NSS_RC5_CBC)
+**      "mode" one of NSS_RC5 or NSS_RC5_CBC
+**
+** When mode is set to NSS_RC5_CBC the RC5 cipher is run in "cipher block
+** chaining" mode.
+*/
+extern RC5Context *RC5_CreateContext(const SECItem *key, unsigned int rounds,
+                     unsigned int wordSize, const unsigned char *iv, int mode);
+extern RC5Context *RC5_AllocateContext(void);
+extern SECStatus   RC5_InitContext(RC5Context *cx, 
+				   const unsigned char *key, 
+				   unsigned int keylen,
+				   const unsigned char *iv, 
+				   int mode,
+				   unsigned int rounds, 
+				   unsigned int wordSize);
+
+/*
+** Destroy an RC5 encryption/decryption context.
+**      "cx" the context
+**      "freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void RC5_DestroyContext(RC5Context *cx, PRBool freeit);
+
+/*
+** Perform RC5 encryption.
+**      "cx" the context
+**      "output" the output buffer to store the encrypted data.
+**      "outputLen" how much data is stored in "output". Set by the routine
+**         after some data is stored in output.
+**      "maxOutputLen" the maximum amount of data that can ever be
+**         stored in "output"
+**      "input" the input data
+**      "inputLen" the amount of input data
+*/
+extern SECStatus RC5_Encrypt(RC5Context *cx, unsigned char *output,
+                            unsigned int *outputLen, unsigned int maxOutputLen,
+                            const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform RC5 decryption.
+**      "cx" the context
+**      "output" the output buffer to store the decrypted data.
+**      "outputLen" how much data is stored in "output". Set by the routine
+**         after some data is stored in output.
+**      "maxOutputLen" the maximum amount of data that can ever be
+**         stored in "output"
+**      "input" the input data
+**      "inputLen" the amount of input data
+*/
+
+extern SECStatus RC5_Decrypt(RC5Context *cx, unsigned char *output,
+                            unsigned int *outputLen, unsigned int maxOutputLen,
+                            const unsigned char *input, unsigned int inputLen);
+
+
+
+/******************************************/
+/*
+** DES symmetric block cypher
+*/
+
+/*
+** Create a new DES context suitable for DES encryption/decryption.
+** 	"key" raw key data
+** 	"len" the number of bytes of key data
+** 	"iv" is the CBC initialization vector (if mode is NSS_DES_CBC or
+** 	   mode is DES_EDE3_CBC)
+** 	"mode" one of NSS_DES, NSS_DES_CBC, NSS_DES_EDE3 or NSS_DES_EDE3_CBC
+**	"encrypt" is PR_TRUE if the context will be used for encryption
+**
+** When mode is set to NSS_DES_CBC or NSS_DES_EDE3_CBC then the DES
+** cipher is run in "cipher block chaining" mode.
+*/
+extern DESContext *DES_CreateContext(const unsigned char *key, 
+                                     const unsigned char *iv,
+				     int mode, PRBool encrypt);
+extern DESContext *DES_AllocateContext(void);
+extern SECStatus   DES_InitContext(DESContext *cx,
+				   const unsigned char *key, 
+				   unsigned int keylen,
+				   const unsigned char *iv, 
+				   int mode,
+				   unsigned int encrypt,
+				   unsigned int );
+
+/*
+** Destroy an DES encryption/decryption context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void DES_DestroyContext(DESContext *cx, PRBool freeit);
+
+/*
+** Perform DES encryption.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+**
+** NOTE: the inputLen must be a multiple of DES_KEY_LENGTH
+*/
+extern SECStatus DES_Encrypt(DESContext *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform DES decryption.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+**
+** NOTE: the inputLen must be a multiple of DES_KEY_LENGTH
+*/
+extern SECStatus DES_Decrypt(DESContext *cx, unsigned char *output,
+			    unsigned int *outputLen, unsigned int maxOutputLen,
+			    const unsigned char *input, unsigned int inputLen);
+
+/******************************************/
+/* 
+** SEED symmetric block cypher		  
+*/
+extern SEEDContext *
+SEED_CreateContext(const unsigned char *key, const unsigned char *iv, 
+		   int mode, PRBool encrypt);
+extern SEEDContext *SEED_AllocateContext(void);
+extern SECStatus   SEED_InitContext(SEEDContext *cx, 
+				    const unsigned char *key, 
+				    unsigned int keylen, 
+				    const unsigned char *iv, 
+				    int mode, unsigned int encrypt, 
+				    unsigned int );
+extern void SEED_DestroyContext(SEEDContext *cx, PRBool freeit);
+extern SECStatus 
+SEED_Encrypt(SEEDContext *cx, unsigned char *output, 
+	     unsigned int *outputLen, unsigned int maxOutputLen, 
+	     const unsigned char *input, unsigned int inputLen);
+extern SECStatus 
+SEED_Decrypt(SEEDContext *cx, unsigned char *output, 
+	     unsigned int *outputLen, unsigned int maxOutputLen, 
+             const unsigned char *input, unsigned int inputLen);
+
+/******************************************/
+/*
+** AES symmetric block cypher (Rijndael)
+*/
+
+/*
+** Create a new AES context suitable for AES encryption/decryption.
+** 	"key" raw key data
+** 	"keylen" the number of bytes of key data (16, 24, or 32)
+**      "blocklen" is the blocksize to use (16, 24, or 32)
+**                        XXX currently only blocksize==16 has been tested!
+*/
+extern AESContext *
+AES_CreateContext(const unsigned char *key, const unsigned char *iv, 
+                  int mode, int encrypt,
+                  unsigned int keylen, unsigned int blocklen);
+extern AESContext *AES_AllocateContext(void);
+extern SECStatus   AES_InitContext(AESContext *cx,
+				   const unsigned char *key, 
+				   unsigned int keylen, 
+				   const unsigned char *iv, 
+				   int mode, 
+				   unsigned int encrypt,
+				   unsigned int blocklen);
+
+/*
+** Destroy a AES encryption/decryption context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void 
+AES_DestroyContext(AESContext *cx, PRBool freeit);
+
+/*
+** Perform AES encryption.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+AES_Encrypt(AESContext *cx, unsigned char *output,
+            unsigned int *outputLen, unsigned int maxOutputLen,
+            const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform AES decryption.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+AES_Decrypt(AESContext *cx, unsigned char *output,
+            unsigned int *outputLen, unsigned int maxOutputLen,
+            const unsigned char *input, unsigned int inputLen);
+
+/******************************************/
+/*
+** AES key wrap algorithm, RFC 3394
+*/
+
+/*
+** Create a new AES context suitable for AES encryption/decryption.
+** 	"key" raw key data
+**      "iv"  The 8 byte "initial value"
+**      "encrypt", a boolean, true for key wrapping, false for unwrapping.
+** 	"keylen" the number of bytes of key data (16, 24, or 32)
+*/
+extern AESKeyWrapContext *
+AESKeyWrap_CreateContext(const unsigned char *key, const unsigned char *iv, 
+                         int encrypt, unsigned int keylen);
+extern AESKeyWrapContext * AESKeyWrap_AllocateContext(void);
+extern SECStatus  
+     AESKeyWrap_InitContext(AESKeyWrapContext *cx, 
+				   const unsigned char *key, 
+				   unsigned int keylen,
+				   const unsigned char *iv, 
+				   int ,
+				   unsigned int encrypt,
+				   unsigned int );
+
+/*
+** Destroy a AES KeyWrap context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void 
+AESKeyWrap_DestroyContext(AESKeyWrapContext *cx, PRBool freeit);
+
+/*
+** Perform AES key wrap.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+AESKeyWrap_Encrypt(AESKeyWrapContext *cx, unsigned char *output,
+            unsigned int *outputLen, unsigned int maxOutputLen,
+            const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform AES key unwrap.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+AESKeyWrap_Decrypt(AESKeyWrapContext *cx, unsigned char *output,
+            unsigned int *outputLen, unsigned int maxOutputLen,
+            const unsigned char *input, unsigned int inputLen);
+
+ /******************************************/
+/*
+** Camellia symmetric block cypher
+*/
+
+/*
+** Create a new Camellia context suitable for Camellia encryption/decryption.
+** 	"key" raw key data
+** 	"keylen" the number of bytes of key data (16, 24, or 32)
+*/
+extern CamelliaContext *
+Camellia_CreateContext(const unsigned char *key, const unsigned char *iv, 
+		       int mode, int encrypt, unsigned int keylen);
+
+extern CamelliaContext *Camellia_AllocateContext(void);
+extern SECStatus   Camellia_InitContext(CamelliaContext *cx,
+					const unsigned char *key, 
+					unsigned int keylen, 
+					const unsigned char *iv, 
+					int mode, 
+					unsigned int encrypt,
+					unsigned int unused);
+/*
+** Destroy a Camellia encryption/decryption context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void 
+Camellia_DestroyContext(CamelliaContext *cx, PRBool freeit);
+
+/*
+** Perform Camellia encryption.
+**	"cx" the context
+**	"output" the output buffer to store the encrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+Camellia_Encrypt(CamelliaContext *cx, unsigned char *output,
+		 unsigned int *outputLen, unsigned int maxOutputLen,
+		 const unsigned char *input, unsigned int inputLen);
+
+/*
+** Perform Camellia decryption.
+**	"cx" the context
+**	"output" the output buffer to store the decrypted data.
+**	"outputLen" how much data is stored in "output". Set by the routine
+**	   after some data is stored in output.
+**	"maxOutputLen" the maximum amount of data that can ever be
+**	   stored in "output"
+**	"input" the input data
+**	"inputLen" the amount of input data
+*/
+extern SECStatus 
+Camellia_Decrypt(CamelliaContext *cx, unsigned char *output,
+		 unsigned int *outputLen, unsigned int maxOutputLen,
+		 const unsigned char *input, unsigned int inputLen);
+
+#endif
+
+/******************************************/
+/*
+** MD5 secure hash function
+*/
+
+typedef struct MD5ContextStr SCMD5Context;
+
+/*
+** Hash a null terminated string "src" into "dest" using MD5
+*/
+extern SECStatus MD5_Hash(unsigned char *dest, const char *src);
+
+/*
+** Hash a non-null terminated string "src" into "dest" using MD5
+*/
+extern SECStatus MD5_HashBuf(unsigned char *dest, const unsigned char *src,
+			     PRUint32 src_length);
+
+/*
+** Create a new MD5 context
+*/
+extern SCMD5Context *MD5_NewContext(HASH_HashType hash);
+
+
+/*
+** Destroy an MD5 secure hash context.
+**	"cx" the context
+*/
+extern void MD5_DestroyContext(SCMD5Context *cx);
+
+/*
+** Reset an MD5 context, preparing it for a fresh round of hashing
+*/
+extern void MD5_Begin(SCMD5Context *cx);
+
+/*
+** Update the MD5 hash function with more data.
+**	"cx" the context
+**	"input" the data to hash
+**	"inputLen" the amount of data to hash
+*/
+extern void MD5_Update(SCMD5Context *cx,
+		       const unsigned char *input, unsigned int inputLen);
+
+/*
+** Finish the MD5 hash function. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 16 bytes of digest data are stored
+**	"digestLen" where the digest length (16) is stored
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void MD5_End(SCMD5Context *cx, unsigned char *digest,
+		    unsigned int *digestLen, unsigned int maxDigestLen);
+
+/*
+** Export the current state of the MD5 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 16 bytes of digest data are stored
+**	"digestLen" where the digest length (16) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void MD5_EndRaw(SCMD5Context *cx, unsigned char *digest,
+		       unsigned int *digestLen, unsigned int maxDigestLen);
+
+/*
+ * Return the the size of a buffer needed to flatten the MD5 Context into
+ *    "cx" the context
+ *  returns size;
+ */
+extern unsigned int MD5_FlattenSize(SCMD5Context *cx);
+
+/*
+ * Flatten the MD5 Context into a buffer:
+ *    "cx" the context
+ *    "space" the buffer to flatten to
+ *  returns status;
+ */
+extern SECStatus MD5_Flatten(SCMD5Context *cx,unsigned char *space);
+
+/*
+ * Resurrect a flattened context into a MD5 Context
+ *    "space" the buffer of the flattend buffer
+ *    "arg" ptr to void used by cryptographic resurrect
+ *  returns resurected context;
+ */
+extern SCMD5Context * MD5_Resurrect(unsigned char *space, void *arg);
+extern void MD5_Clone(SCMD5Context *dest, SCMD5Context *src);
+
+/*
+** trace the intermediate state info of the MD5 hash.
+*/
+extern void MD5_TraceState(SCMD5Context *cx);
+
+#if 0
+
+/******************************************/
+/*
+** MD2 secure hash function
+*/
+
+/*
+** Hash a null terminated string "src" into "dest" using MD2
+*/
+extern SECStatus MD2_Hash(unsigned char *dest, const char *src);
+
+/*
+** Create a new MD2 context
+*/
+extern MD2Context *MD2_NewContext(void);
+
+
+/*
+** Destroy an MD2 secure hash context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void MD2_DestroyContext(MD2Context *cx, PRBool freeit);
+
+/*
+** Reset an MD2 context, preparing it for a fresh round of hashing
+*/
+extern void MD2_Begin(MD2Context *cx);
+
+/*
+** Update the MD2 hash function with more data.
+**	"cx" the context
+**	"input" the data to hash
+**	"inputLen" the amount of data to hash
+*/
+extern void MD2_Update(MD2Context *cx,
+		       const unsigned char *input, unsigned int inputLen);
+
+/*
+** Finish the MD2 hash function. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 16 bytes of digest data are stored
+**	"digestLen" where the digest length (16) is stored
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void MD2_End(MD2Context *cx, unsigned char *digest,
+		    unsigned int *digestLen, unsigned int maxDigestLen);
+
+/*
+ * Return the the size of a buffer needed to flatten the MD2 Context into
+ *    "cx" the context
+ *  returns size;
+ */
+extern unsigned int MD2_FlattenSize(MD2Context *cx);
+
+/*
+ * Flatten the MD2 Context into a buffer:
+ *    "cx" the context
+ *    "space" the buffer to flatten to
+ *  returns status;
+ */
+extern SECStatus MD2_Flatten(MD2Context *cx,unsigned char *space);
+
+/*
+ * Resurrect a flattened context into a MD2 Context
+ *    "space" the buffer of the flattend buffer
+ *    "arg" ptr to void used by cryptographic resurrect
+ *  returns resurected context;
+ */
+extern MD2Context * MD2_Resurrect(unsigned char *space, void *arg);
+extern void MD2_Clone(MD2Context *dest, MD2Context *src);
+
+/******************************************/
+/*
+** SHA-1 secure hash function
+*/
+
+/*
+** Hash a null terminated string "src" into "dest" using SHA-1
+*/
+extern SECStatus SHA1_Hash(unsigned char *dest, const char *src);
+
+/*
+** Hash a non-null terminated string "src" into "dest" using SHA-1
+*/
+extern SECStatus SHA1_HashBuf(unsigned char *dest, const unsigned char *src,
+			      PRUint32 src_length);
+
+/*
+** Create a new SHA-1 context
+*/
+extern SHA1Context *SHA1_NewContext(void);
+
+
+/*
+** Destroy a SHA-1 secure hash context.
+**	"cx" the context
+**	"freeit" if PR_TRUE then free the object as well as its sub-objects
+*/
+extern void SHA1_DestroyContext(SHA1Context *cx, PRBool freeit);
+
+/*
+** Reset a SHA-1 context, preparing it for a fresh round of hashing
+*/
+extern void SHA1_Begin(SHA1Context *cx);
+
+/*
+** Update the SHA-1 hash function with more data.
+**	"cx" the context
+**	"input" the data to hash
+**	"inputLen" the amount of data to hash
+*/
+extern void SHA1_Update(SHA1Context *cx, const unsigned char *input,
+			unsigned int inputLen);
+
+/*
+** Finish the SHA-1 hash function. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 16 bytes of digest data are stored
+**	"digestLen" where the digest length (20) is stored
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA1_End(SHA1Context *cx, unsigned char *digest,
+		     unsigned int *digestLen, unsigned int maxDigestLen);
+
+/*
+** Export the current state of the SHA-1 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 20 bytes of digest data are stored
+**	"digestLen" where the digest length (20) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA1_EndRaw(SHA1Context *cx, unsigned char *digest,
+			unsigned int *digestLen, unsigned int maxDigestLen);
+
+/*
+** trace the intermediate state info of the SHA1 hash.
+*/
+extern void SHA1_TraceState(SHA1Context *cx);
+
+/*
+ * Return the the size of a buffer needed to flatten the SHA-1 Context into
+ *    "cx" the context
+ *  returns size;
+ */
+extern unsigned int SHA1_FlattenSize(SHA1Context *cx);
+
+/*
+ * Flatten the SHA-1 Context into a buffer:
+ *    "cx" the context
+ *    "space" the buffer to flatten to
+ *  returns status;
+ */
+extern SECStatus SHA1_Flatten(SHA1Context *cx,unsigned char *space);
+
+/*
+ * Resurrect a flattened context into a SHA-1 Context
+ *    "space" the buffer of the flattend buffer
+ *    "arg" ptr to void used by cryptographic resurrect
+ *  returns resurected context;
+ */
+extern SHA1Context * SHA1_Resurrect(unsigned char *space, void *arg);
+extern void SHA1_Clone(SHA1Context *dest, SHA1Context *src);
+
+/******************************************/
+
+extern SHA224Context *SHA224_NewContext(void);
+extern void SHA224_DestroyContext(SHA224Context *cx, PRBool freeit);
+extern void SHA224_Begin(SHA224Context *cx);
+extern void SHA224_Update(SHA224Context *cx, const unsigned char *input,
+			unsigned int inputLen);
+extern void SHA224_End(SHA224Context *cx, unsigned char *digest,
+		     unsigned int *digestLen, unsigned int maxDigestLen);
+/*
+** Export the current state of the SHA-224 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 28 bytes of digest data are stored
+**	"digestLen" where the digest length (28) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA224_EndRaw(SHA224Context *cx, unsigned char *digest,
+			  unsigned int *digestLen, unsigned int maxDigestLen);
+extern SECStatus SHA224_HashBuf(unsigned char *dest, const unsigned char *src,
+				PRUint32 src_length);
+extern SECStatus SHA224_Hash(unsigned char *dest, const char *src);
+extern void SHA224_TraceState(SHA224Context *cx);
+extern unsigned int SHA224_FlattenSize(SHA224Context *cx);
+extern SECStatus SHA224_Flatten(SHA224Context *cx,unsigned char *space);
+extern SHA224Context * SHA224_Resurrect(unsigned char *space, void *arg);
+extern void SHA224_Clone(SHA224Context *dest, SHA224Context *src);
+
+/******************************************/
+
+extern SHA256Context *SHA256_NewContext(void);
+extern void SHA256_DestroyContext(SHA256Context *cx, PRBool freeit);
+extern void SHA256_Begin(SHA256Context *cx);
+extern void SHA256_Update(SHA256Context *cx, const unsigned char *input,
+			unsigned int inputLen);
+extern void SHA256_End(SHA256Context *cx, unsigned char *digest,
+		     unsigned int *digestLen, unsigned int maxDigestLen);
+/*
+** Export the current state of the SHA-256 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 32 bytes of digest data are stored
+**	"digestLen" where the digest length (32) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA256_EndRaw(SHA256Context *cx, unsigned char *digest,
+			  unsigned int *digestLen, unsigned int maxDigestLen);
+extern SECStatus SHA256_HashBuf(unsigned char *dest, const unsigned char *src,
+				PRUint32 src_length);
+extern SECStatus SHA256_Hash(unsigned char *dest, const char *src);
+extern void SHA256_TraceState(SHA256Context *cx);
+extern unsigned int SHA256_FlattenSize(SHA256Context *cx);
+extern SECStatus SHA256_Flatten(SHA256Context *cx,unsigned char *space);
+extern SHA256Context * SHA256_Resurrect(unsigned char *space, void *arg);
+extern void SHA256_Clone(SHA256Context *dest, SHA256Context *src);
+
+/******************************************/
+
+extern SHA512Context *SHA512_NewContext(void);
+extern void SHA512_DestroyContext(SHA512Context *cx, PRBool freeit);
+extern void SHA512_Begin(SHA512Context *cx);
+extern void SHA512_Update(SHA512Context *cx, const unsigned char *input,
+			unsigned int inputLen);
+/*
+** Export the current state of the SHA-512 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 64 bytes of digest data are stored
+**	"digestLen" where the digest length (64) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA512_EndRaw(SHA512Context *cx, unsigned char *digest,
+			  unsigned int *digestLen, unsigned int maxDigestLen);
+extern void SHA512_End(SHA512Context *cx, unsigned char *digest,
+		     unsigned int *digestLen, unsigned int maxDigestLen);
+extern SECStatus SHA512_HashBuf(unsigned char *dest, const unsigned char *src,
+				PRUint32 src_length);
+extern SECStatus SHA512_Hash(unsigned char *dest, const char *src);
+extern void SHA512_TraceState(SHA512Context *cx);
+extern unsigned int SHA512_FlattenSize(SHA512Context *cx);
+extern SECStatus SHA512_Flatten(SHA512Context *cx,unsigned char *space);
+extern SHA512Context * SHA512_Resurrect(unsigned char *space, void *arg);
+extern void SHA512_Clone(SHA512Context *dest, SHA512Context *src);
+
+/******************************************/
+
+extern SHA384Context *SHA384_NewContext(void);
+extern void SHA384_DestroyContext(SHA384Context *cx, PRBool freeit);
+extern void SHA384_Begin(SHA384Context *cx);
+extern void SHA384_Update(SHA384Context *cx, const unsigned char *input,
+			unsigned int inputLen);
+extern void SHA384_End(SHA384Context *cx, unsigned char *digest,
+		     unsigned int *digestLen, unsigned int maxDigestLen);
+/*
+** Export the current state of the SHA-384 hash without appending the standard
+** padding and length bytes. Produce the digested results in "digest"
+**	"cx" the context
+**	"digest" where the 48 bytes of digest data are stored
+**	"digestLen" where the digest length (48) is stored (optional)
+**	"maxDigestLen" the maximum amount of data that can ever be
+**	   stored in "digest"
+*/
+extern void SHA384_EndRaw(SHA384Context *cx, unsigned char *digest,
+			  unsigned int *digestLen, unsigned int maxDigestLen);
+extern SECStatus SHA384_HashBuf(unsigned char *dest, const unsigned char *src,
+				PRUint32 src_length);
+extern SECStatus SHA384_Hash(unsigned char *dest, const char *src);
+extern void SHA384_TraceState(SHA384Context *cx);
+extern unsigned int SHA384_FlattenSize(SHA384Context *cx);
+extern SECStatus SHA384_Flatten(SHA384Context *cx,unsigned char *space);
+extern SHA384Context * SHA384_Resurrect(unsigned char *space, void *arg);
+extern void SHA384_Clone(SHA384Context *dest, SHA384Context *src);
+
+/****************************************
+ * implement TLS 1.0 Pseudo Random Function (PRF) and TLS P_hash function
+ */
+
+extern SECStatus
+TLS_PRF(const SECItem *secret, const char *label, SECItem *seed, 
+         SECItem *result, PRBool isFIPS);
+
+extern SECStatus
+TLS_P_hash(HASH_HashType hashAlg, const SECItem *secret, const char *label,
+           SECItem *seed, SECItem *result, PRBool isFIPS);
+
+/******************************************/
+/*
+** Pseudo Random Number Generation.  FIPS compliance desirable.
+*/
+
+/*
+** Initialize the global RNG context and give it some seed input taken
+** from the system.  This function is thread-safe and will only allow
+** the global context to be initialized once.  The seed input is likely
+** small, so it is imperative that RNG_RandomUpdate() be called with
+** additional seed data before the generator is used.  A good way to
+** provide the generator with additional entropy is to call
+** RNG_SystemInfoForRNG().  Note that NSS_Init() does exactly that.
+*/
+extern SECStatus RNG_RNGInit(void);
+
+/*
+** Update the global random number generator with more seeding
+** material
+*/
+extern SECStatus RNG_RandomUpdate(const void *data, size_t bytes);
+
+/*
+** Generate some random bytes, using the global random number generator
+** object.
+*/
+extern SECStatus RNG_GenerateGlobalRandomBytes(void *dest, size_t len);
+
+/* Destroy the global RNG context.  After a call to RNG_RNGShutdown()
+** a call to RNG_RNGInit() is required in order to use the generator again,
+** along with seed data (see the comment above RNG_RNGInit()).
+*/
+extern void  RNG_RNGShutdown(void);
+
+extern void RNG_SystemInfoForRNG(void);
+
+/*
+ * FIPS 186-2 Change Notice 1 RNG Algorithm 1, used both to
+ * generate the DSA X parameter and as a generic purpose RNG.
+ *
+ * The following two FIPS186Change functions are needed for
+ * NIST RNG Validation System.
+ */
+
+/*
+ * FIPS186Change_GenerateX is now deprecated. It will return SECFailure with
+ * the error set to PR_NOT_IMPLEMENTED_ERROR.
+ */
+extern SECStatus
+FIPS186Change_GenerateX(unsigned char *XKEY,
+                        const unsigned char *XSEEDj,
+                        unsigned char *x_j);
+
+/*
+ * When generating the DSA X parameter, we generate 2*GSIZE bytes
+ * of random output and reduce it mod q.
+ *
+ * Input: w, 2*GSIZE bytes
+ *        q, DSA_SUBPRIME_LEN bytes
+ * Output: xj, DSA_SUBPRIME_LEN bytes
+ */
+extern SECStatus
+FIPS186Change_ReduceModQForDSA(const unsigned char *w,
+                               const unsigned char *q,
+                               unsigned char *xj);
+
+/*
+ * The following functions are for FIPS poweron self test and FIPS algorithm
+ * testing.
+ */
+extern SECStatus
+PRNGTEST_Instantiate(const PRUint8 *entropy, unsigned int entropy_len, 
+		const PRUint8 *nonce, unsigned int nonce_len,
+		const PRUint8 *personal_string, unsigned int ps_len);
+
+extern SECStatus
+PRNGTEST_Reseed(const PRUint8 *entropy, unsigned int entropy_len, 
+		  const PRUint8 *additional, unsigned int additional_len);
+
+extern SECStatus
+PRNGTEST_Generate(PRUint8 *bytes, unsigned int bytes_len, 
+		  const PRUint8 *additional, unsigned int additional_len);
+
+extern SECStatus
+PRNGTEST_Uninstantiate(void);
+
+extern SECStatus
+PRNGTEST_RunHealthTests(void);
+
+/* Generate PQGParams and PQGVerify structs.
+ * Length of seed and length of h both equal length of P. 
+ * All lengths are specified by "j", according to the table above.
+ *
+ * The verify parameters will conform to FIPS186-1.
+ */
+extern SECStatus
+PQG_ParamGen(unsigned int j, 	   /* input : determines length of P. */
+             PQGParams **pParams,  /* output: P Q and G returned here */
+	     PQGVerify **pVfy);    /* output: counter and seed. */
+
+/* Generate PQGParams and PQGVerify structs.
+ * Length of P specified by j.  Length of h will match length of P.
+ * Length of SEED in bytes specified in seedBytes.
+ * seedBbytes must be in the range [20..255] or an error will result.
+ *
+ * The verify parameters will conform to FIPS186-1.
+ */
+extern SECStatus
+PQG_ParamGenSeedLen(
+             unsigned int j, 	     /* input : determines length of P. */
+	     unsigned int seedBytes, /* input : length of seed in bytes.*/
+             PQGParams **pParams,    /* output: P Q and G returned here */
+	     PQGVerify **pVfy);      /* output: counter and seed. */
+
+/* Generate PQGParams and PQGVerify structs.
+ * Length of P specified by L in bits.  
+ * Length of Q specified by N in bits.  
+ * Length of SEED in bytes specified in seedBytes.
+ * seedBbytes must be in the range [N..L*2] or an error will result.
+ *
+ * Not that J uses the above table, L is the length exact. L and N must
+ * match the table below or an error will result:
+ *
+ *  L            N
+ * 1024         160
+ * 2048         224
+ * 2048         256
+ * 3072         256
+ *
+ * If N or seedBytes are set to zero, then PQG_ParamGenSeedLen will
+ * pick a default value (typically the smallest secure value for these
+ * variables).
+ *
+ * The verify parameters will conform to FIPS186-3 using the smallest 
+ * permissible hash for the key strength.
+ */
+extern SECStatus
+PQG_ParamGenV2(
+             unsigned int L, 	     /* input : determines length of P. */
+             unsigned int N, 	     /* input : determines length of Q. */
+	     unsigned int seedBytes, /* input : length of seed in bytes.*/
+             PQGParams **pParams,    /* output: P Q and G returned here */
+	     PQGVerify **pVfy);      /* output: counter and seed. */
+
+
+/*  Test PQGParams for validity as DSS PQG values.
+ *  If vfy is non-NULL, test PQGParams to make sure they were generated
+ *       using the specified seed, counter, and h values.
+ *
+ *  Return value indicates whether Verification operation ran successfully
+ *  to completion, but does not indicate if PQGParams are valid or not.
+ *  If return value is SECSuccess, then *pResult has these meanings:
+ *       SECSuccess: PQGParams are valid.
+ *       SECFailure: PQGParams are invalid.
+ *
+ * Verify the PQG againts the counter, SEED and h.
+ * These tests are specified in FIPS 186-3 Appendix A.1.1.1, A.1.1.3, and A.2.2
+ * PQG_VerifyParams will automatically choose the appropriate test.
+ */
+
+extern SECStatus   PQG_VerifyParams(const PQGParams *params, 
+                                    const PQGVerify *vfy, SECStatus *result);
+
+extern void PQG_DestroyParams(PQGParams *params);
+
+extern void PQG_DestroyVerify(PQGVerify *vfy);
+
+
+/*
+ * clean-up any global tables freebl may have allocated after it starts up.
+ * This function is not thread safe and should be called only after the
+ * library has been quiessed.
+ */
+extern void BL_Cleanup(void);
+
+/* unload freebl shared library from memory */
+extern void BL_Unload(void);
+
+/**************************************************************************
+ *  Verify a given Shared library signature                               *
+ **************************************************************************/
+PRBool BLAPI_SHVerify(const char *name, PRFuncPtr addr);
+
+/**************************************************************************
+ *  Verify a given filename's signature                               *
+ **************************************************************************/
+PRBool BLAPI_SHVerifyFile(const char *shName);
+
+/**************************************************************************
+ *  Verify Are Own Shared library signature                               *
+ **************************************************************************/
+PRBool BLAPI_VerifySelf(const char *name);
+
+/*********************************************************************/
+extern const SECHashObject * HASH_GetRawHashObject(HASH_HashType hashType);
+
+extern void BL_SetForkState(PRBool forked);
+
+#ifndef NSS_DISABLE_ECC
+/*
+** pepare an ECParam structure from DEREncoded params
+ */
+extern SECStatus EC_FillParams(PLArenaPool *arena,
+                               const SECItem *encodedParams, ECParams *params);
+extern SECStatus EC_DecodeParams(const SECItem *encodedParams,
+                                 ECParams **ecparams);
+extern SECStatus EC_CopyParams(PLArenaPool *arena, ECParams *dstParams,
+                               const ECParams *srcParams);
+#endif
+
+SEC_END_PROTOS
+
+#endif
+
+#endif /* _UTIL_MD5_H_ */


### PR DESCRIPTION
This PR bypasses libnss for performing md5 calculations.  libnss runs single threaded by the time it reaches the actual md5 calculation causing suricata not to scale with available cores.

This was done by including a copy of Mozilla's MD5 implementation into suricata and placing a wrapper around the MD5 calls to use this code directly.

- PR decanio: https://buildbot.openinfosecfoundation.org/builders/decanio/builds/8
- PR decanio-pcap: https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/8
