### PR TITLE
af-packet: handle per interface config in different orders

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -65,6 +65,27 @@ const char *RunModeAFPGetDefaultMode(void)
     return default_mode_workers;
 }
 
+/**
+ * \brief Get the af-packet configuration node for a device.
+ *
+ * Basically hunts through the list of maps for the first one with a
+ * key of "interface", and a value of the provided interface.
+ */
+static ConfNode *AFPFindDeviceConfig(ConfNode *root, const char *iface)
+{
+    ConfNode *if_root, *item;
+    const char key[] = "interface";
+    TAILQ_FOREACH(if_root, &root->head, next) {
+        TAILQ_FOREACH(item, &if_root->head, next) {
+            if (!(strcmp(item->name, key) && strcmp(item->val, iface))) {
+                return if_root;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 void RunModeIdsAFPRegister(void)
 {
     RunModeRegisterNewRunMode(RUNMODE_AFP_DEV, "single",
@@ -156,7 +177,7 @@ void *ParseAFPConfig(const char *iface)
         return aconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", iface);
+    if_root = AFPFindDeviceConfig(af_packet_node, iface);
 
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
@@ -380,7 +401,7 @@ int AFPRunModeIsIPS()
             return 0;
         }
         char *copymodestr = NULL;
-        if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", live_dev);
+        if_root = AFPFindDeviceConfig(af_packet_node, live_dev);
 
         if (if_root == NULL) {
             if (if_default == NULL) {


### PR DESCRIPTION
Handles the case where the order of items in the mappings in the af-packet sequence have their ordered change, which can happen when the YAML is generated from another tool, as maps generally do not have an order.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1487

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/108
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/109
