### PR TITLE
Eve fix 2015 v1.3

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -571,7 +571,7 @@ static OutputCtx *JsonAlertLogInitCtx(ConfNode *conf)
  */
 static OutputCtx *JsonAlertLogInitCtxSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ajt = parent_ctx->data;
     AlertJsonOutputCtx *json_output_ctx = NULL;
     HttpXFFCfg *xff_cfg = NULL;
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -324,7 +324,7 @@ static void OutputFileLogDeinitSub(OutputCtx *output_ctx)
  * */
 OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     OutputFileCtx *output_file_ctx = SCMalloc(sizeof(OutputFileCtx));
     if (unlikely(output_file_ctx == NULL))
@@ -336,7 +336,7 @@ OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    output_file_ctx->file_ctx = ajt->file_ctx;
+    output_file_ctx->file_ctx = ojc->file_ctx;
 
     if (conf) {
         const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -386,7 +386,7 @@ static void OutputFlowLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
     if (unlikely(flow_ctx == NULL))
@@ -398,7 +398,7 @@ OutputCtx *OutputFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    flow_ctx->file_ctx = ajt->file_ctx;
+    flow_ctx->file_ctx = ojc->file_ctx;
     flow_ctx->flags = LOG_HTTP_DEFAULT;
 
     output_ctx->data = flow_ctx;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -462,7 +462,7 @@ static void OutputHttpLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogHttpFileCtx *http_ctx = SCMalloc(sizeof(LogHttpFileCtx));
     if (unlikely(http_ctx == NULL))
@@ -475,7 +475,7 @@ OutputCtx *OutputHttpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    http_ctx->file_ctx = ajt->file_ctx;
+    http_ctx->file_ctx = ojc->file_ctx;
     http_ctx->flags = LOG_HTTP_DEFAULT;
 
     if (conf) {

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -369,7 +369,7 @@ static void OutputNetFlowLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     LogJsonFileCtx *flow_ctx = SCMalloc(sizeof(LogJsonFileCtx));
     if (unlikely(flow_ctx == NULL))
@@ -381,7 +381,7 @@ OutputCtx *OutputNetFlowLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    flow_ctx->file_ctx = ajt->file_ctx;
+    flow_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = flow_ctx;
     output_ctx->DeInit = OutputNetFlowLogDeinitSub;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -121,7 +121,7 @@ OutputCtx *OutputSmtpLogInit(ConfNode *conf)
 
 static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     OutputJsonEmailCtx *email_ctx = SCMalloc(sizeof(OutputJsonEmailCtx));
     if (unlikely(email_ctx == NULL))
@@ -133,7 +133,7 @@ static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    email_ctx->file_ctx = ajt->file_ctx;
+    email_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = email_ctx;
     output_ctx->DeInit = OutputSmtpLogDeInitCtxSub;

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -248,7 +248,7 @@ static void OutputSshLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     if (OutputSshLoggerEnable() != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'ssh' logger "
@@ -266,7 +266,7 @@ OutputCtx *OutputSshLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    ssh_ctx->file_ctx = ajt->file_ctx;
+    ssh_ctx->file_ctx = ojc->file_ctx;
 
     output_ctx->data = ssh_ctx;
     output_ctx->DeInit = OutputSshLogDeinitSub;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -292,7 +292,7 @@ static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 
 OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
-    AlertJsonThread *ajt = parent_ctx->data;
+    OutputJsonCtx *ojc = parent_ctx->data;
 
     if (OutputTlsLoggerEnable() != 0) {
         SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
@@ -310,7 +310,7 @@ OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         return NULL;
     }
 
-    tls_ctx->file_ctx = ajt->file_ctx;
+    tls_ctx->file_ctx = ojc->file_ctx;
     tls_ctx->flags = LOG_TLS_DEFAULT;
 
     if (conf) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -146,10 +146,6 @@ void TmModuleOutputJsonRegister (void)
 /* Default Sensor ID value */
 static int64_t sensor_id = -1; /* -1 = not defined */
 
-static enum JsonOutput json_out = ALERT_FILE;
-
-static enum JsonFormat format = COMPACT;
-
 /** \brief jsonify tcp flags field
  *  Only add 'true' fields in an attempt to keep things reasonably compact.
  */
@@ -345,9 +341,9 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
         return TM_ECODE_OK;
 
     SCMutexLock(&file_ctx->fp_mutex);
-    if (json_out == ALERT_SYSLOG) {
+    if (file_ctx->type == ALERT_SYSLOG) {
         syslog(alert_syslog_level, "%s", js_s);
-    } else if (json_out == ALERT_FILE || json_out == ALERT_UNIX_DGRAM || json_out == ALERT_UNIX_STREAM) {
+    } else if (file_ctx->type == ALERT_FILE || file_ctx->type == ALERT_UNIX_DGRAM || file_ctx->type == ALERT_UNIX_STREAM) {
         MemBufferWriteString(buffer, "%s\n", js_s);
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
             MEMBUFFER_OFFSET(buffer), file_ctx);
@@ -519,8 +515,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             }
         }
 
-        format = json_ctx->format;
-        json_out = json_ctx->json_out;
+        json_ctx->file_ctx->type = json_ctx->json_out;
     }
 
     SCLogDebug("returning output_ctx %p", output_ctx);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -45,6 +45,9 @@ typedef struct LogFileCtx_ {
      * record cannot be written to the file in one call */
     SCMutex fp_mutex;
 
+    /** the type of file */
+    uint8_t type;
+
     /** The name of the file */
     char *filename;
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -143,7 +143,7 @@ outputs:
         # bi-directional flows
         #- flow
         # uni-directional flows
-        #- newflow
+        #- netflow
 
   # alert output for use with Barnyard2
   - unified2-alert:


### PR DESCRIPTION
As suggested by @inliniac, this is a rework of #1493 using the LogFileCtx to store the file type information. And it is indeed shorter.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/67
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/65

