### PR TITLE
suricatasc: remove "u" prefix when printing JSON output.

### DIFF
--- a/scripts/suricatasc/suricatasc.in
+++ b/scripts/suricatasc/suricatasc.in
@@ -42,7 +42,7 @@ except SuricataReturnException as err:
 if args.command:
     (command, arguments) = sc.parse_command(args.command)
     res = sc.send_command(command, arguments)
-    print(res)
+    print(json.dumps(res))
     sc.close()
     if res['return'] == 'OK':
         sys.exit(0)


### PR DESCRIPTION
If we want to parse suricatasc's output, python's unicode prefix should be removed to make JSON parsers happy.