### PR TITLE
Feature #1454: Add support for CEE/Lumberjack compatibility. 

### DIFF
--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -451,8 +451,8 @@ static void ModbusCheckHeader(ModbusState       *modbus,
         ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_INVALID_LENGTH);
 
     /* Check Unit Identifier field that is not in invalid range */
-    if ((header->length > MODBUS_MIN_INVALID_UNIT_ID)   &&
-        (header->length < MODBUS_MAX_INVALID_UNIT_ID)   )
+    if ((header->unitId > MODBUS_MIN_INVALID_UNIT_ID)   &&
+        (header->unitId < MODBUS_MAX_INVALID_UNIT_ID)   )
         ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_INVALID_UNIT_IDENTIFIER);
 
     SCReturn;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -99,6 +99,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #cee-format: no # Prepend @cee: cookie for CEE/Lumberjack format compatibility
       types:
         - alert:
             # payload: yes           # enable dumping payload in Base64


### PR DESCRIPTION
Updated suricata.yaml section outputs:eve-log section to include 'cee-format' option to prepend '@cee: ' cookie to JSON syslog output. Allows for mmjsonparse compability in rsyslog

NOTE: this feature requires Pull Request #1447 (Bug 1204) to be implemented.