### PR TITLE
Issue 1491: fix capabilities for pf_ring mode when running under non-root account

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -80,7 +80,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
             break;
         case RUNMODE_PFRING:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
-                    CAP_NET_ADMIN,
+                    CAP_NET_ADMIN, CAP_NET_RAW,
                     -1);
             break;
         case RUNMODE_NFQ:


### PR DESCRIPTION
CAP_NET_ADMIN is insufficient to turn promiscuous mode on, so add CAP_NET_RAW.