### PR TITLE
radix-tree - prevent out of bounds array access - v1

### DIFF
--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -570,7 +570,7 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
          * down along one of the paths, since either paths should end up with a
          * node that has a common prefix whose differ bit is greater than the
          * bitlen of the incoming prefix */
-        if (bitlen < node->bit) {
+        if (bitlen <= node->bit) {
             if (node->right == NULL)
                 break;
             node = node->right;


### PR DESCRIPTION
An IPv6 entry specified before an IPv4 entry on the host-os-policy
table can cause the stream byte array to be access one byte after
the end of the allocated memory at util-radix-tree.c:578.

Redmine bug: https://redmine.openinfosecfoundation.org/issues/1467

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/82
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/83
