### PR TITLE
2.0.x: rule vars: strip leading white space before looking up var.

### DIFF
--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -73,6 +73,11 @@ char *SCRuleVarsGetConfVar(const char *conf_var_name,
 
     if (conf_var_name == NULL)
         goto end;
+
+    while (conf_var_name[0] != '\0' && isspace(conf_var_name[0])) {
+        conf_var_name++;
+    }
+
     (conf_var_name[0] == '$') ? conf_var_name++ : conf_var_name;
     conf_var_type_name = SCMapEnumValueToName(conf_vars_type,
                                               sc_rule_vars_type_map);
@@ -204,6 +209,11 @@ int SCRuleVarsPositiveTest01(void)
                       "any") == 0);
     result &= (SCRuleVarsGetConfVar("$AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS) != NULL &&
                strcmp(SCRuleVarsGetConfVar("$AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS),
+                      "any") == 0);
+
+    /* Test that a leading space is stripped. */
+    result &= (SCRuleVarsGetConfVar(" $AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS) != NULL &&
+               strcmp(SCRuleVarsGetConfVar(" $AIM_SERVERS", SC_RULE_VARS_ADDRESS_GROUPS),
                       "any") == 0);
 
     /* check for port-groups */


### PR DESCRIPTION
Backport of PR #1599 to 2.0.x.

Strip leading white space when looking up a variable name in the configuration tree.

Issue: https://redmine.openinfosecfoundation.org/issues/1510

Buildbot output:
- PR build: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/117
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/116
