### PR TITLE
hsbd v1.2: inspect buffer depending on the engine mode

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2467,6 +2467,21 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 exit(EXIT_FAILURE);
             }
             cfg_prec->randomize_range = range;
+        } else if (strcasecmp("http-body-inline", p->name) == 0) {
+            if (!strcmp("yes", p->val)) {
+                cfg_prec->http_body_inline = 1;
+            } else if (!strcmp("no", p->val)) {
+                cfg_prec->http_body_inline = 0;
+            } else {
+                if (strcmp("auto", p->val) != 0) {
+                    WarnInvalidConfEntry("http_body_inline", "%s", "auto");
+                }
+                if (EngineModeIsIPS()) {
+                    cfg_prec->http_body_inline = 1;
+                } else {
+                    cfg_prec->http_body_inline = 0;
+                }
+            }
         } else {
             SCLogWarning(SC_ERR_UNKNOWN_VALUE, "LIBHTP Ignoring unknown "
                          "default config: %s", p->name);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -157,6 +157,7 @@ typedef struct HTPCfgRec_ {
     uint32_t            response_inspect_window;
     int                 randomize;
     int                 randomize_range;
+    int                 http_body_inline;
 } HTPCfgRec;
 
 /** Struct used to hold chunks of a body on a request */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1364,6 +1364,10 @@ app-layer:
            request-body-inspect-window: 4kb
            response-body-minimal-inspect-size: 32kb
            response-body-inspect-window: 4kb
+
+           # auto will use http-body-inline mode in IPS mode, yes or no set it statically
+           http-body-inline: auto
+
            # Take a random value for inspection sizes around the specified value.
            # This lower the risk of some evasion technics but could lead
            # detection change between runs. It is set to 'yes' by default.


### PR DESCRIPTION
Currently, data is buffered up to response-body-minimal size and response-body-inspect-window before being inspected.
With this, in IPS mode, inspect data as it comes in up.

This addresses the comments in the last PR: https://github.com/inliniac/suricata/pull/1513