### PR TITLE
Store previous value to pvalue variable per thread

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -706,6 +706,7 @@ static int StatsOutput(ThreadVars *tv)
             StatsRecord *r = &stats_table.tstats[offset];
             r->name = table[c].name;
             r->tm_name = sts->name;
+            r->pvalue = r->value;
 
             switch (e->type) {
                 case STATS_TYPE_AVERAGE:

--- a/src/counters.c
+++ b/src/counters.c
@@ -45,19 +45,6 @@
 #define STATS_MGMTT_TTS 8
 
 /**
- * \brief Different kinds of qualifier that can be used to modify the behaviour
- *        of the counter to be registered
- */
-enum {
-    STATS_TYPE_NORMAL = 1,
-    STATS_TYPE_AVERAGE = 2,
-    STATS_TYPE_MAXIMUM = 3,
-    STATS_TYPE_FUNC = 4,
-
-    STATS_TYPE_MAX = 5,
-};
-
-/**
  * \brief per thread store of counters
  */
 typedef struct StatsThreadStore_ {
@@ -707,6 +694,7 @@ static int StatsOutput(ThreadVars *tv)
             r->name = table[c].name;
             r->tm_name = sts->name;
             r->pvalue = r->value;
+            r->type = e->type;
 
             switch (e->type) {
                 case STATS_TYPE_AVERAGE:
@@ -733,6 +721,7 @@ static int StatsOutput(ThreadVars *tv)
         table[x].tm_name = "Total";
 
         struct CountersMergeTable *m = &merge_table[x];
+        table[x].type = m->type;
         switch (m->type) {
             case STATS_TYPE_MAXIMUM:
                 if (m->value > table[x].value)

--- a/src/counters.h
+++ b/src/counters.h
@@ -25,6 +25,21 @@
 #ifndef __COUNTERS_H__
 #define __COUNTERS_H__
 
+/**
+ * \brief Different kinds of qualifier that can be used to modify the behaviour
+ *        of the counter to be registered
+ */
+typedef enum {
+    STATS_TYPE_NORMAL = 1,
+    STATS_TYPE_AVERAGE = 2,
+    STATS_TYPE_MAXIMUM = 3,
+    STATS_TYPE_FUNC = 4,
+
+    STATS_TYPE_MAX = 5,
+} StatsType;
+
+
+
 /* forward declaration of the ThreadVars structure */
 struct ThreadVars_;
 

--- a/src/output-stats.h
+++ b/src/output-stats.h
@@ -26,7 +26,10 @@
 #ifndef __OUTPUT_STATS_H__
 #define __OUTPUT_STATS_H__
 
+#include "counters.h"
+
 typedef struct StatsRecord_ {
+    StatsType type;
     const char *name;
     const char *tm_name;
     uint64_t value;         /**< total value */


### PR DESCRIPTION
Storing of previous value is done just for "Totals" counters. I believe that it should be stored also per thread.