### PR TITLE
stream_size operator comparison (fix issue #1488)

### DIFF
--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -241,19 +241,19 @@ DetectStreamSizeData *DetectStreamSizeParse (char *streamstr) {
     if (strlen(mode) == 0)
         goto error;
 
-    if (mode[0] == '<')
-        sd->mode = DETECTSSIZE_LT;
-    else if (strcmp("<=", mode) == 0)
-        sd->mode = DETECTSSIZE_LEQ;
-    else if (mode[0] == '>')
-        sd->mode = DETECTSSIZE_GT;
-    else if (strcmp(">=", mode) == 0)
-        sd->mode = DETECTSSIZE_GEQ;
-    else if (strcmp("!=", mode) == 0)
-        sd->mode = DETECTSSIZE_NEQ;
-    else if (mode[0] == '=')
+    if (mode[0] == '=') {
         sd->mode = DETECTSSIZE_EQ;
-    else {
+    } else if (mode[0] == '<') {
+        sd->mode = DETECTSSIZE_LT;
+        if (strcmp("<=", mode) == 0)
+            sd->mode = DETECTSSIZE_LEQ;
+    } else if (mode[0] == '>') {
+        sd->mode = DETECTSSIZE_GT;
+        if (strcmp(">=", mode) == 0)
+            sd->mode = DETECTSSIZE_GEQ;
+    } else if (strcmp("!=", mode) == 0) {
+        sd->mode = DETECTSSIZE_NEQ;
+    } else {
         SCLogError(SC_ERR_INVALID_OPERATOR, "Invalid operator");
         goto error;
     }


### PR DESCRIPTION
`DetectStreamSizeParse` was first checking if mode[0] is '<', which is true for both '<' and '<=', thus '<=' (and resp. '>=') is never matched. This patch does the `strcmp` to '<=' (resp. '>=') within the if block of '<' (resp. '>') to fix #1488.

Backport into 2.0.x

PRScript:
- PR build: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/281
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/279