### PR TITLE
Allow colon in SSH version string

### DIFF
--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -61,7 +61,7 @@
 /**
  * \brief Regex for parsing the softwareversion string
  */
-#define PARSE_REGEX  "^\\s*\"?\\s*?([0-9a-zA-Z\\.\\-\\_\\+\\s+]+)\\s*\"?\\s*$"
+#define PARSE_REGEX  "^\\s*\"?\\s*?([0-9a-zA-Z\\:\\.\\-\\_\\+\\s+]+)\\s*\"?\\s*$"
 
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;


### PR DESCRIPTION
Simple patch for regex that checks SSH version string (ssh.softwareversion).