### PR TITLE
Af packet new modes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1054,8 +1054,8 @@
             [enable_af_packet="no"],
             [[#include <sys/socket.h>
               #include <linux/if_packet.h>]])
-        AC_CHECK_DECL([PACKET_FANOUT],
-            AC_DEFINE([HAVE_PACKET_FANOUT],[1],[Packet fanout support is available]),
+        AC_CHECK_DECL([PACKET_FANOUT_RND],
+            AC_DEFINE([HAVE_PACKET_FANOUT],[1],[Recent packet fanout support is available]),
             [],
             [[#include <linux/if_packet.h>]])
     ])

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -282,6 +282,19 @@ void *ParseAFPConfig(const char *iface)
         SCLogInfo("Using cpu cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_CPU;
+    } else if (strcmp(tmpctype, "cluster_qm") == 0) {
+        SCLogInfo("Using queue based cluster mode for AF_PACKET (iface %s)",
+                aconf->iface);
+        aconf->cluster_type = PACKET_FANOUT_QM;
+    } else if (strcmp(tmpctype, "cluster_random") == 0) {
+        SCLogInfo("Using random based cluster mode for AF_PACKET (iface %s)",
+                aconf->iface);
+        aconf->cluster_type = PACKET_FANOUT_RND;
+    } else if (strcmp(tmpctype, "cluster_rollover") == 0) {
+        SCLogInfo("Using rollover based cluster mode for AF_PACKET (iface %s)",
+                aconf->iface);
+        aconf->cluster_type = PACKET_FANOUT_ROLLOVER;
+
     } else {
         SCLogError(SC_ERR_INVALID_CLUSTER_TYPE,"invalid cluster-type %s",tmpctype);
         SCFree(aconf);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -301,6 +301,14 @@ void *ParseAFPConfig(const char *iface)
         return NULL;
     }
 
+    int conf_val = 0;
+    ConfGetChildValueBoolWithDefault(if_root, if_default, "rollover", &conf_val);
+    if (conf_val) {
+        SCLogInfo("Using rollover kernel functionality for AF_PACKET (iface %s)",
+                aconf->iface);
+        aconf->cluster_type |= PACKET_FANOUT_FLAG_ROLLOVER;
+    }
+
     /*load af_packet bpf filter*/
     /* command line value has precedence */
     if (ConfGet("bpf-filter", &bpf_filter) != 1) {

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -32,6 +32,11 @@
 #define PACKET_FANOUT_HASH             0
 #define PACKET_FANOUT_LB               1
 #define PACKET_FANOUT_CPU              2
+#define PACKET_FANOUT_ROLLOVER         3
+#define PACKET_FANOUT_RND              4
+#define PACKET_FANOUT_QM               5
+
+#define PACKET_FANOUT_FLAG_ROLLOVER	   0x1000
 #define PACKET_FANOUT_FLAG_DEFRAG      0x8000
 #else /* HAVE_PACKET_FANOUT */
 #include <linux/if_packet.h>

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -424,6 +424,10 @@ af-packet:
     # In some fragmentation case, the hash can not be computed. If "defrag" is set
     # to yes, the kernel will do the needed defragmentation before sending the packets.
     defrag: yes
+    # After Linux kernel 3.10 it is possible to activate the rollover option: if a socket is
+    # full then kernel will send the packet on the next socket with room available. This option
+    # can minimize packet drop and increase the treated bandwith on single intensive flow.
+    #rollover: yes
     # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
     use-mmap: yes
     # Ring size will be computed with respect to max_pending_packets and number
@@ -470,6 +474,7 @@ af-packet:
   - interface: default
     #threads: auto
     #use-mmap: yes
+    rollover: yes
 
 # netmap support
 netmap:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -412,6 +412,14 @@ af-packet:
     #  * cluster_round_robin: round robin load balancing
     #  * cluster_flow: all packets of a given flow are send to the same socket
     #  * cluster_cpu: all packets treated in kernel by a CPU are send to the same socket
+    #  * cluster_qm: all packets linked by network card to a RSS queue are sent to the same
+    #  socket. Requires at least Linux 3.14.
+    #  * cluster_random: packets are sent randomly to sockets but with an equipartition.
+    #  Requires at least Linux 3.14.
+    #  * cluster_rollover: kernel rotates between sockets filling each socket before moving
+    #  to the next. Requires at least Linux 3.10.
+    # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
+    # with capture card using RSS (require cpu affinity tuning and system irq tuning)
     cluster-type: cluster_flow
     # In some fragmentation case, the hash can not be computed. If "defrag" is set
     # to yes, the kernel will do the needed defragmentation before sending the packets.


### PR DESCRIPTION
Implement the new features of AF_PACKET. Last patch of the series should dramatically reduce packets drop and increase treated bandwidth on single bandwidth intensive flow.

 See http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=77f65ebdca506870d99bfabe52bde222511022ec for information of rollover.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/83
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/81 