### PR TITLE
logging: integrate rotation into SCConfLogOpenGeneric - v1.

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -448,7 +448,6 @@ static void AlertDebugLogDeInitCtx(OutputCtx *output_ctx)
 {
     if (output_ctx != NULL) {
         LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-        OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
         if (logfile_ctx != NULL) {
             LogFileFreeCtx(logfile_ctx);
         }
@@ -473,10 +472,9 @@ static OutputCtx *AlertDebugLogInitCtx(ConfNode *conf)
         goto error;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         goto error;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCMalloc(sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -250,11 +250,10 @@ OutputCtx *AlertFastLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
@@ -268,7 +267,6 @@ OutputCtx *AlertFastLogInitCtx(ConfNode *conf)
 static void AlertFastLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     SCFree(output_ctx);
 }

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -294,7 +294,6 @@ static void LogDnsLogExitPrintStats(ThreadVars *tv, void *data)
 static void LogDnsLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogDnsFileCtx *dnslog_ctx = (LogDnsFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&dnslog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(dnslog_ctx->file_ctx);
     SCFree(dnslog_ctx);
     SCFree(output_ctx);
@@ -313,11 +312,10 @@ static OutputCtx *LogDnsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -125,7 +125,6 @@ static void LogDropLogDeInitCtx(OutputCtx *output_ctx)
     if (output_ctx != NULL) {
         LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
         if (logfile_ctx != NULL) {
-            OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
             LogFileFreeCtx(logfile_ctx);
         }
         SCFree(output_ctx);
@@ -151,11 +150,10 @@ static OutputCtx *LogDropLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/log-file.c
+++ b/src/log-file.c
@@ -388,7 +388,6 @@ void LogFileLogExitPrintStats(ThreadVars *tv, void *data)
 static void LogFileLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     free(output_ctx);
 }
@@ -405,11 +404,10 @@ static OutputCtx *LogFileLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -599,11 +599,10 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogHttpFileCtx *httplog_ctx = SCMalloc(sizeof(LogHttpFileCtx));
     if (unlikely(httplog_ctx == NULL)) {
@@ -733,7 +732,6 @@ static void LogHttpLogDeInitCtx(OutputCtx *output_ctx)
     for (i = 0; i < httplog_ctx->cf_n; i++) {
         SCFree(httplog_ctx->cf_nodes[i]);
     }
-    OutputUnregisterFileRotationFlag(&httplog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(httplog_ctx->file_ctx);
     SCFree(httplog_ctx);
     SCFree(output_ctx);

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -221,7 +221,7 @@ OutputCtx *LogStatsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }
@@ -263,14 +263,12 @@ OutputCtx *LogStatsLogInitCtx(ConfNode *conf)
 
     SCLogDebug("STATS log output initialized");
 
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
     return output_ctx;
 }
 
 static void LogStatsLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogStatsFileCtx *statslog_ctx = (LogStatsFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&statslog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(statslog_ctx->file_ctx);
     SCFree(statslog_ctx);
     SCFree(output_ctx);

--- a/src/log-tcp-data.c
+++ b/src/log-tcp-data.c
@@ -293,7 +293,7 @@ OutputCtx *LogTcpDataLogInitCtx(ConfNode *conf)
 
     if (tcpdatalog_ctx->file == 1) {
         SCLogInfo("opening logfile");
-        if (SCConfLogOpenGeneric(conf, file_ctx, filename) < 0) {
+        if (SCConfLogOpenGeneric(conf, file_ctx, filename, 1) < 0) {
             LogFileFreeCtx(file_ctx);
             SCFree(tcpdatalog_ctx);
             return NULL;

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -382,7 +382,6 @@ static void LogTlsLogDeInitCtx(OutputCtx *output_ctx)
     OutputTlsLoggerDisable();
 
     LogTlsFileCtx *tlslog_ctx = (LogTlsFileCtx *) output_ctx->data;
-    OutputUnregisterFileRotationFlag(&tlslog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(tlslog_ctx->file_ctx);
     SCFree(tlslog_ctx);
     SCFree(output_ctx);
@@ -436,10 +435,9 @@ static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
         }
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         goto filectx_error;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogTlsFileCtx *tlslog_ctx = SCCalloc(1, sizeof(LogTlsFileCtx));
     if (unlikely(tlslog_ctx == NULL))

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -550,7 +550,7 @@ static OutputCtx *JsonAlertLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -382,7 +382,7 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -261,7 +261,7 @@ static OutputCtx *JsonDropLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, drop_ctx->file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, drop_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         JsonDropOutputCtxFree(drop_ctx);
         return NULL;
     }

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -352,7 +352,7 @@ OutputCtx *OutputFlowLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -414,7 +414,7 @@ OutputCtx *OutputHttpLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -335,7 +335,7 @@ OutputCtx *OutputNetFlowLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -90,7 +90,7 @@ OutputCtx *OutputSmtpLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -211,7 +211,7 @@ OutputCtx *OutputSshLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -259,7 +259,7 @@ OutputCtx *OutputStatsLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -245,7 +245,7 @@ OutputCtx *OutputTlsLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -488,7 +488,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
             json_ctx->json_out == LOGFILE_TYPE_UNIX_DGRAM ||
             json_ctx->json_out == LOGFILE_TYPE_UNIX_STREAM)
         {
-            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);
@@ -559,7 +559,6 @@ static void OutputJsonDeInitCtx(OutputCtx *output_ctx)
 {
     OutputJsonCtx *json_ctx = (OutputJsonCtx *)output_ctx->data;
     LogFileCtx *logfile_ctx = json_ctx->file_ctx;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     SCFree(json_ctx);
     SCFree(output_ctx);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -142,13 +142,15 @@ static PcieFile *SCLogOpenPcieFp(LogFileCtx *log_ctx, const char *path,
  *  \param conf ConfNode structure for the output section in question
  *  \param log_ctx Log file context allocated by caller
  *  \param default_filename Default name of file to open, if not specified in ConfNode
+ *  \param rotate Register the file for rotation in HUP.
  *  \retval 0 on success
  *  \retval -1 on error
  */
 int
 SCConfLogOpenGeneric(ConfNode *conf,
                      LogFileCtx *log_ctx,
-                     const char *default_filename)
+                     const char *default_filename,
+                     int rotate)
 {
     char log_path[PATH_MAX];
     char *log_dir;
@@ -210,6 +212,9 @@ SCConfLogOpenGeneric(ConfNode *conf,
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for "
                 "filename");
             return -1;
+        }
+        if (rotate) {
+            OutputRegisterFileRotationFlag(&log_ctx->rotation_flag);
         }
     } else if (strcasecmp(filetype, "pcie") == 0) {
         log_ctx->pcie_fp = SCLogOpenPcieFp(log_ctx, log_path, append);
@@ -306,6 +311,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
     if(lf_ctx->filename != NULL)
         SCFree(lf_ctx->filename);
+
+    OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);
 
     SCFree(lf_ctx);
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -85,7 +85,7 @@ typedef struct LogFileCtx_ {
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 
-int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *);
+int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */


### PR DESCRIPTION
Addresses issue 1492, and will make it harder to omit
rotation on new outputs.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1492

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/112
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/113
