### PR TITLE
Disable pcap-config use during cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -961,7 +961,7 @@
     AC_CHECK_LIB(pcap, pcap_activate,, LPCAPVTEST="no")
     if test "$LPCAPVTEST" != "no"; then
         AC_PATH_PROG(HAVE_PCAP_CONFIG, pcap-config, "no")
-        if test "$HAVE_PCAP_CONFIG" = "no"; then
+        if test "$HAVE_PCAP_CONFIG" = "no" -o "$cross_compiling" = "yes"; then
             CFLAGS="${CFLAGS} -DLIBPCAP_VERSION_MAJOR=1"
         else
             CFLAGS="${CFLAGS} `pcap-config --defines` `pcap-config --cflags` -DLIBPCAP_VERSION_MAJOR=1"


### PR DESCRIPTION
This allows cross compilation where the host system has pcap-config
installed and would create an invalid entry in the cross-CFLAGS.