### PR TITLE
mime-decode: fix unquoted boundary strings

### DIFF
--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -62,7 +62,7 @@
 #define CTNT_DISP_STR     "content-disposition"
 #define CTNT_TRAN_STR     "content-transfer-encoding"
 #define MSG_ID_STR        "message-id"
-#define BND_START_STR     "boundary=\""
+#define BND_START_STR     "boundary="
 #define TOK_END_STR       "\""
 #define MSG_STR           "message/"
 #define MULTIPART_STR     "multipart/"
@@ -1888,6 +1888,12 @@ static int ProcessMimeHeaders(const uint8_t *buf, uint32_t len,
             if (bptr != NULL) {
                 state->found_child = 1;
                 entity->ctnt_flags |= CTNT_IS_MULTIPART;
+
+                if (*bptr == '"') {
+                    /* remove surrounding quotes */
+                    bptr++;
+                    blen -= 2;
+                }
 
                 /* Store boundary in parent node */
                 state->stack->top->bdef = SCMalloc(blen);


### PR DESCRIPTION
This fixes a problem in the MIME decoder.  Boundary strings are optionally surrounded by quotes, and only when the string contains special characters.  The MIME decoder had been assuming that Boundary strings were always surrounded by quotes.  This was causing the MIME decoder to mis-parse email content potentially missing URL and attachments.

- PR decanio: https://buildbot.openinfosecfoundation.org/builders/decanio/builds/9
- PR decanio-pcap: https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/9
