### PR TITLE
Use unlikely for error treatment in alert-prelude.c

### DIFF
--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -131,22 +131,22 @@ static int SetupAnalyzer(idmef_analyzer_t *analyzer)
     SCEnter();
 
     ret = idmef_analyzer_new_model(analyzer, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
     prelude_string_set_constant(string, ANALYZER_MODEL);
 
     ret = idmef_analyzer_new_class(analyzer, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
     prelude_string_set_constant(string, ANALYZER_CLASS);
 
     ret = idmef_analyzer_new_manufacturer(analyzer, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
     prelude_string_set_constant(string, ANALYZER_MANUFACTURER);
 
     ret = idmef_analyzer_new_version(analyzer, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
     prelude_string_set_constant(string, VERSION);
 
@@ -174,11 +174,11 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
     SCEnter();
 
     ret = idmef_alert_new_assessment(alert, &assessment);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_assessment_new_impact(assessment, &impact);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     if ( (unsigned int)pa->s->prio < mid_priority )
@@ -199,7 +199,7 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
         idmef_action_t *action;
 
         ret = idmef_action_new(&action);
-        if (ret < 0)
+        if (unlikely(ret < 0))
             SCReturnInt(ret);
 
         idmef_action_set_category(action, IDMEF_ACTION_CATEGORY_BLOCK_INSTALLED);
@@ -208,7 +208,7 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
 
     if (pa->s->class_msg) {
         ret = idmef_impact_new_description(impact, &str);
-        if (ret < 0)
+        if (unlikely(ret < 0))
             SCReturnInt(ret);
 
         prelude_string_set_ref(str, pa->s->class_msg);
@@ -259,11 +259,11 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
         SCReturnInt(0);
 
     ret = idmef_alert_new_source(alert, &source, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_source_new_service(source, &service);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
@@ -273,25 +273,25 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     idmef_service_set_iana_protocol_number(service, ip_proto);
 
     ret = idmef_source_new_node(source, &node);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_node_new_address(node, &address, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_address_new_address(address, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     prelude_string_set_ref(string, saddr);
 
     ret = idmef_alert_new_target(alert, &target, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_target_new_service(target, &service);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
@@ -301,15 +301,15 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     idmef_service_set_iana_protocol_number(service, ip_proto);
 
     ret = idmef_target_new_node(target, &node);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_node_new_address(node, &address, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_address_new_address(address, &string);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     prelude_string_set_ref(string, daddr);
@@ -335,25 +335,25 @@ static int AddByteData(idmef_alert_t *alert, const char *meaning, const unsigned
         SCReturnInt(0);
 
     ret = idmef_alert_new_additional_data(alert, &ad, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(0);
 
     ret = idmef_additional_data_set_byte_string_ref(ad, data, size);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("%s: error setting byte string data: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
 
     ret = idmef_additional_data_new_meaning(ad, &str);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("%s: error creating additional-data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
 
     ret = prelude_string_set_ref(str, meaning);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("%s: error setting byte string data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
@@ -377,20 +377,20 @@ static int AddIntData(idmef_alert_t *alert, const char *meaning, uint32_t data)
     SCEnter();
 
     ret = idmef_alert_new_additional_data(alert, &ad, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     idmef_additional_data_set_integer(ad, data);
 
     ret = idmef_additional_data_new_meaning(ad, &str);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("%s: error creating additional-data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
 
     ret = prelude_string_set_ref(str, meaning);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("%s: error setting integer data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
@@ -449,7 +449,7 @@ static int PacketToData(const Packet *p, const PacketAlert *pa, idmef_alert_t *a
 {
     SCEnter();
 
-    if ( ! p )
+    if (unlikely(p == NULL))
         SCReturnInt(0);
 
     AddIntData(alert, "snort_rule_sid", pa->s->id);
@@ -513,11 +513,11 @@ static int AddSnortReference(idmef_classification_t *class, int gen_id, int sig_
         SCReturnInt(0);
 
     ret = idmef_classification_new_reference(class, &ref, IDMEF_LIST_APPEND);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_reference_new_name(ref, &str);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     idmef_reference_set_origin(ref, IDMEF_REFERENCE_ORIGIN_VENDOR_SPECIFIC);
@@ -527,19 +527,19 @@ static int AddSnortReference(idmef_classification_t *class, int gen_id, int sig_
     else
         ret = prelude_string_sprintf(str, "%u:%u", gen_id, sig_id);
 
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_reference_new_meaning(ref, &str);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = prelude_string_sprintf(str, "Snort Signature ID");
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = idmef_reference_new_url(ref, &str);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     if ( gen_id == 0 )
@@ -566,18 +566,18 @@ static int EventToReference(const PacketAlert *pa, const Packet *p, idmef_classi
     SCEnter();
 
     ret = idmef_classification_new_ident(class, &str);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     if ( pa->s->gid == 0 )
         ret = prelude_string_sprintf(str, "%u", pa->s->id);
     else
         ret = prelude_string_sprintf(str, "%u:%u", pa->s->gid, pa->s->id);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     ret = AddSnortReference(class, pa->s->gid, pa->s->id);
-    if (ret < 0)
+    if (unlikely(ret < 0))
         SCReturnInt(ret);
 
     SCReturnInt(0);
@@ -606,7 +606,7 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, void *initdata, void **data
 
     SCEnter();
 
-    if(initdata == NULL)
+    if(unlikely(initdata == NULL))
     {
         SCLogDebug("Error getting context for Prelude.  \"initdata\" argument NULL");
         SCReturnInt(TM_ECODE_FAILED);
@@ -635,7 +635,7 @@ static TmEcode AlertPreludeThreadDeinit(ThreadVars *t, void *data)
 
     SCEnter();
 
-    if (aun == NULL) {
+    if (unlikely(aun == NULL)) {
         SCLogDebug("AlertPreludeThreadDeinit done (error)");
         SCReturnInt(TM_ECODE_FAILED);
     }
@@ -677,7 +677,7 @@ static OutputCtx *AlertPreludeInitCtx(ConfNode *conf)
     SCEnter();
 
     ret = prelude_init(0, NULL);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         prelude_perror(ret, "unable to initialize the prelude library");
         SCReturnPtr(NULL, "AlertPreludeCtx");
     }
@@ -690,14 +690,14 @@ static OutputCtx *AlertPreludeInitCtx(ConfNode *conf)
     log_packet_header = ConfNodeLookupChildValue(conf, "log-packet-header");
 
     ret = prelude_client_new(&client, prelude_profile_name);
-    if ( ret < 0 || ! client ) {
+    if ( unlikely(ret < 0 || client == NULL )) {
         prelude_perror(ret, "Unable to create a prelude client object");
         prelude_client_destroy(client, PRELUDE_CLIENT_EXIT_STATUS_SUCCESS);
         SCReturnPtr(NULL, "AlertPreludeCtx");
     }
 
     ret = prelude_client_set_flags(client, prelude_client_get_flags(client) | PRELUDE_CLIENT_FLAGS_ASYNC_TIMER|PRELUDE_CLIENT_FLAGS_ASYNC_SEND);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         SCLogDebug("Unable to set asynchronous send and timer.");
         prelude_client_destroy(client, PRELUDE_CLIENT_EXIT_STATUS_SUCCESS);
         SCReturnPtr(NULL, "AlertPreludeCtx");
@@ -706,7 +706,7 @@ static OutputCtx *AlertPreludeInitCtx(ConfNode *conf)
     SetupAnalyzer(prelude_client_get_analyzer(client));
 
     ret = prelude_client_start(client);
-    if (ret < 0) {
+    if (unlikely(ret < 0)) {
         prelude_perror(ret, "Unable to start prelude client");
         prelude_client_destroy(client, PRELUDE_CLIENT_EXIT_STATUS_SUCCESS);
         SCReturnPtr(NULL, "AlertPreludeCtx");
@@ -779,7 +779,7 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
 
     SCEnter();
 
-    if (apn == NULL || apn->ctx == NULL) {
+    if (unlikely(apn == NULL || apn->ctx == NULL)) {
         SCReturnInt(TM_ECODE_FAILED);
     }
 
@@ -792,43 +792,43 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
     /* XXX which one to add to this alert? Lets see how Snort solves this.
      * For now just take last alert. */
     pa = &p->alerts.alerts[p->alerts.cnt-1];
-    if (pa->s == NULL)
+    if (unlikely(pa->s == NULL))
         goto err;
 
     ret = idmef_message_new(&idmef);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         SCReturnInt(TM_ECODE_FAILED);
 
     ret = idmef_message_new_alert(idmef, &alert);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     ret = idmef_alert_new_classification(alert, &class);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     if (pa->s->msg) {
         ret = idmef_classification_new_text(class, &str);
-        if ( ret < 0 )
+        if (unlikely(ret < 0))
             goto err;
 
         prelude_string_set_ref(str, pa->s->msg);
     }
 
     ret = EventToImpact(pa, p, alert);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     ret = EventToReference(pa, p, class);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     ret = EventToSourceTarget(p, alert);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     ret = PacketToData(p, pa, alert, apn->ctx);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
 
     if (PKT_IS_TCP(p) && (pa->flags & PACKET_ALERT_FLAG_STATE_MATCH)) {
@@ -842,16 +842,16 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
                                    PreludePrintStreamSegmentCallback,
                                    (void *)alert);
     }
-    if (ret < 0)
+    if (unlikely(ret < 0))
         goto err;
 
     ret = idmef_alert_new_detect_time(alert, &time);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
     idmef_time_set_from_timeval(time, &p->ts);
 
     ret = idmef_time_new_from_gettimeofday(&time);
-    if ( ret < 0 )
+    if (unlikely(ret < 0))
         goto err;
     idmef_alert_set_create_time(alert, time);
 


### PR DESCRIPTION
When handling error cases on creation of a new idmef field, we are in an unlikely case. This patch adds the unlikely() expression to indicate this to gcc.