### PR TITLE
Support for reconnecting unix domain socket log files

### DIFF
--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -56,6 +56,11 @@ typedef struct LogFileCtx_ {
     /** The name of the file */
     char *filename;
 
+    /** Handle auto-connecting / reconnecting sockets */
+    int is_sock;
+    int sock_type;
+    uint64_t reconn_timer;
+
     /**< Used by some alert loggers like the unified ones that append
      * the date onto the end of files. */
     char *prefix;
@@ -77,6 +82,9 @@ typedef struct LogFileCtx_ {
     /* Flag set when file rotation notification is received. */
     int rotation_flag;
 } LogFileCtx;
+
+/* Min time (msecs) before trying to reconnect a Unix domain socket */
+#define LOGFILE_RECONN_MIN_TIME     500
 
 /* flags for LogFileCtx */
 #define LOGFILE_HEADER_WRITTEN 0x01


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/1423

Updated as discussed in #1467:
- Changed clock_gettime to more portable gettimeofday
- Changed SCLogError to SCLogWarning for recoverable failures
- Made return value of SCLogFileWrite clearer
- Rebased to current master

This patch changes the behavior of the code that writes log records to a unix domain socket:
If suricata cannot immediately connect to the receiver, the receiver socket path name and socket type (stream vs dgram) will be remembered in the LogFileCtx. When log records are written later, the connect will be attempted.

Also, if a connection to the receiver is broken -- for example, if the receiver program is restarted -- suricata will now clean up the old connection and automatically reconnect.

Since creating the unix domain socket then unsuccessfully attempting to connect then tearing it down requires relatively significant kernel resources, the reconnection is only retried occasionally (currently set to 1/2 second). 

Tested with both unix_stream and unix_dgram socket types. Only tested with fast-alert log, but should work for any caller of SCConfLogOpenGeneric.