### PR TITLE
netmap-ids-fix

### DIFF
--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -628,8 +628,10 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     ntv->capture_kernel_drops = StatsRegisterCounter("capture.kernel_drops",
             ntv->tv);
 
+    /* enable zero-copy mode for workers runmode */
     char const *active_runmode = RunmodeGetActive();
-    if (active_runmode && !strcmp("workers", active_runmode)) {
+    if ((aconf->copy_mode != NETMAP_COPY_MODE_NONE) && active_runmode
+            && !strcmp("workers", active_runmode)) {
         if (likely(ntv->ifsrc->mem == ntv->ifdst->mem)) {
             ntv->flags |= NETMAP_FLAG_ZERO_COPY;
             SCLogInfo("Enabling zero copy mode for %s->%s",
@@ -638,7 +640,6 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
             SCLogInfo("Unable to set zero copy mode for %s->%s",
                       aconf->iface_name, aconf->out_iface_name);
         }
-
     }
 
     if (aconf->bpf_filter) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -501,6 +501,12 @@ netmap:
    # interface will be copied to the copy-iface interface. If 'tap' is set, the
    # copy is complete. If 'ips' is set, the packet matching a 'drop' action
    # will not be copied.
+   # To specify the OS as the copy-iface (so the OS can route packets, or forward
+   # to a service running on the same machine) add a plus sign at the end 
+   # (e.g. "copy-iface: eth0+"). Don't forget to set up a symmetrical eth0+ -> eth0
+   # for return packets. Hardware checksumming must be *off* on the interface if
+   # using an OS endpoint (e.g. 'ifconfig eth0 -rxcsum -txcsum -rxcsum6 -txcsum6' for FreeBSD
+   # or 'ethtool -K eth0 tx off rx off' for Linux).
    #copy-mode: tap
    #copy-iface: eth3
    # Set to yes to disable promiscuous mode


### PR DESCRIPTION
Fixed bug causes suricata in netmap mode crash in IDS mode.
Extended comments in configuration file about copy-mode using OS endpoints.