### PR TITLE
rule vars: strip leading white space before looking up var - v1

### DIFF
--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -74,6 +74,11 @@ char *SCRuleVarsGetConfVar(const DetectEngineCtx *de_ctx,
 
     if (conf_var_name == NULL)
         goto end;
+
+    while (conf_var_name[0] != '\0' && isspace(conf_var_name[0])) {
+        conf_var_name++;
+    }
+
     (conf_var_name[0] == '$') ? conf_var_name++ : conf_var_name;
     conf_var_type_name = SCMapEnumValueToName(conf_vars_type,
                                               sc_rule_vars_type_map);
@@ -212,6 +217,11 @@ int SCRuleVarsPositiveTest01(void)
                       "any") == 0);
     result &= (SCRuleVarsGetConfVar(NULL,"$AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS) != NULL &&
                strcmp(SCRuleVarsGetConfVar(NULL,"$AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS),
+                      "any") == 0);
+
+    /* Test that a leading space is stripped. */
+    result &= (SCRuleVarsGetConfVar(NULL," $AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS) != NULL &&
+               strcmp(SCRuleVarsGetConfVar(NULL," $AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS),
                       "any") == 0);
 
     /* check for port-groups */


### PR DESCRIPTION
I first looked at altering the parsing state machine, but this was simpler.  Just strip leading white space before looking at the variable in the configuration tree.

Issue: https://redmine.openinfosecfoundation.org/issues/1508

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/115
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/116
