### PR TITLE
file-json: add file_id to message

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -241,6 +241,9 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     }
     json_object_set_new(fjs, "stored",
                         (ff->flags & FILE_STORED) ? json_true() : json_false());
+    if (ff->flags & FILE_STORED) {
+        json_object_set_new(fjs, "file_id", json_integer(ff->file_id));
+    }
     json_object_set_new(fjs, "size", json_integer(ff->size));
     json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 


### PR DESCRIPTION
This will allow to get the filename and by consequence the file
after a parsing of the EVE log file.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/82
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/80