### PR TITLE
Fix bug #1435 (data loss when dumping payloads to JSON) v3

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -93,12 +93,10 @@ typedef struct JsonAlertLogThread_ {
 
 /* Callback function to pack payload contents from a stream into a buffer
  * so we can report them in JSON output. */
-static int AlertJsonPrintStreamSegmentCallback(const Packet *p, void *data, uint8_t *buf, uint32_t buflen)
+static int AlertJsonDumpStreamSegmentCallback(const Packet *p, void *data, uint8_t *buf, uint32_t buflen)
 {
     MemBuffer *payload = (MemBuffer *)data;
-
-    PrintStringsToBuffer(payload->buffer, &payload->offset, payload->size,
-                         buf, buflen);
+    MemBufferWriteRaw(payload, buf, buflen);
 
     return 1;
 }
@@ -276,7 +274,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 }
 
                 StreamSegmentForEach((const Packet *)p, flag,
-                                    AlertJsonPrintStreamSegmentCallback,
+                                    AlertJsonDumpStreamSegmentCallback,
                                     (void *)payload);
 
                 if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
@@ -287,27 +285,30 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 }
 
                 if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
+                    uint8_t printable_buf[payload->offset + 1];
+                    uint32_t offset = 0;
+                    PrintStringsToBuffer(printable_buf, &offset,
+                                     sizeof(printable_buf),
+                                     (unsigned char *)payload, payload->offset);
                     json_object_set_new(js, "payload_printable",
-                                        json_string((char *)payload->buffer));
+                                        json_string((char *)printable_buf));
                 }
             } else {
                 /* This is a single packet and not a stream */
-                unsigned char packet_buf[p->payload_len + 1];
-                uint32_t offset = 0;
-
-                PrintStringsToBuffer(packet_buf, &offset,
-                                     p->payload_len + 1,
-                                     p->payload, p->payload_len);
-
                 if (json_output_ctx->flags & LOG_JSON_PAYLOAD_BASE64) {
-                    unsigned long len = sizeof(packet_buf) * 2;
+                    size_t len = p->payload_len * 2 + 1;
                     unsigned char encoded[len];
-                    Base64Encode(packet_buf, offset, encoded, &len);
+                    Base64Encode(p->payload, p->payload_len, encoded, &len);
                     json_object_set_new(js, "payload", json_string((char *)encoded));
                 }
 
                 if (json_output_ctx->flags & LOG_JSON_PAYLOAD) {
-                    json_object_set_new(js, "payload_printable", json_string((char *)packet_buf));
+                    unsigned char printable_buf[p->payload_len + 1];
+                    uint32_t offset = 0;
+                    PrintStringsToBuffer(printable_buf, &offset,
+                                     p->payload_len + 1,
+                                     p->payload, p->payload_len);
+                    json_object_set_new(js, "payload_printable", json_string((char *)printable_buf));
                 }
             }
 

--- a/src/util-buffer.h
+++ b/src/util-buffer.h
@@ -144,8 +144,6 @@ void MemBufferFree(MemBuffer *buffer);
         memcpy((dst)->buffer + (dst)->offset, (raw_buffer), write_len); \
         (dst)->offset += write_len;                                     \
         dst->buffer[dst->offset] = '\0';                                \
-                                                                        \
-        return;                                                         \
     } while (0)
 
 /**


### PR DESCRIPTION
Fixed #1455 - use MemBufferWriteRaw() wrapper instead of memcpy. Also fixed MemBufferWriteRaw() - there was unneeded return stetement.