### PR TITLE
app-layer: add modbus to AppProtoToString

### DIFF
--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -71,6 +71,9 @@ const char *AppProtoToString(AppProto alproto)
         case ALPROTO_DNS:
             proto_name = "dns";
             break;
+        case ALPROTO_MODBUS:
+            proto_name = "modbus";
+            break;
         case ALPROTO_FAILED:
 #ifdef UNITTESTS
         case ALPROTO_TEST:


### PR DESCRIPTION
It was missing causing protocol identified as modbus not to be
displayed in netflow events.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/81
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/79