### PR TITLE
stream_size operator comparison (fix issue #1488)

### DIFF
--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -244,19 +244,19 @@ DetectStreamSizeData *DetectStreamSizeParse (char *streamstr)
     if (strlen(mode) == 0)
         goto error;
 
-    if (mode[0] == '<')
-        sd->mode = DETECTSSIZE_LT;
-    else if (strcmp("<=", mode) == 0)
-        sd->mode = DETECTSSIZE_LEQ;
-    else if (mode[0] == '>')
-        sd->mode = DETECTSSIZE_GT;
-    else if (strcmp(">=", mode) == 0)
-        sd->mode = DETECTSSIZE_GEQ;
-    else if (strcmp("!=", mode) == 0)
-        sd->mode = DETECTSSIZE_NEQ;
-    else if (mode[0] == '=')
+    if (mode[0] == '=') {
         sd->mode = DETECTSSIZE_EQ;
-    else {
+    } else if (mode[0] == '<') {
+        sd->mode = DETECTSSIZE_LT;
+        if (strcmp("<=", mode) == 0)
+            sd->mode = DETECTSSIZE_LEQ;
+    } else if (mode[0] == '>') {
+        sd->mode = DETECTSSIZE_GT;
+        if (strcmp(">=", mode) == 0)
+            sd->mode = DETECTSSIZE_GEQ;
+    } else if (strcmp("!=", mode) == 0) {
+        sd->mode = DETECTSSIZE_NEQ;
+    } else {
         SCLogError(SC_ERR_INVALID_OPERATOR, "Invalid operator");
         goto error;
     }


### PR DESCRIPTION
Funny bug.

`DetectStreamSizeParse` was first checking if `mode[0] == '<'`, which is true for both `<` and `<=`, thus `<=` (resp. `>=`) is never matched. This patch does the `strcmp` to `<=` (resp. `>=`) within the if block of `<` (resp. `>`) to fix [#1488](https://redmine.openinfosecfoundation.org/issues/1488).