### PR TITLE
Flowvar eve dump

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -185,7 +185,7 @@ static void AlertJsonFlowVars(const Flow *f, json_t *js)
                 json_object_set_new(fvjs, tag, json_integer((long)fv->data.fv_int.value));
                 SCLogDebug("outputting a flowint: %d %d", fv->idx, fv->data.fv_int.value);
             } else {
-                SCLogDebug("found a flowvar with bad datatype %d", fv->datatype) ;
+                SCLogError("found a flowvar with bad datatype %d", fv->datatype) ;
             }
         }
     }
@@ -309,8 +309,6 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 FLOWLOCK_UNLOCK(p->flow);
             }
         }
-
-        SCLogDebug("This is where I want to dump PktVars/FlowVars");
 
         //Dump Pktvars to eve.json
         if(json_output_ctx->flags & LOG_JSON_PKTVARS) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -108,6 +108,8 @@ outputs:
             # http: yes              # enable dumping of http fields
             # tls: yes               # enable dumping of tls fields
             # ssh: yes               # enable dumping of ssh fields
+            # flowvars: no           # enable dumping of flowvars
+            # pktvars: no            # enable dumping of pktvars
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)


### PR DESCRIPTION
This is slightly a work in progress, but it is (to me) useful in its current state as it allows to use lua to extract parts of the payload data and inspect them in the eve log.  My next aim is to improve what is done here by adding flowvar names also into the eve log,  but this seems a bit involved as the variable names exist only in the detect engine context, and not in the flow->flowvar list.