### PR TITLE
Add Feature #1454. Generic eve-log prefix support v3

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -94,6 +94,7 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream
       filename: eve.json
+      #prefix: "@cee: " # prefix to prepend to each eve-log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
       #facility: local5


### PR DESCRIPTION
Support for adding a prefix to eve-log entries. Targeted use case is CEE/Lumberjack rsyslog compatibility ("@cee: " cookie), but any string can be specified as a prefix.