### PR TITLE
Fix rcode parsing, as noticed by Coverity.

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -71,6 +71,8 @@
 #define DNS_RCODE_NXRRSET       8
 #define DNS_RCODE_NOTAUTH       9
 #define DNS_RCODE_NOTZONE       10
+// Support for OPT RR from RFC6891 will be needed to
+// parse RCODE values over 15
 #define DNS_RCODE_BADVERS       16
 #define DNS_RCODE_BADSIG        16
 #define DNS_RCODE_BADKEY        17

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -449,7 +449,7 @@ static int DNSReponseParseData(Flow *f, DNSState *dns_state, const uint8_t *inpu
 
     /* parse rcode, e.g. "noerror" or "nxdomain" */
     uint8_t rcode = ntohs(dns_header->flags) & 0x0F;
-    if (rcode <= DNS_RCODE_NOTZONE || (rcode >= DNS_RCODE_BADSIG && rcode <= DNS_RCODE_BADTRUNC)) {
+    if (rcode <= DNS_RCODE_NOTZONE) {
         SCLogDebug("rcode %u", rcode);
         if (tx != NULL)
             tx->rcode = rcode;

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -271,7 +271,7 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
 
     /* parse rcode, e.g. "noerror" or "nxdomain" */
     uint8_t rcode = ntohs(dns_header->flags) & 0x0F;
-    if (rcode <= DNS_RCODE_NOTZONE || (rcode >= DNS_RCODE_BADSIG && rcode <= DNS_RCODE_BADTRUNC)) {
+    if (rcode <= DNS_RCODE_NOTZONE) {
         SCLogDebug("rcode %u", rcode);
         if (tx != NULL)
             tx->rcode = rcode;


### PR DESCRIPTION
Without support for OPT RR from RFC6891 (Extension mechanisms for DNS)
values of RCODE above 15 are not possible.  Remove dead code which will
never match.