### PR TITLE
2.0.x: logging: integrate rotation into SCConfLogOpenGeneric - v1

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -445,7 +445,6 @@ static void AlertDebugLogDeInitCtx(OutputCtx *output_ctx)
 {
     if (output_ctx != NULL) {
         LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-        OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
         if (logfile_ctx != NULL) {
             LogFileFreeCtx(logfile_ctx);
         }
@@ -470,10 +469,9 @@ static OutputCtx *AlertDebugLogInitCtx(ConfNode *conf)
         goto error;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         goto error;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCMalloc(sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -248,11 +248,10 @@ OutputCtx *AlertFastLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
@@ -266,7 +265,6 @@ OutputCtx *AlertFastLogInitCtx(ConfNode *conf)
 static void AlertFastLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     SCFree(output_ctx);
 }

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -288,7 +288,6 @@ static void LogDnsLogExitPrintStats(ThreadVars *tv, void *data) {
 static void LogDnsLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogDnsFileCtx *dnslog_ctx = (LogDnsFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&dnslog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(dnslog_ctx->file_ctx);
     SCFree(dnslog_ctx);
     SCFree(output_ctx);
@@ -307,11 +306,10 @@ static OutputCtx *LogDnsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
     if (unlikely(dnslog_ctx == NULL)) {

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -125,7 +125,6 @@ static void LogDropLogDeInitCtx(OutputCtx *output_ctx)
     if (output_ctx != NULL) {
         LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
         if (logfile_ctx != NULL) {
-            OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
             LogFileFreeCtx(logfile_ctx);
         }
         SCFree(output_ctx);
@@ -151,11 +150,10 @@ static OutputCtx *LogDropLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL)) {

--- a/src/log-file.c
+++ b/src/log-file.c
@@ -349,7 +349,6 @@ void LogFileLogExitPrintStats(ThreadVars *tv, void *data) {
 static void LogFileLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogFileCtx *logfile_ctx = (LogFileCtx *)output_ctx->data;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     free(output_ctx);
 }
@@ -366,11 +365,10 @@ static OutputCtx *LogFileLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&logfile_ctx->rotation_flag);
 
     OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -596,11 +596,10 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogHttpFileCtx *httplog_ctx = SCMalloc(sizeof(LogHttpFileCtx));
     if (unlikely(httplog_ctx == NULL)) {
@@ -730,7 +729,6 @@ static void LogHttpLogDeInitCtx(OutputCtx *output_ctx)
     for (i = 0; i < httplog_ctx->cf_n; i++) {
         SCFree(httplog_ctx->cf_nodes[i]);
     }
-    OutputUnregisterFileRotationFlag(&httplog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(httplog_ctx->file_ctx);
     SCFree(httplog_ctx);
     SCFree(output_ctx);

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -382,7 +382,6 @@ static void LogTlsLogDeInitCtx(OutputCtx *output_ctx)
     OutputTlsLoggerDisable();
 
     LogTlsFileCtx *tlslog_ctx = (LogTlsFileCtx *) output_ctx->data;
-    OutputUnregisterFileRotationFlag(&tlslog_ctx->file_ctx->rotation_flag);
     LogFileFreeCtx(tlslog_ctx->file_ctx);
     SCFree(tlslog_ctx);
     SCFree(output_ctx);
@@ -436,10 +435,9 @@ static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
         }
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         goto filectx_error;
     }
-    OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
 
     LogTlsFileCtx *tlslog_ctx = SCCalloc(1, sizeof(LogTlsFileCtx));
     if (unlikely(tlslog_ctx == NULL))

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -284,7 +284,7 @@ static OutputCtx *JsonAlertLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -326,7 +326,7 @@ static OutputCtx *JsonDnsLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -215,7 +215,7 @@ static OutputCtx *JsonDropLogInitCtx(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, logfile_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(logfile_ctx);
         return NULL;
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -397,7 +397,7 @@ OutputCtx *OutputHttpLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -203,7 +203,7 @@ OutputCtx *OutputSshLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -238,7 +238,7 @@ OutputCtx *OutputTlsLogInit(ConfNode *conf)
         return NULL;
     }
 
-    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
         LogFileFreeCtx(file_ctx);
         return NULL;
     }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -405,7 +405,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
 
         if (json_ctx->json_out == ALERT_FILE || json_ctx->json_out == ALERT_UNIX_DGRAM || json_ctx->json_out == ALERT_UNIX_STREAM) {
 
-            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME) < 0) {
+            if (SCConfLogOpenGeneric(conf, json_ctx->file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
                 LogFileFreeCtx(json_ctx->file_ctx);
                 SCFree(json_ctx);
                 SCFree(output_ctx);
@@ -477,7 +477,6 @@ static void OutputJsonDeInitCtx(OutputCtx *output_ctx)
 {
     OutputJsonCtx *json_ctx = (OutputJsonCtx *)output_ctx->data;
     LogFileCtx *logfile_ctx = json_ctx->file_ctx;
-    OutputUnregisterFileRotationFlag(&logfile_ctx->rotation_flag);
     LogFileFreeCtx(logfile_ctx);
     SCFree(json_ctx);
     SCFree(output_ctx);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -138,13 +138,15 @@ static PcieFile *SCLogOpenPcieFp(LogFileCtx *log_ctx, const char *path,
  *  \param conf ConfNode structure for the output section in question
  *  \param log_ctx Log file context allocated by caller
  *  \param default_filename Default name of file to open, if not specified in ConfNode
+ *  \param rotate Register the file for rotation in HUP.
  *  \retval 0 on success
  *  \retval -1 on error
  */
 int
 SCConfLogOpenGeneric(ConfNode *conf,
                      LogFileCtx *log_ctx,
-                     const char *default_filename)
+                     const char *default_filename,
+                     int rotate)
 {
     char log_path[PATH_MAX];
     char *log_dir;
@@ -205,6 +207,9 @@ SCConfLogOpenGeneric(ConfNode *conf,
             SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for "
                 "filename");
             return -1;
+        }
+        if (rotate) {
+            OutputRegisterFileRotationFlag(&log_ctx->rotation_flag);
         }
     } else if (strcasecmp(filetype, "pcie") == 0) {
         log_ctx->pcie_fp = SCLogOpenPcieFp(log_ctx, log_path, append);
@@ -301,6 +306,8 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
     if(lf_ctx->filename != NULL)
         SCFree(lf_ctx->filename);
+
+    OutputUnregisterFileRotationFlag(&lf_ctx->rotation_flag);
 
     SCFree(lf_ctx);
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -77,7 +77,7 @@ typedef struct LogFileCtx_ {
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);
 
-int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *);
+int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
 int SCConfLogReopen(LogFileCtx *);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */


### PR DESCRIPTION
Addresses issue 1492, and will make it harder to omit
rotation on new outputs.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1501

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/114
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/113
