### PR TITLE
--set fixup - v1

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -61,8 +61,7 @@ static ConfNode *root_backup = NULL;
  * \retval The existing configuration node if it exists, or a newly
  *   created node for the provided name.  On error, NULL will be returned.
  */
-static ConfNode *
-ConfGetNodeOrCreate(const char *name, int final)
+static ConfNode *ConfGetNodeOrCreate(const char *name, int final)
 {
     ConfNode *parent = root;
     ConfNode *node = NULL;
@@ -111,8 +110,7 @@ end:
 /**
  * \brief Initialize the configuration system.
  */
-void
-ConfInit(void)
+void ConfInit(void)
 {
     if (root != NULL) {
         SCLogDebug("already initialized");
@@ -133,8 +131,7 @@ ConfInit(void)
  *
  * \retval An allocated configuration node on success, NULL on failure.
  */
-ConfNode *
-ConfNodeNew(void)
+ConfNode *ConfNodeNew(void)
 {
     ConfNode *new;
 
@@ -152,8 +149,7 @@ ConfNodeNew(void)
  *
  * \param node The configuration node to SCFree.
  */
-void
-ConfNodeFree(ConfNode *node)
+void ConfNodeFree(ConfNode *node)
 {
     ConfNode *tmp;
 
@@ -177,8 +173,7 @@ ConfNodeFree(ConfNode *node)
  * \retval A pointer to ConfNode is found or NULL if the configuration
  *    node does not exist.
  */
-ConfNode *
-ConfGetNode(const char *name)
+ConfNode *ConfGetNode(const char *name)
 {
     ConfNode *node = root;
     char node_name[NODE_NAME_MAX];
@@ -205,8 +200,7 @@ ConfGetNode(const char *name)
 /**
  * \brief Get the root configuration node.
  */
-ConfNode *
-ConfGetRootNode(void)
+ConfNode *ConfGetRootNode(void)
 {
     return root;
 }
@@ -223,8 +217,7 @@ ConfGetRootNode(void)
  *
  * \retval 1 if the value was set otherwise 0.
  */
-int
-ConfSet(const char *name, char *val)
+int ConfSet(const char *name, char *val)
 {
     ConfNode *node = ConfGetNodeOrCreate(name, 0);
     if (node == NULL || node->final) {
@@ -253,8 +246,7 @@ ConfSet(const char *name, char *val)
  *
  * \retval 1 if the value was set otherwise 0.
  */
-int
-ConfSetFinal(const char *name, char *val)
+int ConfSetFinal(const char *name, char *val)
 {
     ConfNode *node = ConfGetNodeOrCreate(name, 1);
     if (node == NULL) {
@@ -286,8 +278,7 @@ ConfSetFinal(const char *name, char *val)
  * \retval 1 will be returned if the name is found, otherwise 0 will
  *   be returned.
  */
-int
-ConfGet(const char *name, char **vptr)
+int ConfGet(const char *name, char **vptr)
 {
     ConfNode *node = ConfGetNode(name);
     if (node == NULL) {
@@ -315,7 +306,8 @@ int ConfGetChildValue(const ConfNode *base, const char *name, char **vptr)
 }
 
 
-int ConfGetChildValueWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, char **vptr)
+int ConfGetChildValueWithDefault(const ConfNode *base, const ConfNode *dflt,
+    const char *name, char **vptr)
 {
     int ret = ConfGetChildValue(base, name, vptr);
     /* Get 'default' value */
@@ -335,8 +327,7 @@ int ConfGetChildValueWithDefault(const ConfNode *base, const ConfNode *dflt, con
  * \retval 1 will be returned if the name is found and was properly
  * converted to an interger, otherwise 0 will be returned.
  */
-int
-ConfGetInt(const char *name, intmax_t *val)
+int ConfGetInt(const char *name, intmax_t *val)
 {
     char *strval;
     intmax_t tmpint;
@@ -376,7 +367,8 @@ int ConfGetChildValueInt(const ConfNode *base, const char *name, intmax_t *val)
 
 }
 
-int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, intmax_t *val)
+int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt,
+    const char *name, intmax_t *val)
 {
     int ret = ConfGetChildValueInt(base, name, val);
     /* Get 'default' value */
@@ -397,8 +389,7 @@ int ConfGetChildValueIntWithDefault(const ConfNode *base, const ConfNode *dflt, 
  * \retval 1 will be returned if the name is found and was properly
  * converted to a boolean, otherwise 0 will be returned.
  */
-int
-ConfGetBool(const char *name, int *val)
+int ConfGetBool(const char *name, int *val)
 {
     char *strval;
 
@@ -424,7 +415,8 @@ int ConfGetChildValueBool(const ConfNode *base, const char *name, int *val)
     return 1;
 }
 
-int ConfGetChildValueBoolWithDefault(const ConfNode *base, const ConfNode *dflt, const char *name, int *val)
+int ConfGetChildValueBoolWithDefault(const ConfNode *base, const ConfNode *dflt,
+    const char *name, int *val)
 {
     int ret = ConfGetChildValueBool(base, name, val);
     /* Get 'default' value */
@@ -446,8 +438,7 @@ int ConfGetChildValueBoolWithDefault(const ConfNode *base, const ConfNode *dflt,
  *
  * \retval 1 If the value is true, 0 if not.
  */
-int
-ConfValIsTrue(const char *val)
+int ConfValIsTrue(const char *val)
 {
     char *trues[] = {"1", "yes", "true", "on"};
     size_t u;
@@ -472,8 +463,7 @@ ConfValIsTrue(const char *val)
  *
  * \retval 1 If the value is false, 0 if not.
  */
-int
-ConfValIsFalse(const char *val)
+int ConfValIsFalse(const char *val)
 {
     char *falses[] = {"0", "no", "false", "off"};
     size_t u;
@@ -497,8 +487,7 @@ ConfValIsFalse(const char *val)
  * \retval 1 will be returned if the name is found and was properly
  * converted to a double, otherwise 0 will be returned.
  */
-int
-ConfGetDouble(const char *name, double *val)
+int ConfGetDouble(const char *name, double *val)
 {
     char *strval;
     double tmpdo;
@@ -528,8 +517,7 @@ ConfGetDouble(const char *name, double *val)
  * \retval 1 will be returned if the name is found and was properly
  * converted to a double, otherwise 0 will be returned.
  */
-int
-ConfGetFloat(const char *name, float *val)
+int ConfGetFloat(const char *name, float *val)
 {
     char *strval;
     double tmpfl;
@@ -552,8 +540,7 @@ ConfGetFloat(const char *name, float *val)
 /**
  * \brief Remove (and SCFree) the provided configuration node.
  */
-void
-ConfNodeRemove(ConfNode *node)
+void ConfNodeRemove(ConfNode *node)
 {
     if (node->parent != NULL)
         TAILQ_REMOVE(&node->parent->head, node, next);
@@ -568,8 +555,7 @@ ConfNodeRemove(ConfNode *node)
  * \retval Returns 1 if the parameter was removed, otherwise 0 is returned
  *   most likely indicating the parameter was not set.
  */
-int
-ConfRemove(const char *name)
+int ConfRemove(const char *name)
 {
     ConfNode *node;
 
@@ -585,8 +571,7 @@ ConfRemove(const char *name)
 /**
  * \brief Creates a backup of the conf_hash hash_table used by the conf API.
  */
-void
-ConfCreateContextBackup(void)
+void ConfCreateContextBackup(void)
 {
     root_backup = root;
     root = NULL;
@@ -598,8 +583,7 @@ ConfCreateContextBackup(void)
  * \brief Restores the backup of the hash_table present in backup_conf_hash
  *        back to conf_hash.
  */
-void
-ConfRestoreContextBackup(void)
+void ConfRestoreContextBackup(void)
 {
     root = root_backup;
     root_backup = NULL;
@@ -610,8 +594,7 @@ ConfRestoreContextBackup(void)
 /**
  * \brief De-initializes the configuration system.
  */
-void
-ConfDeInit(void)
+void ConfDeInit(void)
 {
     if (root != NULL) {
         ConfNodeFree(root);
@@ -621,8 +604,7 @@ ConfDeInit(void)
     SCLogDebug("configuration module de-initialized");
 }
 
-static char *
-ConfPrintNameArray(char **name_arr, int level)
+static char *ConfPrintNameArray(char **name_arr, int level)
 {
     static char name[128*128];
     int i;
@@ -640,8 +622,7 @@ ConfPrintNameArray(char **name_arr, int level)
 /**
  * \brief Dump a configuration node and all its children.
  */
-void
-ConfNodeDump(const ConfNode *node, const char *prefix)
+void ConfNodeDump(const ConfNode *node, const char *prefix)
 {
     ConfNode *child;
 
@@ -671,8 +652,7 @@ ConfNodeDump(const ConfNode *node, const char *prefix)
 /**
  * \brief Dump configuration to stdout.
  */
-void
-ConfDump(void)
+void ConfDump(void)
 {
     ConfNodeDump(root, NULL);
 }
@@ -688,8 +668,7 @@ ConfDump(void)
  *
  * \retval A pointer the child ConfNode if found otherwise NULL.
  */
-ConfNode *
-ConfNodeLookupChild(const ConfNode *node, const char *name)
+ConfNode *ConfNodeLookupChild(const ConfNode *node, const char *name)
 {
     ConfNode *child;
 
@@ -713,8 +692,7 @@ ConfNodeLookupChild(const ConfNode *node, const char *name)
  *
  * \retval A pointer the child ConfNodes value if found otherwise NULL.
  */
-const char *
-ConfNodeLookupChildValue(const ConfNode *node, const char *name)
+const char *ConfNodeLookupChildValue(const ConfNode *node, const char *name)
 {
     ConfNode *child;
 
@@ -731,7 +709,8 @@ ConfNodeLookupChildValue(const ConfNode *node, const char *name)
  * \return the ConfNode matching or NULL
  */
 
-ConfNode *ConfNodeLookupKeyValue(const ConfNode *base, const char *key, const char *value)
+ConfNode *ConfNodeLookupKeyValue(const ConfNode *base, const char *key,
+    const char *value)
 {
     ConfNode *child;
 
@@ -758,8 +737,7 @@ ConfNode *ConfNodeLookupKeyValue(const ConfNode *base, const char *key, const ch
  * \retval 1 if the child node has a true value, otherwise 0 is
  *     returned, even if the child node does not exist.
  */
-int
-ConfNodeChildValueIsTrue(const ConfNode *node, const char *key)
+int ConfNodeChildValueIsTrue(const ConfNode *node, const char *key)
 {
     const char *val;
 
@@ -814,8 +792,7 @@ char *ConfLoadCompleteIncludePath(const char *file)
  *
  * \param node The configuration node to prune.
  */
-void
-ConfNodePrune(ConfNode *node)
+void ConfNodePrune(ConfNode *node)
 {
     ConfNode *item, *it;
 
@@ -847,8 +824,7 @@ ConfNodePrune(ConfNode *node)
  *
  * \return 1 if node is a seuence, otherwise 0.
  */
-int
-ConfNodeIsSequence(const ConfNode *node)
+int ConfNodeIsSequence(const ConfNode *node)
 {
     return node->is_seq == 0 ? 0 : 1;
 }
@@ -858,8 +834,7 @@ ConfNodeIsSequence(const ConfNode *node)
 /**
  * Lookup a non-existant value.
  */
-static int
-ConfTestGetNonExistant(void)
+static int ConfTestGetNonExistant(void)
 {
     char name[] = "non-existant-value";
     char *value;
@@ -870,8 +845,7 @@ ConfTestGetNonExistant(void)
 /**
  * Set then lookup a value.
  */
-static int
-ConfTestSetAndGet(void)
+static int ConfTestSetAndGet(void)
 {
     char name[] = "some-name";
     char value[] = "some-value";
@@ -894,8 +868,7 @@ ConfTestSetAndGet(void)
  * Test that overriding a value is allowed provided allow_override is
  * true and that the config parameter gets the new value.
  */
-static int
-ConfTestOverrideValue1(void)
+static int ConfTestOverrideValue1(void)
 {
     char name[] = "some-name";
     char value0[] = "some-value";
@@ -921,8 +894,7 @@ ConfTestOverrideValue1(void)
 /**
  * Test that a final value will not be overrided by a ConfSet.
  */
-static int
-ConfTestOverrideValue2(void)
+static int ConfTestOverrideValue2(void)
 {
     char name[] = "some-name";
     char value0[] = "some-value";
@@ -948,8 +920,7 @@ ConfTestOverrideValue2(void)
 /**
  * Test retrieving an integer value from the configuration db.
  */
-static int
-ConfTestGetInt(void)
+static int ConfTestGetInt(void)
 {
     char name[] = "some-int.x";
     intmax_t val;
@@ -987,8 +958,7 @@ ConfTestGetInt(void)
 /**
  * Test retrieving a boolean value from the configuration db.
  */
-static int
-ConfTestGetBool(void)
+static int ConfTestGetBool(void)
 {
     char name[] = "some-bool";
     char *trues[] = {
@@ -1028,8 +998,7 @@ ConfTestGetBool(void)
     return 1;
 }
 
-static int
-ConfNodeLookupChildTest(void)
+static int ConfNodeLookupChildTest(void)
 {
     char *test_vals[] = { "one", "two", "three" };
     size_t u;
@@ -1077,8 +1046,7 @@ ConfNodeLookupChildTest(void)
     return 1;
 }
 
-static int
-ConfNodeLookupChildValueTest(void)
+static int ConfNodeLookupChildValueTest(void)
 {
     char *test_vals[] = { "one", "two", "three" };
     size_t u;
@@ -1212,8 +1180,7 @@ static int ConfGetChildValueBoolWithDefaultTest(void)
 /**
  * Test the removal of a configuration node.
  */
-static int
-ConfNodeRemoveTest(void)
+static int ConfNodeRemoveTest(void)
 {
     ConfCreateContextBackup();
     ConfInit();
@@ -1236,8 +1203,7 @@ ConfNodeRemoveTest(void)
     return 1;
 }
 
-static int
-ConfSetTest(void)
+static int ConfSetTest(void)
 {
     ConfCreateContextBackup();
     ConfInit();
@@ -1270,8 +1236,7 @@ ConfSetTest(void)
     return 1;
 }
 
-static int
-ConfGetNodeOrCreateTest(void)
+static int ConfGetNodeOrCreateTest(void)
 {
     ConfNode *node;
     int ret = 0;
@@ -1363,8 +1328,7 @@ end:
     return ret;
 }
 
-static int
-ConfNodePruneTest(void)
+static int ConfNodePruneTest(void)
 {
     int ret = 0;
     ConfNode *node;
@@ -1411,8 +1375,7 @@ end:
     return ret;
 }
 
-int
-ConfNodeIsSequenceTest(void)
+int ConfNodeIsSequenceTest(void)
 {
     int retval = 0;
     ConfNode *node = ConfNodeNew();
@@ -1436,8 +1399,7 @@ end:
     return retval;
 }
 
-void
-ConfRegisterTests(void)
+void ConfRegisterTests(void)
 {
     UtRegisterTest("ConfTestGetNonExistant", ConfTestGetNonExistant, 1);
     UtRegisterTest("ConfSetTest", ConfSetTest, 1);

--- a/src/conf.c
+++ b/src/conf.c
@@ -233,6 +233,56 @@ int ConfSet(const char *name, char *val)
 }
 
 /**
+ * \brief Set a configuration parameter from a string.
+ *
+ * Where the input string is something like:
+ *    stream.midstream=true
+ *
+ * \param input the input string to be parsed.
+ *
+ * \retval 1 if the value of set, otherwise 0.
+ */
+int ConfSetFromString(const char *input, int final)
+{
+    int retval = 0;
+    char *name = SCStrdup(input), *val = NULL;
+    if (unlikely(name == NULL)) {
+        goto done;
+    }
+    val = strchr(name, '=');
+    if (val == NULL) {
+        goto done;
+    }
+    *val++ = '\0';
+
+    while (isspace(name[strlen(name) - 1])) {
+        name[strlen(name) - 1] = '\0';
+    }
+
+    while (isspace(*val)) {
+        val++;
+    }
+
+    if (final) {
+        if (!ConfSetFinal(name, val)) {
+            goto done;
+        }
+    }
+    else {
+        if (!ConfSet(name, val)) {
+            goto done;
+        }
+    }
+
+    retval = 1;
+done:
+    if (name != NULL) {
+        SCFree(name);
+    }
+    return retval;
+}
+
+/**
  * \brief Set a final configuration value.
  *
  * A final configuration value is a value that cannot be overridden by
@@ -1399,6 +1449,65 @@ end:
     return retval;
 }
 
+static int ConfSetFromStringTest(void)
+{
+    int retval = 0;
+    ConfNode *n;
+
+    ConfCreateContextBackup();
+    ConfInit();
+
+    if (!ConfSetFromString("stream.midstream=true", 0)) {
+        goto end;
+    }
+    n = ConfGetNode("stream.midstream");
+    if (n == NULL) {
+        goto end;
+    }
+    if (n->val == NULL || strcmp("true", n->val)) {
+        goto end;
+    }
+
+    if (!ConfSetFromString("stream.midstream =false", 0)) {
+        goto end;
+    }
+    n = ConfGetNode("stream.midstream");
+    if (n == NULL) {
+        goto end;
+    }
+    if (n->val == NULL || strcmp("false", n->val)) {
+        goto end;
+    }
+
+    if (!ConfSetFromString("stream.midstream= true", 0)) {
+        goto end;
+    }
+    n = ConfGetNode("stream.midstream");
+    if (n == NULL) {
+        goto end;
+    }
+    if (n->val == NULL || strcmp("true", n->val)) {
+        goto end;
+    }
+
+    if (!ConfSetFromString("stream.midstream = false", 0)) {
+        goto end;
+    }
+    n = ConfGetNode("stream.midstream");
+    if (n == NULL) {
+        goto end;
+    }
+    if (n->val == NULL || strcmp("false", n->val)) {
+        goto end;
+    }
+
+    retval = 1;
+end:
+    ConfDeInit();
+    ConfRestoreContextBackup();
+    return retval;
+}
+
 void ConfRegisterTests(void)
 {
     UtRegisterTest("ConfTestGetNonExistant", ConfTestGetNonExistant, 1);
@@ -1417,6 +1526,7 @@ void ConfRegisterTests(void)
     UtRegisterTest("ConfGetNodeOrCreateTest", ConfGetNodeOrCreateTest, 1);
     UtRegisterTest("ConfNodePruneTest", ConfNodePruneTest, 1);
     UtRegisterTest("ConfNodeIsSequenceTest", ConfNodeIsSequenceTest, 1);
+    UtRegisterTest("ConfSetFromStringTest", ConfSetFromStringTest, 1);
 }
 
 #endif /* UNITTESTS */

--- a/src/conf.h
+++ b/src/conf.h
@@ -62,6 +62,7 @@ int ConfGetBool(const char *name, int *val);
 int ConfGetDouble(const char *name, double *val);
 int ConfGetFloat(const char *name, float *val);
 int ConfSet(const char *name, char *val);
+int ConfSetFromString(const char *input, int final);
 int ConfSetFinal(const char *name, char *val);
 void ConfDump(void);
 void ConfNodeDump(const ConfNode *node, const char *prefix);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1476,14 +1476,14 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif
             else if (strcmp((long_opts[option_index]).name, "set") == 0) {
                 if (optarg != NULL) {
+                    /* Quick validation. */
                     char *val = strchr(optarg, '=');
                     if (val == NULL) {
                         SCLogError(SC_ERR_CMD_LINE,
                                 "Invalid argument for --set, must be key=val.");
                         exit(EXIT_FAILURE);
                     }
-                    *val++ = '\0';
-                    if (ConfSetFinal(optarg, val) != 1) {
+                    if (!ConfSetFromString(optarg, val)) {
                         fprintf(stderr, "Failed to set configuration value %s.",
                                 optarg);
                         exit(EXIT_FAILURE);


### PR DESCRIPTION
Spoted by @regit .

Handle spaces around the '=' in --set.

The first commit just fixes up style to make all function declarations the same.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/93
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/94
