### PR TITLE
app-layer template: add mpm for buffer -v1

### DIFF
--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -478,6 +478,8 @@ static void EngineAnalysisRulesPrintFP(Signature *s)
         fprintf(rule_engine_analysis_FD, "http user agent content");
     else if (list_type == DETECT_SM_LIST_DNSQUERYNAME_MATCH)
         fprintf(rule_engine_analysis_FD, "dns query name content");
+    else if (list_type == DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH)
+        fprintf(rule_engine_analysis_FD, "template buffer content");
 
     fprintf(rule_engine_analysis_FD, "\" buffer.\n");
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -680,6 +680,43 @@ uint32_t DnsQueryPatternSearch(DetectEngineThreadCtx *det_ctx,
     SCReturnUInt(ret);
 }
 
+/**
+ * \brief Template buffer match -- searches for one pattern per signature.
+ *
+ * \param det_ctx      Detection engine thread ctx.
+ * \param buffer       Buffer to inspect.
+ * \param buffer_len   Buffer length.
+ * \param flags        Flags
+ *
+ *  \retval ret Number of matches.
+ */
+uint32_t TemplateBufferPatternSearch(DetectEngineThreadCtx *det_ctx,
+    uint8_t *buffer, uint32_t buffer_len, uint8_t flags)
+{
+    SCEnter();
+
+    uint32_t ret = 0;
+
+    if (flags & STREAM_TOSERVER) {
+        if (det_ctx->sgh->mpm_template_buffer_ctx_ts == NULL)
+            SCReturnUInt(0);
+
+        ret = mpm_table[det_ctx->sgh->mpm_template_buffer_ctx_ts->mpm_type].
+            Search(det_ctx->sgh->mpm_template_buffer_ctx_ts, &det_ctx->mtcu,
+                   &det_ctx->pmq, buffer, buffer_len);
+    }
+    else if (flags & STREAM_TOCLIENT) {
+        if (det_ctx->sgh->mpm_template_buffer_ctx_tc == NULL)
+            SCReturnUInt(0);
+
+        ret = mpm_table[det_ctx->sgh->mpm_template_buffer_ctx_tc->mpm_type].
+            Search(det_ctx->sgh->mpm_template_buffer_ctx_tc, &det_ctx->mtcu,
+                   &det_ctx->pmq, buffer, buffer_len);
+    }
+
+    SCReturnUInt(ret);
+}
+
 /** \brief Pattern match -- searches for only one pattern per signature.
  *
  *  \param det_ctx detection engine thread ctx
@@ -1094,6 +1131,22 @@ void PatternMatchDestroyGroup(SigGroupHead *sh)
         sh->mpm_dnsquery_ctx_ts = NULL;
     }
 
+    /* Template buffer. */
+    if (sh->mpm_template_buffer_ctx_ts != NULL) {
+        if (!sh->mpm_template_buffer_ctx_ts->global) {
+            mpm_table[sh->mpm_template_buffer_ctx_ts->mpm_type].DestroyCtx(sh->mpm_template_buffer_ctx_ts);
+            SCFree(sh->mpm_template_buffer_ctx_ts);
+        }
+        sh->mpm_template_buffer_ctx_ts = NULL;
+    }
+    if (sh->mpm_template_buffer_ctx_tc != NULL) {
+        if (!sh->mpm_template_buffer_ctx_tc->global) {
+            mpm_table[sh->mpm_template_buffer_ctx_tc->mpm_type].DestroyCtx(sh->mpm_template_buffer_ctx_tc);
+            SCFree(sh->mpm_template_buffer_ctx_tc);
+        }
+        sh->mpm_template_buffer_ctx_tc = NULL;
+    }
+
     return;
 }
 
@@ -1497,6 +1550,7 @@ static void PopulateMpmAddPatternToMpm(DetectEngineCtx *de_ctx,
         case DETECT_SM_LIST_HHHDMATCH:
         case DETECT_SM_LIST_HRHHDMATCH:
         case DETECT_SM_LIST_DNSQUERYNAME_MATCH:
+        case DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH:
         {
             MpmCtx *mpm_ctx_ts = NULL;
             MpmCtx *mpm_ctx_tc = NULL;
@@ -1611,6 +1665,15 @@ static void PopulateMpmAddPatternToMpm(DetectEngineCtx *de_ctx,
                 if (s->flags & SIG_FLAG_TOCLIENT)
                     mpm_ctx_tc = NULL;
                 sgh->flags |= SIG_GROUP_HEAD_MPM_DNSQUERY;
+                s->flags |= SIG_FLAG_MPM_APPLAYER;
+                if (cd->flags & DETECT_CONTENT_NEGATED)
+                    s->flags |= SIG_FLAG_MPM_APPLAYER_NEG;
+            } else if (sm_list == DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH) {
+                if (s->flags & SIG_FLAG_TOSERVER)
+                    mpm_ctx_ts = sgh->mpm_template_buffer_ctx_ts;
+                if (s->flags & SIG_FLAG_TOCLIENT)
+                    mpm_ctx_tc = sgh->mpm_template_buffer_ctx_tc;
+                sgh->flags |= SIG_GROUP_HEAD_MPM_TEMPLATE_BUFFER;
                 s->flags |= SIG_FLAG_MPM_APPLAYER;
                 if (cd->flags & DETECT_CONTENT_NEGATED)
                     s->flags |= SIG_FLAG_MPM_APPLAYER_NEG;
@@ -2005,6 +2068,8 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
     uint32_t sig = 0;
     /* sgh has at least one sig with dns_query */
     int has_co_dnsquery = 0;
+    /* sgh has at least one sig with template_buffer */
+    int has_co_template_buffer = 0;
 
     /* see if this head has content and/or uricontent */
     for (sig = 0; sig < sh->sig_cnt; sig++) {
@@ -2080,6 +2145,11 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
 
         if (s->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH] != NULL) {
             has_co_dnsquery = 1;
+        }
+
+        if (s->sm_lists[DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH] != NULL) {
+            has_co_template_buffer = 1;
+            SCLogNotice("Setting has_co_template_buffer = 1.");
         }
     }
 
@@ -2362,6 +2432,33 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
         MpmInitCtx(sh->mpm_dnsquery_ctx_ts, de_ctx->mpm_matcher);
     }
 
+    if (has_co_template_buffer) {
+        if (de_ctx->sgh_mpm_context == ENGINE_SGH_MPM_FACTORY_CONTEXT_SINGLE) {
+            sh->mpm_template_buffer_ctx_ts = MpmFactoryGetMpmCtxForProfile(de_ctx,
+                de_ctx->sgh_mpm_context_template_buffer, 0);
+            sh->mpm_template_buffer_ctx_tc = MpmFactoryGetMpmCtxForProfile(de_ctx,
+                de_ctx->sgh_mpm_context_template_buffer, 1);
+        } else {
+            sh->mpm_template_buffer_ctx_ts = MpmFactoryGetMpmCtxForProfile(de_ctx,
+                MPM_CTX_FACTORY_UNIQUE_CONTEXT, 0);
+            sh->mpm_template_buffer_ctx_tc = MpmFactoryGetMpmCtxForProfile(de_ctx,
+                MPM_CTX_FACTORY_UNIQUE_CONTEXT, 1);
+        }
+        if (sh->mpm_template_buffer_ctx_ts == NULL) {
+            SCLogDebug("sh->mpm_template_buffer_ctx_ts == NULL. This should never happen");
+            exit(EXIT_FAILURE);
+        }
+        if (sh->mpm_template_buffer_ctx_tc == NULL) {
+            SCLogDebug("sh->mpm_template_buffer_ctx_tc == NULL. This should never happen");
+            exit(EXIT_FAILURE);
+        }
+
+        MpmInitCtx(sh->mpm_template_buffer_ctx_ts, de_ctx->mpm_matcher);
+        MpmInitCtx(sh->mpm_template_buffer_ctx_tc, de_ctx->mpm_matcher);
+
+        SCLogNotice("MPM content for template buffer setup.");
+    }
+
     if (has_co_packet ||
         has_co_stream ||
         has_co_uri ||
@@ -2378,7 +2475,8 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
         has_co_huad ||
         has_co_hhhd ||
         has_co_hrhhd ||
-        has_co_dnsquery)
+        has_co_dnsquery ||
+        has_co_template_buffer)
     {
 
         PatternMatchPreparePopulateMpm(de_ctx, sh);
@@ -2688,6 +2786,33 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
                  }
              }
          }
+
+         if (sh->mpm_template_buffer_ctx_ts != NULL) {
+             if (sh->mpm_template_buffer_ctx_ts->pattern_cnt == 0) {
+                 SCLogNotice("Template buffer pattern count is 0, reclaiming MPM.");
+                 MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_template_buffer_ctx_ts);
+                 sh->mpm_template_buffer_ctx_ts = NULL;
+             } else {
+                 if (de_ctx->sgh_mpm_context == ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL) {
+                     if (mpm_table[sh->mpm_template_buffer_ctx_ts->mpm_type].Prepare != NULL)
+                         mpm_table[sh->mpm_template_buffer_ctx_ts->mpm_type].Prepare(sh->mpm_template_buffer_ctx_ts);
+                 }
+             }
+         }
+
+         if (sh->mpm_template_buffer_ctx_tc != NULL) {
+             if (sh->mpm_template_buffer_ctx_tc->pattern_cnt == 0) {
+                 SCLogNotice("Template buffer pattern count is 0, reclaiming MPM.");
+                 MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_template_buffer_ctx_tc);
+                 sh->mpm_template_buffer_ctx_tc = NULL;
+             } else {
+                 if (de_ctx->sgh_mpm_context == ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL) {
+                     if (mpm_table[sh->mpm_template_buffer_ctx_tc->mpm_type].Prepare != NULL)
+                         mpm_table[sh->mpm_template_buffer_ctx_tc->mpm_type].Prepare(sh->mpm_template_buffer_ctx_tc);
+                 }
+             }
+         }
+
         //} /* if (de_ctx->sgh_mpm_context == ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL) */
     } else {
         MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_proto_other_ctx);
@@ -2723,6 +2848,8 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
         sh->mpm_dnsquery_ctx_ts = NULL;
         MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_smtp_filedata_ctx_ts);
         sh->mpm_smtp_filedata_ctx_ts = NULL;
+        MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_template_buffer_ctx_ts);
+        sh->mpm_template_buffer_ctx_ts = NULL;
 
         MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_proto_tcp_ctx_tc);
         sh->mpm_proto_tcp_ctx_tc = NULL;
@@ -2740,6 +2867,8 @@ int PatternMatchPrepareGroup(DetectEngineCtx *de_ctx, SigGroupHead *sh)
         sh->mpm_hsmd_ctx_tc = NULL;
         MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_hscd_ctx_tc);
         sh->mpm_hscd_ctx_tc = NULL;
+        MpmFactoryReClaimMpmCtx(de_ctx, sh->mpm_template_buffer_ctx_tc);
+        sh->mpm_template_buffer_ctx_tc = NULL;
     }
 
     return 0;

--- a/src/detect-engine-mpm.h
+++ b/src/detect-engine-mpm.h
@@ -53,6 +53,7 @@ uint32_t HttpHHPatternSearch(DetectEngineThreadCtx *, uint8_t *, uint32_t, uint8
 uint32_t HttpHRHPatternSearch(DetectEngineThreadCtx *, uint8_t *, uint32_t, uint8_t);
 uint32_t DnsQueryPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
 uint32_t SMTPFiledataPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
+uint32_t TemplateBufferPatternSearch(DetectEngineThreadCtx *det_ctx, uint8_t *buffer, uint32_t buffer_len, uint8_t flags);
 
 void PacketPatternCleanup(ThreadVars *, DetectEngineThreadCtx *);
 void StreamPatternCleanup(ThreadVars *t, DetectEngineThreadCtx *det_ctx, StreamMsg *smsg);

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -135,6 +135,7 @@ void SupportFastPatternForSigMatchTypes(void)
     SupportFastPatternForSigMatchList(DETECT_SM_LIST_HSMDMATCH, 3);
 
     SupportFastPatternForSigMatchList(DETECT_SM_LIST_DNSQUERYNAME_MATCH, 2);
+    SupportFastPatternForSigMatchList(DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH, 2);
 
 #if 0
     SCFPSupportSMList *tmp = sm_fp_support_smlist_list;
@@ -225,6 +226,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, char *a
         s->sm_lists_tail[DETECT_SM_LIST_HUADMATCH] == NULL &&
         s->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH] == NULL &&
         s->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH] == NULL &&
+        s->sm_lists_tail[DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH] == NULL &&
         s->sm_lists_tail[DETECT_SM_LIST_DNSQUERYNAME_MATCH] == NULL) {
         SCLogWarning(SC_WARN_COMPATIBILITY, "fast_pattern found inside the "
                      "rule, without a preceding content based keyword.  "
@@ -232,8 +234,8 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, char *a
                      "uricontent, http_client_body, http_server_body, http_header, "
                      "http_raw_header, http_method, http_cookie, "
                      "http_raw_uri, http_stat_msg, http_stat_code, "
-                     "http_user_agent, http_host, http_raw_host or "
-                     "dns_query option");
+                     "http_user_agent, http_host, http_raw_host, dns_query "
+                     "or template_buffer option");
         return -1;
     }
 
@@ -252,6 +254,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, char *a
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_HUADMATCH],
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH],
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH],
+            DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH],
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_DNSQUERYNAME_MATCH]);
     if (pm == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "fast_pattern found inside "

--- a/src/detect-template-buffer.h
+++ b/src/detect-template-buffer.h
@@ -21,5 +21,7 @@
 #include "app-layer-template.h"
 
 void DetectTemplateBufferRegister(void);
+uint32_t DetectTemplateBufferInspectMpm(DetectEngineThreadCtx *, Flow *,
+    TemplateState *, uint8_t, void *, uint64_t);
 
 #endif /* __DETECT_TEMPLATE_BUFFER_H__ */

--- a/src/detect.h
+++ b/src/detect.h
@@ -686,6 +686,7 @@ typedef struct DetectEngineCtx_ {
     int32_t sgh_mpm_context_app_proto_detect;
     int32_t sgh_mpm_context_dnsquery;
     int32_t sgh_mpm_context_smtp;
+    int32_t sgh_mpm_context_template_buffer;
 
     /* the max local id used amongst all sigs */
     int32_t byte_extract_max_local_id;
@@ -966,6 +967,7 @@ typedef struct SigTableElmt_ {
 #define SIG_GROUP_HEAD_HAVEFILESIZE     (1 << 22)
 #define SIG_GROUP_HEAD_MPM_DNSQUERY     (1 << 23)
 #define SIG_GROUP_HEAD_MPM_FD_SMTP      (1 << 24)
+#define SIG_GROUP_HEAD_MPM_TEMPLATE_BUFFER (1 << 25)
 
 typedef struct SigGroupHeadInitData_ {
     /* list of content containers */
@@ -1023,6 +1025,7 @@ typedef struct SigGroupHead_ {
     MpmCtx *mpm_hrhhd_ctx_ts;
     MpmCtx *mpm_dnsquery_ctx_ts;
     MpmCtx *mpm_smtp_filedata_ctx_ts;
+    MpmCtx *mpm_template_buffer_ctx_ts;
 
     MpmCtx *mpm_proto_tcp_ctx_tc;
     MpmCtx *mpm_proto_udp_ctx_tc;
@@ -1033,6 +1036,7 @@ typedef struct SigGroupHead_ {
     MpmCtx *mpm_hcd_ctx_tc;
     MpmCtx *mpm_hsmd_ctx_tc;
     MpmCtx *mpm_hscd_ctx_tc;
+    MpmCtx *mpm_template_buffer_ctx_tc;
 
     uint16_t mpm_uricontent_maxlen;
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -314,6 +314,7 @@ typedef enum PacketProfileDetectId_ {
     PROF_DETECT_CLEANUP,
     PROF_DETECT_GETSGH,
     PROF_DETECT_MPM_FD_SMTP,
+    PROF_DETECT_MPM_TEMPLATE_BUFFER,
 
     PROF_DETECT_SIZE,
 } PacketProfileDetectId;


### PR DESCRIPTION
Adds MPM for decoded application layer buffer.

NOTE: The changes to detect-fast-pattern.c were required
for the MPM to be called, but the fast_pattern keyword
errors out at the moment. I'm not sure whats going on here right now.

Is the fast pattern stuff required for the MPM?

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/127
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/128
