### PR TITLE
Redisdead v1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ compiler:
   - gcc
   - clang
 # Change this to your needs
-script: sh autogen.sh && ./configure --enable-nfqueue --enable-unittests && make && make check
+script: sh autogen.sh && ./configure --enable-nfqueue --enable-unittests --enable-hiredis && make && make check
 before_install:
   - sudo add-apt-repository -y ppa:npalix/coccinelle
   - sudo apt-get update -qq
-  - sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 coccinelle
+  - sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 coccinelle libjansson-dev libhiredis-dev
   - ./qa/travis-libhtp.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -1648,6 +1648,46 @@
         fi
     fi
 
+# libhiredis
+    AC_ARG_ENABLE(hiredis,
+	        AS_HELP_STRING([--enable-hiredis],[Enable Redis support]),
+	        [ enable_hiredis="yes"],
+	        [ enable_hiredis="no"])
+    AC_ARG_WITH(libhiredis_includes,
+            [  --with-libhiredis-includes=DIR  libhiredis include directory],
+            [with_libhiredis_includes="$withval"],[with_libhiredis_includes="no"])
+    AC_ARG_WITH(libhiredis_libraries,
+            [  --with-libhiredis-libraries=DIR    libhiredis library directory],
+            [with_libhiredis_libraries="$withval"],[with_libhiredis_libraries="no"])
+
+    if test "$enable_hiredis" = "yes"; then
+        if test "$with_libhiredis_includes" != "no"; then
+            CPPFLAGS="${CPPFLAGS} -I${with_libhiredis_includes}"
+        fi
+
+        AC_CHECK_HEADER("hiredis/hiredis.h",HIREDIS="yes",HIREDIS="no")
+        if test "$HIREDIS" = "yes"; then
+            if test "$with_libhiredis_libraries" != "no"; then
+                LDFLAGS="${LDFLAGS}  -L${with_libhiredis_libraries}"
+            fi
+            AC_CHECK_LIB(hiredis, redisConnect,, HIREDIS="no")
+        fi
+        if test "$HIREDIS" = "no"; then
+            echo
+            echo "   ERROR!  libhiredis library not found, go get it"
+            echo "   from https://github.com/redis/hiredis or your distribution:"
+            echo
+            echo "   Ubuntu: apt-get install libhiredis-dev"
+            echo "   Fedora: yum install libhiredis-devel"
+            echo
+            exit 1
+        fi
+        if test "$HIREDIS" = "yes"; then
+            AC_DEFINE([HAVE_LIBHIREDIS],[1],[libhiredis available])
+            enable_hiredis="yes"
+        fi
+    fi
+
 # get cache line size
     AC_PATH_PROG(HAVE_GETCONF_CMD, getconf, "no")
     if test "$HAVE_GETCONF_CMD" != "no"; then
@@ -1747,6 +1787,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   libnss support:                          ${enable_nss}
   libnspr support:                         ${enable_nspr}
   libjansson support:                      ${enable_jansson}
+  hiredis support:                         ${enable_hiredis}
   Prelude support:                         ${enable_prelude}
   PCRE jit:                                ${pcre_jit_available}
   LUA support:                             ${enable_lua}

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -332,8 +332,17 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
 
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
 {
-    char *js_s = json_dumps(js,
-                            JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
+    char *js_s = NULL;
+
+#ifdef HAVE_LIBHIREDIS
+    if (file_ctx->type == LOGFILE_TYPE_REDIS) {
+        json_object_set_new(js, "host",
+                            json_string(file_ctx->redis_setup.sensor_name));
+    }
+#endif
+
+    js_s = json_dumps(js,
+            JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
 #ifdef JSON_ESCAPE_SLASH
                             JSON_ESCAPE_SLASH
 #else
@@ -545,10 +554,19 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
 #if HAVE_LIBHIREDIS
         else if (json_ctx->json_out == LOGFILE_TYPE_REDIS) {
             ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
+            const char *sensor_name = ConfNodeLookupChildValue(conf, "sensor-name");
             const char *redis_server = NULL;
             const char *redis_port = NULL;
             const char *redis_mode = NULL;
             const char *redis_key = NULL;
+
+            if (!sensor_name) {
+                char hostname[1024];
+                gethostname(hostname, 1023);
+                sensor_name = hostname;
+            }
+            json_ctx->file_ctx->redis_setup.sensor_name = SCStrdup(sensor_name);
+
 
             if (redis_node) {
                 redis_server = ConfNodeLookupChildValue(redis_node, "server");

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -122,10 +122,6 @@ void OutputJsonRegisterTests (void)
 
 #define OUTPUT_BUFFER_SIZE 65535
 
-#ifndef OS_WIN32
-static int alert_syslog_level = DEFAULT_ALERT_SYSLOG_LEVEL;
-#endif /* OS_WIN32 */
-
 TmEcode OutputJson (ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
 TmEcode OutputJsonThreadInit(ThreadVars *, void *, void **);
 TmEcode OutputJsonThreadDeinit(ThreadVars *, void *);
@@ -352,40 +348,8 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
     if (unlikely(js_s == NULL))
         return TM_ECODE_OK;
 
-    SCMutexLock(&file_ctx->fp_mutex);
-    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
-        syslog(alert_syslog_level, "%s", js_s);
-    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
-               file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
-    {
-        MemBufferWriteString(buffer, "%s\n", js_s);
-        file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
-            MEMBUFFER_OFFSET(buffer), file_ctx);
-    }
-#if HAVE_LIBHIREDIS
-    else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
-        /* FIXME go async here */
-        redisReply *reply = redisCommand(file_ctx->redis, "%s %s %s",
-                                         file_ctx->redis_setup.command,
-                                         file_ctx->redis_setup.key,
-                                         js_s);
-        switch (reply->type) {
-            case REDIS_REPLY_ERROR:
-                SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
-                break;
-            case REDIS_REPLY_INTEGER:
-                SCLogDebug("Redis integer %lld", reply->integer);
-                break;
-            default:
-                SCLogError(SC_ERR_INVALID_VALUE,
-                           "Redis default triggered with %d", reply->type);
-                break;
-        }
-        freeReplyObject(reply);
-    }
-#endif
-    SCMutexUnlock(&file_ctx->fp_mutex);
+    LogFileWrite(file_ctx, buffer, js_s, strlen(js_s));
+
     free(js_s);
     return 0;
 }
@@ -540,7 +504,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             if (level_s != NULL) {
                 int level = SCMapEnumNameToValue(level_s, SCSyslogGetLogLevelMap());
                 if (level != -1) {
-                    alert_syslog_level = level;
+                    json_ctx->file_ctx->syslog_setup.alert_syslog_level = level;
                 }
             }
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -110,6 +110,9 @@ void OutputJsonRegisterTests (void)
 #else /* implied we do have JSON support */
 
 #include <jansson.h>
+#if HAVE_LIBHIREDIS
+#include <hiredis/hiredis.h>
+#endif
 
 #define DEFAULT_LOG_FILENAME "eve.json"
 #define DEFAULT_ALERT_SYSLOG_FACILITY_STR       "local0"
@@ -351,6 +354,28 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
             MEMBUFFER_OFFSET(buffer), file_ctx);
     }
+#if HAVE_LIBHIREDIS
+    else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
+        /* FIXME go async here */
+        redisReply *reply = redisCommand(file_ctx->redis, "%s %s %s",
+                                         file_ctx->redis_setup.command,
+                                         file_ctx->redis_setup.key,
+                                         js_s);
+        switch (reply->type) {
+            case REDIS_REPLY_ERROR:
+                SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
+                break;
+            case REDIS_REPLY_INTEGER:
+                SCLogDebug("Redis integer %lld", reply->integer);
+                break;
+            default:
+                SCLogError(SC_ERR_INVALID_VALUE,
+                           "Redis default triggered with %d", reply->type);
+                break;
+        }
+        freeReplyObject(reply);
+    }
+#endif
     SCMutexUnlock(&file_ctx->fp_mutex);
     free(js_s);
     return 0;
@@ -449,6 +474,14 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                 json_ctx->json_out = LOGFILE_TYPE_UNIX_DGRAM;
             } else if (strcmp(output_s, "unix_stream") == 0) {
                 json_ctx->json_out = LOGFILE_TYPE_UNIX_STREAM;
+            } else if (strcmp(output_s, "redis") == 0) {
+#if HAVE_LIBHIREDIS
+                json_ctx->json_out = LOGFILE_TYPE_REDIS;
+#else
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                           "redis JSON output option is not compiled");
+                exit(EXIT_FAILURE);
+#endif
             } else {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                            "Invalid JSON output option: %s", output_s);
@@ -509,6 +542,58 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             openlog(ident, LOG_PID|LOG_NDELAY, facility);
 
         }
+#if HAVE_LIBHIREDIS
+        else if (json_ctx->json_out == LOGFILE_TYPE_REDIS) {
+            ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
+            const char *redis_server = NULL;
+            const char *redis_port = NULL;
+            const char *redis_mode = NULL;
+            const char *redis_key = NULL;
+
+            if (redis_node) {
+                redis_server = ConfNodeLookupChildValue(redis_node, "server");
+                redis_port =  ConfNodeLookupChildValue(redis_node, "port");
+                redis_mode =  ConfNodeLookupChildValue(redis_node, "mode");
+                redis_key =  ConfNodeLookupChildValue(redis_node, "key");
+            }
+            if (!redis_server) {
+                redis_server = "127.0.0.1";
+                SCLogInfo("Using default redis server (127.0.0.1)");
+            }
+            if (!redis_port)
+                redis_port = "6379";
+            if (!redis_mode)
+                redis_mode = "list";
+            if (!redis_key)
+                redis_key = "suricata";
+            json_ctx->file_ctx->redis_setup.key = SCStrdup(redis_key);
+
+            if (!json_ctx->file_ctx->redis_setup.key) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key name");
+                exit(EXIT_FAILURE);
+            }
+
+            if (!strcmp(redis_mode, "list")) {
+                json_ctx->file_ctx->redis_setup.command = SCStrdup("LPUSH");
+                if (!json_ctx->file_ctx->redis_setup.command) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+                    exit(EXIT_FAILURE);
+                }
+            } else {
+                json_ctx->file_ctx->redis_setup.command = SCStrdup("PUBLISH");
+                if (!json_ctx->file_ctx->redis_setup.command) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+                    exit(EXIT_FAILURE);
+                }
+            }
+            redisContext *c = redisConnect(redis_server, atoi(redis_port));
+            if (c != NULL && c->err) {
+                SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
+                exit(EXIT_FAILURE);
+            }
+            json_ctx->file_ctx->redis = c;
+        }
+#endif
 
         const char *sensor_id_s = ConfNodeLookupChildValue(conf, "sensor-id");
         if (sensor_id_s != NULL) {

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -519,11 +519,6 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
         else if (json_ctx->json_out == LOGFILE_TYPE_REDIS) {
             ConfNode *redis_node = ConfNodeLookupChild(conf, "redis");
             const char *sensor_name = ConfNodeLookupChildValue(conf, "sensor-name");
-            const char *redis_server = NULL;
-            const char *redis_port = NULL;
-            const char *redis_mode = NULL;
-            const char *redis_key = NULL;
-
             if (!sensor_name) {
                 char hostname[1024];
                 gethostname(hostname, 1023);
@@ -531,49 +526,12 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             }
             json_ctx->file_ctx->redis_setup.sensor_name = SCStrdup(sensor_name);
 
-
-            if (redis_node) {
-                redis_server = ConfNodeLookupChildValue(redis_node, "server");
-                redis_port =  ConfNodeLookupChildValue(redis_node, "port");
-                redis_mode =  ConfNodeLookupChildValue(redis_node, "mode");
-                redis_key =  ConfNodeLookupChildValue(redis_node, "key");
+            if (SCConfLogOpenRedis(redis_node, json_ctx->file_ctx) < 0) {
+                LogFileFreeCtx(json_ctx->file_ctx);
+                SCFree(json_ctx);
+                SCFree(output_ctx);
+                return NULL;
             }
-            if (!redis_server) {
-                redis_server = "127.0.0.1";
-                SCLogInfo("Using default redis server (127.0.0.1)");
-            }
-            if (!redis_port)
-                redis_port = "6379";
-            if (!redis_mode)
-                redis_mode = "list";
-            if (!redis_key)
-                redis_key = "suricata";
-            json_ctx->file_ctx->redis_setup.key = SCStrdup(redis_key);
-
-            if (!json_ctx->file_ctx->redis_setup.key) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key name");
-                exit(EXIT_FAILURE);
-            }
-
-            if (!strcmp(redis_mode, "list")) {
-                json_ctx->file_ctx->redis_setup.command = SCStrdup("LPUSH");
-                if (!json_ctx->file_ctx->redis_setup.command) {
-                    SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
-                    exit(EXIT_FAILURE);
-                }
-            } else {
-                json_ctx->file_ctx->redis_setup.command = SCStrdup("PUBLISH");
-                if (!json_ctx->file_ctx->redis_setup.command) {
-                    SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
-                    exit(EXIT_FAILURE);
-                }
-            }
-            redisContext *c = redisConnect(redis_server, atoi(redis_port));
-            if (c != NULL && c->err) {
-                SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
-                exit(EXIT_FAILURE);
-            }
-            json_ctx->file_ctx->redis = c;
         }
 #endif
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -39,7 +39,6 @@ TmEcode OutputJSON(json_t *js, void *data, uint64_t *count);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer);
 OutputCtx *OutputJsonInitCtx(ConfNode *);
 
-
 enum JsonFormat { COMPACT, INDENT };
 
 /*

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -262,6 +262,62 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
     return 0;
 }
 
+
+#if HAVE_LIBHIREDIS
+int SCConfLogOpenRedis(ConfNode *redis_node, LogFileCtx *log_ctx)
+{
+    const char *redis_server = NULL;
+    const char *redis_port = NULL;
+    const char *redis_mode = NULL;
+    const char *redis_key = NULL;
+
+    if (redis_node) {
+        redis_server = ConfNodeLookupChildValue(redis_node, "server");
+        redis_port =  ConfNodeLookupChildValue(redis_node, "port");
+        redis_mode =  ConfNodeLookupChildValue(redis_node, "mode");
+        redis_key =  ConfNodeLookupChildValue(redis_node, "key");
+    }
+    if (!redis_server) {
+        redis_server = "127.0.0.1";
+        SCLogInfo("Using default redis server (127.0.0.1)");
+    }
+    if (!redis_port)
+        redis_port = "6379";
+    if (!redis_mode)
+        redis_mode = "list";
+    if (!redis_key)
+        redis_key = "suricata";
+    log_ctx->redis_setup.key = SCStrdup(redis_key);
+
+    if (!log_ctx->redis_setup.key) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key name");
+        exit(EXIT_FAILURE);
+    }
+
+    if (!strcmp(redis_mode, "list")) {
+        log_ctx->redis_setup.command = SCStrdup("LPUSH");
+        if (!log_ctx->redis_setup.command) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        log_ctx->redis_setup.command = SCStrdup("PUBLISH");
+        if (!log_ctx->redis_setup.command) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+            exit(EXIT_FAILURE);
+        }
+    }
+    redisContext *c = redisConnect(redis_server, atoi(redis_port));
+    if (c != NULL && c->err) {
+        SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
+        exit(EXIT_FAILURE);
+    }
+    log_ctx->redis = c;
+
+    return 0;
+}
+#endif
+
 /** \brief LogFileNewCtx() Get a new LogFileCtx
  *  \retval LogFileCtx * pointer if succesful, NULL if error
  *  */

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -317,3 +317,43 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
     SCReturnInt(1);
 }
+
+int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t string_len)
+{
+    SCMutexLock(&file_ctx->fp_mutex);
+    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
+        syslog(file_ctx->syslog_setup.alert_syslog_level, "%s", string);
+    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
+               file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
+               file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
+    {
+        MemBufferWriteString(buffer, "%s\n", string);
+        file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
+            MEMBUFFER_OFFSET(buffer), file_ctx);
+    }
+#if HAVE_LIBHIREDIS
+    else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
+        /* FIXME go async here */
+        redisReply *reply = redisCommand(file_ctx->redis, "%s %s %s",
+                                         file_ctx->redis_setup.command,
+                                         file_ctx->redis_setup.key,
+                                         string);
+        switch (reply->type) {
+            case REDIS_REPLY_ERROR:
+                SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
+                break;
+            case REDIS_REPLY_INTEGER:
+                SCLogDebug("Redis integer %lld", reply->integer);
+                break;
+            default:
+                SCLogError(SC_ERR_INVALID_VALUE,
+                           "Redis default triggered with %d", reply->type);
+                break;
+        }
+        freeReplyObject(reply);
+    }
+#endif
+    SCMutexUnlock(&file_ctx->fp_mutex);
+
+    return 0;
+}

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -264,6 +264,15 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
 
 
 #if HAVE_LIBHIREDIS
+
+static void SCLogFileCloseRedis(LogFileCtx *log_ctx)
+{
+    if (log_ctx->redis)
+        redisFree(log_ctx->redis);
+    log_ctx->redis_setup.tried = 0;
+    SC_ATOMIC_SET(log_ctx->redis_setup.batch_count, 0);
+}
+
 int SCConfLogOpenRedis(ConfNode *redis_node, LogFileCtx *log_ctx)
 {
     const char *redis_server = NULL;
@@ -337,10 +346,46 @@ int SCConfLogOpenRedis(ConfNode *redis_node, LogFileCtx *log_ctx)
         SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
         exit(EXIT_FAILURE);
     }
+
+    /* store server params for reconnection */
+    log_ctx->redis_setup.server = SCStrdup(redis_server);
+    log_ctx->redis_setup.port = atoi(redis_port);
+    log_ctx->redis_setup.tried = 0;
+    
     log_ctx->redis = c;
+
+    log_ctx->Close = SCLogFileCloseRedis;
 
     return 0;
 }
+
+int SCConfLogReopenRedis(LogFileCtx *log_ctx)
+{
+    if (log_ctx->redis != NULL) {
+        redisFree(log_ctx->redis);
+        log_ctx->redis = NULL;
+    }
+
+    /* only try to reconnect once per second */
+    if (log_ctx->redis_setup.tried >= time(NULL)) {
+        return -1;
+    }
+
+    redisContext *c = redisConnect(log_ctx->redis_setup.server, log_ctx->redis_setup.port);
+    if (c != NULL && c->err) {
+        if (log_ctx->redis_setup.tried == 0) {
+            SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
+        }
+        redisFree(c);
+        log_ctx->redis_setup.tried = time(NULL);
+        return -1;
+    }
+    log_ctx->redis = c;
+    log_ctx->redis_setup.tried = 0;
+    SC_ATOMIC_SET(log_ctx->redis_setup.batch_count, 0);
+    return 0;
+}
+
 #endif
 
 /** \brief LogFileNewCtx() Get a new LogFileCtx
@@ -387,6 +432,9 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 #ifdef HAVE_LIBHIREDIS
     if (lf_ctx->type == LOGFILE_TYPE_REDIS && lf_ctx->redis) {
         redisFree(lf_ctx->redis);
+        SCFree(lf_ctx->redis_setup.server);
+        SCFree(lf_ctx->redis_setup.command);
+        SCFree(lf_ctx->redis_setup.key);
     }
 #endif
 
@@ -418,6 +466,16 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t s
     }
 #if HAVE_LIBHIREDIS
     else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
+        if (file_ctx->redis == NULL) {
+            /* FIXME temporisation */
+            SCConfLogReopenRedis(file_ctx);
+            if (file_ctx->redis == NULL) {
+                SCMutexUnlock(&file_ctx->fp_mutex);
+                return -1;
+            } else {
+                SCLogInfo("Reconnected to redis server");
+            }
+        }
         /* FIXME go async here ? */
         if (file_ctx->redis_setup.batch_size) {
             redisAppendCommand(file_ctx->redis, "%s %s %s",
@@ -432,7 +490,30 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t s
                         freeReplyObject(reply);
                     } else {
                         /* FIXME treat error */
-                        SCLogInfo("Error when fetching reply");
+                        if (file_ctx->redis->err) {
+                            SCLogInfo("Error when fetching reply: %s (%d)",
+                                      file_ctx->redis->errstr,
+                                      file_ctx->redis->err);
+                        }
+                        switch (file_ctx->redis->err) {
+                            case REDIS_ERR_EOF:
+                            case REDIS_ERR_IO:
+                                SCLogInfo("Reopening connection to redis server");
+                                SCConfLogReopenRedis(file_ctx);
+                                if (file_ctx->redis) {
+                                    SCLogInfo("Reconnected to redis server");
+                                    SCMutexUnlock(&file_ctx->fp_mutex);
+                                    return 0;
+                                } else {
+                                    SCLogInfo("Unable to reconnect to redis server");
+                                    SCMutexUnlock(&file_ctx->fp_mutex);
+                                    return 0;
+                                }
+                                break;
+                            default:
+                                SCLogInfo("Unsupported error code %d",
+                                          file_ctx->redis->err);
+                        }
                     }
                 }
             } else {
@@ -447,6 +528,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t s
             switch (reply->type) {
                 case REDIS_REPLY_ERROR:
                     SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
+                    SCConfLogReopenRedis(file_ctx);
                     break;
                 case REDIS_REPLY_INTEGER:
                     SCLogDebug("Redis integer %lld", reply->integer);
@@ -454,6 +536,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t s
                 default:
                     SCLogError(SC_ERR_INVALID_VALUE,
                             "Redis default triggered with %d", reply->type);
+                    SCConfLogReopenRedis(file_ctx);
                     break;
             }
             freeReplyObject(reply);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -299,6 +299,12 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
         SCMutexUnlock(&lf_ctx->fp_mutex);
     }
 
+#ifdef HAVE_LIBHIREDIS
+    if (lf_ctx->type == LOGFILE_TYPE_REDIS && lf_ctx->redis) {
+        redisFree(lf_ctx->redis);
+    }
+#endif
+
     SCMutexDestroy(&lf_ctx->fp_mutex);
 
     if (lf_ctx->prefix != NULL)

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -294,6 +294,31 @@ int SCConfLogOpenRedis(ConfNode *redis_node, LogFileCtx *log_ctx)
         exit(EXIT_FAILURE);
     }
 
+    log_ctx->redis_setup.batch_timeout = 0;
+    log_ctx->redis_setup.batch_size = 0;
+
+    ConfNode *pipelining = ConfNodeLookupChild(redis_node, "pipelining");
+    if (pipelining) {
+        int enabled = 0;
+        int ret;
+        intmax_t val;
+        ret = ConfGetChildValueBool(pipelining, "enabled", &enabled);
+        if (ret && enabled) {
+            ret = ConfGetChildValueInt(pipelining, "batch-size", &val);
+            if (ret) {
+                log_ctx->redis_setup.batch_size = val;
+            } else {
+                log_ctx->redis_setup.batch_size = 10;
+            }
+            ret = ConfGetChildValueInt(pipelining, "batch-timeout", &val);
+            if (ret) {
+                log_ctx->redis_setup.batch_timeout = val;
+            } else {
+                log_ctx->redis_setup.batch_timeout = 1;
+            }
+        }
+    }
+
     if (!strcmp(redis_mode, "list")) {
         log_ctx->redis_setup.command = SCStrdup("LPUSH");
         if (!log_ctx->redis_setup.command) {
@@ -335,6 +360,10 @@ LogFileCtx *LogFileNewCtx(void)
     // Default Write and Close functions
     lf_ctx->Write = SCLogFileWrite;
     lf_ctx->Close = SCLogFileClose;
+
+#ifdef HAVE_LIBHIREDIS
+    SC_ATOMIC_INIT(lf_ctx->redis_setup.batch_count);
+#endif
 
     return lf_ctx;
 }
@@ -389,24 +418,46 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t s
     }
 #if HAVE_LIBHIREDIS
     else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
-        /* FIXME go async here */
-        redisReply *reply = redisCommand(file_ctx->redis, "%s %s %s",
-                                         file_ctx->redis_setup.command,
-                                         file_ctx->redis_setup.key,
-                                         string);
-        switch (reply->type) {
-            case REDIS_REPLY_ERROR:
-                SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
-                break;
-            case REDIS_REPLY_INTEGER:
-                SCLogDebug("Redis integer %lld", reply->integer);
-                break;
-            default:
-                SCLogError(SC_ERR_INVALID_VALUE,
-                           "Redis default triggered with %d", reply->type);
-                break;
+        /* FIXME go async here ? */
+        if (file_ctx->redis_setup.batch_size) {
+            redisAppendCommand(file_ctx->redis, "%s %s %s",
+                    file_ctx->redis_setup.command,
+                    file_ctx->redis_setup.key,
+                    string);
+            if (SC_ATOMIC_CAS(&file_ctx->redis_setup.batch_count, file_ctx->redis_setup.batch_size, 0)) {
+                redisReply *reply;
+                int i;
+                for(i = 0; i <= file_ctx->redis_setup.batch_size; i++) {
+                    if (redisGetReply(file_ctx->redis, (void **)&reply) == REDIS_OK) {
+                        freeReplyObject(reply);
+                    } else {
+                        /* FIXME treat error */
+                        SCLogInfo("Error when fetching reply");
+                    }
+                }
+            } else {
+                SC_ATOMIC_ADD(file_ctx->redis_setup.batch_count, 1);
+            }
+        } else {
+            redisReply *reply = redisCommand(file_ctx->redis, "%s %s %s",
+                    file_ctx->redis_setup.command,
+                    file_ctx->redis_setup.key,
+                    string);
+
+            switch (reply->type) {
+                case REDIS_REPLY_ERROR:
+                    SCLogWarning(SC_WARN_NO_UNITTESTS, "Redis error: %s", reply->str);
+                    break;
+                case REDIS_REPLY_INTEGER:
+                    SCLogDebug("Redis integer %lld", reply->integer);
+                    break;
+                default:
+                    SCLogError(SC_ERR_INVALID_VALUE,
+                            "Redis default triggered with %d", reply->type);
+                    break;
+            }
+            freeReplyObject(reply);
         }
-        freeReplyObject(reply);
     }
 #endif
     SCMutexUnlock(&file_ctx->fp_mutex);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -27,7 +27,9 @@
 #include "conf.h"            /* ConfNode   */
 #include "tm-modules.h"      /* LogFileCtx */
 
+#ifdef HAVE_LIBHIREDIS
 #include "hiredis/hiredis.h"
+#endif
 
 typedef struct {
     uint16_t fileno;
@@ -39,13 +41,16 @@ enum LogFileType { LOGFILE_TYPE_FILE,
                    LOGFILE_TYPE_UNIX_STREAM,
                    LOGFILE_TYPE_REDIS };
 
+#ifdef HAVE_LIBHIREDIS
 enum RedisMode { REDIS_LIST, REDIS_CHANNEL };
 
 typedef struct RedisSetup_ {
     enum RedisMode mode;
     char *command;
     char *key;
+    char *sensor_name;
 } RedisSetup;
+#endif
 
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -27,6 +27,8 @@
 #include "conf.h"            /* ConfNode   */
 #include "tm-modules.h"      /* LogFileCtx */
 
+#include "hiredis/hiredis.h"
+
 typedef struct {
     uint16_t fileno;
 } PcieFile;
@@ -34,14 +36,30 @@ typedef struct {
 enum LogFileType { LOGFILE_TYPE_FILE,
                    LOGFILE_TYPE_SYSLOG,
                    LOGFILE_TYPE_UNIX_DGRAM,
-                   LOGFILE_TYPE_UNIX_STREAM };
+                   LOGFILE_TYPE_UNIX_STREAM,
+                   LOGFILE_TYPE_REDIS };
+
+enum RedisMode { REDIS_LIST, REDIS_CHANNEL };
+
+typedef struct RedisSetup_ {
+    enum RedisMode mode;
+    char *command;
+    char *key;
+} RedisSetup;
 
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
     union {
         FILE *fp;
         PcieFile *pcie_fp;
+#ifdef HAVE_LIBHIREDIS
+        redisContext *redis;
+#endif
     };
+
+#ifdef HAVE_LIBHIREDIS
+    RedisSetup redis_setup;
+#endif
 
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -57,6 +57,9 @@ typedef struct RedisSetup_ {
     int  batch_size;
     int  batch_timeout;
     SC_ATOMIC_DECLARE(int, batch_count);
+    char *server;
+    int  port;
+    int  tried;
 } RedisSetup;
 #endif
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -118,6 +118,7 @@ int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t string_len);
 
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *);
+int SCConfLogOpenRedis(ConfNode *conf, LogFileCtx *log_ctx);
 int SCConfLogReopen(LogFileCtx *);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -26,6 +26,7 @@
 
 #include "conf.h"            /* ConfNode   */
 #include "tm-modules.h"      /* LogFileCtx */
+#include "util-buffer.h"
 
 #ifdef HAVE_LIBHIREDIS
 #include "hiredis/hiredis.h"
@@ -40,6 +41,10 @@ enum LogFileType { LOGFILE_TYPE_FILE,
                    LOGFILE_TYPE_UNIX_DGRAM,
                    LOGFILE_TYPE_UNIX_STREAM,
                    LOGFILE_TYPE_REDIS };
+
+typedef struct SyslogSetup_ {
+    int alert_syslog_level;
+} SyslogSetup;
 
 #ifdef HAVE_LIBHIREDIS
 enum RedisMode { REDIS_LIST, REDIS_CHANNEL };
@@ -62,9 +67,12 @@ typedef struct LogFileCtx_ {
 #endif
     };
 
+    union {
+    SyslogSetup syslog_setup;
 #ifdef HAVE_LIBHIREDIS
     RedisSetup redis_setup;
 #endif
+    };
 
     int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
     void (*Close)(struct LogFileCtx_ *fp);
@@ -107,6 +115,7 @@ typedef struct LogFileCtx_ {
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
+int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer, char *string, size_t string_len);
 
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *);
 int SCConfLogReopen(LogFileCtx *);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -54,6 +54,9 @@ typedef struct RedisSetup_ {
     char *command;
     char *key;
     char *sensor_name;
+    int  batch_size;
+    int  batch_timeout;
+    SC_ATOMIC_DECLARE(int, batch_count);
 } RedisSetup;
 #endif
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -92,13 +92,18 @@ outputs:
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
       enabled: yes
-      filetype: regular #regular|syslog|unix_dgram|unix_stream
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       # the following are valid when type: syslog above
       #identity: "suricata"
       #facility: local5
       #level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
+      #redis:
+      #  server: 127.0.0.1
+      #  port: 6379
+      #  mode: list ## possible values: list (default), channel
+      #  key: suricata ## key or channel to use (default to suricata)
       types:
         - alert:
             # payload: yes           # enable dumping payload in Base64

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -104,6 +104,13 @@ outputs:
       #  port: 6379
       #  mode: list ## possible values: list (default), channel
       #  key: suricata ## key or channel to use (default to suricata)
+      # Redis pipelining set up. This will enable t only do a query every
+      # 'batch-size' events. This should lower the latency induced by network
+      # connection at the cost of some memory.
+      #  pipelining:
+      #    enabled: yes ## set enable to yes to enable query pipelining
+      #    batch-size: 10 ## number of entry to keep in buffer
+      #    batch-timeout: 1 ## second before flush
       types:
         - alert:
             # payload: yes           # enable dumping payload in Base64


### PR DESCRIPTION
This patchset adds redis output to EVE. redis can now be alternatively selected as output mode. It implements:
- LIST mode: software like logstash can fetch events from the LIST and process them
- SUBSCRIPTION mode: this is a multicast for events which are sent to multiple listeners.
- pipelining: it could also be called batch mode. Events are sent by block. This lower the number of write and read on the TCP socket

Sadly, hiredis is not threadsafe so suricata is making all operations inside the usual lock. An update to this part of the code could be to have one file/socket per threads to allow non mutex-protected writing.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/70
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/68