### PR TITLE
conf - process includes even if not at root node - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -244,9 +244,7 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq)
                 }
                 else if (state == CONF_KEY) {
 
-                    /* Top level include statements. */
-                    if ((strcmp(value, "include") == 0) &&
-                        (parent == ConfGetRootNode())) {
+                    if (strcmp(value, "include") == 0) {
                         state = CONF_INCLUDE;
                         goto next;
                     }


### PR DESCRIPTION
Addresses Redmine issue: https://redmine.openinfosecfoundation.org/issues/1466

The reload was loading the YAML configuration node at a new node, instead of the root node, and includes are only processed if belonging to a root node.  This was done as not to conflict with any other configuration sections that might use "include" as a valid keyword.

This patch removes that check, and will process includes everywhere.  I doesn't look like any existing configuration sections use "include" as a valid keyword, but if it might be we can consider these alternatives:

- Pass in a pointer to ConfYamlParse that the parser will use as the root node.  That way to caller can override the rood node.
- Pass in a depth value, initially 0, that ConfYamlParse can use to track the depth, and only process includes at depth 0.

Both allow the caller to pass in its view of the root node, which would allow us to do this during reload.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/83
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/84
