### PR TITLE
enip/cip support

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -193,6 +193,9 @@ detect-uricontent.c detect-uricontent.h \
 detect-urilen.c detect-urilen.h \
 detect-window.c detect-window.h \
 detect-within.c detect-within.h \
+detect-cipservice.c detect-cipservice.h \
+decode-enip.c decode-enip.h \
+decode-cip.c decode-cip.h \
 flow-bit.c flow-bit.h \
 flow.c flow.h \
 flow-hash.c flow-hash.h \

--- a/src/decode-cip.c
+++ b/src/decode-cip.c
@@ -1,0 +1,575 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ *
+ * Decode CIP
+ */
+
+#include "suricata-common.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "util-byte.h"
+#include "pkt-var.h"
+#include "util-profiling.h"
+#include "decode-cip.h"
+
+
+/**
+ * entry Point for CIP parsing - Decode the Common Industrial Protocol
+ */
+int DecodeCIP(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+	if (enip_data->encap_data_item.length == 0)
+	{
+		SCLogDebug("DecodeCIP: No CIP Data\n");
+		return 0;
+	}
+
+	if (offset > p->payload_len)
+	{
+		SCLogDebug("DecodeCIP: Parsing beyond payload length\n");
+		return 0;
+	}
+
+	uint8_t service = 0;
+	service = *(p->payload + offset);
+
+	SCLogDebug("CIP Service 0x%x\n",service);
+
+	//use service code first bit to determine request/response, no need to save or push offset
+	if (service >> 7)
+	{
+		ret = DecodeCIPResponse(p, enip_data, offset);
+	} else {
+		ret = DecodeCIPRequest(p, enip_data, offset);
+	}
+
+	return ret;
+}
+
+
+/**
+ * Parse the CIP Request
+ */
+int DecodeCIPRequest(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+	if (enip_data->encap_data_item.length < sizeof(CIP_REQUEST_HEADER)) {
+		SCLogDebug("DecodeCIPRequest - Malformed CIP Data\n");
+		return 0;
+	}
+
+	uint8_t service; //<-----CIP SERVICE
+	uint8_t path_size;
+
+
+	ENIPExtractUint8(&service, p->payload, &offset);
+	ENIPExtractUint8(&path_size, p->payload, &offset);
+
+	if (service > MAX_CIP_SERVICE)
+	{ // service codes of value 0x80 or greater are not permitted because in the CIP protocol the highest order bit is used to flag request(0)/response(1)
+		SCLogDebug("DecodeCIPRequest - INVALID CIP SERVICE 0x%x\n", service);
+		return 0;
+	}
+
+	//save CIP data
+	CIP_SERVICE_DATA *node = CreateCIPServiceData(enip_data);
+	node->service = service;
+	node->request.path_size = path_size;
+	node->request.path_offset = offset;
+
+
+	SCLogDebug("DecodeCIPRequestPath: service 0x%x size %d\n",node->service, node->request.path_size);
+
+	offset += path_size * sizeof (uint16_t); //move offset past pathsize
+
+	//list of CIP services is large and can be vendor specific, store CIP service  anyways and let the rule decide the action
+	switch (service) {
+		case CIP_RESERVED:
+			SCLogDebug("DecodeCIPRequest - CIP_RESERVED\n");
+			break;
+		case CIP_GET_ATTR_ALL:
+			SCLogDebug("DecodeCIPRequest - CIP_GET_ATTR_ALL\n");
+			break;
+		case CIP_GET_ATTR_LIST:
+			SCLogDebug("DecodeCIPRequest - CIP_GET_ATTR_LIST\n");
+			break;
+		case CIP_SET_ATTR_LIST:
+			SCLogDebug("DecodeCIPRequest - CIP_SET_ATTR_LIST\n");
+			break;
+		case CIP_RESET:
+			SCLogDebug("DecodeCIPRequest - CIP_RESET\n");
+			break;
+		case CIP_START:
+			SCLogDebug("DecodeCIPRequest - CIP_START\n");
+			break;
+		case CIP_STOP:
+			SCLogDebug("DecodeCIPRequest - CIP_STOP\n");
+			break;
+		case CIP_CREATE:
+			SCLogDebug("DecodeCIPRequest - CIP_CREATE\n");
+			break;
+		case CIP_DELETE:
+			SCLogDebug("DecodeCIPRequest - CIP_DELETE\n");
+			break;
+		case CIP_MSP:
+			SCLogDebug("DecodeCIPRequest - CIP_MSP\n");
+			DecodeCIPRequestMSP(p, enip_data, offset);
+			break;
+		case CIP_APPLY_ATTR:
+			SCLogDebug("DecodeCIPRequest - CIP_APPLY_ATTR\n");
+			break;
+		case CIP_KICK_TIMER:
+			SCLogDebug("DecodeCIPRequest - CIP_KICK_TIMER\n");
+			break;
+		case CIP_OPEN_CONNECTION:
+			SCLogDebug("DecodeCIPRequest - CIP_OPEN_CONNECTION\n");
+			break;
+		case CIP_CHANGE_START:
+			SCLogDebug("DecodeCIPRequest - CIP_CHANGE_START\n");
+			break;
+		case CIP_GET_STATUS:
+			SCLogDebug("DecodeCIPRequest - CIP_GET_STATUS\n");
+			break;
+		default:
+			SCLogDebug("DecodeCIPRequest - CIP SERVICE 0x%x\n", service);
+	}
+
+	return ret;
+}
+
+
+/**
+ * Parse the CIP Request Path and match against the CIP Service rule
+ * retval 1 if match, 0 if fail
+ */
+int DecodeCIPRequestPath(Packet *p, CIP_SERVICE_DATA *node, uint16_t offset, DetectCipServiceData *cipserviced)
+{
+
+	if (node->request.path_size < 1)
+	{
+		//SCLogDebug("DecodeCIPRequestPath: empty path or CIP Response\n");
+		return 0;
+	}
+
+	SCLogDebug("DecodeCIPRequestPath: service 0x%x size %d length %d\n",node->service, node->request.path_size, p->payload_len);
+	int bytes_remain = node->request.path_size;
+
+
+	uint8_t segment;
+	uint8_t reserved; //unused byte reserved by ODVA
+
+	//8 bit fields
+	uint8_t req_path_class8;
+	uint8_t req_path_instance8;
+	uint8_t req_path_attr8;
+
+	//16 bit fields
+	uint16_t req_path_class16;
+	uint16_t req_path_instance16;
+
+	uint16_t class = 0;
+	uint16_t attrib = 0;
+	int found_class = 0;
+
+	while (bytes_remain > 0) {
+
+		ENIPExtractUint8(&segment, p->payload, &offset);
+		switch (segment)
+		{	//assume order is class then instance.  Can have multiple
+			case PATH_CLASS_8BIT:
+				ENIPExtractUint8(&req_path_class8, p->payload, &offset);
+				class = (uint16_t)req_path_class8;
+				SCLogDebug("DecodeCIPRequestPath: 8bit class 0x%x\n",class);
+
+				if (cipserviced->cipclass == class)
+				{
+					if (cipserviced->tokens == 2){// if rule only has class
+						return 1;
+					}else{
+						found_class = 1;
+					}
+				}
+				bytes_remain--;
+				break;
+			case PATH_INSTANCE_8BIT:
+				ENIPExtractUint8(&req_path_instance8, p->payload, &offset);
+				SCLogDebug("DecodeCIPRequestPath: 8bit instance 0x%x\n",req_path_instance8);
+				bytes_remain--;
+				break;
+			case PATH_ATTR_8BIT:	//single attribute
+				ENIPExtractUint8(&req_path_attr8, p->payload, &offset);
+				attrib = (uint16_t)req_path_attr8;
+				SCLogDebug("DecodeCIPRequestPath: 8bit attribute 0x%x\n",attrib);
+
+				if ( (cipserviced->tokens == 3) && (cipserviced->cipclass == class)
+						&& (cipserviced->cipattribute == attrib) )
+				{  // if rule has class & attribute, matched all here
+					return 1;
+				}
+				bytes_remain--;
+				break;
+			case PATH_CLASS_16BIT:
+				ENIPExtractUint8(&reserved, p->payload, &offset);	//skip reserved
+				ENIPExtractUint16(&req_path_class16, p->payload, &offset);
+				class = req_path_class16;
+				SCLogDebug("DecodeCIPRequestPath: 16bit class 0x%x\n",class);
+
+				if (cipserviced->cipclass == class)
+				{
+					if (cipserviced->tokens == 2){// if rule only has class
+						return 1;
+					}else{
+						found_class = 1;
+					}
+				}
+				bytes_remain = bytes_remain-2;
+				break;
+			case PATH_INSTANCE_16BIT:
+				ENIPExtractUint8(&reserved, p->payload, &offset); // skip reserved
+				ENIPExtractUint16(&req_path_instance16, p->payload, &offset);
+				SCLogDebug("DecodeCIPRequestPath: 16bit instance 0x%x\n",attrib);
+				bytes_remain = bytes_remain-2;
+				break;
+			default:
+				SCLogDebug("DecodeCIPRequestPath: UNKNOWN SEGMENT 0x%x service 0x%x\n",segment, node->service);
+				return 0;
+		}
+	}
+
+
+	if (found_class == 0)
+	{ // if haven't matched class yet, no need to check attribute
+		return 0;
+	}
+
+	if ( (node->service == CIP_SET_ATTR_LIST) || (node->service == CIP_GET_ATTR_LIST) )
+	{
+		uint16_t attr_list_count;
+		uint16_t attribute;
+		//parse get/set attribute list
+		ENIPExtractUint16(&attr_list_count, p->payload, &offset);
+		SCLogDebug("DecodeCIPRequestPath: attribute list count %d\n", attr_list_count);
+		for (int i = 0; i < attr_list_count; i++)
+		{
+			ENIPExtractUint16(&attribute, p->payload, &offset);
+			SCLogDebug("DecodeCIPRequestPath: attribute %d\n",attribute);
+
+			if (cipserviced->cipattribute == attribute){
+				return 1;
+			}
+
+		}
+	}
+
+	return 0;
+}
+
+
+
+/**
+ * Parse the CIP Response
+  */
+int DecodeCIPResponse(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+	if (enip_data->encap_data_item.length < sizeof(CIP_RESPONSE_HEADER)) {
+		SCLogDebug("DecodeCIPResponse - Malformed CIP Data\n");
+		return 0;
+	}
+
+	uint8_t service; //<----CIP SERVICE
+	uint8_t reserved; //unused byte reserved by ODVA
+	uint16_t status;
+
+	ENIPExtractUint8(&service, p->payload, &offset);
+	ENIPExtractUint8(&reserved, p->payload, &offset);
+	ENIPExtractUint16(&status, p->payload, &offset);
+
+	//SCLogDebug("DecodeCIPResponse: service 0x%x\n",service);
+	service &= 0x7f; //strip off top bit to get service code.  Responses have first bit as 1
+
+	SCLogDebug("CIP service 0x%x status 0x%x\n",service, status);
+
+	//save CIP data
+	CIP_SERVICE_DATA *node = CreateCIPServiceData(enip_data);
+	node->service = service;
+	node->response.status = status;
+
+	//list of CIP services is large and can be vendor specific, store CIP service  anyways and let the rule decide the action
+	switch (service) {
+		case CIP_RESERVED:
+			SCLogDebug("DecodeCIPResponse - CIP_RESERVED\n");
+			break;
+		case CIP_GET_ATTR_ALL:
+			SCLogDebug("DecodeCIPResponse - CIP_GET_ATTR_ALL\n");
+			break;
+		case CIP_GET_ATTR_LIST:
+			SCLogDebug("DecodeCIPResponse - CIP_GET_ATTR_LIST\n");
+			break;
+		case CIP_SET_ATTR_LIST:
+			SCLogDebug("DecodeCIPResponse - CIP_SET_ATTR_LIST\n");
+			break;
+		case CIP_RESET:
+			SCLogDebug("DecodeCIPResponse - CIP_RESET\n");
+			break;
+		case CIP_START:
+			SCLogDebug("DecodeCIPResponse - CIP_START\n");
+			break;
+		case CIP_STOP:
+			SCLogDebug("DecodeCIPResponse - CIP_STOP\n");
+			break;
+		case CIP_CREATE:
+			SCLogDebug("DecodeCIPResponse - CIP_CREATE\n");
+			break;
+		case CIP_DELETE:
+			SCLogDebug("DecodeCIPResponse - CIP_DELETE\n");
+			break;
+		case CIP_MSP:
+			SCLogDebug("DecodeCIPResponse - CIP_MSP\n");
+			DecodeCIPResponseMSP(p, enip_data, offset);
+			break;
+		case CIP_APPLY_ATTR:
+			SCLogDebug("DecodeCIPResponse - CIP_APPLY_ATTR\n");
+			break;
+		case CIP_KICK_TIMER:
+			SCLogDebug("DecodeCIPResponse - CIP_KICK_TIMER\n");
+			break;
+		case CIP_OPEN_CONNECTION:
+			SCLogDebug("DecodeCIPResponse - CIP_OPEN_CONNECTION\n");
+			break;
+		case CIP_CHANGE_START:
+			SCLogDebug("DecodeCIPResponse - CIP_CHANGE_START\n");
+			break;
+		case CIP_GET_STATUS:
+			SCLogDebug("DecodeCIPResponse - CIP_GET_STATUS\n");
+			break;
+		default:
+			SCLogDebug("DecodeCIPResponse - CIP SERVICE 0x%x\n", service);
+	}
+
+	return ret;
+}
+
+
+/**
+ * Decode the CIP Request Multi Service Packet
+  */
+int DecodeCIPRequestMSP(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+	//use temp_offset just to grab the service offset, don't want to use and push offset
+	uint16_t temp_offset = offset;
+	uint16_t num_services;
+	ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+			(const uint8_t *) (p->payload + temp_offset));
+	temp_offset += sizeof(uint16_t);
+	//SCLogDebug("DecodeCIPRequestMSP number of services %d\n",num_services);
+
+	for (int svc = 1; svc < num_services + 1; svc++)
+	{
+		if (temp_offset > p->payload_len)
+		{
+			SCLogDebug("DecodeCIPRequestMSP: Parsing beyond payload length\n");
+			return 0;
+		}
+
+		uint16_t svc_offset; //read set of service offsets
+		ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+				(const uint8_t *) (p->payload + temp_offset));
+		temp_offset += sizeof(uint16_t);
+		//SCLogDebug("parseCIPRequestMSP service %d offset %d\n",svc, svc_offset);
+
+		DecodeCIP(p, enip_data, offset + svc_offset); //parse CIP at found offset
+	}
+
+	return ret;
+}
+
+
+/**
+ * Decode the CIP Response Multi Service Packet
+  */
+int DecodeCIPResponseMSP(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+	//use temp_offset just to grab the service offset, don't want to use and push offset
+	uint16_t temp_offset = offset;
+	uint16_t num_services;
+	ByteExtractUint16(&num_services, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+			(const uint8_t *) (p->payload + temp_offset));
+	temp_offset += sizeof(uint16_t);
+	//SCLogDebug("DecodeCIPResponseMSP number of services %d\n", num_services);
+
+	for (int svc = 0; svc < num_services; svc++)
+	{
+
+		if (temp_offset > p->payload_len)
+		{
+			SCLogDebug("DecodeCIPResponseMSP: Parsing beyond payload length\n");
+			return 0;
+		}
+
+		uint16_t svc_offset; //read set of service offsets
+		ByteExtractUint16(&svc_offset, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+				(const uint8_t *) (p->payload + temp_offset));
+		temp_offset += sizeof(uint16_t);
+		//SCLogDebug("parseCIPResponseMSP service %d offset %d\n", svc, svc_offset);
+
+		DecodeCIP(p, enip_data, offset + svc_offset); //parse CIP at found offset
+	}
+
+	return ret;
+}
+
+
+
+
+#ifdef UNITTESTS
+/** CIPTestMatch
+ *  \brief Valid CIP packet
+ *  \retval 1 Packet match signature
+ */
+
+int CIPTestMatch(uint8_t *raw_eth_pkt, uint16_t pktsize, char *sig,
+                      uint32_t sid)
+{
+    int result = 0;
+    FlowInitConfig(FLOW_QUIET);
+    Packet *p = UTHBuildPacketFromEth(raw_eth_pkt, pktsize);
+    result = UTHPacketMatchSig(p, sig);
+    PACKET_RECYCLE(p);
+    FlowShutdown();
+    return result;
+}
+
+
+static int DecodeCIPTest01 (void)
+{
+    /* Single Get Attribute All */
+    uint8_t raw_eth_pkt[] = {
+    	0x00, 0x00, 0xbc, 0x3e, 0xeb, 0xe4, 0x00, 0x1d,
+    	0x09, 0x99, 0xb2, 0x2c, 0x08, 0x00, 0x45, 0x00,
+    	0x00, 0x5c, 0x81, 0xb9, 0x40, 0x00, 0x80, 0x06,
+    	0xe2, 0xb0, 0xc0, 0xa8, 0x0a, 0x69, 0xc0, 0xa8,
+    	0x0a, 0x78, 0x04, 0x4e, 0xaf, 0x12, 0x46, 0xb6,
+    	0xaf, 0x0e, 0x91, 0xb1, 0x1f, 0x2a, 0x50, 0x18,
+    	0xfd, 0xae, 0x96, 0x80, 0x00, 0x00, 0x70, 0x00,
+    	0x1c, 0x00, 0x00, 0x01, 0x02, 0x11, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0xa1, 0x00,
+    	0x04, 0x00, 0x01, 0x29, 0x83, 0x00, 0xb1, 0x00,
+    	0x08, 0x00, 0x26, 0x00, 0x01, 0x02, 0x20, 0x02,
+    	0x24, 0x01
+    };
+
+    char *sig = "alert tcp any any -> any 80 (msg:\"Nothing..\"; cip_service:1; sid:1;)";
+
+    return CIPTestMatch(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt),
+                                 sig, 1);
+}
+
+static int DecodeCIPTest02 (void)
+{
+    /* Multi Service Packet with Get Attribute Lists*/
+    uint8_t raw_eth_pkt[] = {
+    	0x00, 0x00, 0xbc, 0x3e, 0xeb, 0xe4, 0x00, 0x1d,
+    	0x09, 0x99, 0xb2, 0x2c, 0x08, 0x00, 0x45, 0x00,
+    	0x00, 0x9c, 0x81, 0x95, 0x40, 0x00, 0x80, 0x06,
+    	0xe2, 0x94, 0xc0, 0xa8, 0x0a, 0x69, 0xc0, 0xa8,
+    	0x0a, 0x78, 0x04, 0x4e, 0xaf, 0x12, 0x46, 0xb6,
+    	0xa6, 0xc3, 0x91, 0xb1, 0x15, 0xfb, 0x50, 0x18,
+    	0xfb, 0x56, 0x96, 0xc0, 0x00, 0x00, 0x70, 0x00,
+    	0x5c, 0x00, 0x00, 0x01, 0x02, 0x11, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0xa1, 0x00,
+    	0x04, 0x00, 0x01, 0x29, 0x83, 0x00, 0xb1, 0x00,
+    	0x48, 0x00, 0x05, 0x00, 0x0a, 0x02, 0x20, 0x02,
+    	0x24, 0x01, 0x05, 0x00, 0x0c, 0x00, 0x16, 0x00,
+    	0x22, 0x00, 0x2c, 0x00, 0x36, 0x00, 0x03, 0x02,
+    	0x20, 0x8e, 0x24, 0x01, 0x01, 0x00, 0x08, 0x00,
+    	0x03, 0x02, 0x20, 0x64, 0x24, 0x01, 0x02, 0x00,
+    	0x01, 0x00, 0x02, 0x00, 0x03, 0x02, 0x20, 0x01,
+    	0x24, 0x01, 0x01, 0x00, 0x05, 0x00, 0x03, 0x02,
+    	0x20, 0x69, 0x24, 0x00, 0x01, 0x00, 0x0b, 0x00,
+    	0x03, 0x02, 0x20, 0x69, 0x24, 0x01, 0x01, 0x00,
+    	0x0a, 0x00
+    };
+
+    char *sig = "alert tcp any any -> any 80 (msg:\"Nothing..\"; cip_service:3; sid:1;)";
+
+    return CIPTestMatch(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt), sig, 1);
+}
+
+static int DecodeCIPTest03 (void)
+{
+    /* Set Attribute List Change Time*/
+    uint8_t raw_eth_pkt[] = {
+    	0x00, 0x00, 0xbc, 0x3e, 0xeb, 0xe4, 0x00, 0x1d,
+    	0x09, 0x99, 0xb2, 0x2c, 0x08, 0x00, 0x45, 0x00,
+    	0x00, 0x68, 0x5e, 0x7d, 0x40, 0x00, 0x80, 0x06,
+    	0x05, 0xe1, 0xc0, 0xa8, 0x0a, 0x69, 0xc0, 0xa8,
+    	0x0a, 0x78, 0x0b, 0xd9, 0xaf, 0x12, 0xcf, 0xce,
+    	0x17, 0xe7, 0x8d, 0xf5, 0x35, 0x00, 0x50, 0x18,
+    	0xfa, 0xd2, 0x96, 0x8c, 0x00, 0x00, 0x70, 0x00,
+    	0x28, 0x00, 0x00, 0x01, 0x02, 0x11, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    	0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0xa1, 0x00,
+    	0x04, 0x00, 0x01, 0x0b, 0x7c, 0x00, 0xb1, 0x00,
+    	0x14, 0x00, 0xb2, 0x04, 0x04, 0x02, 0x20, 0x8b,
+    	0x24, 0x01, 0x01, 0x00, 0x06, 0x00, 0xc0, 0x32,
+    	0x5c, 0xff, 0xf3, 0x59, 0x04, 0x00
+    };
+
+    char *sig = "alert tcp any any -> any 80 (msg:\"Nothing..\"; cip_service:4,139,6; sid:1;)";
+
+    return CIPTestMatch(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt), sig, 1);
+}
+
+#endif /* UNITTESTS */
+
+
+/**
+ * \brief Registers CIP unit tests
+ * \todo More CIP tests
+ */
+void DecodeCIPRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DecodeCIPTest01", DecodeCIPTest01, 1);
+    UtRegisterTest("DecodeCIPTest02", DecodeCIPTest02, 1);
+    UtRegisterTest("DecodeCIPTest02", DecodeCIPTest03, 1);
+#endif /* UNITTESTS */
+}
+/**
+ * @}
+ */

--- a/src/decode-cip.h
+++ b/src/decode-cip.h
@@ -1,0 +1,108 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ */
+
+#ifndef _DETECT_CIP_H
+#define	_DETECT_CIP_H
+
+#include "detect-cipservice.h"
+
+#define MAX_CIP_SERVICE		127
+#define MAX_CIP_CLASS		65535
+#define MAX_CIP_ATTRIBUTE	65535
+
+// CIP service codes
+#define CIP_RESERVED	    0x00
+#define CIP_GET_ATTR_ALL    0x01
+#define CIP_GET_ATTR_LIST   0x03
+#define CIP_SET_ATTR_LIST   0x04
+#define CIP_RESET           0x05
+#define CIP_START           0x06
+#define CIP_STOP            0x07
+#define CIP_CREATE          0x08
+#define CIP_DELETE          0x09
+#define CIP_MSP             0x0a
+#define CIP_APPLY_ATTR      0x0d
+#define CIP_GET_ATTR_SINGLE 0x0e
+#define CIP_SET_ATTR_SINGLE 0x10
+#define CIP_KICK_TIMER      0x4b
+#define CIP_OPEN_CONNECTION 0x4c
+#define CIP_CHANGE_START    0x4f
+#define CIP_GET_STATUS      0x50
+
+//PATH sizing codes
+#define PATH_CLASS_8BIT      	0x20
+#define PATH_CLASS_16BIT      	0x21
+#define PATH_INSTANCE_8BIT      0x24
+#define PATH_INSTANCE_16BIT     0x25
+#define PATH_ATTR_8BIT      	0x30
+#define PATH_ATTR_16BIT      	0x31 //possible value
+
+
+typedef struct _CIP_REQUEST_HEADER
+{
+    u_int8_t service;
+    u_int8_t path_size;
+} CIP_REQUEST_HEADER;
+
+typedef struct _CIP_RESPONSE_HEADER
+{
+    u_int8_t service;
+    u_int8_t pad;
+    u_int8_t status;
+    u_int8_t status_size;
+} CIP_RESPONSE_HEADER;
+
+
+/**
+ * Decode CIP
+ */
+int DecodeCIP(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+/**
+ * Decode CIP Response
+ */
+int DecodeCIPResponse(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+/**
+ * Decode CIP Request
+ */
+int DecodeCIPRequest(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+/**
+ * Decode CIP Request Path
+ */
+int DecodeCIPRequestPath(Packet *p, CIP_SERVICE_DATA *node, uint16_t offset, DetectCipServiceData *cipserviced);
+
+
+/**
+ * Decode CIP Request MultiService Packet
+ */
+int DecodeCIPRequestMSP(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+/**
+ * Decode CIP Response MultiService Packet
+ */
+int DecodeCIPResponseMSP(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+#endif	/* _DETECT_CIP_H */
+

--- a/src/decode-enip.c
+++ b/src/decode-enip.c
@@ -1,0 +1,260 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ *
+ * Decode EtherNet/IP
+ */
+
+#include "suricata-common.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "util-byte.h"
+#include "pkt-var.h"
+#include "util-profiling.h"
+#include "decode-enip.h"
+
+
+/**
+ * EtherNet/IP decoding entry point,  decode the Encapsulation Header
+ */
+int DecodeENIP(Packet *p, ENIP_DATA *enip_data)
+{
+	int ret = 1;
+
+	if ((p->payload == NULL) || (p->payload_len == 0))
+	{
+		SCLogDebug("DecodeENIP: no data in packet\n");
+		return 0;
+	}
+
+	if (p->payload_len < sizeof(ENIP_ENCAP_HEADER))
+	{
+		SCLogDebug("DecodeENIP: Malformed ENIP packet\n");
+		return 0;
+	}
+
+	uint16_t offset = 0; //byte offset
+
+	//Decode Encapsulation Header
+	uint16_t cmd;
+	uint16_t len;
+	uint32_t session;
+	uint32_t status;
+	uint64_t context;
+	uint32_t option;
+	ENIPExtractUint16(&cmd, p->payload, &offset);
+	ENIPExtractUint16(&len, p->payload, &offset);
+	ENIPExtractUint32(&session, p->payload, &offset);
+	ENIPExtractUint32(&status, p->payload, &offset);
+	ENIPExtractUint64(&context, p->payload, &offset);
+	ENIPExtractUint32(&option, p->payload, &offset);
+
+	enip_data->header.command = cmd;
+	enip_data->header.length = len;
+	enip_data->header.session = session;
+	enip_data->header.status = status;
+	enip_data->header.context = context;
+	enip_data->header.option = option;
+
+
+	switch (enip_data->header.command)
+	{
+		case NOP:
+			SCLogDebug("DecodeENIP - NOP\n");
+			break;
+		case LIST_SERVICES:
+			SCLogDebug("DecodeENIP - LIST_SERVICES\n");
+			break;
+		case LIST_IDENTITY:
+			SCLogDebug("DecodeENIP - LIST_IDENTITY\n");
+			break;
+		case LIST_INTERFACES:
+			SCLogDebug("DecodeENIP - LIST_INTERFACES\n");
+			break;
+		case REGISTER_SESSION:
+			SCLogDebug("DecodeENIP - REGISTER_SESSION\n");
+			break;
+		case UNREGISTER_SESSION:
+			SCLogDebug("DecodeENIP - UNREGISTER_SESSION\n");
+			break;
+		case SEND_RR_DATA:
+			SCLogDebug("DecodeENIP - SEND_RR_DATA - parse Common Packet Format\n");
+			ret = DecodeCommonPacketFormat(p, enip_data, offset);
+			break;
+		case SEND_UNIT_DATA:
+			SCLogDebug("DecodeENIP - SEND UNIT DATA - parse Common Packet Format\n");
+			ret = DecodeCommonPacketFormat(p, enip_data, offset);
+			break;
+		case INDICATE_STATUS:
+			SCLogDebug("DecodeENIP - INDICATE_STATUS\n");
+			break;
+		case CANCEL:
+			SCLogDebug("DecodeENIP - CANCEL\n");
+			break;
+		default:
+			SCLogDebug("DecodeENIP - UNSUPPORTED COMMAND 0x%x\n",
+					enip_data->header.command);
+	}
+
+	return ret;
+}
+
+
+/**
+ * Decode the Common Packet Format
+ */
+int DecodeCommonPacketFormat(Packet *p, ENIP_DATA *enip_data, uint16_t offset)
+{
+	int ret = 1;
+
+
+	if (enip_data->header.length < sizeof(ENIP_ENCAP_DATA_HEADER))
+	{
+		SCLogDebug("DecodeCommonPacketFormat: Malformed ENIP packet\n");
+		return 0;
+	}
+
+	uint32_t handle;
+	uint16_t timeout;
+	uint16_t count;
+	ENIPExtractUint32(&handle, p->payload, &offset);
+	ENIPExtractUint16(&timeout, p->payload, &offset);
+	ENIPExtractUint16(&count, p->payload, &offset);
+
+	enip_data->encap_data_header.interface_handle = handle;
+	enip_data->encap_data_header.timeout = timeout;
+	enip_data->encap_data_header.item_count = count;
+
+	uint16_t address_type;
+	uint16_t address_length; //length of connection id in bytes
+	uint32_t address_connectionid = 0;
+	uint32_t address_sequence = 0;
+
+	ENIPExtractUint16(&address_type, p->payload, &offset);
+	ENIPExtractUint16(&address_length, p->payload, &offset);
+
+	//depending on addr type, get connection id, sequence if needed.  Can also use addr length too?
+	if (address_type == CONNECTION_BASED)
+	{ //get 4 byte connection id
+			ENIPExtractUint32(&address_connectionid, p->payload, &offset);
+	} else if (address_type == SEQUENCE_ADDR_ITEM) { // get 4 byte connection id and 4 byte sequence
+			ENIPExtractUint32(&address_connectionid, p->payload, &offset);
+			ENIPExtractUint32(&address_sequence, p->payload, &offset);
+	}
+
+	enip_data->encap_addr_item.type = address_type;
+	enip_data->encap_addr_item.length = address_length;
+	enip_data->encap_addr_item.conn_id = address_connectionid;
+	enip_data->encap_addr_item.sequence_num = address_sequence;
+
+	uint16_t data_type;
+	uint16_t data_length; //length of data in bytes
+	uint16_t data_sequence_count;
+
+	ENIPExtractUint16(&data_type, p->payload, &offset);
+	ENIPExtractUint16(&data_length, p->payload, &offset);
+
+	enip_data->encap_data_item.type = data_type;
+	enip_data->encap_data_item.length = data_length;
+
+	if (enip_data->encap_data_item.type == CONNECTED_DATA_ITEM)
+	{ //connected data items have seq number
+		ENIPExtractUint16(&data_sequence_count, p->payload, &offset);
+		enip_data->encap_data_item.sequence_count = data_sequence_count;
+	}
+
+	switch (enip_data->encap_data_item.type)
+	{
+		case CONNECTED_DATA_ITEM:
+			SCLogDebug("DecodeCommonPacketFormat - CONNECTED DATA ITEM - parse CIP\n");
+			ret = DecodeCIP(p, enip_data, offset);
+			break;
+		case UNCONNECTED_DATA_ITEM:
+			SCLogDebug("DecodeCommonPacketFormat - UNCONNECTED DATA ITEM\n");
+			ret = DecodeCIP(p, enip_data, offset);
+			break;
+		default:
+			SCLogDebug("DecodeCommonPacketFormat - UNKNOWN TYPE 0x%x\n\n",
+					enip_data->encap_data_item.type);
+			return 0;
+	}
+
+	return ret;
+
+}
+
+
+#ifdef UNITTESTS
+/** ENIPTestMatch
+ *  \brief Valid CIP packet
+ *  \retval 1 Packet match signature
+ */
+
+int ENIPTestMatch(uint8_t *raw_eth_pkt, uint16_t pktsize, char *sig,
+                      uint32_t sid)
+{
+    int result = 0;
+    FlowInitConfig(FLOW_QUIET);
+    Packet *p = UTHBuildPacketFromEth(raw_eth_pkt, pktsize);
+    result = UTHPacketMatchSig(p, sig);
+    PACKET_RECYCLE(p);
+    FlowShutdown();
+    return result;
+}
+
+
+static int DecodeENIPTest01 (void)
+{
+    /* List Identity */
+    uint8_t raw_eth_pkt[] = {
+    		0x00, 0x0f, 0x73, 0x02, 0xfd, 0xa8, 0x00, 0xe0,
+    		0xed, 0x0d, 0x1e, 0xe4, 0x08, 0x00, 0x45, 0x00,
+    		0x00, 0x34, 0x00, 0x00, 0x00, 0x00, 0xff, 0x11,
+    		0x37, 0x68, 0xc0, 0xa8, 0x01, 0x01, 0xc0, 0xa8,
+    		0x01, 0xff, 0xaf, 0x12, 0xaf, 0x12, 0x00, 0x20,
+    		0xba, 0x37, 0x63, 0x00, 0x00, 0x00, 0x00, 0x00,
+    		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    		0x00, 0x00
+    };
+
+    char *sig = "alert udp any any -> any any (msg:\"Nothing..\"; enip_command:99; sid:1;)";
+
+    return ENIPTestMatch(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt), sig, 1);
+}
+#endif /* UNITTESTS */
+
+
+/**
+ * \brief Registers Ethernet unit tests
+ * \todo More Ethernet tests
+ */
+void DecodeENIPRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DecodeENIPTest01", DecodeENIPTest01, 1);
+#endif /* UNITTESTS */
+}
+/**
+ * @}
+ */

--- a/src/decode-enip.h
+++ b/src/decode-enip.h
@@ -1,0 +1,74 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ */
+
+#ifndef _DETECT_ENIP_H
+#define	_DETECT_ENIP_H
+
+#include "detect-cipservice.h"
+#include "decode-cip.h"
+
+#define MAX_ENIP_CMD	65535
+
+// EtherNet/IP commands
+#define NOP                0x0000
+#define LIST_SERVICES      0x0004
+#define LIST_IDENTITY      0x0063
+#define LIST_INTERFACES    0x0064
+#define REGISTER_SESSION   0x0065
+#define UNREGISTER_SESSION 0x0066
+#define SEND_RR_DATA       0x006F
+#define SEND_UNIT_DATA     0x0070
+#define INDICATE_STATUS    0x0072
+#define CANCEL             0x0073
+
+//Common Packet Format Types
+#define NULL_ADDR              	0x0000
+#define CONNECTION_BASED		0x00a1
+#define CONNECTED_DATA_ITEM 	0x00b1
+#define UNCONNECTED_DATA_ITEM 	0x00b2
+#define SEQUENCE_ADDR_ITEM      0xB002
+
+
+//status codes
+#define SUCCESS               0x0000
+#define INVALID_CMD           0x0001
+#define NO_RESOURCES          0x0002
+#define INCORRECT_DATA        0x0003
+#define INVALID_SESSION       0x0064
+#define INVALID_LENGTH        0x0065
+#define UNSUPPORTED_PROT_REV  0x0069
+
+
+/**
+ * Entry point for decoding ENIP Packet
+ */
+int DecodeENIP(Packet *p, ENIP_DATA *enip_data);
+
+/**
+ * Decodes Common Packet Format
+ */
+int DecodeCommonPacketFormat(Packet *p, ENIP_DATA *enip_data, uint16_t offset);
+
+
+#endif	/* _DETECT_ENIP_H */
+

--- a/src/detect-cipservice.c
+++ b/src/detect-cipservice.c
@@ -1,0 +1,739 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ *
+ * Set up CIP Service rule parsing and entry point for matching1
+ */
+
+#include "suricata-common.h"
+#include "util-unittest.h"
+#include "detect-parse.h"
+#include "detect-engine.h"
+#include "util-byte.h"
+
+#include "detect-cipservice.h"
+#include "decode-enip.h"
+
+
+/**
+ * Read 8 bits and push offset
+ */
+void ENIPExtractUint8(uint8_t *res, uint8_t *input, uint16_t *offset)
+{
+	SCEnter();
+	*res = *(input + *offset);
+	*offset += sizeof(uint8_t);
+	SCReturn;
+}
+
+/**
+ * Read 16 bits and push offset
+ */
+void ENIPExtractUint16(uint16_t *res, uint8_t *input, uint16_t *offset)
+{
+	SCEnter();
+	ByteExtractUint16(res, BYTE_LITTLE_ENDIAN, sizeof(uint16_t),
+			(const uint8_t *) (input + *offset));
+	*offset += sizeof(uint16_t);
+	SCReturn;
+}
+
+/**
+ * Read 32 bits and push offset
+ */
+void ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset)
+{
+	SCEnter();
+	ByteExtractUint32(res, BYTE_LITTLE_ENDIAN, sizeof(uint32_t),
+			(const uint8_t *) (input + *offset));
+	*offset += sizeof(uint32_t);
+	SCReturn;
+}
+
+/**
+ * Read 64 bits and push offset
+ */
+void ENIPExtractUint64(uint64_t *res, uint8_t *input, uint16_t *offset)
+{
+	SCEnter();
+	ByteExtractUint64(res, BYTE_LITTLE_ENDIAN, sizeof(uint64_t),
+			(const uint8_t *) (input + *offset));
+	*offset += sizeof(uint64_t);
+	SCReturn;
+}
+
+
+/**
+ * Create cip service structures for storage
+ */
+CIP_SERVICE_DATA *CreateCIPServiceData(ENIP_DATA *enip_data)
+{
+
+	CIP_SERVICE_DATA *node = malloc(sizeof(CIP_SERVICE_DATA));
+	memset(node, 0, sizeof(CIP_SERVICE_DATA));
+	node->next = 0;
+
+	if (enip_data->service_head == NULL)
+	{//init first node
+		enip_data->service_head = node;
+	} else {
+		enip_data->service_tail->next = node; //connect tail to new node
+	}
+	enip_data->service_tail = node; //set new tail
+
+	return node;
+}
+
+/**
+ * Free CIP Service data
+ */
+void FreeCIPServiceData(CIP_SERVICE_DATA *cip_data)
+{
+	if (cip_data == NULL)
+		return;
+
+	CIP_SERVICE_DATA *next = cip_data->next;
+	free(cip_data);
+	if (next != NULL) {
+		FreeCIPServiceData(next);
+	}
+}
+
+
+
+
+/*
+ *
+ ************************************************************ CIP SERVICE CODE ********************************************************************
+ *
+*/
+
+
+
+/**
+ * Check if ENIP data matches CIP Service rule
+ * return 1 for match, 0 for fail
+ */
+int CIPServiceMatch(Packet *p, ENIP_DATA *enip_data, DetectCipServiceData *cipserviced)
+{
+
+	int count = 1;
+	CIP_SERVICE_DATA *temp = enip_data->service_head;
+	while (temp != NULL)
+	{
+		//SCLogDebug("CIP Service #%d : 0x%x\n", count, temp->service);
+		if (cipserviced->cipservice == temp->service) { // compare service
+			//SCLogDebug("Rule Match for cip service %d\n",cipserviced->cipservice );
+			if (cipserviced->tokens > 1){ //if rule params have class and attribute
+				if ( (temp->service == CIP_SET_ATTR_LIST) || (temp->service == CIP_SET_ATTR_SINGLE) || (temp->service == CIP_GET_ATTR_LIST) || (temp->service == CIP_GET_ATTR_SINGLE)  ){ //decode path
+					if (DecodeCIPRequestPath(p, temp, temp->request.path_offset, cipserviced) == 1){
+						return 1;
+					}
+				}
+			}else {
+				return 1;
+			}
+		}
+		count++;
+		temp = temp->next;
+	}
+	return 0;
+}
+
+
+/**
+ * Print ENIP data
+ */
+void PrintENIP(ENIP_DATA *enip_data)
+{
+	printf("============================================\n");
+	printf("ENCAP HEADER cmd 0x%x, length %d, session 0x%x, status 0x%x\n",
+			enip_data->header.command, enip_data->header.length,
+			enip_data->header.session, enip_data->header.status);
+	//printf("context 0x%x option 0x%x\n", enip_data->header.context, enip_data->header.option);
+	printf("ENCAP DATA HEADER handle 0x%x, timeout %d, count %d\n",
+			enip_data->encap_data_header.interface_handle,
+			enip_data->encap_data_header.timeout,
+			enip_data->encap_data_header.item_count);
+	printf("ENCAP ADDR ITEM type 0x%x, length %d \n",
+			enip_data->encap_addr_item.type, enip_data->encap_addr_item.length);
+	printf("ENCAP DATA ITEM type 0x%x, length %d sequence 0x%x\n",
+			enip_data->encap_data_item.type, enip_data->encap_data_item.length,
+			enip_data->encap_data_item.sequence_count);
+
+	int count = 1;
+	CIP_SERVICE_DATA *temp = enip_data->service_head;
+		while (temp != NULL)
+		{
+			printf("CIP Service #%d : 0x%x\n", count, temp->service);
+			count++;
+			temp = temp->next;
+		}
+}
+
+
+
+
+/**
+ * Rule Function Prototypes
+ */
+static int DetectCipServiceMatch(ThreadVars *, DetectEngineThreadCtx *,
+		Packet *, Signature *, SigMatch *);
+static int DetectCipServiceSetup(DetectEngineCtx *, Signature *, char *);
+static void DetectCipServiceFree(void *);
+static void DetectCipServiceRegisterTests(void);
+
+/**
+ * \brief Registration function for cip_service: keyword
+ */
+void DetectCipServiceRegister(void)
+{
+	sigmatch_table[DETECT_CIPSERVICE].name = "cip_service"; //rule keyword
+	sigmatch_table[DETECT_CIPSERVICE].desc = "Rules for detecting CIP Service ";
+	sigmatch_table[DETECT_CIPSERVICE].url = "www.solananetworks.com";
+	sigmatch_table[DETECT_CIPSERVICE].Match = DetectCipServiceMatch;
+	sigmatch_table[DETECT_CIPSERVICE].Setup = DetectCipServiceSetup;
+	sigmatch_table[DETECT_CIPSERVICE].Free = DetectCipServiceFree;
+	sigmatch_table[DETECT_CIPSERVICE].RegisterTests
+			= DetectCipServiceRegisterTests;
+
+}
+
+/**
+ * \brief This function is used to match cip_service rule option on a packet
+ *
+ * \param t pointer to thread vars
+ * \param det_ctx pointer to the pattern matcher thread
+ * \param p pointer to the current packet
+ * \param m pointer to the sigmatch with context that we will cast into DetectCipServiceData
+ *
+ * \retval 0 no match
+ * \retval 1 match
+ */
+int DetectCipServiceMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
+		Packet *p, Signature *s, SigMatch *m)
+{
+	int ret = 0;
+	DetectCipServiceData *cipserviced = (DetectCipServiceData *) m->ctx;
+
+
+	if (PKT_IS_PSEUDOPKT(p)) {
+		SCLogDebug("Packet is fake");
+	}
+
+	if (PKT_IS_IPV4(p)) {
+		/* ipv4 pkt */
+	} else if (PKT_IS_IPV6(p)) {
+		SCLogDebug("Packet is IPv6");
+		return ret;
+	} else {
+		SCLogDebug("Packet is not IPv4 or IPv6");
+		return ret;
+	}
+
+
+	ENIP_DATA enip_data;
+	enip_data.service_head = NULL; //initialize pointer
+	enip_data.service_tail = NULL;
+
+//	SCLogDebug("payload total length %d\n", p->payload_len);
+
+	//basic port check
+	if ((p->sp == ENIP_PORT) || (p->dp == ENIP_PORT))
+	{
+		if (p->dp == ENIP_PORT)
+			enip_data.direction = 0;
+		else
+			enip_data.direction = 1;
+	} else {
+		return 0;
+	}
+
+	int status = DecodeENIP(p, &enip_data); //perform EtherNet/IP decoding
+
+	if (status != 0)
+	{
+		//PrintENIP(&enip_data); //print gathered ENIP data
+		ret = CIPServiceMatch(p, &enip_data, cipserviced); //check if rule matches
+	}
+
+	FreeCIPServiceData(enip_data.service_head); //free CIP service data
+
+	return ret;
+}
+
+/**
+ * \brief This function is used to parse cip_service options passed via cip_service: keyword
+ *
+ * \param rulestr Pointer to the user provided rulestr options
+ * Takes comma seperated string with numeric tokens.  Only first 3 are used
+ *
+ * \retval cipserviced pointer to DetectCipServiceData on success
+ * \retval NULL on failure
+ */
+
+DetectCipServiceData *DetectCipServiceParse(char *rulestr)
+{
+	const char delims[] = ",";
+	DetectCipServiceData *cipserviced = NULL;
+
+//	SCLogDebug("DetectCipServiceParse - rule string  %s\n", rulestr);
+
+	cipserviced = SCMalloc(sizeof(DetectCipServiceData));
+
+	if (unlikely(cipserviced == NULL))
+		goto error;
+
+
+	char* token;
+	int var;
+	int input[3];
+	int i = 0;
+
+	token = strtok (rulestr, delims);
+	while (token != NULL)
+	{
+		if (i > 2) //for now only need 3 parameters
+		{
+			printf("DetectEnipCommandParse: Too many parameters\n");
+		   	goto error;
+		}
+
+		if (!isdigit((int) *token))
+		{
+			printf("DetectCipServiceParse - Parameter Error %s\n", token);
+			goto error;
+		}
+
+		unsigned long num = atol(token);
+		if ((num > MAX_CIP_SERVICE) && (i == 0))//if service greater than 7 bit
+		{
+			printf("DetectEnipCommandParse: Invalid CIP service %lu\n", num);
+			goto error;
+		}
+		else if ((num > MAX_CIP_CLASS) && (i == 1))//if service greater than 16 bit
+		{
+			printf("DetectEnipCommandParse: Invalid CIP class %lu\n", num);
+			goto error;
+		}
+		else if ((num > MAX_CIP_ATTRIBUTE) && (i == 2))//if service greater than 16 bit
+		{
+			printf("DetectEnipCommandParse: Invalid CIP attribute %lu\n", num);
+			goto error;
+		}
+
+	    sscanf (token, "%d", &var);
+	    input[i++] = var;
+
+	    token = strtok (NULL, delims);
+	}
+
+	cipserviced->cipservice = input[0];
+	cipserviced->cipclass = input[1];
+	cipserviced->cipattribute = input[2];
+	cipserviced->tokens = i;
+
+
+//	SCLogDebug("DetectCipServiceParse - tokens %d\n", cipserviced->tokens);
+//	SCLogDebug("DetectCipServiceParse - service %d\n", cipserviced->cipservice );
+//	SCLogDebug("DetectCipServiceParse - class %d\n", cipserviced->cipclass );
+//	SCLogDebug("DetectCipServiceParse - attribute %d\n", cipserviced->cipattribute );
+
+	return cipserviced;
+
+	error: if (cipserviced)
+		SCFree(cipserviced);
+	printf("DetectCipServiceParse - Error Parsing Parameters\n");
+	return NULL;
+}
+
+/**
+ * \brief this function is used to acipserviced the parsed cip_service data into the current signature
+ *
+ * \param de_ctx pointer to the Detection Engine Context
+ * \param s pointer to the Current Signature
+ * \param helloworldstr pointer to the user provided helloworld options
+ *
+ * \retval 0 on Success
+ * \retval -1 on Failure
+ */
+static int DetectCipServiceSetup(DetectEngineCtx *de_ctx, Signature *s,
+		char *rulestr)
+{
+	DetectCipServiceData *cipserviced = NULL;
+	SigMatch *sm = NULL;
+
+	cipserviced = DetectCipServiceParse(rulestr);
+	if (cipserviced == NULL)
+		goto error;
+
+	sm = SigMatchAlloc();
+	if (sm == NULL)
+		goto error;
+
+	sm->type = DETECT_CIPSERVICE;
+	sm->ctx = (void *) cipserviced;
+
+	SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+	s->flags |= SIG_FLAG_REQUIRE_PACKET;
+
+	return 0;
+
+	error: if (cipserviced != NULL)
+		DetectCipServiceFree(cipserviced);
+	if (sm != NULL)
+		SCFree(sm);
+	printf("DetectCipServiceSetup - Error\n");
+	return -1;
+}
+
+/**
+ * \brief this function will free memory associated with DetectCipServiceData
+ *
+ * \param ptr pointer to DetectCipServiceData
+ */
+void DetectCipServiceFree(void *ptr) {
+	DetectCipServiceData *cipserviced = (DetectCipServiceData *) ptr;
+	SCFree(cipserviced);
+}
+
+#ifdef UNITTESTS
+
+/**
+ * \test description of the test
+ */
+
+static int DetectCipServiceParseTest01 (void)
+{
+	DetectCipServiceData *cipserviced = NULL;
+	uint8_t res = 0;
+
+	cipserviced = DetectCipServiceParse("1");
+	if (cipserviced != NULL)
+	{
+		if (cipserviced->cipservice == 1)
+		res = 1;
+
+		DetectCipServiceFree(cipserviced);
+	}
+
+	return res;
+}
+
+static int DetectCipServiceSignatureTest01 (void)
+{
+	uint8_t res = 0;
+
+	DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+	if (de_ctx == NULL)
+	goto end;
+
+	Signature *sig = DetectEngineAppendSig(de_ctx, "alert ip any any -> any any (cip_service:1; sid:1; rev:1;)");
+	if (sig == NULL)
+	{
+		printf("parsing signature failed: ");
+		goto end;
+	}
+
+	/* if we get here, all conditions pass */
+	res = 1;
+	end:
+	if (de_ctx != NULL)
+	DetectEngineCtxFree(de_ctx);
+	return res;
+}
+
+#endif /* UNITTESTS */
+
+/**
+ * \brief this function registers unit tests for DetectCipService
+ */
+void DetectCipServiceRegisterTests(void)
+{
+#ifdef UNITTESTS
+	UtRegisterTest("DetectCipServiceParseTest01",
+			DetectCipServiceParseTest01, 1);
+	UtRegisterTest("DetectCipServiceSignatureTest01",
+			DetectCipServiceSignatureTest01, 1);
+#endif /* UNITTESTS */
+}
+
+
+
+
+/*
+ *
+ ************************************************************ ENIP COMMAND CODE ********************************************************************
+ *
+*/
+
+/* rule function prototypes */
+static int DetectEnipCommandMatch(ThreadVars *, DetectEngineThreadCtx *,
+		Packet *, Signature *, SigMatch *);
+static int DetectEnipCommandSetup(DetectEngineCtx *, Signature *, char *);
+static void DetectEnipCommandFree(void *);
+static void DetectEnipCommandRegisterTests(void);
+
+/**
+ * \brief Registration function for enip_command: keyword
+ */
+void DetectEnipCommandRegister(void)
+{
+	sigmatch_table[DETECT_ENIPCOMMAND].name = "enip_command"; //rule keyword
+	sigmatch_table[DETECT_ENIPCOMMAND].desc = "Rules for detecting EtherNet/IP command";
+	sigmatch_table[DETECT_ENIPCOMMAND].url = "www.solananetworks.com";
+	sigmatch_table[DETECT_ENIPCOMMAND].Match = DetectEnipCommandMatch;
+	sigmatch_table[DETECT_ENIPCOMMAND].Setup = DetectEnipCommandSetup;
+	sigmatch_table[DETECT_ENIPCOMMAND].Free = DetectEnipCommandFree;
+	sigmatch_table[DETECT_ENIPCOMMAND].RegisterTests
+			= DetectEnipCommandRegisterTests;
+
+}
+
+/**
+ * \brief This function is used to match cip_service rule option on a packet
+ *
+ * \param t pointer to thread vars
+ * \param det_ctx pointer to the pattern matcher thread
+ * \param p pointer to the current packet
+ * \param m pointer to the sigmatch with context that we will cast into DetectCipServiceData
+ *
+ * \retval 0 no match
+ * \retval 1 match
+ */
+int DetectEnipCommandMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
+		Packet *p, Signature *s, SigMatch *m)
+{
+	int ret = 0;
+	DetectEnipCommandData *enipcmdd = (DetectEnipCommandData *) m->ctx;
+
+
+	if (PKT_IS_PSEUDOPKT(p))
+	{
+		SCLogDebug("Packet is fake");
+	}
+
+	if (PKT_IS_IPV4(p))
+	{
+		/* ipv4 pkt */
+	} else if (PKT_IS_IPV6(p)) {
+		SCLogDebug("Packet is IPv6");
+		return ret;
+	} else {
+		SCLogDebug("Packet is not IPv4 or IPv6");
+		return ret;
+	}
+
+
+	ENIP_DATA enip_data;
+	enip_data.service_head = NULL; //initialize pointer
+	enip_data.service_tail = NULL;
+
+//	SCLogDebug("payload total length %d\n", p->payload_len);
+
+	//basic port check
+	if ((p->sp == ENIP_PORT) || (p->dp == ENIP_PORT))
+	{
+		if (p->dp == ENIP_PORT)
+			enip_data.direction = 0;
+		else
+			enip_data.direction = 1;
+	} else {
+		return 0;
+	}
+
+	//    SCLogDebug("CIPSERVICE %d\n",enipcmdd->enipcommand);
+
+	int status = DecodeENIP(p, &enip_data); //perform EtherNet/IP decoding
+
+	if (status > 0)
+	{
+		if (enipcmdd->enipcommand == enip_data.header.command) //check if rule matches
+		{
+			ret = 1;
+		}
+	}
+
+	FreeCIPServiceData(enip_data.service_head); //free CIP service data
+
+	return ret;
+}
+
+/**
+ * \brief This function is used to parse cip_service options passed via enip_command: keyword
+ *
+ * \param rulestr Pointer to the user provided rulestr options
+ * Takes single single numeric value
+ *
+ * \retval enipcmdd pointer to DetectCipServiceData on success
+ * \retval NULL on failure
+ */
+
+DetectEnipCommandData *DetectEnipCommandParse(char *rulestr)
+{
+	DetectEnipCommandData *enipcmdd = NULL;
+
+	enipcmdd = SCMalloc(sizeof(DetectEnipCommandData));
+	if (isdigit((int) *rulestr))
+	{
+		unsigned long cmd = atol(rulestr);
+		if (cmd > MAX_ENIP_CMD) //if command greater than 16 bit
+		{
+			printf("DetectEnipCommandParse: Invalid ENIP command %lu\n", cmd);
+			goto error;
+		}
+
+		enipcmdd->enipcommand = (uint16_t) atoi(rulestr);
+
+	} else {
+		goto error;
+	}
+
+	if (unlikely(enipcmdd == NULL))
+		goto error;
+
+	return enipcmdd;
+
+	error: if (enipcmdd)
+		SCFree(enipcmdd);
+	printf("DetectEnipCommandParse - Error Parsing Parameters\n");
+	return NULL;
+}
+
+/**
+ * \brief this function is used to enipcmdd the parsed cip_service data into the current signature
+ *
+ * \param de_ctx pointer to the Detection Engine Context
+ * \param s pointer to the Current Signature
+ * \param rulestr pointer to the user provided enip command options
+ *
+ * \retval 0 on Success
+ * \retval -1 on Failure
+ */
+static int DetectEnipCommandSetup(DetectEngineCtx *de_ctx, Signature *s,
+		char *rulestr)
+{
+	DetectEnipCommandData *enipcmdd = NULL;
+	SigMatch *sm = NULL;
+
+	enipcmdd = DetectEnipCommandParse(rulestr);
+	if (enipcmdd == NULL)
+		goto error;
+
+	sm = SigMatchAlloc();
+	if (sm == NULL)
+		goto error;
+
+	sm->type = DETECT_ENIPCOMMAND;
+	sm->ctx = (void *) enipcmdd;
+
+	SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_MATCH);
+	s->flags |= SIG_FLAG_REQUIRE_PACKET;
+
+	return 0;
+
+	error: if (enipcmdd != NULL)
+		DetectEnipCommandFree(enipcmdd);
+	if (sm != NULL)
+		SCFree(sm);
+	printf("DetectEnipCommandSetup - Error\n");
+	return -1;
+}
+
+/**
+ * \brief this function will free memory associated with DetectEnipCommandData
+ *
+ * \param ptr pointer to DetectEnipCommandData
+ */
+void DetectEnipCommandFree(void *ptr)
+{
+	DetectEnipCommandData *enipcmdd = (DetectEnipCommandData *) ptr;
+	SCFree(enipcmdd);
+}
+
+#ifdef UNITTESTS
+
+/**
+ * \test description of the test
+ */
+
+static int DetectEnipCommandParseTest01 (void)
+{
+	DetectEnipCommandData *enipcmdd = NULL;
+	uint8_t res = 0;
+
+	enipcmdd = DetectEnipCommandParse("1");
+	if (enipcmdd != NULL)
+	{
+		if (enipcmdd->enipcommand == 1)
+		res = 1;
+
+		DetectEnipCommandFree(enipcmdd);
+	}
+
+	return res;
+}
+
+static int DetectEnipCommandSignatureTest01 (void)
+{
+	uint8_t res = 0;
+
+	DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+	if (de_ctx == NULL)
+	goto end;
+
+	Signature *sig = DetectEngineAppendSig(de_ctx, "alert ip any any -> any any (enip_command:1; sid:1; rev:1;)");
+	if (sig == NULL)
+	{
+		printf("parsing signature failed: ");
+		goto end;
+	}
+
+	/* if we get here, all conditions pass */
+	res = 1;
+	end:
+	if (de_ctx != NULL)
+	DetectEngineCtxFree(de_ctx);
+	return res;
+}
+
+#endif /* UNITTESTS */
+
+/**
+ * \brief this function registers unit tests for DetectEnipCommand
+ */
+void DetectEnipCommandRegisterTests(void)
+{
+#ifdef UNITTESTS
+	UtRegisterTest("DetectEnipCommandParseTest01",
+			DetectEnipCommandParseTest01, 1);
+	UtRegisterTest("DetectEnipCommandSignatureTest01",
+			DetectEnipCommandSignatureTest01, 1);
+#endif /* UNITTESTS */
+}
+
+
+
+
+
+
+
+

--- a/src/detect-cipservice.h
+++ b/src/detect-cipservice.h
@@ -1,0 +1,157 @@
+/* Copyright (C) 2012 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Kevin Wong <kwong@solananetworks.com>
+ */
+
+#ifndef _DETECT_CIPSERVICE_H
+#define	_DETECT_CIPSERVICE_H
+
+
+/**
+ * Byte extraction utilities
+ */
+void ENIPExtractUint8(uint8_t *res, uint8_t  *input, uint16_t *offset);
+void ENIPExtractUint16(uint16_t *res,  uint8_t *input, uint16_t *offset) ;
+void ENIPExtractUint32(uint32_t *res, uint8_t *input, uint16_t *offset);
+void ENIPExtractUint64(uint64_t *res, uint8_t *input, uint16_t *offset) ;
+
+#define ENIP_PORT 44818 //standard EtherNet/IP port
+
+/**
+ * CIP Service rule data structure
+ */
+typedef struct DetectCipServiceData_ {
+    uint8_t cipservice;   /* cip service type */
+    uint16_t cipclass;   /* cip service type */
+    uint16_t cipattribute;   /* cip service type */
+    uint8_t tokens;		/* number of parameters*/
+} DetectCipServiceData;
+
+/**
+ * ENIP Command rule data structure
+ */
+typedef struct DetectEnipCommandData_ {
+	u_int16_t enipcommand;   /**< enip command */
+} DetectEnipCommandData;
+
+
+void DetectCipServiceRegister(void);
+void DetectEnipCommandRegister(void);
+
+/**
+ * ENIP encapsulation header
+ */
+typedef struct _ENIP_ENCAP_HEADER
+{
+    u_int16_t command;
+    u_int16_t length;
+    u_int32_t session;
+    u_int32_t status;
+    u_int64_t context;
+    u_int32_t option;
+} ENIP_ENCAP_HEADER;
+
+
+/**
+ * ENIP encapsulation data header
+ */
+typedef struct _ENIP_ENCAP_DATA_HEADER
+{
+	u_int32_t interface_handle;
+	u_int16_t timeout;
+	u_int16_t item_count;
+} ENIP_ENCAP_DATA_HEADER;
+
+
+/**
+ * ENIP encapsulation address header
+ */
+typedef struct _ENIP_ENCAP_ADDRESS_ITEM
+{
+	u_int16_t type;
+	u_int16_t length;
+	u_int16_t conn_id;
+	u_int16_t sequence_num;
+} ENIP_ENCAP_ADDRESS_ITEM;
+
+
+/**
+ * ENIP encapsulation data item
+ */
+typedef struct _ENIP_ENCAP_DATA_ITEM
+{
+	u_int16_t type;
+	u_int16_t length;
+    u_int16_t sequence_count;
+} ENIP_ENCAP_DATA_ITEM;
+
+
+/**
+ * link list node for storing CIP service data
+ */
+typedef struct _CIP_SERVICE_DATA
+{
+	uint8_t service; 	//cip service
+	union {
+	        struct {
+	            uint8_t path_size; 		//cip path size
+	        	uint16_t path_offset;	//offset to cip path
+	        } request;
+	        struct {
+	            u_int8_t status;
+	        } response;
+	    };
+	struct _CIP_SERVICE_DATA* next;
+} CIP_SERVICE_DATA;
+
+
+/**
+ * ENIP data structure
+ */
+typedef struct _ENIP_DATA
+{
+	int direction;
+	ENIP_ENCAP_HEADER header;	//encapsulation header
+	ENIP_ENCAP_DATA_HEADER encap_data_header; //encapsulation data header
+	ENIP_ENCAP_ADDRESS_ITEM encap_addr_item; //encapsulated address item
+	ENIP_ENCAP_DATA_ITEM encap_data_item; //encapsulated data item
+
+	CIP_SERVICE_DATA* service_head; //head of cip service data list
+	CIP_SERVICE_DATA* service_tail; //tail of cip service data list
+
+} ENIP_DATA;
+
+
+
+/**
+ * Ccompare cip service data to cip servicerule
+ */
+int CIPServiceMatch(Packet *p, ENIP_DATA *enip_data, DetectCipServiceData *cipserviced );
+
+
+/**
+ * Create cip service structures
+ */
+CIP_SERVICE_DATA *CreateCIPServiceData(ENIP_DATA *enip_data);
+
+
+#endif	/* _DETECT_CIPSERVICE_H */
+

--- a/src/detect.c
+++ b/src/detect.c
@@ -165,6 +165,7 @@
 #include "detect-http-stat-code.h"
 #include "detect-ssl-version.h"
 #include "detect-ssl-state.h"
+#include "detect-cipservice.h"
 
 #include "action-globals.h"
 #include "tm-threads.h"
@@ -4774,6 +4775,8 @@ void SigTableSetup(void) {
     DetectLuajitRegister();
     DetectIPRepRegister();
     DetectDnsQueryRegister();
+    DetectCipServiceRegister();
+    DetectEnipCommandRegister();
     DetectAppLayerProtocolRegister();
 }
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -1144,6 +1144,9 @@ enum {
 
     DETECT_AL_DNS_QUERY,
 
+    DETECT_CIPSERVICE,
+    DETECT_ENIPCOMMAND,
+
     /* make sure this stays last */
     DETECT_TBLSIZE,
 };


### PR DESCRIPTION
Forgot to select the base previous, now set to the correct one

Add support for SCADA EtherNet/IP(ENIP) and Common Industrial Protocol (CIP).  New keywords are "cip_service" and "enip_command"