### PR TITLE
af-packet: don't activate rollover by default

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -478,7 +478,7 @@ af-packet:
   - interface: default
     #threads: auto
     #use-mmap: yes
-    rollover: yes
+    #rollover: yes
 
 # Netmap support
 #


### PR DESCRIPTION
Rollover option is causing issue with TCP streaming code because
packets from the same flow to be treated out of order. As long as
the situation is not fixed in the streaming engine, it is a bad idea
to enable it by default.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/89
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/87
