### PR TITLE
Email memory leak fixes

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1126,8 +1126,9 @@ static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
     /* Free list of MIME message recursively */
     MimeDecFreeEntity(tx->msg_head);
 
-    if (tx->decoder_events != NULL) {
+    if (tx->decoder_events != NULL)
         AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
+
     if (tx->de_state != NULL)
         DetectEngineStateFree(tx->de_state);
 #if 0
@@ -1136,7 +1137,6 @@ static void SMTPTransactionFree(SMTPTransaction *tx, SMTPState *state)
         else
             smtp_state->events = 0;
 #endif
-    }
     SCFree(tx);
 }
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -126,6 +126,7 @@ static TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packe
                         //printf("got another addr: \"%s\"\n", p);
                         json_array_append_new(js_to, json_string(&p[strspn(p, " ")]));
                     }
+                    SCFree(to_line);
                     json_object_set_new(sjs, "to", js_to);
                 }
             }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -149,6 +149,7 @@ static TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packe
                         //printf("got another addr: \"%s\"\n", p);
                         json_array_append_new(js_cc, json_string(&p[strspn(p, " ")]));
                     }
+                    SCFree(cc_line);
                     json_object_set_new(sjs, "cc", js_cc);
                 }
             }


### PR DESCRIPTION
A series of memory leak fixes for email related code. It was found via valgrind.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/63
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/61