### PR TITLE
htp multi encoding v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1121,6 +1121,7 @@
         # check for htp_tx_get_response_headers_raw
         AC_CHECK_LIB([htp], [htp_tx_get_response_headers_raw],AC_DEFINE_UNQUOTED([HAVE_HTP_TX_GET_RESPONSE_HEADERS_RAW],[1],[Found htp_tx_get_response_headers_raw in libhtp]) ,,[-lhtp])
         AC_CHECK_LIB([htp], [htp_decode_query_inplace],AC_DEFINE_UNQUOTED([HAVE_HTP_DECODE_QUERY_INPLACE],[1],[Found htp_decode_query_inplace function in libhtp]) ,,[-lhtp])
+        AC_CHECK_LIB([htp], [htp_config_set_response_decompression_layer_limit],AC_DEFINE_UNQUOTED([HAVE_HTP_CONFIG_SET_RESPONSE_DECOMPRESSION_LAYER_LIMIT],[1],[Found htp_config_set_response_decompression_layer_limit function in libhtp]) ,,[-lhtp])
         AC_EGREP_HEADER(htp_config_set_path_decode_u_encoding, htp/htp.h, AC_DEFINE_UNQUOTED([HAVE_HTP_SET_PATH_DECODE_U_ENCODING],[1],[Found usable htp_config_set_path_decode_u_encoding function in libhtp]) )
     ])
 
@@ -1140,10 +1141,12 @@
             AC_DEFINE_UNQUOTED([HAVE_HTP_URI_NORMALIZE_HOOK],[1],[Assuming htp_config_register_request_uri_normalize function in bundled libhtp])
             AC_DEFINE_UNQUOTED([HAVE_HTP_TX_GET_RESPONSE_HEADERS_RAW],[1],[Assuming htp_tx_get_response_headers_raw function in bundled libhtp])
             AC_DEFINE_UNQUOTED([HAVE_HTP_DECODE_QUERY_INPLACE],[1],[Assuming htp_decode_query_inplace function in bundled libhtp])
+            # enable when libhtp has been updated
+            #AC_DEFINE_UNQUOTED([HAVE_HTP_CONFIG_SET_RESPONSE_DECOMPRESSION_LAYER_LIMIT],[1],[Assuming htp_config_set_response_decompression_layer_limit function in bundled libhtp])
         else
             echo
             echo "  ERROR: Libhtp is not bundled. Get libhtp by doing:"
-            echo "     git clone https://github.com/ironbee/libhtp"
+            echo "     git clone https://github.com/OISF/libhtp"
             echo "  Then re-run Suricata's autogen.sh and configure script."
             echo "  Or, if libhtp is installed in a different location,"
             echo "  pass --enable-non-bundled-htp to Suricata's configure script."

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2382,6 +2382,19 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                 exit(EXIT_FAILURE);
             }
 
+        } else if (strcasecmp("response-body-decompress-layer-limit", p->name) == 0) {
+            uint32_t value = 2;
+            if (ParseSizeStringU32(p->val, &value) < 0) {
+                SCLogError(SC_ERR_SIZE_PARSE, "Error parsing response-body-inspect-window "
+                           "from conf file - %s.  Killing engine", p->val);
+                exit(EXIT_FAILURE);
+            }
+#ifdef HAVE_HTP_CONFIG_SET_RESPONSE_DECOMPRESSION_LAYER_LIMIT
+            htp_config_set_response_decompression_layer_limit(cfg_prec->cfg, value);
+#else
+            SCLogWarning(SC_WARN_OUTDATED_LIBHTP, "can't set response-body-decompress-layer-limit "
+                    "to %u, libhtp version too old", value);
+#endif
         } else if (strcasecmp("path-convert-backslash-separators", p->name) == 0) {
             htp_config_set_backslash_convert_slashes(cfg_prec->cfg,
                                                      HTP_DECODER_URL_PATH,

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -3409,7 +3409,7 @@ static int DetectEngineHttpServerBodyTest22(void)
 
     r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
     if (r != 0) {
-        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        printf("toserver chunk 2 returned %" PRId32 ", expected 0: \n", r);
         result = 0;
         goto end;
     }

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1315,6 +1315,9 @@ app-layer:
       #                           by file_data, http_server_body & pcre /Q option.
       #   double-decode-path:     Double decode path section of the URI
       #   double-decode-query:    Double decode query section of the URI
+      #   response-body-decompress-layer-limit:
+      #                           Limit to how many layers of compression will be
+      #                           decompressed. Defaults to 2.
       #
       # server-config:            List of server configurations to use if address matches
       #   address:                List of ip addresses or networks for this block
@@ -1369,6 +1372,9 @@ app-layer:
            request-body-inspect-window: 4kb
            response-body-minimal-inspect-size: 32kb
            response-body-inspect-window: 4kb
+
+           # response body decompression (0 disables)
+           response-body-decompress-layer-limit: 2
 
            # auto will use http-body-inline mode in IPS mode, yes or no set it statically
            http-body-inline: auto


### PR DESCRIPTION
For use with https://github.com/OISF/libhtp/pull/108, which introduces support for multiple compression layers.

This Suricata PR just allows for setting decompression limits.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/259
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/261