### PR TITLE
TimeMachine - In memory pcap store for historic data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@
     AC_CHECK_HEADERS([limits.h netdb.h netinet/in.h poll.h sched.h signal.h])
     AC_CHECK_HEADERS([stdarg.h stdint.h stdio.h stdlib.h string.h sys/ioctl.h])
     AC_CHECK_HEADERS([syslog.h sys/prctl.h sys/socket.h sys/stat.h sys/syscall.h])
-    AC_CHECK_HEADERS([sys/time.h time.h unistd.h])
+    AC_CHECK_HEADERS([sys/sysinfo.h sys/time.h time.h unistd.h])
     AC_CHECK_HEADERS([sys/ioctl.h linux/if_ether.h linux/if_packet.h linux/filter.h])
     AC_CHECK_HEADERS([linux/ethtool.h linux/sockios.h])
     AC_CHECK_HEADER(glob.h,,[AC_ERROR(glob.h not found ...)])
@@ -919,8 +919,32 @@
     else
         LIBNET_DETECT_FAIL="yes"
         LIBNET_FAIL_WARN($libnet_dir)
+    fi  
+
+  # libbsd
+     AC_ARG_WITH(libbsd_includes,
+            [  --with-libbsd-includes=DIR  libbsd include directory],
+            [with_libbsd_includes="$withval"],[with_libbsd_includes=no])
+
+    if test "$with_libbsd_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_libbsd_includes}"
     fi
 
+    LIBBSD=""
+    AC_CHECK_HEADER(bsd/sys/tree.h,, LIBBSD="no")
+
+    if test "$LIBBSD" = "no"; then
+        echo
+        echo "   ERROR!  libbsd-dev files not found, go get them"
+        echo
+        echo "   Ubuntu: apt-get install libbsd-dev"
+        echo "   Fedora: yum install libbsd-devel"
+        echo
+        exit 1
+    fi   
+     
+    AC_DEFINE([HAVE_SYS_TREE_H],[1],[bsd/sys/tree.h available])
+                     
   # libpcap
     AC_ARG_WITH(libpcap_includes,
             [  --with-libpcap-includes=DIR  libpcap include directory],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -295,6 +295,11 @@ stream-tcp-util.c stream-tcp-util.h \
 suricata.c suricata.h \
 threads.c threads.h threads-arch-tile.h \
 threads-debug.h threads-profile.h \
+timemachine.c timemachine.h \
+timemachine-flow.c timemachine-flow.h \
+timemachine-heap.c timemachine-heap.h \
+timemachine-output.c timemachine-output.h \
+timemachine-packet.c timemachine-packet.h \
 tm-modules.c tm-modules.h \
 tmqh-flow.c tmqh-flow.h \
 tmqh-nfq.c tmqh-nfq.h \

--- a/src/decode.h
+++ b/src/decode.h
@@ -214,6 +214,7 @@ typedef struct Address_ {
 #define GET_PKT_DATA(p) ((((p)->ext_pkt) == NULL ) ? (uint8_t *)((p) + 1) : (p)->ext_pkt)
 #define GET_PKT_DIRECT_DATA(p) (uint8_t *)((p) + 1)
 #define GET_PKT_DIRECT_MAX_SIZE(p) (default_packet_size)
+#define GET_PKT_PAYLOAD_LEN(p) ((p)->payload_len)
 
 #define SET_PKT_LEN(p, len) do { \
     (p)->pktlen = (len); \

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -152,6 +152,10 @@
 #include <sys/stat.h>
 #endif
 
+#ifdef HAVE_SYS_SYSINFO_H
+#include <sys/sysinfo.h>
+#endif
+
 #if HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
@@ -174,6 +178,10 @@
 
 #ifdef HAVE_PCAP_BPF_H
 #include <pcap/bpf.h>
+#endif
+
+#ifdef HAVE_SYS_TREE_H
+#include <bsd/sys/tree.h>
 #endif
 
 #if __CYGWIN__

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -195,6 +195,8 @@
 #include "util-storage.h"
 #include "host-storage.h"
 
+#include "timemachine.h"
+
 /*
  * we put this here, because we only use it here in main.
  */
@@ -909,6 +911,8 @@ void RegisterAllModules()
     TmModuleReceiveNFLOGRegister();
     TmModuleDecodeNFLOGRegister();
 
+    /* timemachine */
+    TmModuleTimeMachineRegister();
 }
 
 TmEcode LoadYamlConfig(char *conf_filename)

--- a/src/timemachine-flow.c
+++ b/src/timemachine-flow.c
@@ -1,0 +1,321 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Flow related functions for usage within TimeMachine
+ */
+#include "suricata-common.h"
+
+#include "flow-private.h"
+
+#include "util-hash-lookup3.h"
+
+#include "timemachine.h"
+#include "timemachine-flow.h"
+#include "timemachine-packet.h"
+
+typedef struct TimeMachineFlowHashKey4_ TimeMachineFlowHashKey4;
+typedef struct TimeMachineFlowHashKey6_ TimeMachineFlowHashKey6;
+typedef struct TimeMachineFlowNode_ TimeMachineFlowNode;
+
+struct TimeMachineFlowHashKey4_ {
+    union {
+        struct {
+            uint32_t src, dst;
+            uint16_t sp, dp;
+            uint32_t proto;
+        };
+        const uint32_t u32[4];
+    };
+};
+
+struct TimeMachineFlowHashKey6_ {
+    union {
+        struct {
+            uint32_t src[4], dst[4];
+            uint16_t sp, dp;
+            uint32_t proto;
+        };
+        const uint32_t u32[10];
+    };
+};
+
+/* TimeMachineFlowNode's are entries within a SPLAY tree */
+struct TimeMachineFlowNode_ {
+    uint32_t  hash;
+    void      *data;
+
+    SPLAY_ENTRY(TimeMachineFlowNode_) ent;
+};
+
+/* SPLAY tree comparison callback */
+static inline int TimeMachineFlowCompare(TimeMachineFlowNode *a, TimeMachineFlowNode *b) {
+    
+    if (a->hash == b->hash) {
+        return 0;
+    }
+
+    if (a->hash < b->hash) {
+        return -1;
+    }
+
+    if (a->hash > b->hash) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/** \brief compare two raw ipv6 addrs
+ *
+ *  \note we don't care about the real ipv6 ip's, this is just
+ *        to consistently fill the FlowHashKey6 struct, without all
+ *        the ntohl calls.
+ *
+ *  \warning do not use elsewhere unless you know what you're doing.
+ *           detect-engine-address-ipv6.c's AddressIPv6GtU32 is likely
+ *           what you are looking for.
+ */
+static inline int TimeMachineFlowHashRawAddressIPv6GtU32(const uint32_t *a, const uint32_t *b)
+{
+    for (int i = 0; i < 4; i++) {
+        if (a[i] > b[i])
+            return 1;
+        if (a[i] < b[i])
+            break;
+    }
+
+    return 0;
+}
+
+/* SPLAY Tree Macros */
+SPLAY_PROTOTYPE(TimeMachineFlows_, TimeMachineFlowNode_, ent, TimeMachineFlowCompare);
+SPLAY_GENERATE(TimeMachineFlows_, TimeMachineFlowNode_, ent, TimeMachineFlowCompare);
+
+/* calculate the hash key for this packet
+ *
+ * we're using:
+ *  hash_rand -- set at init time
+ *  source port
+ *  destination port
+ *  source address
+ *  destination address
+ *
+ *  For ICMP we only consider UNREACHABLE errors atm.
+ */
+static inline uint32_t TimeMachineFlowGetKey(const Packet* p) {
+    uint32_t key;
+    
+    if (p->ip4h != NULL) {
+                    
+        if (p->tcph != NULL || p->udph != NULL) {
+            TimeMachineFlowHashKey4 fhk;
+            
+            if (p->src.addr_data32[0] > p->dst.addr_data32[0]) {
+                fhk.src = p->src.addr_data32[0];
+                fhk.dst = p->dst.addr_data32[0];
+            } else {
+                fhk.src = p->dst.addr_data32[0];
+                fhk.dst = p->src.addr_data32[0];
+            }
+            
+            if (p->sp > p->dp) {
+                fhk.sp = p->sp;
+                fhk.dp = p->dp;
+            } else {
+                fhk.sp = p->dp;
+                fhk.dp = p->sp;
+            }
+            fhk.proto = (uint32_t)p->proto;
+
+            key = hashword(fhk.u32, 4, flow_config.hash_rand);         
+        } else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
+            uint32_t psrc = IPV4_GET_RAW_IPSRC_U32(ICMPV4_GET_EMB_IPV4(p));
+            uint32_t pdst = IPV4_GET_RAW_IPDST_U32(ICMPV4_GET_EMB_IPV4(p));
+            TimeMachineFlowHashKey4 fhk;
+            if (psrc > pdst) {
+                fhk.src = psrc;
+                fhk.dst = pdst;
+            } else {
+                fhk.src = pdst;
+                fhk.dst = psrc;
+            }
+            if (p->icmpv4vars.emb_sport > p->icmpv4vars.emb_dport) {
+                fhk.sp = p->icmpv4vars.emb_sport;
+                fhk.dp = p->icmpv4vars.emb_dport;
+            } else {
+                fhk.sp = p->icmpv4vars.emb_dport;
+                fhk.dp = p->icmpv4vars.emb_sport;
+            }
+            fhk.proto = (uint32_t)ICMPV4_GET_EMB_PROTO(p);
+
+            key = hashword(fhk.u32, 4, flow_config.hash_rand);
+        } else {
+            TimeMachineFlowHashKey4 fhk;
+            if (p->src.addr_data32[0] > p->dst.addr_data32[0]) {
+                fhk.src = p->src.addr_data32[0];
+                fhk.dst = p->dst.addr_data32[0];
+            } else {
+                fhk.src = p->dst.addr_data32[0];
+                fhk.dst = p->src.addr_data32[0];
+            }
+            fhk.sp = 0xfeed;
+            fhk.dp = 0xbeef;
+            fhk.proto = (uint32_t)p->proto;
+
+            key = hashword(fhk.u32, 4, flow_config.hash_rand);
+        }
+    } else if (p->ip6h != NULL) {
+
+        TimeMachineFlowHashKey6 fhk;
+        if (TimeMachineFlowHashRawAddressIPv6GtU32(p->src.addr_data32, p->dst.addr_data32)) {
+            fhk.src[0] = p->src.addr_data32[0];
+            fhk.src[1] = p->src.addr_data32[1];
+            fhk.src[2] = p->src.addr_data32[2];
+            fhk.src[3] = p->src.addr_data32[3];
+            fhk.dst[0] = p->dst.addr_data32[0];
+            fhk.dst[1] = p->dst.addr_data32[1];
+            fhk.dst[2] = p->dst.addr_data32[2];
+            fhk.dst[3] = p->dst.addr_data32[3];
+        } else {
+            fhk.src[0] = p->dst.addr_data32[0];
+            fhk.src[1] = p->dst.addr_data32[1];
+            fhk.src[2] = p->dst.addr_data32[2];
+            fhk.src[3] = p->dst.addr_data32[3];
+            fhk.dst[0] = p->src.addr_data32[0];
+            fhk.dst[1] = p->src.addr_data32[1];
+            fhk.dst[2] = p->src.addr_data32[2];
+            fhk.dst[3] = p->src.addr_data32[3];
+        }
+        if (p->sp > p->dp) {
+            fhk.sp = p->sp;
+            fhk.dp = p->dp;
+        } else {
+            fhk.sp = p->dp;
+            fhk.dp = p->sp;
+        }
+        fhk.proto = (uint32_t)p->proto;
+        
+        key = hashword(fhk.u32, 10, flow_config.hash_rand);
+    } else
+        key = 0;
+
+    return key;
+}
+
+TimeMachineFlow* TimeMachineFlowNew(TimeMachineFlows* flows, Packet* p) {
+    TimeMachineFlow* flow;
+    TimeMachineFlowNode* ent;
+        
+    flow = SCMalloc(sizeof(TimeMachineFlow));
+        
+    if (p->ip4h != NULL) {
+        FLOW_SET_IPV4_SRC_ADDR_FROM_PACKET(p, &flow->src);
+        FLOW_SET_IPV4_DST_ADDR_FROM_PACKET(p, &flow->dst);
+        flow->datalink = p->datalink;
+        flow->ip_hdr = 1;
+          
+        if (p->tcph != NULL || p->udph != NULL) {
+            flow->sp = p->sp;
+            flow->dp = p->dp;
+            flow->proto = (uint8_t)p->proto;
+        }   
+        else if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
+            flow->sp = p->icmpv4vars.emb_sport;
+            flow->dp = p->icmpv4vars.emb_dport;
+            flow->proto = (uint8_t)ICMPV4_GET_EMB_PROTO(p);
+        } 
+        else {
+            flow->sp = 0xfeed;
+            flow->dp = 0xbeef;
+            flow->proto = (uint8_t)p->proto;
+        }
+    }
+    else if (p->ip6h != NULL) {
+        FLOW_SET_IPV6_SRC_ADDR_FROM_PACKET(p, &flow->src);
+        FLOW_SET_IPV6_DST_ADDR_FROM_PACKET(p, &flow->dst);
+        flow->proto = (uint8_t)p->proto;
+        flow->datalink = p->datalink;        
+        flow->sp = p->sp;
+        flow->dp = p->dp;
+        flow->ip_hdr = 2;
+    }
+    else {
+        return NULL;
+    }
+    
+    memcpy(&flow->ts, &p->ts, sizeof(struct timeval));
+    TAILQ_INIT(&flow->packets);
+    flow->packet_count = 0;
+    flow->output = NULL;  
+    
+    ent = SCMalloc(sizeof(TimeMachineFlowNode));
+    ent->hash = TimeMachineFlowGetKey(p);
+    ent->data = flow;
+    flow->ent = ent;
+
+    SPLAY_INSERT(TimeMachineFlows_, flows, ent);  
+    return flow;         
+}
+
+void TimeMachineFlowDestroy(TimeMachineFlows* flows, TimeMachineFlow* flow) {
+    TimeMachineFlowNode search;
+    TimeMachineFlowNode* ret;
+    
+    search = *flow->ent;     
+    ret = SPLAY_FIND(TimeMachineFlows_, flows, &search);
+
+    if (ret == NULL) {
+        return;
+    }
+
+    SPLAY_REMOVE(TimeMachineFlows_, flows, ret);
+    SCFree(ret);
+    SCFree(flow);
+}
+
+TimeMachineFlow* TimeMachineFlowLookup(TimeMachineFlows* flows, Packet* p) {
+    TimeMachineFlowNode search;
+    TimeMachineFlowNode* ret;
+    
+    search.hash = TimeMachineFlowGetKey(p);
+        
+    ret = SPLAY_FIND(TimeMachineFlows_, flows, &search);
+    
+    if (ret) {
+        return ret->data;
+    }
+   
+    return NULL;
+}
+
+TimeMachineFlow* TimeMachineFlowFirst(TimeMachineFlows* flows) {
+    TimeMachineFlowNode* ret;
+    
+    ret = SPLAY_MIN(TimeMachineFlows_, flows);
+    
+    if (ret) {
+        return ret->data;
+    }
+    
+    return NULL;
+}

--- a/src/timemachine-flow.h
+++ b/src/timemachine-flow.h
@@ -1,0 +1,74 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Provides Flow related data structures required for the timemachine module 
+ */
+
+#ifndef __TIMEMACHINE_FLOW_H__
+#define __TIMEMACHINE_FLOW_H__
+
+#include "suricata-common.h"
+#include "flow.h"
+#include "timemachine.h"
+#include "timemachine-packet.h"
+
+struct TimeMachineFlows_;
+
+#define TIMEMACHINE_FLOW_IS_IPV4 1
+#define TIMEMACHINE_FLOW_IS_IPV6 2
+
+/* represents a network flow */
+struct TimeMachineFlow_ {
+
+    struct timeval ts;
+    FlowAddress src, dst;
+    union {
+        Port sp;
+        uint8_t type;
+    };
+    union {
+        Port dp;
+        uint8_t code;
+    };
+    uint8_t proto;
+    uint8_t ip_hdr;
+    int datalink;
+    
+    TimeMachineThreadData* td;
+    TimeMachineOutput* output;
+    TimeMachineFlowNode* ent;   
+    
+    size_t              packet_count;
+    TimeMachinePackets  packets;
+};
+
+/* SPLAY Tree Macros */
+SPLAY_HEAD(TimeMachineFlows_, TimeMachineFlowNode_);
+
+TimeMachineFlow* TimeMachineFlowNew(TimeMachineFlows*, Packet*);
+void TimeMachineFlowDestroy(TimeMachineFlows*, TimeMachineFlow*);
+
+TimeMachineFlow* TimeMachineFlowLookup(TimeMachineFlows*, Packet*);
+TimeMachineFlow* TimeMachineFlowFirst(TimeMachineFlows*);
+
+#endif /* __TIMEMACHINE_FLOW_H__ */

--- a/src/timemachine-heap.c
+++ b/src/timemachine-heap.c
@@ -1,0 +1,131 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Heap related functions for usage within TimeMachine
+ */
+
+#include "suricata-common.h"
+#include "timemachine.h"
+#include "timemachine-flow.h"
+#include "timemachine-heap.h"
+#include "timemachine-packet.h"
+
+TimeMachineHeap* TimeMachineHeapNew(TimeMachineData* tm, TimeMachineHeapConf* conf) {
+
+    TimeMachineHeap *heap = SCMalloc(sizeof(TimeMachineHeap));
+    
+    if (heap == NULL) {
+        SCLogError(SC_ERR_FATAL, "Fatal error could not create TimeMachine heap. Exiting...");
+        exit(EXIT_FAILURE);        
+    }
+
+    heap->conf = conf;
+    heap->used_pool_count = 0;
+    heap->unused_pool_count = 0;
+    
+    TAILQ_INIT(&heap->used_mem_pools);
+    TAILQ_INIT(&heap->unused_mem_pools);
+    TAILQ_INIT(&heap->unused_packets);    
+    
+    TimeMachineHeapExpand(tm, heap);
+    return heap;
+}
+
+void TimeMachineHeapDestroy(TimeMachineHeap* heap) {
+    
+    if (heap == NULL) {
+        return;
+    }
+    
+    /* delete all the used pool data */
+    while (heap->used_pool_count > 0) {
+        TimeMachineMemPool* mem_pool;
+            
+        mem_pool = TAILQ_FIRST(&heap->used_mem_pools);
+        TAILQ_REMOVE(&heap->used_mem_pools, mem_pool, next);
+        SCFree(mem_pool);
+
+        heap->used_pool_count--;    
+    }
+    
+    /* delete all the unused pool data */
+    while (heap->unused_pool_count > 0) {
+        TimeMachinePacket* packet;
+        TimeMachineMemPool* mem_pool;
+
+        packet = TAILQ_FIRST(&heap->unused_packets);
+        TAILQ_REMOVE(&heap->unused_packets, packet, next);
+        TimeMachinePacketDestroy(packet);
+            
+        mem_pool = TAILQ_FIRST(&heap->unused_mem_pools);
+        TAILQ_REMOVE(&heap->unused_mem_pools, mem_pool, next);
+        SCFree(mem_pool);
+                
+        heap->unused_pool_count--;
+    }    
+}
+
+uint32_t TimeMachineHeapExpand(TimeMachineData* tm, TimeMachineHeap* heap) {
+    uint32_t i;
+    
+    if (heap == NULL) {
+        return 0;
+    }
+    
+    for (i = 0; i < heap->conf->expand_by; i++) {
+        TimeMachineMemPool* mem_pool;
+        TimeMachinePacket* packet;
+        
+        mem_pool = SCCalloc(sizeof(TimeMachineMemPool), 1);
+        if (mem_pool == NULL) {
+            return i;
+        }    
+        
+        mem_pool->mem = SCMalloc(heap->conf->max_packet_size);
+        if (mem_pool->mem == NULL) {
+            SCFree(mem_pool);
+            return i;
+        }
+        
+        packet = TimeMachinePacketNew();
+        
+        tm->current_memory += sizeof(TimeMachineMemPool) + heap->conf->max_packet_size +
+                              sizeof(TimeMachinePacket);
+                              
+        TAILQ_INSERT_TAIL(&heap->unused_mem_pools, mem_pool, next);
+        TAILQ_INSERT_TAIL(&heap->unused_packets, packet, next);
+        heap->unused_pool_count += 1;
+    }
+    
+    return i;
+}
+
+int TimeMachineHeapCanExpand(TimeMachineData *tm) {
+
+    /* first check time machine mem usage < % of total ram */
+    if (tm->current_memory > tm->max_memory) {
+        return 0;
+    }
+            
+    return 1;
+}

--- a/src/timemachine-heap.h
+++ b/src/timemachine-heap.h
@@ -1,0 +1,74 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Heap related functions for usage within TimeMachine
+ */
+
+#ifndef __TIMEMACHINE_HEAP_H__
+#define __TIMEMACHINE_HEAP_H__
+
+#include "suricata-common.h"
+#include "timemachine.h"
+#include "timemachine-packet.h"
+
+struct TimeMachineHeaps_;
+
+struct TimeMachineHeapConf_ {
+    const char*                         name;
+    uint32_t                            expand_by;
+    uint32_t                            prealloc_count;
+    uint32_t                            max_packet_size;
+    TAILQ_ENTRY(TimeMachineHeapConf_)   next;
+};
+
+struct TimeMachineMemPool_ {
+    TimeMachinePacket                   *packet;
+    void                                *mem;
+    TAILQ_ENTRY(TimeMachineMemPool_)    next;
+};
+
+
+/* TAILQ Macros */
+TAILQ_HEAD(TimeMachineMemPools_, TimeMachineMemPool_);
+
+typedef struct TimeMachineHeap_ {
+    TimeMachineHeapConf                 *conf;
+
+    size_t                              used_pool_count;
+    size_t                              unused_pool_count;
+
+    TimeMachineMemPools                 used_mem_pools;
+    TimeMachineMemPools                 unused_mem_pools;
+    TimeMachinePackets                  unused_packets;
+    
+    TAILQ_ENTRY(TimeMachineHeap_)       next;
+} TimeMachineHeap;
+
+/* prototypes */
+TimeMachineHeap* TimeMachineHeapNew(TimeMachineData*, TimeMachineHeapConf*);
+void TimeMachineHeapDestroy(TimeMachineHeap*);
+
+uint32_t TimeMachineHeapExpand(TimeMachineData*, TimeMachineHeap*);
+int TimeMachineHeapCanExpand(TimeMachineData*);
+
+#endif /* __TIMEMACHINE_HEAP_H__ */

--- a/src/timemachine-output.c
+++ b/src/timemachine-output.c
@@ -1,0 +1,155 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Provides output related data structures required for the timemachine module 
+ */
+ 
+#include "suricata-common.h"
+
+#include "util-path.h"
+#include "util-print.h"
+#include "util-proto-name.h"
+#include "util-time.h"
+
+#include "timemachine.h"
+#include "timemachine-flow.h"
+#include "timemachine-heap.h"
+#include "timemachine-output.h"
+#include "timemachine-packet.h"
+ 
+TimeMachineOutput* TimeMachineOutputNew(TimeMachineFlow* flow) {
+    TimeMachineOutput* output;
+    TimeMachinePacket* packet;
+    
+    char proto[16] = "", timebuf[64] = "";
+    char srcip[46] = "", dstip[46] = "", directory[PATH_MAX], filename[PATH_MAX];
+         
+    if (flow == NULL) {
+        return NULL;
+    }
+     
+    output = SCMalloc(sizeof(TimeMachineOutput));
+    if (output == NULL) {
+        SCLogError(SC_ERR_FATAL, "Fatal error could not create TimeMachine output. Exiting...");
+        exit(EXIT_FAILURE);             
+     }
+     
+    output->pcap_out = pcap_open_dead(flow->datalink, 65535);
+    if (output->pcap_out == NULL) {
+        SCLogError(SC_ERR_FATAL, "Fatal error, could not create TimeMachine pcap output. Exiting...");
+        exit(EXIT_FAILURE);
+    }
+
+    CreateIsoTimeString(&flow->ts, timebuf, sizeof(timebuf));
+    
+    if (flow->ip_hdr == TIMEMACHINE_FLOW_IS_IPV4) {
+        PrintInet(AF_INET, (const void*)&flow->src.addr_data32[0], srcip, sizeof(srcip));
+        PrintInet(AF_INET, (const void*)&flow->dst.addr_data32[0], dstip, sizeof(dstip));
+    } else if (flow->ip_hdr == TIMEMACHINE_FLOW_IS_IPV6) {
+        PrintInet(AF_INET, (const void*)&flow->src.addr_data32, srcip, sizeof(srcip));
+        PrintInet(AF_INET, (const void*)&flow->dst.addr_data32, dstip, sizeof(dstip));
+    }
+
+    if (SCProtoNameValid(flow->proto) == TRUE) {
+        strlcpy(proto, known_proto[flow->proto], sizeof(proto));
+    } else {
+        snprintf(proto, sizeof(proto), "%03" PRIu32, flow->proto);
+    }
+
+    snprintf(directory, sizeof(directory), "%s/tm/%.10s/%s-%s", 
+             ConfigGetLogDirectory(), timebuf, srcip, dstip);
+
+    if (flow->proto == IPPROTO_ICMP) {
+        snprintf(filename, sizeof(filename), "%s/%s-%s-%s.ICMP.cap", 
+                 directory, srcip, dstip, timebuf); 
+    } else {
+        snprintf(filename, sizeof(filename), "%s/%s:%hu-%s:%hu-%s.%s.cap", 
+                 directory, srcip, flow->sp, dstip, flow->dp, timebuf, proto);
+    }
+
+    struct stat stat_buf;
+    if (stat(directory, &stat_buf) != 0) {
+        int ret;
+        ret = MakePath(filename, S_IRWXU|S_IXGRP|S_IRGRP);
+        if (ret != 0) {
+            int err = errno;
+            if (err != EEXIST) {
+                SCLogError(SC_ERR_LOGDIR_CONFIG,
+                           "Cannot create file drop directory %s: %s",
+                           directory, strerror(err));
+                exit(EXIT_FAILURE);
+            }
+        } else {
+            SCLogInfo("Created timemachine pcap directory %s",
+                      directory);
+        }
+    }    
+
+    output->pcap_dumper = pcap_dump_open(output->pcap_out, filename);
+    if (output->pcap_dumper == NULL) {
+        SCLogError(SC_ERR_LOGDIR_CONFIG, 
+                   "Cannot create timemachine output file %s: %s",
+                   filename, pcap_geterr(output->pcap_out));
+        exit(EXIT_FAILURE);
+    }    
+
+    output->output_file=pcap_dump_file(output->pcap_dumper);
+    
+    while (flow->packet_count > 0) {
+        packet = TAILQ_FIRST(&flow->packets);
+        pcap_dump((u_char*)output->output_file, &packet->header, packet->data);
+
+        /* remove this packet from the heap and flow */
+        TimeMachineMemPool *rem_mem_pool = packet->mem_pool;
+
+        TimeMachineHeap *heap = packet->heap;
+        TAILQ_REMOVE(&heap->used_mem_pools, rem_mem_pool, next);
+        TAILQ_REMOVE(&flow->packets, packet, next);
+        heap->used_pool_count--;
+        
+        rem_mem_pool->packet = NULL;
+        TAILQ_INSERT_TAIL(&heap->unused_mem_pools, rem_mem_pool, next);
+        TAILQ_INSERT_TAIL(&heap->unused_packets, packet, next);
+        heap->unused_pool_count++;
+        flow->packet_count--;
+    }    
+        
+    fflush(output->output_file);
+    TimeGet(&output->updated); 
+    output->flow = flow;
+    return output;
+}
+
+void TimeMachineOutputDestroy(TimeMachineOutput* output) {
+    
+    if (output->pcap_dumper) {
+        pcap_dump_flush(output->pcap_dumper);
+        pcap_dump_close(output->pcap_dumper);
+    }
+    
+    if (output->pcap_out) {
+        pcap_close(output->pcap_out);
+    }
+    
+    SCFree(output);
+}

--- a/src/timemachine-output.h
+++ b/src/timemachine-output.h
@@ -1,0 +1,47 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Provides output related data structures required for the timemachine module 
+ */
+
+#ifndef __TIMEMACHINE_OUTPUT_H__
+#define __TIMEMACHINE_OUTPUT_H__
+
+#include "suricata-common.h"
+#include "timemachine.h"
+
+struct TimeMachineOutput_ {
+    pcap_t                                    *pcap_out;
+    pcap_dumper_t                             *pcap_dumper;
+    FILE                                      *output_file;
+
+    TimeMachineFlow                           *flow;
+
+    struct timeval                            updated;
+    TAILQ_ENTRY(TimeMachineOutput_)           next;     
+};
+ 
+TimeMachineOutput* TimeMachineOutputNew(TimeMachineFlow*);
+void TimeMachineOutputDestroy(TimeMachineOutput*);
+
+#endif /* __TIMEMACHINE_OUTPUT_H__ */

--- a/src/timemachine-packet.c
+++ b/src/timemachine-packet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2012 Open Information Security Foundation
+/* Copyright (C) 2007-2014 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -15,18 +15,35 @@
  * 02110-1301, USA.
  */
 
+
 /**
  * \file
  *
- * \author Victor Julien <victor@inliniac.net>
+ * \author Mat Oldham <mat.oldham@gmail.com>
  *
+ * Packet related functions for usage within TimeMachine
  */
+#include "suricata-common.h"
+#include "timemachine.h"
+#include "timemachine-packet.h"
+ 
+TimeMachinePacket* TimeMachinePacketNew() {
 
-#ifndef __UTIL_PATH_H__
-#define __UTIL_PATH_H__
+    TimeMachinePacket* packet = SCMalloc(sizeof(TimeMachinePacket));
+    
+    if (packet == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for packet.");
+        exit(EXIT_FAILURE);
+    }
 
-int PathIsAbsolute(const char *);
-int PathIsRelative(const char *);
-int MakePath(char*, mode_t);
+    return packet;
+}
 
-#endif /* __UTIL_PATH_H__ */
+void TimeMachinePacketDestroy(TimeMachinePacket* packet) {
+        
+    if (packet == NULL) {
+        return;
+    }
+    
+    SCFree(packet);
+}

--- a/src/timemachine-packet.h
+++ b/src/timemachine-packet.h
@@ -1,0 +1,51 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * Provides packet related data structures required for the timemachine module 
+ */
+ 
+#ifndef __TIMEMACHINE_PACKET_H__
+#define __TIMEMACHINE_PACKET_H__
+ 
+#include "suricata-common.h"
+#include "timemachine.h"
+ 
+struct TimeMachinePackets_;
+ 
+struct TimeMachinePacket_ {
+    TimeMachineFlow                         *flow;
+    TimeMachineHeap                         *heap;
+    TimeMachineMemPool                      *mem_pool;
+    
+    struct pcap_pkthdr                      header;
+    void                                    *data;
+    TAILQ_ENTRY(TimeMachinePacket_)         next;
+};
+ 
+/* TAILQ Macros */
+TAILQ_HEAD(TimeMachinePackets_, TimeMachinePacket_);
+
+TimeMachinePacket* TimeMachinePacketNew();
+void TimeMachinePacketDestroy(TimeMachinePacket*);
+
+#endif /* __TIMEMACHINE_PACKET_H__ */

--- a/src/timemachine.c
+++ b/src/timemachine.c
@@ -1,0 +1,599 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * In-memory PCAP buffer for retrieving previously seen packets after an alert 
+ * fires
+ */
+
+#include "suricata-common.h"
+#include "debug.h"
+#include "decode.h"
+#include "detect.h"
+#include "conf.h"
+#include "output.h"
+
+#include "threads.h"
+#include "threadvars.h"
+#include "tm-threads.h"
+
+#include "util-error.h"
+#include "util-debug.h"
+#include "util-time.h"
+#include "util-byte.h"
+#include "util-misc.h"
+#include "util-cpu.h"
+#include "util-atomic.h"
+#include "util-time.h"
+
+#include "timemachine.h"
+#include "timemachine-flow.h"
+#include "timemachine-heap.h"
+#include "timemachine-output.h"
+#include "timemachine-packet.h"
+
+#define MODULE_NAME                               "TimeMachine"
+#define DEFAULT_MAX_MEMORY                        1024 * 1024 * 1024
+#define DEFAULT_MAX_PACKET_SIZE                   1500
+#define DEFAULT_HEAP_PREALLOC_COUNT               5000
+#define DEFAULT_HEAP_EXPAND_BY                    1000
+#define DEFAULT_OUTPUT_TIMEOUT                    21600
+
+SC_ATOMIC_DECLARE(uint32_t, thread_cnt);
+
+/* global pcap data for when we're using multi mode. At exit we'll
+ * merge counters into this one and then report counters. */
+static TimeMachineData *g_tm_data = NULL;
+
+static TmEcode TimeMachineProcess(ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
+static TmEcode TimeMachineInit(ThreadVars *, void *, void **);
+static TmEcode TimeMachineDeinit(ThreadVars *, void *);
+static OutputCtx *TimeMachineInitCtx(ConfNode *);
+static void TimeMachineDeInitCtx(OutputCtx *);
+
+void TmModuleTimeMachineRegister(void)
+{
+    tmm_modules[TMM_TIMEMACHINE].name = MODULE_NAME;
+    tmm_modules[TMM_TIMEMACHINE].ThreadInit = TimeMachineInit;
+    tmm_modules[TMM_TIMEMACHINE].Func = TimeMachineProcess;
+    tmm_modules[TMM_TIMEMACHINE].ThreadDeinit = TimeMachineDeinit;
+    tmm_modules[TMM_TIMEMACHINE].RegisterTests = NULL;
+
+    OutputRegisterModule(MODULE_NAME, "timemachine", TimeMachineInitCtx);
+
+    SC_ATOMIC_INIT(thread_cnt);
+    return;
+}
+
+/**
+ * \brief TimeMachine main logging function
+ *
+ * \param t threadvar
+ * \param p packet
+ * \param data thread module specific data
+ * \param pq pre-packet-queue
+ * \param postpq post-packet-queue
+ *
+ * \retval TM_ECODE_OK on succes
+ * \retval TM_ECODE_FAILED on serious error
+ */
+static TmEcode TimeMachineProcess(ThreadVars *t, Packet *p, void *thread_data, PacketQueue *pq,
+                 PacketQueue *postpq)
+{    
+    TimeMachineFlow *flow;
+    TimeMachineHeap *heap;
+    TimeMachineMemPool *mem_pool;
+    TimeMachinePacket *packet;
+    struct pcap_pkthdr pkthdr;
+    struct timeval current_time;
+    
+    TimeGet(&current_time);
+    
+    TimeMachineThreadData *td = (TimeMachineThreadData *)thread_data;
+    TimeMachineData *tm = td->tm_data;
+    
+    /* make sure packet has real data */
+    if (GET_PKT_PAYLOAD_LEN(p) == 0) {
+        return TM_ECODE_OK;
+    }
+    
+    /* check whether a corresponding flow already exists */
+    if (!(flow = TimeMachineFlowLookup(td->flows, p))) {
+        flow = TimeMachineFlowNew(td->flows, p);       
+        td->flow_count++;
+        flow->td = td;
+    }
+       
+    /* if this packet has an alert but flow doesn't have a output, create one */
+    if (p->alerts.cnt > 0 && flow->output == NULL) {
+        flow->output = TimeMachineOutputNew(flow);
+        TAILQ_INSERT_TAIL(&td->outputs, flow->output, next);
+        td->output_count += 1;
+    }
+     
+     /* create the packet header info */
+    pkthdr.ts.tv_sec = p->ts.tv_sec;
+    pkthdr.ts.tv_usec = p->ts.tv_usec;
+    pkthdr.caplen = GET_PKT_LEN(p);
+    pkthdr.len = GET_PKT_LEN(p);
+                                         
+    /* dump the traffic if this has already been marked as a output */
+    if (flow->output != NULL) {
+        pcap_dump((u_char*)flow->output->output_file, &pkthdr, GET_PKT_DATA(p));
+        fflush(flow->output->output_file);
+        memcpy(&flow->output->updated, &current_time, sizeof(struct timeval));
+        
+        /* make this the most recently accessed output */
+        TAILQ_REMOVE(&td->outputs, flow->output, next);
+        TAILQ_INSERT_TAIL(&td->outputs,flow->output, next);
+        
+        return TM_ECODE_OK;
+    } 
+    
+    /* find the queue the packet should fall in */
+    TAILQ_FOREACH(heap, &td->heaps, next) {
+        if (pkthdr.caplen <= heap->conf->max_packet_size) {
+            break;
+        }
+    }
+   
+    /* see if something is already available in the unusued mem pool */
+    if (TAILQ_EMPTY(&heap->unused_mem_pools)) {
+
+        /* first check if the heap can expand, if so then expand it */
+        SCMutexLock(&tm->tm_lock);   
+        if (TimeMachineHeapCanExpand(tm)) {
+            TimeMachineHeapExpand(tm, heap);
+            SCMutexUnlock(&tm->tm_lock);
+        }
+        /* couldn't expand, need to remove the first entry */
+        else {
+            SCMutexUnlock(&tm->tm_lock);
+           
+            TimeMachineFlow* rem_flow;                                                                                                                                                                                                                                        
+            TimeMachineMemPool* rem_mem_pool;
+            TimeMachinePacket* rem_packet;
+            
+            /* get the most recent entry from the heap (packet and flow) */
+            rem_mem_pool = TAILQ_FIRST(&heap->used_mem_pools);
+            rem_packet = rem_mem_pool->packet;
+            rem_flow = rem_packet->flow;
+            
+            TAILQ_REMOVE(&heap->used_mem_pools, rem_mem_pool, next);
+            TAILQ_REMOVE(&rem_flow->packets, rem_packet, next);
+            heap->used_pool_count--;
+            
+            if (rem_flow != flow) {
+                if (TAILQ_EMPTY(&rem_flow->packets)) {
+                    TimeMachineFlowDestroy(td->flows, rem_flow);
+                    SCFree(rem_flow);
+                    td->flow_count--;
+                }
+            }
+            
+            rem_mem_pool->packet = NULL;
+            TAILQ_INSERT_TAIL(&heap->unused_mem_pools, rem_mem_pool, next);
+            TAILQ_INSERT_TAIL(&heap->unused_packets, rem_packet, next);
+            heap->unused_pool_count++;
+        }
+    }
+
+    /* remove the heap from the unusued to used list */        
+    mem_pool = TAILQ_FIRST(&heap->unused_mem_pools);
+    TAILQ_REMOVE(&heap->unused_mem_pools, mem_pool, next);
+    heap->unused_pool_count--;
+    
+    TAILQ_INSERT_TAIL(&heap->used_mem_pools, mem_pool, next);
+    heap->used_pool_count++;
+    
+    /* remove the packet from the unused to used list */
+    packet = TAILQ_FIRST(&heap->unused_packets);
+    TAILQ_REMOVE(&heap->unused_packets, packet, next);
+    TAILQ_INSERT_TAIL(&flow->packets, packet, next);
+ 
+    /* make sure this heap points to the corresponding packet */   
+    mem_pool->packet = packet; 
+    memcpy(&packet->header, &pkthdr, sizeof(struct pcap_pkthdr));
+    
+    packet->data = mem_pool->mem;
+    memcpy(packet->data, GET_PKT_DATA(p), GET_PKT_LEN(p));
+    
+    /* make sure the packet is associated with a flow */
+    packet->flow = flow;
+    flow->packet_count++;
+       
+    /* make sure the packet can reference the heap and mempool */
+    packet->heap = heap;
+    packet->mem_pool = mem_pool;
+    
+    /* remove any open outputs that have been open for a time period */
+    TimeMachineOutput* output = TAILQ_FIRST(&td->outputs);
+    while (td->output_count > 0) {
+        output = TAILQ_FIRST(&td->outputs);
+        if (current_time.tv_sec - output->updated.tv_sec < 600) {
+            break;
+        }     
+
+        /* delete the flow, which will destroy the output */
+        TimeMachineFlowDestroy(td->flows, output->flow);
+        td->flow_count--;
+        
+        /* remove the output from the list of outputs */
+        TAILQ_REMOVE(&td->outputs, output, next);
+        TimeMachineOutputDestroy(output);
+        td->output_count--;          
+    }
+     
+    return TM_ECODE_OK;
+}
+
+static TmEcode TimeMachineInit(ThreadVars *t, void *initdata, void **data)
+{
+    TimeMachineHeapConf *heap_conf;
+
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for TimeMachine. \"initdata\" argument NULL");
+        return TM_ECODE_FAILED;
+    }
+
+    TimeMachineData *tm = ((OutputCtx *)initdata)->data;
+
+    TimeMachineThreadData *td = SCCalloc(1, sizeof(*td));
+    if (unlikely(td == NULL))
+        return TM_ECODE_FAILED;
+
+    /* create the flows tree for this thread */
+    td->flows = SCMalloc(sizeof(TimeMachineFlows));
+    SPLAY_INIT(td->flows);
+    td->flow_count = 0;
+    
+    /* create all the open outputs */
+    TAILQ_INIT(&td->outputs);
+    td->output_count = 0;
+    
+    /* create all the heaps for this thread */
+    TAILQ_INIT(&td->heaps);
+    
+    TAILQ_FOREACH(heap_conf, &tm->heap_confs, next) {
+        SCMutexLock(&tm->tm_lock);
+        TimeMachineHeap* heap = TimeMachineHeapNew(tm, heap_conf);
+        SCMutexUnlock(&tm->tm_lock);
+        
+        TAILQ_INSERT_TAIL(&td->heaps, heap, next);
+        td->heap_count++;
+    }
+        
+    td->tm_data = tm;
+    
+    /* count threads in the global structure */
+    SCMutexLock(&tm->tm_lock);
+    tm->threads++;
+    SCMutexUnlock(&tm->tm_lock);
+
+    *data = (void *)td;
+    return TM_ECODE_OK;
+}
+
+/**
+ *  \brief Thread DeInit function.
+ *
+ *  \param t Thread Variable containing input/output queue, cpu affinity etc.
+ *  \param thread_data TimeMachine thread data.
+ *
+ *  \retval TM_ECODE_OK on succces
+ *  \retval TM_ECODE_FAILED on failure
+ **/
+static TmEcode TimeMachineDeinit(ThreadVars *t, void *thread_data)
+{
+    TimeMachineThreadData *td = (TimeMachineThreadData *)thread_data;
+    
+    /* cleanup all the open output files */
+    while (td->output_count > 0) {
+        TimeMachineOutput* output = TAILQ_FIRST(&td->outputs);
+        TimeMachineFlowDestroy(td->flows, output->flow);
+        td->flow_count--;
+        
+        TAILQ_REMOVE(&td->outputs, output, next);
+        TimeMachineOutputDestroy(output);
+        td->output_count--;          
+    }
+    
+    /* cleanup all the heaps */
+    while (td->heap_count > 0) {
+        TimeMachineHeap* heap = TAILQ_FIRST(&td->heaps);
+        TimeMachineHeapDestroy(heap);
+
+        TAILQ_REMOVE(&td->heaps, heap, next);
+        td->heap_count--;
+    }
+    
+    /* cleanup all the flows */
+    while (td->flow_count > 0) {
+        TimeMachineFlow* flow = TimeMachineFlowFirst(td->flows);
+        TimeMachineFlowDestroy(td->flows, flow);
+        td->flow_count--;
+    }
+        
+    SCFree(td->flows);
+    return TM_ECODE_OK;
+}
+
+/** \brief Fill in timemachine struct from the provided ConfNode.
+ *
+ *  \param conf The configuration node for this output.
+ *
+ *  \retval output_ctx
+ **/
+static OutputCtx *TimeMachineInitCtx(ConfNode *conf) 
+{       
+    TimeMachineData *tm = SCMalloc(sizeof(TimeMachineData));
+
+    if (unlikely(tm == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate Memory for TimeMachineData");
+        exit(EXIT_FAILURE);
+    }
+    memset(tm, 0, sizeof(TimeMachineData));
+
+    SCMutexInit(&tm->tm_lock, NULL);
+
+    tm->max_memory = DEFAULT_MAX_MEMORY;
+    if (conf != NULL) {
+        const char *max_memory_s = NULL;
+        max_memory_s = ConfNodeLookupChildValue(conf, "max-memory");
+        if (max_memory_s != NULL) {
+            if (ParseSizeStringU64(max_memory_s, &tm->max_memory) < 0) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "Failed to initialize max memory for timemachien output "
+                    "invalid limit: %s", max_memory_s);
+                exit(EXIT_FAILURE);
+            }
+        }
+    }
+
+    uint32_t global_heap_prealloc_count = DEFAULT_HEAP_PREALLOC_COUNT;
+    if (conf != NULL) {
+        const char* global_heap_prealloc_count_s = NULL;
+        global_heap_prealloc_count_s = 
+          ConfNodeLookupChildValue(conf, "heap-prealloc-count");
+        
+        if (global_heap_prealloc_count_s != NULL) {
+            if (ByteExtractStringUint32(&global_heap_prealloc_count, 10, 0, 
+                                        global_heap_prealloc_count_s) == -1) {
+              SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                         "timemachine output, invalid heap-packet-prealloc-count: %s",
+                         global_heap_prealloc_count_s);
+              exit(EXIT_FAILURE);
+            } else if (global_heap_prealloc_count < 1) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "Failed to initialize timemachine output, limit less than "
+                    "allowed minimum.");
+                exit(EXIT_FAILURE);
+            } else {
+                tm->heap_prealloc_count = global_heap_prealloc_count;
+            }
+        }
+    }
+
+    uint32_t global_heap_expand_by = DEFAULT_HEAP_EXPAND_BY;
+    if (conf != NULL) {
+        const char* global_heap_expand_by_s = NULL;
+        global_heap_expand_by_s = ConfNodeLookupChildValue(conf, "heap-expand-by");
+        if (global_heap_expand_by_s != NULL) {
+            if (ByteExtractStringUint32(&global_heap_expand_by, 10, 0, 
+                                        global_heap_expand_by_s) == -1) {
+              SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                         "timemachine output, invalid heap-expand-by count: %s",
+                         global_heap_expand_by_s);
+              exit(EXIT_FAILURE);
+            } else if (global_heap_expand_by < 1) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "Failed to initialize timemachine output, limit less than "
+                    "allowed minimum.");
+                exit(EXIT_FAILURE);
+            } else {
+                tm->heap_expand_by = global_heap_expand_by;
+            }
+        }
+    }
+    
+    uint32_t global_output_timeout = DEFAULT_OUTPUT_TIMEOUT;
+    if (conf != NULL) {
+        const char* global_output_timeout_s = NULL;
+        global_output_timeout_s = ConfNodeLookupChildValue(conf, "output-timeout");
+        if (global_output_timeout_s != NULL) {
+            if (ByteExtractStringUint32(&global_output_timeout, 10, 0,
+                                        global_output_timeout_s) == -1) {
+              SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                         "timemachine output, invalid output timeout: %s",
+                         global_output_timeout_s);
+              exit(EXIT_FAILURE);
+            } else if (global_output_timeout < 1) {
+                SCLogError(SC_ERR_INVALID_ARGUMENT,
+                    "Failed to initialize timemachine output, limit less than "
+                    "allowed minimum.");
+                exit(EXIT_FAILURE);
+            } else {
+                tm->output_timeout = global_output_timeout;
+            }
+        }
+    }
+        
+    TAILQ_INIT(&tm->heap_confs);
+
+    if (conf != NULL) {
+        ConfNode* heaps = ConfNodeLookupChild(conf, "heaps");
+        if (heaps != NULL) {
+
+            if (!ConfNodeIsSequence(heaps)) {
+                SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid timemachine "
+                             "heap configuration section, expected a list");
+            }
+            else {
+                ConfNode* heap_conf_node = NULL;
+                TAILQ_FOREACH(heap_conf_node, &heaps->head, next) {
+                    /* create a new heap */
+                    TimeMachineHeapConf *heap_conf = SCMalloc(sizeof(TimeMachineHeapConf));
+                    heap_conf->name = ConfNodeLookupChildValue(heap_conf_node, "name");
+                    if (heap_conf->name == NULL) {
+                        SCLogError(SC_ERR_INVALID_ARGUMENT, "Heaps must have a "
+                                   "corresponding name field");
+                        exit(EXIT_FAILURE);
+                    }
+
+                    const char* max_packet_size_s = NULL;
+                    max_packet_size_s = ConfNodeLookupChildValue(heap_conf_node, "max-packet-size");
+                    if (max_packet_size_s != NULL) {
+                        uint32_t heap_max_packet_size;
+                        if (ByteExtractStringUint32(&heap_max_packet_size, 10, 0, 
+                                                    max_packet_size_s) == -1) {
+                            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                                       "timemachine output, invalidate min_payload count: %s",
+                                       max_packet_size_s);
+                            exit(EXIT_FAILURE);
+                        }
+                        else if (heap_max_packet_size < 1) {
+                            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                                       "timemachine output, max heap packet size cannot "
+                                       "be zero: %s", max_packet_size_s);
+                            exit(EXIT_FAILURE);        
+                        }
+                        else {
+                            heap_conf->max_packet_size = heap_max_packet_size;
+                        }
+                    }
+
+                    const char* heap_prealloc_count_s = NULL;
+                    heap_prealloc_count_s = ConfNodeLookupChildValue(heap_conf_node, "heap-prealloc-count");
+                    if (heap_prealloc_count_s != NULL) {
+                        uint32_t heap_prealloc_count;
+                        if (ByteExtractStringUint32(&heap_prealloc_count, 10, 0, 
+                                                    heap_prealloc_count_s) == -1) {
+                            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                                       "timemachine output, invalid heap-prealloc-count: %s",
+                                       heap_prealloc_count_s);
+                            exit(EXIT_FAILURE);
+                        }
+                        heap_conf->prealloc_count = heap_prealloc_count;
+                    }
+                    else {
+                        heap_conf->prealloc_count = global_heap_prealloc_count;
+                    }
+                    
+                    const char* heap_expand_by_s = NULL;
+                    heap_expand_by_s = ConfNodeLookupChildValue(heap_conf_node, "heap-expand-by");
+                    if (heap_expand_by_s != NULL) {
+                        uint32_t heap_expand_by;
+                        if (ByteExtractStringUint32(&heap_expand_by, 10, 0,
+                                                    heap_expand_by_s) == -1) {
+                            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                                       "timemachine output, invalid heap-expand-by-count: %s",
+                                       heap_expand_by_s);
+                            exit(EXIT_FAILURE);
+                        }
+                        else if (heap_expand_by < 1) {
+                            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                                       "timemachine output, heap_expand_by_count cannot be "
+                                       "zero: %s", heap_expand_by_s);
+                            exit(EXIT_FAILURE);
+                        }
+                        else {
+                            heap_conf->expand_by = heap_expand_by;
+                        }                                        
+                    }
+                    else {
+                        heap_conf->expand_by = global_heap_expand_by;
+                    }
+                    
+                    TAILQ_INSERT_TAIL(&tm->heap_confs, heap_conf, next);
+                }
+            }
+        }
+    }
+
+    /* use the default-packet-size for max_packet_size of default heap */
+    TimeMachineHeapConf *default_heap_conf = SCMalloc(sizeof(TimeMachineHeapConf));
+
+    const char* default_packet_size_s = NULL;
+    default_packet_size_s = ConfNodeLookupChildValue(conf, "default-packet-size");
+    if (default_packet_size_s != NULL) {
+        if (ByteExtractStringUint32(&default_packet_size, 10, 0, 
+                                    default_packet_size_s) == -1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                       "default heap max packet size, using default: %s",
+                       default_packet_size_s);
+            default_heap_conf->max_packet_size = DEFAULT_MAX_PACKET_SIZE;
+        }
+        else if (default_packet_size < 1) {
+            SCLogError(SC_ERR_INVALID_ARGUMENT, "Failed to initialize "
+                       "default heap max packet size, using default: %s",
+                       default_packet_size_s); 
+            default_heap_conf->max_packet_size = DEFAULT_MAX_PACKET_SIZE;                   
+        } 
+        else {
+            default_heap_conf->max_packet_size = DEFAULT_MAX_PACKET_SIZE;
+        }              
+    }
+    else {
+        default_heap_conf->max_packet_size = DEFAULT_MAX_PACKET_SIZE;
+    }
+
+    /* there is always one heap, it's the default heap */
+    default_heap_conf->name = "default";
+    default_heap_conf->expand_by = global_heap_expand_by;
+    default_heap_conf->prealloc_count = global_heap_prealloc_count;
+    TAILQ_INSERT_TAIL(&tm->heap_confs, default_heap_conf, next);
+
+    /* create the output ctx and send it back */
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(OutputCtx));
+    if (unlikely(output_ctx == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for OutputCtx.");
+        exit(EXIT_FAILURE);
+    }
+
+    output_ctx->data = tm;
+    output_ctx->DeInit = TimeMachineDeInitCtx;
+    
+    /* assignment the global tm data struct */
+    g_tm_data = tm;
+    return output_ctx;
+}
+
+/** \brief Deinitialize the time machine context
+ *  \param output_ctx The output context generated from TimeMachineInitCtx
+ **/
+static void TimeMachineDeInitCtx(OutputCtx *output_ctx)
+{
+    if (output_ctx == NULL) 
+        return;
+        
+    TimeMachineData *tm = output_ctx->data;
+    
+    TimeMachineHeapConf *heap_conf = NULL;
+    while (!TAILQ_EMPTY(&tm->heap_confs)) {
+        heap_conf = TAILQ_FIRST(&tm->heap_confs);
+        TAILQ_REMOVE(&tm->heap_confs, heap_conf, next);
+        SCFree(heap_conf);
+    }
+
+    SCFree(output_ctx);
+    return;
+}

--- a/src/timemachine.h
+++ b/src/timemachine.h
@@ -1,0 +1,76 @@
+/* Copyright (C) 2007-2014 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+
+/**
+ * \file
+ *
+ * \author Mat Oldham <mat.oldham@gmail.com>
+ *
+ * In-memory PCAP buffer for retrieving previously seen packets after an alert 
+ * fires
+ */
+
+#ifndef __TIMEMACHINE_H__
+#define __TIMEMACHINE_H__
+
+typedef struct TimeMachineData_ TimeMachineData;
+typedef struct TimeMachineThreadData_ TimeMachineThreadData;
+typedef struct TimeMachineFlow_ TimeMachineFlow;
+typedef struct TimeMachineFlows_ TimeMachineFlows;
+typedef struct TimeMachineFlowNode_ TimeMachineFlowNode;
+typedef struct TimeMachineHeap_ TimeMachineHeap;
+typedef struct TimeMachineHeapConf_ TimeMachineHeapConf;
+typedef struct TimeMachineMemPool_ TimeMachineMemPool;
+typedef struct TimeMachineMemPools_ TimeMachineMemPools;
+typedef struct TimeMachineOutput_ TimeMachineOutput;
+typedef struct TimeMachinePacket_ TimeMachinePacket;
+typedef struct TimeMachinePackets_ TimeMachinePackets;
+
+/* main time machine struct to hold config data */
+struct TimeMachineData_ {
+    uint64_t                            max_memory;
+    uint64_t                            current_memory;
+    uint32_t                            min_payload; 
+    uint32_t                            heap_prealloc_count;
+    uint32_t                            heap_expand_by;
+    uint32_t                            heap_count;
+    uint32_t                            output_count;
+    uint32_t                            output_timeout;
+        
+    SCMutex                             tm_lock;  
+
+    TAILQ_HEAD(,TimeMachineHeapConf_)   heap_confs;
+    int                                 threads; 
+};
+
+struct TimeMachineThreadData_ {
+    TimeMachineData                     *tm_data;
+
+    uint32_t                            heap_count;
+    TAILQ_HEAD(,TimeMachineHeap_)       heaps;
+    
+    uint32_t                            flow_count;
+    TimeMachineFlows                    *flows;
+    
+    uint32_t                            output_count;    
+    TAILQ_HEAD(,TimeMachineOutput_)     outputs;
+};
+
+void TmModuleTimeMachineRegister(void);
+
+#endif /* __TIMEMACHINE_H__ */

--- a/src/tm-modules.c
+++ b/src/tm-modules.c
@@ -275,7 +275,8 @@ const char * TmModuleTmmIdToString(TmmId id)
         CASE_CODE (TMM_RECEIVENETMAP);
         CASE_CODE (TMM_DECODENETMAP);
         CASE_CODE (TMM_TLSSTORE);
-
+        CASE_CODE (TMM_TIMEMACHINE);
+        
         CASE_CODE (TMM_SIZE);
     }
     return "<unknown>";

--- a/src/tm-threads-common.h
+++ b/src/tm-threads-common.h
@@ -110,6 +110,7 @@ typedef enum {
 
     TMM_LUALOG,
     TMM_TLSSTORE,
+    TMM_TIMEMACHINE,
     TMM_SIZE,
 } TmmId;
 

--- a/src/util-path.c
+++ b/src/util-path.c
@@ -64,3 +64,26 @@ int PathIsRelative(const char *path)
 {
     return PathIsAbsolute(path) ? 0 : 1;
 }
+
+/**
+ *  \brief Given a string recusrively create a path of directories
+ *
+ *  \param path string with the path
+ *  \param mode directory mode
+ *
+ *  \retval 0 if the path was created successfully 
+ */
+int MakePath(char* file_path, mode_t mode) {
+    char* p;
+    for (p=strchr(file_path+1, '/'); p; p=strchr(p+1, '/')) {
+        *p='\0';
+        if (mkdir(file_path, mode)==-1) {
+            if (errno != EEXIST) {
+                *p='/';
+                return -1;
+            }
+        }
+        *p='/';
+    }
+    return 0;
+}

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -359,6 +359,53 @@ outputs:
       scripts:
       #   - script1.lua
 
+  # Timemachine keeps a list of connections and packets in memory for almost
+  # all packets and connections seen.  This can be useful when an alert fires 
+  # further in a stream (e.g. a string in an HTTP response), however there may
+  # be useful information at the beginning of the stream (like the HTTP request).
+  #
+  # Once an alarm fires, timemachine will output all previous packets to disk
+  # and subsequently continue logging the rest of the stream.
+  - timemachine:
+      enabled: yes
+
+      # Max packet size (packets greater than this will be truncated)
+      packet-size: 1500
+
+      # The maximum system memory to use for time machine
+      max-memory: 1024gb
+
+      # The amount of pre-allocated heap spaces to generate (note: this
+      # does not account for max-memory requirements) (this can be overriden
+      # per heap)
+      heap-prealloc-count: 5000
+
+      # The number of elements to expand a heap by (this can be overriden
+      # per heap)
+      heap-expand-by: 1000
+
+      # The maximum amount of time an output file should be open.  Anything
+      # beyond this timeout will cause for a truncated session.
+      output-timeout: 21600
+
+      # Timemachine creates a heap of "existing" packets and re-uses those 
+      # pre-created packets for speed.  This has a downside where not all 
+      # memory is used because the packets are a predefined size.  Since we do 
+      # this, we go ahead and break the heap into different configerable sizes.
+      heaps: 
+          -   
+              name: micro
+              max-packet-size: 200
+          -
+              name: small
+              max-packet-size: 400
+          -
+              name: medium
+              max-packet-size: 800
+          -
+              name: normal
+              max-packet-size: 1500
+
 # Magic file. The extension .mgc is added to the value here.
 #magic-file: /usr/share/file/magic
 magic-file: @e_magic_file@


### PR DESCRIPTION
TimeMachine provides a fast way to store captured network traffic in memory.  When an alarm fires, TimeMachine will identify the associated stream and dump all data from memory to disk and will continue to dump all data to disk.  With enough memory, this allows for storing the beginning of sessions (e.g. if you have a signature that hits on an HTTP response, you can actually output the entire HTTP stream including the original HTTP request).

Addresses feature request #120 Capture full session on alert - https://redmine.openinfosecfoundation.org/issues/120