### PR TITLE
Bug 1416 - Make urilen ranges inclusive - v2

### DIFF
--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -519,8 +519,12 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
                     r = 1;
                 break;
             case DETECT_URILEN_RA:
-                if (buffer_len > urilend->urilen1 &&
-                    buffer_len < urilend->urilen2) {
+                /* Note that when using a range we are inclusive of
+                 * the values, unlike greater than or less than which
+                 * are exclusive. This is to match Snort's
+                 * behaviour. */
+                if (buffer_len >= urilend->urilen1 &&
+                    buffer_len <= urilend->urilen2) {
                     r = 1;
                 }
                 break;


### PR DESCRIPTION
[Last PR closed by accident when I killed the remote branch]

Last PR: #1417.

Fixes bug 1416. Verified that in Snort, urilen ranges are
inclusive of the boundary values.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1416

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/78
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/79
