### PR TITLE
output-lua: sync variable name with yaml

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -692,7 +692,7 @@ static void LogLuaMasterFree(OutputCtx *oc) {
  */
 static OutputCtx *OutputLuaLogInit(ConfNode *conf)
 {
-    const char *dir = ConfNodeLookupChildValue(conf, "script-dir");
+    const char *dir = ConfNodeLookupChildValue(conf, "scripts-dir");
     if (dir == NULL)
         dir = "";
 


### PR DESCRIPTION
'script-dir' was used in the code but we had 'scripts-dir' in the
configuration file. This patch fixes it to 'scripts-dir'.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/77
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/75
