### PR TITLE
travis: move off legacy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,34 @@ compiler:
   - clang
 # Change this to your needs
 script: sh autogen.sh && ./configure --enable-nfqueue --enable-unittests && make && make check
+addons:
+  apt:
+    packages:
+    - libpcre3
+    - libpcre3-dbg
+    - libpcre3-dev
+    - build-essential
+    - autoconf
+    - automake
+    - libtool
+    - libpcap-dev
+    - libnet1-dev
+    - libyaml-0-2
+    - libyaml-dev
+    - zlib1g
+    - zlib1g-dev
+    - libcap-ng-dev
+    - libcap-ng0
+    - make
+    - libmagic-dev
+    - libnetfilter-queue-dev
+    - libnetfilter-queue1
+    - libnfnetlink-dev
+    - libnfnetlink0
+    - coccinelle
 before_install:
-  - sudo add-apt-repository -y ppa:npalix/coccinelle
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 coccinelle
+#  - sudo add-apt-repository -y ppa:npalix/coccinelle
+#  - sudo apt-get update -qq
+#  - sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 coccinelle
   - ./qa/travis-libhtp.sh
-
+sudo: false


### PR DESCRIPTION
http://docs.travis-ci.com/user/migrating-from-legacy

Currently fails to build:

<pre>
Disallowing packages: libpcre3-dbg, libnet1-dev, libcap-ng-dev, libcap-ng0, libnetfilter-queue-dev, libnetfilter-queue1, coccinelle

If you require these packages, please review the package approval process at: https://github.com/travis-ci/apt-package-whitelist#package-approval-process
</pre>
