### PR TITLE
DNS: refactor tx completion logic

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -223,24 +223,26 @@ uint64_t DNSGetTxCnt(void *alstate)
 int DNSGetAlstateProgress(void *tx, uint8_t direction)
 {
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
-    if (direction & STREAM_TOCLIENT)
-        return (dns_tx->replied|dns_tx->reply_lost) ? 2 : 1;
+    if (direction & STREAM_TOCLIENT) {
+        /* response side of the tx is done if we parsed a reply
+         * or if we tagged this tx as 'reply lost'. */
+        return (dns_tx->replied|dns_tx->reply_lost) ? 1 : 0;
+    }
     else {
-        /* toserver/query is complete if we have stored a query */
-        return (TAILQ_FIRST(&dns_tx->query_list) != NULL);
+        /* tx is only created if we have a complete request,
+         * or if we lost the request. Either way, if we have
+         * a tx it we consider the request complete. */
+        return 1;
     }
 }
 
 /** \brief get value for 'complete' status in DNS
  *
- *  For DNS we use a simple bool.
+ *  For DNS we use a simple bool. 1 means done.
  */
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction)
 {
-    if (direction & STREAM_TOCLIENT)
-        return 2;
-    else
-        return 1;
+    return 1;
 }
 
 void DNSSetEvent(DNSState *s, uint8_t e)


### PR DESCRIPTION
Use simple bool values to track the transaction state in both directions.

A tx is only created in two cases:
1. full request parsed
2. response parsed (request missing)

This is true even for multi-packet TCP requests.

This leads to the following tx completion logic for the request side:
the presence of a tx implies the request is complete

On the response side, we consider the tx complete when we have seen
the response. If the DNS parser thinks the response was lost, we also
flag the response side as complete.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/274
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/276