### PR TITLE
Add Feature #1454. CEE/Lumberjack syslog support v2

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -341,9 +341,18 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
         return TM_ECODE_OK;
 
     SCMutexLock(&file_ctx->fp_mutex);
-    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
-        syslog(alert_syslog_level, "%s", js_s);
-    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
+    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) 
+    {
+        if (file_ctx->syslog_cee_format == TRUE)
+        {
+            syslog(alert_syslog_level, "%s%s", "@cee: ",  js_s);
+        }
+        else
+        {
+            syslog(alert_syslog_level, "%s", js_s);
+        }
+    } 
+    else if (file_ctx->type == LOGFILE_TYPE_FILE ||
                file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
                file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
     {
@@ -499,6 +508,16 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                 int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
                 if (level != -1) {
                     alert_syslog_level = level;
+                }
+            }
+            
+            const char *cee_format = ConfNodeLookupChildValue(conf, "cee-format");
+            if (cee_format != NULL)
+            {
+                json_ctx->file_ctx->syslog_cee_format = FALSE;
+                if (ConfValIsTrue(cee_format))
+                {
+                    json_ctx->file_ctx->syslog_cee_format = TRUE;
                 }
             }
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -76,6 +76,9 @@ typedef struct LogFileCtx_ {
 
     /* Flag set when file rotation notification is received. */
     int rotation_flag;
+
+    /* Flag set to prepend @cee: cookie for CEE/Lumberjack compatibility */
+    int syslog_cee_format;
 } LogFileCtx;
 
 /* flags for LogFileCtx */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -99,6 +99,7 @@ outputs:
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #cee-format: yes # Prepend @cee: cookie for CEE/Lumberjack format compatibility
       types:
         - alert:
             # payload: yes           # enable dumping payload in Base64


### PR DESCRIPTION
Rework addressing comments from PR #1449 and subsequent refactoring of JSON output module.

@inliniac @regit - I elected to add a new flag to the LogFileCtx structure instead of adding the @cee: cookie to the 'prefix' field, but let me know if you'd prefer it done differently. 