### PR TITLE
file_data: check for signature alproto and flow

### DIFF
--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -84,9 +84,15 @@ static int DetectFiledataSetup (DetectEngineCtx *de_ctx, Signature *s, char *str
         return -1;
     }
 
-    if ((s->init_flags & SIG_FLAG_INIT_FLOW) &&
+    if (s->alproto == ALPROTO_HTTP && (s->init_flags & SIG_FLAG_INIT_FLOW) &&
         (s->flags & SIG_FLAG_TOSERVER) && !(s->flags & SIG_FLAG_TOCLIENT)) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with flow:to_server or from_client with http or smtp.");
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with flow:to_server or from_client with http.");
+            return -1;
+    }
+
+    if (s->alproto == ALPROTO_SMTP && (s->init_flags & SIG_FLAG_INIT_FLOW) &&
+        !(s->flags & SIG_FLAG_TOSERVER) && (s->flags & SIG_FLAG_TOCLIENT)) {
+            SCLogError(SC_ERR_INVALID_SIGNATURE, "Can't use file_data with flow:to_client or from_server with smtp.");
             return -1;
     }
 
@@ -169,6 +175,117 @@ end:
 
     return result;
 }
+
+static int DetectFiledataParseTest03(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    int result = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any 25 "
+                               "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)");
+    if (de_ctx->sig_list == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_PMATCH] != NULL) {
+        printf("content is still in PMATCH list: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_FILEDATA] == NULL) {
+       printf("content not in FILEDATA list: ");
+       goto end;
+    }
+
+    result = 1;
+end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
+
+static int DetectFiledataParseTest04(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    int result = 1;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert smtp any any -> any any "
+                               "(msg:\"test\"; flow:to_client,established; file_data; content:\"abc\"; sid:1;)");
+    if (de_ctx->sig_list == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_PMATCH] != NULL) {
+        printf("content is still in PMATCH list: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_FILEDATA] == NULL) {
+       printf("content not in FILEDATA list: ");
+       goto end;
+    }
+
+    result = 0;
+end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
+
+static int DetectFiledataParseTest05(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    int result = 1;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any "
+                               "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)");
+    if (de_ctx->sig_list == NULL) {
+        printf("sig parse failed: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_PMATCH] != NULL) {
+        printf("content is still in PMATCH list: ");
+        goto end;
+    }
+
+    if (de_ctx->sig_list->sm_lists[DETECT_SM_LIST_FILEDATA] == NULL) {
+       printf("content not in FILEDATA list: ");
+       goto end;
+    }
+
+    result = 0;
+end:
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    return result;
+}
 #endif
 
 void DetectFiledataRegisterTests(void)
@@ -176,5 +293,8 @@ void DetectFiledataRegisterTests(void)
 #ifdef UNITTESTS
     UtRegisterTest("DetectFiledataParseTest01", DetectFiledataParseTest01, 1);
     UtRegisterTest("DetectFiledataParseTest02", DetectFiledataParseTest02, 1);
+    UtRegisterTest("DetectFiledataParseTest03", DetectFiledataParseTest03, 1);
+    UtRegisterTest("DetectFiledataParseTest04", DetectFiledataParseTest04, 1);
+    UtRegisterTest("DetectFiledataParseTest05", DetectFiledataParseTest05, 1);
 #endif
 }


### PR DESCRIPTION
Currently the following rule can't be loaded:
alert tcp any any -> any 25 (msg:"SMTP file_data test"; flow:to_server,established; file_data; content:"abc";sid:1;)
and produces the error output:
"Can't use file_data with flow:to_server or from_client with http or smtp."

This checks if the alproto is not http in a signature,
so permits to use flow keyword also.

Issue reported by rmkml.

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/48
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/47

Last PR: https://github.com/inliniac/suricata/pull/1534