### PR TITLE
Bug 1340: fix missing flow cleanup

### DIFF
--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -469,6 +469,7 @@ void RunModeShutDown(void)
     OutputFiledataShutdown();
     OutputStreamingShutdown();
     OutputStatsShutdown();
+    OutputFlowShutdown();
 
     /* Close any log files. */
     RunModeOutput *output;


### PR DESCRIPTION
Fix missing flow output cleanup function leading to a crash in the
unix socket mode.