### PR TITLE
Add Feature #1454. Generic eve-log prefix support v4

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -341,13 +341,29 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
         return TM_ECODE_OK;
 
     SCMutexLock(&file_ctx->fp_mutex);
-    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
-        syslog(alert_syslog_level, "%s", js_s);
-    } else if (file_ctx->type == LOGFILE_TYPE_FILE ||
+    if (file_ctx->type == LOGFILE_TYPE_SYSLOG) 
+    {
+        if (file_ctx->prefix != NULL)
+        {
+            syslog(alert_syslog_level, "%s%s", file_ctx->prefix, js_s);
+        }
+        else
+        {
+            syslog(alert_syslog_level, "%s", js_s);
+        }
+    } 
+    else if (file_ctx->type == LOGFILE_TYPE_FILE ||
                file_ctx->type == LOGFILE_TYPE_UNIX_DGRAM ||
                file_ctx->type == LOGFILE_TYPE_UNIX_STREAM)
     {
-        MemBufferWriteString(buffer, "%s\n", js_s);
+        if (file_ctx->prefix != NULL)
+        {
+            MemBufferWriteString(buffer, "%s%s\n", file_ctx->prefix, js_s);
+        }
+        else
+        {
+            MemBufferWriteString(buffer, "%s\n", js_s);
+        }
         file_ctx->Write((const char *)MEMBUFFER_BUFFER(buffer),
             MEMBUFFER_OFFSET(buffer), file_ctx);
     }
@@ -452,6 +468,18 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             } else {
                 SCLogError(SC_ERR_INVALID_ARGUMENT,
                            "Invalid JSON output option: %s", output_s);
+                exit(EXIT_FAILURE);
+            }
+        }
+
+        const char *prefix = ConfNodeLookupChildValue(conf, "prefix");
+        if (prefix != NULL)
+        {
+            json_ctx->file_ctx->prefix = SCStrdup(prefix);
+            if (json_ctx->file_ctx->prefix == NULL)
+            {
+                SCLogError(SC_ERR_MEM_ALLOC, 
+                    "Failed to allocate memory for eve-log.prefix setting.");
                 exit(EXIT_FAILURE);
             }
         }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -94,6 +94,7 @@ outputs:
       enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream
       filename: eve.json
+      #prefix: "@cee: " # prefix to prepend to each log entry
       # the following are valid when type: syslog above
       #identity: "suricata"
       #facility: local5


### PR DESCRIPTION
Checking that memory is allocated successfully. I elected to log an error and exit because an inability to allocate memory indicates a greater issue, even if it's not fatal in this particular case.

Also, memory is freed on line 305 of util-logopenfile.c in the LogFileFreeCtx function, which is called from the OutputJsonDeInitCtx function.