### PR TITLE
af-packet: use maps instead of sequences.

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -65,6 +65,27 @@ const char *RunModeAFPGetDefaultMode(void)
     return default_mode_workers;
 }
 
+/**
+ * \brief Get the af-packet configuration node for a device.
+ *
+ * Basically hunts through the list of maps for the first one with a
+ * key of "interface", and a value of the provided interface.
+ */
+static ConfNode *AFPFindDeviceConfig(ConfNode *root, const char *iface)
+{
+    ConfNode *if_root, *item;
+    const char key[] = "interface";
+    TAILQ_FOREACH(if_root, &root->head, next) {
+        TAILQ_FOREACH(item, &if_root->head, next) {
+            if (!(strcmp(item->name, key) && strcmp(item->val, iface))) {
+                return if_root;
+            }
+        }
+    }
+
+    return NULL;
+}
+
 void RunModeIdsAFPRegister(void)
 {
     RunModeRegisterNewRunMode(RUNMODE_AFP_DEV, "single",
@@ -156,7 +177,7 @@ void *ParseAFPConfig(const char *iface)
         return aconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", iface);
+    if_root = AFPFindDeviceConfig(af_packet_node, iface);
 
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
@@ -380,7 +401,7 @@ int AFPRunModeIsIPS()
             return 0;
         }
         char *copymodestr = NULL;
-        if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", live_dev);
+        if_root = AFPFindDeviceConfig(af_packet_node, live_dev);
 
         if (if_root == NULL) {
             if (if_default == NULL) {

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -150,6 +150,18 @@ int LiveBuildDeviceListCustom(char * runmode, char * itemname)
     if (base == NULL)
         return 0;
 
+    /* First check if there in an "interfaces" mapping. */
+    ConfNode *interfaces = ConfNodeLookupChild(base, "interfaces");
+    if (interfaces != NULL) {
+        TAILQ_FOREACH(child, &interfaces->head, next) {
+            SCLogInfo("Adding %s %s from config file", itemname, child->name);
+            LiveRegisterDevice(child->name);
+            i++;
+        }
+        return i;
+    }
+
+    /* Fall back to a list of interfaces. */
     TAILQ_FOREACH(child, &base->head, next) {
         ConfNode *subchild;
         TAILQ_FOREACH(subchild, &child->head, next) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -398,69 +398,73 @@ nflog:
 # af-packet support
 # Set threads to > 1 to use PACKET_FANOUT support
 af-packet:
-  - interface: eth0
-    # Number of receive threads. "auto" uses the number of cores
-    threads: auto
-    # Default clusterid.  AF_PACKET will load balance packets based on flow.
-    # All threads/processes that will participate need to have the same
-    # clusterid.
-    cluster-id: 99
-    # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
-    # This is only supported for Linux kernel > 3.1
-    # possible value are:
-    #  * cluster_round_robin: round robin load balancing
-    #  * cluster_flow: all packets of a given flow are send to the same socket
-    #  * cluster_cpu: all packets treated in kernel by a CPU are send to the same socket
-    cluster-type: cluster_flow
-    # In some fragmentation case, the hash can not be computed. If "defrag" is set
-    # to yes, the kernel will do the needed defragmentation before sending the packets.
-    defrag: yes
-    # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
-    use-mmap: yes
-    # Ring size will be computed with respect to max_pending_packets and number
-    # of threads. You can set manually the ring size in number of packets by setting
-    # the following value. If you are using flow cluster-type and have really network
-    # intensive single-flow you could want to set the ring-size independantly of the number
-    # of threads:
-    #ring-size: 2048
-    # On busy system, this could help to set it to yes to recover from a packet drop
-    # phase. This will result in some packets (at max a ring flush) being non treated.
-    #use-emergency-flush: yes
-    # recv buffer size, increase value could improve performance
-    # buffer-size: 32768
-    # Set to yes to disable promiscuous mode
-    # disable-promisc: no
-    # Choose checksum verification mode for the interface. At the moment
-    # of the capture, some packets may be with an invalid checksum due to
-    # offloading to the network card of the checksum computation.
-    # Possible values are:
-    #  - kernel: use indication sent by kernel for each packet (default)
-    #  - yes: checksum validation is forced
-    #  - no: checksum validation is disabled
-    #  - auto: suricata uses a statistical approach to detect when
-    #  checksum off-loading is used.
-    # Warning: 'checksum-validation' must be set to yes to have any validation
-    #checksum-checks: kernel
-    # BPF filter to apply to this interface. The pcap filter syntax apply here.
-    #bpf-filter: port 80 or udp
-    # You can use the following variables to activate AF_PACKET tap od IPS mode.
-    # If copy-mode is set to ips or tap, the traffic coming to the current
-    # interface will be copied to the copy-iface interface. If 'tap' is set, the
-    # copy is complete. If 'ips' is set, the packet matching a 'drop' action
-    # will not be copied.
-    #copy-mode: ips
-    #copy-iface: eth1
-  - interface: eth1
-    threads: auto
-    cluster-id: 98
-    cluster-type: cluster_flow
-    defrag: yes
-    # buffer-size: 32768
-    # disable-promisc: no
-  # Put default values here
-  - interface: default
+  defaults:
     #threads: auto
     #use-mmap: yes
+  interfaces:
+    eth0:
+      threads: auto
+      # Default clusterid.  AF_PACKET will load balance packets based on flow.
+      # All threads/processes that will participate need to have the same
+      # clusterid.
+      cluster-id: 99
+      # Default AF_PACKET cluster type. AF_PACKET can load balance per
+      # flow or per hash.  This is only supported for Linux kernel > 3.1
+      # Possible value are:
+      #  * cluster_round_robin: round robin load balancing
+      #  * cluster_flow: all packets of a given flow are send to the same socket
+      #  * cluster_cpu: all packets treated in kernel by a CPU are send to the
+      #                 same socket
+      cluster-type: cluster_flow
+      # In some fragmentation case, the hash can not be computed. If
+      # "defrag" is set to yes, the kernel will do the needed
+      # defragmentation before sending the packets.
+      defrag: yes
+      # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
+      use-mmap: yes
+      # Ring size will be computed with respect to
+      # max_pending_packets and number of threads. You can set
+      # manually the ring size in number of packets by setting the
+      # following value. If you are using flow cluster-type and have
+      # really network intensive single-flow you could want to set
+      # the ring-size independantly of the number of threads:
+      #ring-size: 2048
+      # On busy system, this could help to set it to yes to recover
+      # from a packet drop phase. This will result in some packets
+      # (at max a ring flush) being non treated.
+      #use-emergency-flush: yes
+      # recv buffer size, increase value could improve performance
+      # buffer-size: 32768
+      # Set to yes to disable promiscuous mode
+      # disable-promisc: no
+      # Choose checksum verification mode for the interface. At the moment
+      # of the capture, some packets may be with an invalid checksum due to
+      # offloading to the network card of the checksum computation.
+      # Possible values are:
+      #  - kernel: use indication sent by kernel for each packet (default)
+      #  - yes: checksum validation is forced
+      #  - no: checksum validation is disabled
+      #  - auto: suricata uses a statistical approach to detect when
+      #  checksum off-loading is used.
+      # Warning: 'checksum-validation' must be set to yes to have any validation
+      #checksum-checks: kernel
+      # BPF filter to apply to this interface. The pcap filter syntax apply here.
+      #bpf-filter: port 80 or udp
+      # You can use the following variables to activate AF_PACKET tap
+      # or IPS mode.  If copy-mode is set to ips or tap, the traffic
+      # coming to the current interface will be copied to the
+      # copy-iface interface. If 'tap' is set, the copy is
+      # complete. If 'ips' is set, the packet matching a 'drop' action
+      # will not be copied.
+      #copy-mode: ips
+      #copy-iface: eth1
+    eth1:
+      threads: auto
+      cluster-id: 98
+      cluster-type: cluster_flow
+      defrag: yes
+      # buffer-size: 32768
+      # disable-promisc: no
 
 # netmap support
 netmap:


### PR DESCRIPTION
Builds on PR #1554 .

This is an idea of a new way to configure af-packet interfaces which is probably a bit more true to YAML.  Some discussion here: https://redmine.openinfosecfoundation.org/issues/1487

Includes fallback to old config with a deprecation warning.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/109
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/110

Consider this an RFC, as we'd probably want to convert all input configurations in one go.
