### PR TITLE
Heap buffer overflow bug 1475 v1

### DIFF
--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -283,7 +283,7 @@ static uint8_t readCoilsReq[] = {/* Transaction ID */    0x00, 0x00,
 /* Example of a request to read input register 9 */
 static uint8_t readInputsRegistersReq[] = {/* Transaction ID */          0x00, 0x0A,
                                            /* Protocol ID */             0x00, 0x00,
-                                           /* Length */                  0x00, 0x05,
+                                           /* Length */                  0x00, 0x06,
                                            /* Unit ID */                 0x00,
                                            /* Function code */           0x04,
                                            /* Starting Address */        0x00, 0x08,


### PR DESCRIPTION
Modbus parser does not check length to extract/read data (read or write address, quantity of data, etc.) that should be present. In case of malformed data (invalid length in header), Modbus parser reads data over the input data length. Add check before extracting/reading data from input buffer to avoid head buffer overflow.