### PR TITLE
Updated CUDA to use sm_50 and sm_52, deprecated sm_10, sm_11, sm_12, sm_13

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -422,35 +422,19 @@ util-mpm-ac-cuda-kernel.cu
 NVCCFLAGS=-O2
 
 SUFFIXES = \
-.ptx_sm_10 \
-.ptx_sm_11 \
-.ptx_sm_12 \
-.ptx_sm_13 \
 .ptx_sm_20 \
 .ptx_sm_21 \
 .ptx_sm_30 \
-.ptx_sm_35
+.ptx_sm_35 \
+.ptx_sm_50 \
+.ptx_sm_52
 
-PTXS =  $(suricata_CUDA_KERNELS:.cu=.ptx_sm_10)
-PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_11)
-PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_12)
-PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_13)
-PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_20)
+PTXS =  $(suricata_CUDA_KERNELS:.cu=.ptx_sm_20)
 PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_21)
 PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_30)
 PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_35)
-
-.cu.ptx_sm_10:
-	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_10 -ptx $<
-
-.cu.ptx_sm_11:
-	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_11 -ptx $<
-
-.cu.ptx_sm_12:
-	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_12 -ptx $<
-
-.cu.ptx_sm_13:
-	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_13 -ptx $<
+PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_50)
+PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_52)
 
 .cu.ptx_sm_20:
 	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_20 -ptx $<
@@ -463,6 +447,12 @@ PTXS += $(suricata_CUDA_KERNELS:.cu=.ptx_sm_35)
 
 .cu.ptx_sm_35:
 	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_35 -ptx $<
+
+.cu.ptx_sm_50:
+	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_50 -ptx $<
+
+.cu.ptx_sm_52:
+	$(NVCC) $(NVCCFLAGS) -o $@ -arch=sm_52 -ptx $<
 
 cuda-ptxdump.h: $(PTXS)
 	$(PYTHON) ptxdump.py cuda-ptxdump $(PTXS)


### PR DESCRIPTION
sm_1x architectures were deprecated in CUDA Toolkit 6.0. Meaning that these architectures can only run on CUDA Toolkit 4.0 -> 5.5. This adds sm_50 and sm_52 for the most recent cards and allows suricata to be compiled with CUDA Toolkit 6.x and 7.0.

The CUDA Toolkit Documentation states "When in doubt about the compute capability of the hardware that will be present at runtime, it is best to assume a compute capability of 2.0 as defined in the CUDA C Programming Guide section on Technical and Feature Specifications." which means it suggests sm_20 being the baseline (not sm_10).