### PR TITLE
logging: fix modules ordering during logging

### DIFF
--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -485,6 +485,7 @@ void TmModuleLogFilestoreRegister (void)
     tmm_modules[TMM_FILESTORE].RegisterTests = NULL;
     tmm_modules[TMM_FILESTORE].cap_flags = 0;
     tmm_modules[TMM_FILESTORE].flags = TM_FLAG_LOGAPI_TM;
+    tmm_modules[TMM_FILESTORE].priority = 10;
 
     OutputRegisterFiledataModule(MODULE_NAME, "file", LogFilestoreLogInitCtx,
             LogFilestoreLogger);

--- a/src/tm-modules.h
+++ b/src/tm-modules.h
@@ -61,6 +61,8 @@ typedef struct TmModule_ {
                              the given TmModule */
     /* Other flags used by the module */
     uint8_t flags;
+    /* priority in the logging order, higher priority is runned first */
+    uint8_t priority;
 } TmModule;
 
 TmModule tmm_modules[TMM_SIZE];


### PR DESCRIPTION
Here's a fixing invalid value for some keys in the EVE fileinfo output.

With the previous code the order of the logging modules in the
YAML were determining which module was run first. This was not
wished and a consequences was that the EVE fileinfo module was
not correctly displaying the key 'stored' because it was
depending on a flag set alter by the filestore module.

This patch adds a priority file to the TmModule structure. The
higher the priority is set, the sooner the module is run in the
logging process. The RunModeOutput structure has also been
updated to contain the name of the original TmModule. Thus allowing
to define a priority for a RunModeOutput.

Currently only the filestore module has a priority set. The rest of them is
set to the default value of zero.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/75
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/73