### PR TITLE
Eve fix 2015 v1.2

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -78,14 +78,13 @@
 #define JSON_STREAM_BUFFER_SIZE 4096
 
 typedef struct AlertJsonOutputCtx_ {
-    LogFileCtx* file_ctx;
+    OutputJsonCtx* json_ctx;
     uint8_t flags;
     HttpXFFCfg *xff_cfg;
 } AlertJsonOutputCtx;
 
 typedef struct JsonAlertLogThread_ {
     /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx* file_ctx;
     MemBuffer *json_buffer;
     MemBuffer *payload_buffer;
     AlertJsonOutputCtx* json_output_ctx;
@@ -362,7 +361,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             }
         }
 
-        OutputJSONBuffer(js, aft->file_ctx, aft->json_buffer);
+        OutputJSONBuffer(js, json_output_ctx->json_ctx, aft->json_buffer);
         json_object_del(js, "alert");
     }
     json_object_clear(js);
@@ -433,7 +432,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
 
         /* alert */
         json_object_set_new(js, "alert", ajs);
-        OutputJSONBuffer(js, aft->file_ctx, buffer);
+        OutputJSONBuffer(js, aft->json_output_ctx->json_ctx, buffer);
         json_object_clear(js);
         json_decref(js);
     }
@@ -486,7 +485,6 @@ static TmEcode JsonAlertLogThreadInit(ThreadVars *t, void *initdata, void **data
 
     /** Use the Output Context (file pointer and mutex) */
     AlertJsonOutputCtx *json_output_ctx = ((OutputCtx *)initdata)->data;
-    aft->file_ctx = json_output_ctx->file_ctx;
     aft->json_output_ctx = json_output_ctx;
 
     *data = (void *)aft;
@@ -571,7 +569,7 @@ static OutputCtx *JsonAlertLogInitCtx(ConfNode *conf)
  */
 static OutputCtx *JsonAlertLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    OutputJsonCtx *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
     AlertJsonOutputCtx *json_output_ctx = NULL;
     HttpXFFCfg *xff_cfg = NULL;
 
@@ -591,7 +589,7 @@ static OutputCtx *JsonAlertLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
     memset(xff_cfg, 0, sizeof(HttpXFFCfg));
 
-    json_output_ctx->file_ctx = ajt->file_ctx;
+    json_output_ctx->json_ctx = ojc;
     json_output_ctx->xff_cfg = xff_cfg;
 
     if (conf != NULL) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -571,7 +571,7 @@ static OutputCtx *JsonAlertLogInitCtx(ConfNode *conf)
  */
 static OutputCtx *JsonAlertLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ajt = parent_ctx->data;
     AlertJsonOutputCtx *json_output_ctx = NULL;
     HttpXFFCfg *xff_cfg = NULL;
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -58,7 +58,7 @@
 #define QUERY 0
 
 typedef struct LogDnsFileCtx_ {
-    LogFileCtx *file_ctx;
+    OutputJsonCtx *json_ctx;
     uint32_t flags; /** Store mode */
 } LogDnsFileCtx;
 
@@ -109,7 +109,7 @@ static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
 
     /* dns */
     json_object_set_new(js, "dns", djs);
-    OutputJSONBuffer(js, aft->dnslog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(js, aft->dnslog_ctx->json_ctx, buffer);
     json_object_del(js, "dns");
 }
 
@@ -181,7 +181,7 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
     /* reset */
     MemBufferReset(buffer);
     json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(djs, aft->dnslog_ctx->json_ctx, buffer);
     json_object_del(djs, "dns");
 
     return;
@@ -216,7 +216,7 @@ static void OutputFailure(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx,
     /* reset */
     MemBufferReset(buffer);
     json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(djs, aft->dnslog_ctx->json_ctx, buffer);
     json_object_del(djs, "dns");
 
     return;
@@ -326,7 +326,8 @@ static TmEcode LogDnsLogThreadDeinit(ThreadVars *t, void *data)
 static void LogDnsLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogDnsFileCtx *dnslog_ctx = (LogDnsFileCtx *)output_ctx->data;
-    LogFileFreeCtx(dnslog_ctx->file_ctx);
+    LogFileFreeCtx(dnslog_ctx->json_ctx->file_ctx);
+    SCFree(dnslog_ctx->json_ctx);
     SCFree(dnslog_ctx);
     SCFree(output_ctx);
 }
@@ -341,7 +342,7 @@ static void LogDnsLogDeInitCtxSub(OutputCtx *output_ctx)
 
 static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {
@@ -349,7 +350,7 @@ static OutputCtx *JsonDnsLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
     }
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
-    dnslog_ctx->file_ctx = ajt->file_ctx;
+    dnslog_ctx->json_ctx = ojc;
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
@@ -394,8 +395,6 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
     }
     memset(dnslog_ctx, 0x00, sizeof(LogDnsFileCtx));
 
-    dnslog_ctx->file_ctx = file_ctx;
-
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {
         LogFileFreeCtx(file_ctx);
@@ -403,6 +402,16 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
+    OutputJsonCtx *json_output_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
+    if (unlikely(json_output_ctx == NULL)) {
+        LogFileFreeCtx(file_ctx);
+        SCFree(dnslog_ctx);
+        SCFree(output_ctx);
+        return NULL;
+    }
+
+    dnslog_ctx->json_ctx = json_output_ctx;
+    json_output_ctx->file_ctx = file_ctx;
     output_ctx->data = dnslog_ctx;
     output_ctx->DeInit = LogDnsLogDeInitCtx;
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -249,7 +249,7 @@ int JsonEmailLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
     MemBufferReset(buffer);
 
     if (JsonEmailLogJson(jhl, js, p, f, state, tx, tx_id) == TM_ECODE_OK) {
-        OutputJSONBuffer(js, jhl->emaillog_ctx->file_ctx, buffer);
+        OutputJSONBuffer(js, jhl->emaillog_ctx->json_ctx, buffer);
     }
     json_object_del(js, "smtp");
 

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -25,7 +25,7 @@
 #define __OUTPUT_JSON_EMAIL_COMMON_H__
 
 typedef struct OutputJsonEmailCtx_ {
-    LogFileCtx *file_ctx;
+    OutputJsonCtx *json_ctx;
     uint32_t flags; /** Store mode */
 } OutputJsonEmailCtx;
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -65,7 +65,7 @@
 #include <jansson.h>
 
 typedef struct OutputFileCtx_ {
-    LogFileCtx *file_ctx;
+    OutputJsonCtx *json_ctx;
     uint32_t file_cnt;
 } OutputFileCtx;
 
@@ -246,7 +246,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 
     /* originally just 'file', but due to bug 1127 naming it fileinfo */
     json_object_set_new(js, "fileinfo", fjs);
-    OutputJSONBuffer(js, aft->filelog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(js, aft->filelog_ctx->json_ctx, buffer);
     json_object_del(js, "fileinfo");
     json_object_del(js, "http");
 
@@ -336,7 +336,7 @@ OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    output_file_ctx->file_ctx = ojc->file_ctx;
+    output_file_ctx->json_ctx = ojc;
 
     if (conf) {
         const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -324,7 +324,7 @@ static void OutputFileLogDeinitSub(OutputCtx *output_ctx)
  * */
 OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     OutputFileCtx *output_file_ctx = SCMalloc(sizeof(OutputFileCtx));
     if (unlikely(output_file_ctx == NULL))
@@ -336,7 +336,7 @@ OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    output_file_ctx->file_ctx = ajt->file_ctx;
+    output_file_ctx->file_ctx = ojc->file_ctx;
 
     if (conf) {
         const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -386,7 +386,7 @@ static void OutputFlowLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
     if (unlikely(flow_ctx == NULL))
@@ -398,7 +398,7 @@ OutputCtx *OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    flow_ctx->file_ctx = ajt->file_ctx;
+    flow_ctx->file_ctx = ojc->file_ctx;
     flow_ctx->flags = LOG_HTTP_DEFAULT;
 
     output_ctx->data = flow_ctx;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -462,7 +462,7 @@ static void OutputHttpLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogHttpFileCtx *http_ctx = SCMalloc(sizeof(LogHttpFileCtx));
     if (unlikely(http_ctx == NULL))
@@ -475,7 +475,7 @@ OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    http_ctx->file_ctx = ajt->file_ctx;
+    http_ctx->file_ctx = ojc->file_ctx;
     http_ctx->flags = LOG_HTTP_DEFAULT;
 
     if (conf) {

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -369,7 +369,7 @@ static void OutputNetFlowLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
     if (unlikely(flow_ctx == NULL))
@@ -381,7 +381,7 @@ OutputCtx *OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    flow_ctx->file_ctx = ajt->file_ctx;
+    flow_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputNetFlowLogDeinitSub;

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -52,7 +52,7 @@
 #include <jansson.h>
 
 typedef struct LogJsonFileCtx_ {
-    LogFileCtx *file_ctx;
+    OutputJsonCtx *json_ctx;
 } LogJsonFileCtx;
 
 typedef struct JsonNetFlowLogThread_ {
@@ -297,7 +297,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToServer(jhl, js, f);
-    OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(js, jhl->flowlog_ctx->json_ctx, buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
     json_decref(js);
@@ -308,7 +308,7 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
     JsonNetFlowLogJSONToClient(jhl, js, f);
-    OutputJSONBuffer(js, jhl->flowlog_ctx->file_ctx, buffer);
+    OutputJSONBuffer(js, jhl->flowlog_ctx->json_ctx, buffer);
     json_object_del(js, "netflow");
     json_object_clear(js);
     json_decref(js);
@@ -319,8 +319,9 @@ static int JsonNetFlowLogger(ThreadVars *tv, void *thread_data, Flow *f)
 static void OutputNetFlowLogDeinit(OutputCtx *output_ctx)
 {
     LogJsonFileCtx *flow_ctx = output_ctx->data;
-    LogFileCtx *logfile_ctx = flow_ctx->file_ctx;
+    LogFileCtx *logfile_ctx = flow_ctx->json_ctx->file_ctx;
     LogFileFreeCtx(logfile_ctx);
+    SCFree(flow_ctx->json_ctx);
     SCFree(flow_ctx);
     SCFree(output_ctx);
 }
@@ -353,7 +354,16 @@ OutputCtx *OutputNetFlowLogInit(ConfNode *conf)
         return NULL;
     }
 
-    flow_ctx->file_ctx = file_ctx;
+    OutputJsonCtx *json_output_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
+    if (unlikely(json_output_ctx == NULL)) {
+        LogFileFreeCtx(file_ctx);
+        SCFree(output_ctx);
+        SCFree(flow_ctx);
+        return NULL;
+    }
+
+    flow_ctx->json_ctx = json_output_ctx;
+    flow_ctx->json_ctx->file_ctx = file_ctx;
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputNetFlowLogDeinit;
 
@@ -381,7 +391,7 @@ OutputCtx *OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    flow_ctx->file_ctx = ojc->file_ctx;
+    flow_ctx->json_ctx = ojc;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputNetFlowLogDeinitSub;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -121,7 +121,7 @@ OutputCtx *OutputSmtpLogInit(ConfNode *conf)
 
 static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     OutputJsonEmailCtx *email_ctx = SCMalloc(sizeof(OutputJsonEmailCtx));
     if (unlikely(email_ctx == NULL))
@@ -133,7 +133,7 @@ static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    email_ctx->file_ctx = ajt->file_ctx;
+    email_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = email_ctx;
     output_ctx->DeInit = OutputSmtpLogDeInitCtxSub;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -65,7 +65,8 @@ static void OutputSmtpLogDeInitCtx(OutputCtx *output_ctx)
 {
     OutputJsonEmailCtx *email_ctx = output_ctx->data;
     if (email_ctx != NULL) {
-        LogFileFreeCtx(email_ctx->file_ctx);
+        LogFileFreeCtx(email_ctx->json_ctx->file_ctx);
+        SCFree(email_ctx->json_ctx);
         SCFree(email_ctx);
     }
     SCFree(output_ctx);
@@ -108,7 +109,16 @@ OutputCtx *OutputSmtpLogInit(ConfNode *conf)
         return NULL;
     }
 
-    email_ctx->file_ctx = file_ctx;
+    OutputJsonCtx *json_output_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
+    if (unlikely(json_output_ctx == NULL)) {
+        LogFileFreeCtx(file_ctx);
+        SCFree(output_ctx);
+        SCFree(email_ctx);
+        return NULL;
+    }
+
+    email_ctx->json_ctx = json_output_ctx;
+    email_ctx->json_ctx->file_ctx = file_ctx;
 
     output_ctx->data = email_ctx;
     output_ctx->DeInit = OutputSmtpLogDeInitCtx;
@@ -133,7 +143,7 @@ static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    email_ctx->file_ctx = ojc->file_ctx;
+    email_ctx->json_ctx = ojc;
 
     output_ctx->data = email_ctx;
     output_ctx->DeInit = OutputSmtpLogDeInitCtxSub;

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -248,7 +248,7 @@ static void OutputSshLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     if (OutputSshLoggerEnable() != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'ssh' logger "
@@ -266,7 +266,7 @@ OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    ssh_ctx->file_ctx = ajt->file_ctx;
+    ssh_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinitSub;

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -55,7 +55,7 @@
 #define MODULE_NAME "LogSshLog"
 
 typedef struct OutputSshCtx_ {
-    LogFileCtx *file_ctx;
+    OutputJsonCtx *json_ctx;
     uint32_t flags; /** Store mode */
 } OutputSshCtx;
 
@@ -131,7 +131,7 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 
     json_object_set_new(js, "ssh", tjs);
 
-    OutputJSONBuffer(js, ssh_ctx->file_ctx, buffer);
+    OutputJSONBuffer(js, ssh_ctx->json_ctx, buffer);
     json_object_clear(js);
     json_decref(js);
 
@@ -190,8 +190,9 @@ static void OutputSshLogDeinit(OutputCtx *output_ctx)
     OutputSshLoggerDisable();
 
     OutputSshCtx *ssh_ctx = output_ctx->data;
-    LogFileCtx *logfile_ctx = ssh_ctx->file_ctx;
+    LogFileCtx *logfile_ctx = ssh_ctx->json_ctx->file_ctx;
     LogFileFreeCtx(logfile_ctx);
+    SCFree(ssh_ctx->json_ctx);
     SCFree(ssh_ctx);
     SCFree(output_ctx);
 }
@@ -229,7 +230,16 @@ OutputCtx *OutputSshLogInit(ConfNode *conf)
         return NULL;
     }
 
-    ssh_ctx->file_ctx = file_ctx;
+    OutputJsonCtx *json_output_ctx = SCCalloc(1, sizeof(OutputJsonCtx));
+    if (unlikely(json_output_ctx == NULL)) {
+        LogFileFreeCtx(file_ctx);
+        SCFree(ssh_ctx);
+        SCFree(output_ctx);
+        return NULL;
+    }
+
+    ssh_ctx->json_ctx = json_output_ctx;
+    ssh_ctx->json_ctx->file_ctx = file_ctx;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinit;
@@ -266,7 +276,7 @@ OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    ssh_ctx->file_ctx = ojc->file_ctx;
+    ssh_ctx->json_ctx = ojc;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinitSub;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -292,7 +292,7 @@ static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     if (OutputTlsLoggerEnable() != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
@@ -310,7 +310,7 @@ OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    tls_ctx->file_ctx = ajt->file_ctx;
+    tls_ctx->file_ctx = ojc->file_ctx;
     tls_ctx->flags = LOG_TLS_DEFAULT;
 
     if (conf) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -32,18 +32,16 @@ void TmModuleOutputJsonRegister (void);
 #include "util-buffer.h"
 #include "util-logopenfile.h"
 
-void CreateJSONFlowId(json_t *js, const Flow *f);
-void JsonTcpFlags(uint8_t flags, json_t *js);
-json_t *CreateJSONHeader(Packet *p, int direction_sensative, char *event_type);
-TmEcode OutputJSON(json_t *js, void *data, uint64_t *count);
-int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer);
-OutputCtx *OutputJsonInitCtx(ConfNode *);
-
 enum JsonOutput { ALERT_FILE,
                   ALERT_SYSLOG,
                   ALERT_UNIX_DGRAM,
                   ALERT_UNIX_STREAM };
 enum JsonFormat { COMPACT, INDENT };
+
+typedef struct AlertJsonThread_ {
+    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
+    LogFileCtx *file_ctx;
+} AlertJsonThread;
 
 /*
  * Global configuration context data
@@ -54,11 +52,13 @@ typedef struct OutputJsonCtx_ {
     enum JsonFormat format;
 } OutputJsonCtx;
 
+void CreateJSONFlowId(json_t *js, const Flow *f);
+void JsonTcpFlags(uint8_t flags, json_t *js);
+json_t *CreateJSONHeader(Packet *p, int direction_sensative, char *event_type);
+TmEcode OutputJSON(json_t *js, void *data, uint64_t *count);
+int OutputJSONBuffer(json_t *js, OutputJsonCtx *json_ctx, MemBuffer *buffer);
+OutputCtx *OutputJsonInitCtx(ConfNode *);
 
-typedef struct AlertJsonThread_ {
-    /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
-    LogFileCtx *file_ctx;
-} AlertJsonThread;
 
 #endif /* HAVE_LIBJANSSON */
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -143,7 +143,7 @@ outputs:
         # bi-directional flows
         #- flow
         # uni-directional flows
-        #- newflow
+        #- netflow
 
   # alert output for use with Barnyard2
   - unified2-alert:


### PR DESCRIPTION
This patchset mainly update the JSON output submodules to get rid of global variable.

It could be used as a base for #1449 code rework if @inliniac is ok with this basis.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/66
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/64
