### PR TITLE
docker: add ASAN to pcaps build

### DIFF
--- a/qa/docker/buildbot.cfg
+++ b/qa/docker/buildbot.cfg
@@ -126,7 +126,7 @@ pcaps_list = [ os.path.join(PCAP_PATH, pcap) for pcap in pcaps_list if pcap.ends
 factory_stress_pcap = SuriBuildFactory()
 # run the tests (note that this will require that 'trial' is installed)
 factory_stress_pcap.addStep(ShellCommand(command=["./autogen.sh"]))
-factory_stress_pcap.addStep(ShellCommand(command=["./configure","--enable-debug-validation"]))
+factory_stress_pcap.addStep(ShellCommand(command=["./configure","--enable-debug-validation"],env={"CFLAGS" : "-fsanitize=address -fno-omit-frame-pointer"}))
 factory_stress_pcap.addStep(ShellCommand(command=["make"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "make","install"]))
 factory_stress_pcap.addStep(ShellCommand(command=["sudo", "rm", "-f", "/usr/local/etc/suricata/suricata.yaml"]))


### PR DESCRIPTION
This patch updates the pcaps build to use ASAN.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/90
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/88