### PR TITLE
Enhanced smtp v1.4

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -4537,6 +4537,16 @@ int SMTPParserTest14(void)
         SCMutexUnlock(&f.m);
         goto end;
     }
+
+    if ((smtp_state->curr_tx->mail_from_len != 14) ||
+        strncmp("asdff@asdf.com", (char *)smtp_state->curr_tx->mail_from, 14)) {
+        printf("incorrect parsing of MAIL FROM field '%s' (%d)\n",
+               smtp_state->curr_tx->mail_from,
+               smtp_state->curr_tx->mail_from_len);
+        SCMutexUnlock(&f.m);
+        goto end;
+    }
+
     SCMutexUnlock(&f.m);
     if (smtp_state->input_len != 0 ||
             smtp_state->cmds_cnt != 0 ||

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -4493,6 +4493,13 @@ int SMTPParserTest14(void)
         SCMutexUnlock(&f.m);
         goto end;
     }
+
+    if ((smtp_state->helo_len != 7) || strncmp("boo.com", (char *)smtp_state->helo, 7)) {
+        printf("incorrect parsing of HELO field '%s' (%d)\n", smtp_state->helo, smtp_state->helo_len);
+        SCMutexUnlock(&f.m);
+        goto end;
+    }
+
     SCMutexUnlock(&f.m);
     if (smtp_state->input_len != 0 ||
             smtp_state->cmds_cnt != 0 ||

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -369,7 +369,7 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
             if (smtp_state->files_ts == NULL) {
                 ret = MIME_DEC_ERR_MEM;
                 SCLogError(SC_ERR_MEM_ALLOC, "Could not create file container");
-                goto end;
+                SCReturnInt(ret);
             }
         }
         files = smtp_state->files_ts;
@@ -451,7 +451,7 @@ int SMTPProcessDataChunk(const uint8_t *chunk, uint32_t len,
     if (files != NULL) {
         FilePrune(files);
     }
-end:
+
     SCReturnInt(ret);
 }
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -220,7 +220,7 @@ SCEnumCharMap smtp_reply_map[ ] = {
 };
 
 /* Create SMTP config structure */
-SMTPConfig smtp_config = { 0, { 0, 0, 0, 0 }, 0, 0, 0};
+SMTPConfig smtp_config = { 0, { 0, 0, 0, 0, 0 }, 0, 0, 0};
 
 static SMTPString *SMTPStringAlloc(void);
 
@@ -265,6 +265,11 @@ static void SMTPConfigure(void) {
         ret = ConfGetChildValueBool(config, "extract-urls", &val);
         if (ret) {
             smtp_config.mime_config.extract_urls = val;
+        }
+
+        ret = ConfGetChildValueBool(config, "body-md5", &val);
+        if (ret) {
+            smtp_config.mime_config.body_md5 = val;
         }
     }
 

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -65,6 +65,10 @@ typedef struct SMTPTransaction_ {
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
     DetectEngineState *de_state;
 
+    /* MAIL FROM parameters */
+    uint8_t *mail_from;
+    uint16_t mail_from_len;
+
     TAILQ_ENTRY(SMTPTransaction_) next;
 } SMTPTransaction;
 
@@ -136,6 +140,9 @@ typedef struct SMTPState_ {
     /** the list of files sent to the server */
     FileContainer *files_ts;
 
+    /* HELO of HELO message content */
+    uint8_t *helo;
+    uint16_t helo_len;
 } SMTPState;
 
 /* Create SMTP config structure */

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -51,6 +51,13 @@ enum {
     SMTP_DECODER_EVENT_MIME_BOUNDARY_TOO_LONG,
 };
 
+typedef struct SMTPString_ {
+    uint8_t *str;
+    uint16_t len;
+
+    TAILQ_ENTRY(SMTPString_) next;
+} SMTPString;
+
 typedef struct SMTPTransaction_ {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
@@ -68,6 +75,8 @@ typedef struct SMTPTransaction_ {
     /* MAIL FROM parameters */
     uint8_t *mail_from;
     uint16_t mail_from_len;
+
+    TAILQ_HEAD(, SMTPString_) rcpt_to_list;  /**< rcpt to string list */
 
     TAILQ_ENTRY(SMTPTransaction_) next;
 } SMTPTransaction;

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -55,6 +55,7 @@
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
 #include "output-json-smtp.h"
+#include "output-json-email-common.h"
 
 #include "util-byte.h"
 #include "util-privs.h"
@@ -249,6 +250,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                     hjs = JsonSMTPAddMetadata(p->flow, pa->tx_id);
                     if (hjs)
                         json_object_set_new(js, "smtp", hjs);
+
+                    hjs = JsonEmailAddMetadata(p->flow, pa->tx_id);
+                    if (hjs)
+                        json_object_set_new(js, "email", hjs);
                 }
 
                 FLOWLOCK_UNLOCK(p->flow);

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -146,6 +146,11 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
         action = "blocked";
     }
 
+    /* Add tx_id to root element for correlation with other events. */
+    json_object_del(js, "tx_id");
+    if (pa->flags & PACKET_ALERT_FLAG_TX)
+        json_object_set_new(js, "tx_id", json_integer(pa->tx_id));
+
     json_t *ajs = json_object();
     if (ajs == NULL) {
         json_decref(js);
@@ -161,9 +166,6 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
     json_object_set_new(ajs, "category",
             json_string((pa->s->class_msg) ? pa->s->class_msg : ""));
     json_object_set_new(ajs, "severity", json_integer(pa->s->prio));
-
-    if (pa->flags & PACKET_ALERT_FLAG_TX)
-        json_object_set_new(ajs, "tx_id", json_integer(pa->tx_id));
 
     if (p->tenant_id > 0)
         json_object_set_new(ajs, "tenant_id", json_integer(p->tenant_id));

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -204,7 +204,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
                 /* http alert */
                 if (proto == ALPROTO_HTTP) {
-                    hjs = JsonHttpAddMetadata(p->flow);
+                    hjs = JsonHttpAddMetadata(p->flow, pa->tx_id);
                     if (hjs)
                         json_object_set_new(js, "http", hjs);
                 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -246,7 +246,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
                 /* http alert */
                 if (proto == ALPROTO_SMTP) {
-                    hjs = JsonSMTPAddMetadata(p->flow);
+                    hjs = JsonSMTPAddMetadata(p->flow, pa->tx_id);
                     if (hjs)
                         json_object_set_new(js, "smtp", hjs);
                 }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -90,6 +90,20 @@ TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, F
             SCReturnInt(TM_ECODE_FAILED);
         }
 
+#ifdef HAVE_NSS
+        if (mime_state->md5_ctx && (mime_state->state_flag == PARSE_DONE)) {
+            size_t x;
+            int i;
+            char s[256];
+            if (likely(s != NULL)) {
+                for (i = 0, x = 0; x < sizeof(mime_state->md5); x++) {
+                    i += snprintf(s + i, 255-i, "%02x", mime_state->md5[x]);
+                }
+                json_object_set_new(sjs, "body_md5", json_string(s));
+            }
+        }
+#endif
+
         if ((entity->header_flags & HDR_IS_LOGGED) == 0) {
             MimeDecField *field;
             //printf("email LOG\n");

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -75,7 +75,13 @@ struct {
     { "user_agent", "user-agent", LOG_EMAIL_EXTENDED },
     { "received", "received", LOG_EMAIL_ARRAY },
     { "x_originating_ip", "x-originating-ip", LOG_EMAIL_DEFAULT },
-    { "relays", "relays", LOG_EMAIL_ARRAY },
+    { "in_reply_to",  "in-reply-to", LOG_EMAIL_DEFAULT },
+    { "references",  "references", LOG_EMAIL_DEFAULT },
+    { "importance",  "importance", LOG_EMAIL_DEFAULT },
+    { "priority",  "priority", LOG_EMAIL_DEFAULT },
+    { "sensitivity",  "sensitivity", LOG_EMAIL_DEFAULT },
+    { "organization",  "organization", LOG_EMAIL_DEFAULT },
+    { "content_md5",  "content-md5", LOG_EMAIL_DEFAULT },
     { NULL, NULL, LOG_EMAIL_DEFAULT},
 };
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2015 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -19,6 +19,7 @@
  * \file
  *
  * \author Tom DeCanio <td@npulsetech.com>
+ * \author Eric Leblond <eric@regit.org>
  *
  * Implements json common email logging portion of the engine.
  */

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -68,6 +68,7 @@ struct {
     { "reply_to", "reply-to", LOG_EMAIL_DEFAULT },
     { "bcc", "bcc", LOG_EMAIL_COMMA },
     { "message_id", "message-id", LOG_EMAIL_EXTENDED },
+    { "subject", "subject", LOG_EMAIL_EXTENDED },
     { "x_mailer", "x-mailer", LOG_EMAIL_EXTENDED },
     { "user_agent", "user-agent", LOG_EMAIL_EXTENDED },
     { "received", "received", LOG_EMAIL_ARRAY },
@@ -252,17 +253,6 @@ json_t *JsonEmailLogJsonData(const Flow *f, void *state, void *vtx, uint64_t tx_
                 json_t *ajs = JsonEmailJsonArrayFromCommaList(field->value, field->value_len);
                 if (ajs) {
                     json_object_set_new(sjs, "cc", ajs);
-                }
-            }
-
-            /* Subject: */
-            field = MimeDecFindField(entity, "subject");
-            if (field != NULL) {
-                char *s = BytesToString((uint8_t *)field->value, (size_t) field->value_len);
-                if (likely(s != NULL)) {
-                    //printf("Subject: \"%s\"\n", s);
-                    json_object_set_new(sjs, "subject", json_string(s));
-                    SCFree(s);
                 }
             }
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -69,7 +69,7 @@ struct {
     uint32_t flags;
 } email_fields[] =  {
     { "reply_to", "reply-to", LOG_EMAIL_DEFAULT },
-    { "bcc", "bcc", LOG_EMAIL_COMMA },
+    { "bcc", "bcc", LOG_EMAIL_COMMA|LOG_EMAIL_EXTENDED },
     { "message_id", "message-id", LOG_EMAIL_EXTENDED },
     { "subject", "subject", LOG_EMAIL_EXTENDED },
     { "x_mailer", "x-mailer", LOG_EMAIL_EXTENDED },

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -104,6 +104,9 @@ TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, F
         }
 #endif
 
+        json_object_set_new(sjs, "status",
+                            json_string(MimeDecParseStateGetStatus(mime_state)));
+
         if ((entity->header_flags & HDR_IS_LOGGED) == 0) {
             MimeDecField *field;
             //printf("email LOG\n");

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -83,6 +83,7 @@ struct {
     { "sensitivity",  "sensitivity", LOG_EMAIL_DEFAULT },
     { "organization",  "organization", LOG_EMAIL_DEFAULT },
     { "content_md5",  "content-md5", LOG_EMAIL_DEFAULT },
+    { "date", "date", LOG_EMAIL_DEFAULT },
     { NULL, NULL, LOG_EMAIL_DEFAULT},
 };
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -231,7 +231,8 @@ json_t *JsonEmailLogJsonData(const Flow *f, void *state, void *vtx, uint64_t tx_
                                         (size_t)field->value_len);
                 if (likely(s != NULL)) {
                     //printf("From: \"%s\"\n", s);
-                    json_object_set_new(sjs, "from", json_string(s));
+                    char * sp = SkipWhiteSpaceTill(s, s + strlen(s));
+                    json_object_set_new(sjs, "from", json_string(sp));
                     SCFree(s);
                 }
             }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -440,11 +440,11 @@ void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx)
             TAILQ_FOREACH(field, &md5_conf->head, next) {
                 if (field != NULL) {
                     if (strcmp("body", field->val) == 0) {
-                        SCLogInfo("Going to log email body md5");
+                        SCLogInfo("Going to log the md5 sum of email body");
                         email_ctx->flags |= LOG_EMAIL_BODY_MD5;
                     }
                     if (strcmp("subject", field->val) == 0) {
-                        SCLogInfo("Going to log email subject md5");
+                        SCLogInfo("Going to log the md5 sum of email subject");
                         email_ctx->flags |= LOG_EMAIL_SUBJECT_MD5;
                     }
                 }

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -76,20 +76,31 @@ struct {
     { NULL, NULL, LOG_EMAIL_DEFAULT},
 };
 
+static inline char *SkipWhiteSpaceTill(char *p, char *savep)
+{
+    char *sp = p;
+    while (((*sp == '\t') || (*sp == ' ')) && (sp < savep)) {
+        sp++;
+    }
+    return sp;
+}
+
 static json_t* JsonEmailJsonArrayFromCommaList(const uint8_t *val, size_t len)
 {
     json_t *ajs = json_array();
     if (likely(ajs != NULL)) {
         char *savep = NULL;
         char *p;
+        char *sp;
         char *to_line = BytesToString((uint8_t *)val, len);
         if (likely(to_line != NULL)) {
             p = strtok_r(to_line, ",", &savep);
-            json_array_append_new(ajs, json_string(p));
+            sp = SkipWhiteSpaceTill(p, savep);
+            json_array_append_new(ajs, json_string(sp));
             while ((p = strtok_r(NULL, ",", &savep)) != NULL) {
-                json_array_append_new(ajs, json_string(&p[strspn(p, " ")]));
+                sp = SkipWhiteSpaceTill(p, savep);
+                json_array_append_new(ajs, json_string(sp));
             }
-            SCFree(to_line);
         }
     }
 

--- a/src/output-json-email-common.c
+++ b/src/output-json-email-common.c
@@ -387,11 +387,10 @@ TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, F
         SCReturnInt(TM_ECODE_FAILED);
 }
 
-json_t *JsonEmailAddMetadata(const Flow *f)
+json_t *JsonEmailAddMetadata(const Flow *f, uint32_t tx_id)
 {
     SMTPState *smtp_state = (SMTPState *)FlowGetAppState(f);
     if (smtp_state) {
-        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, smtp_state, tx_id);
 
         if (tx) {

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -27,6 +27,7 @@
 typedef struct OutputJsonEmailCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    uint64_t fields;/** Store fields */
 } OutputJsonEmailCtx;
 
 
@@ -37,5 +38,7 @@ typedef struct JsonEmailLogThread_ {
 
 TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
 json_t *JsonEmailAddMetadata(const Flow *f);
+
+void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx);
 
 #endif /* __OUTPUT_JSON_EMAIL_COMMON_H__ */

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -36,5 +36,6 @@ typedef struct JsonEmailLogThread_ {
 } JsonEmailLogThread;
 
 TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
+json_t *JsonEmailAddMetadata(const Flow *f);
 
 #endif /* __OUTPUT_JSON_EMAIL_COMMON_H__ */

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -37,7 +37,7 @@ typedef struct JsonEmailLogThread_ {
 } JsonEmailLogThread;
 
 TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
-json_t *JsonEmailAddMetadata(const Flow *f);
+json_t *JsonEmailAddMetadata(const Flow *f, uint32_t tx_id);
 
 void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx);
 

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -24,6 +24,7 @@
 #ifndef __OUTPUT_JSON_EMAIL_COMMON_H__
 #define __OUTPUT_JSON_EMAIL_COMMON_H__
 
+#ifdef HAVE_LIBJANSSON
 typedef struct OutputJsonEmailCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
@@ -40,5 +41,6 @@ TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, F
 json_t *JsonEmailAddMetadata(const Flow *f, uint32_t tx_id);
 
 void OutputEmailInitConf(ConfNode *conf, OutputJsonEmailCtx *email_ctx);
+#endif
 
 #endif /* __OUTPUT_JSON_EMAIL_COMMON_H__ */

--- a/src/output-json-email-common.h
+++ b/src/output-json-email-common.h
@@ -35,6 +35,6 @@ typedef struct JsonEmailLogThread_ {
     MemBuffer *buffer;
 } JsonEmailLogThread;
 
-int JsonEmailLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id);
+TmEcode JsonEmailLogJson(JsonEmailLogThread *aft, json_t *js, const Packet *p, Flow *f, void *state, void *vtx, uint64_t tx_id);
 
 #endif /* __OUTPUT_JSON_EMAIL_COMMON_H__ */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -94,7 +94,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 
     switch (p->flow->alproto) {
         case ALPROTO_HTTP:
-            hjs = JsonHttpAddMetadata(p->flow);
+            hjs = JsonHttpAddMetadata(p->flow, ff->txid);
             if (hjs)
                 json_object_set_new(js, "http", hjs);
             break;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -102,7 +102,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             hjs = JsonSMTPAddMetadata(p->flow, ff->txid);
             if (hjs)
                 json_object_set_new(js, "smtp", hjs);
-            hjs = JsonEmailAddMetadata(p->flow);
+            hjs = JsonEmailAddMetadata(p->flow, ff->txid);
             if (hjs)
                 json_object_set_new(js, "email", hjs);
             break;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -99,7 +99,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
                 json_object_set_new(js, "http", hjs);
             break;
         case ALPROTO_SMTP:
-            hjs = JsonSMTPAddMetadata(p->flow);
+            hjs = JsonSMTPAddMetadata(p->flow, ff->txid);
             if (hjs)
                 json_object_set_new(js, "smtp", hjs);
             hjs = JsonEmailAddMetadata(p->flow);

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -55,6 +55,7 @@
 #include "output-json.h"
 #include "output-json-http.h"
 #include "output-json-smtp.h"
+#include "output-json-email-common.h"
 
 #include "log-file.h"
 #include "util-logopenfile.h"
@@ -101,6 +102,9 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             hjs = JsonSMTPAddMetadata(p->flow);
             if (hjs)
                 json_object_set_new(js, "smtp", hjs);
+            hjs = JsonEmailAddMetadata(p->flow);
+            if (hjs)
+                json_object_set_new(js, "email", hjs);
             break;
     }
 
@@ -164,6 +168,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             break;
         case ALPROTO_SMTP:
             json_object_del(js, "smtp");
+            json_object_del(js, "email");
             break;
     }
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -53,6 +53,7 @@
 
 #include "output.h"
 #include "output-json.h"
+#include "output-json-http.h"
 
 #include "log-file.h"
 #include "util-logopenfile.h"
@@ -74,99 +75,6 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
-static json_t *LogFileMetaGetUri(const Packet *p, const File *ff)
-{
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
-    json_t *js = NULL;
-    if (htp_state != NULL) {
-        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
-        if (tx != NULL) {
-            HtpTxUserData *tx_ud = htp_tx_get_user_data(tx);
-            if (tx_ud != NULL && tx_ud->request_uri_normalized != NULL) {
-                char *s = bstr_util_strdup_to_c(tx_ud->request_uri_normalized);
-                if (s != NULL) {
-                    js = json_string(s);
-                    SCFree(s);
-                    if (js != NULL)
-                        return js;
-                }
-            }
-        }
-    }
-
-    return NULL;
-}
-
-static json_t *LogFileMetaGetHost(const Packet *p, const File *ff)
-{
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
-    json_t *js = NULL;
-    if (htp_state != NULL) {
-        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
-        if (tx != NULL && tx->request_hostname != NULL) {
-            char *s = bstr_util_strdup_to_c(tx->request_hostname);
-            if (s != NULL) {
-                js = json_string(s);
-                SCFree(s);
-                if (js != NULL)
-                    return js;
-            }
-        }
-    }
-
-    return NULL;
-}
-
-static json_t *LogFileMetaGetReferer(const Packet *p, const File *ff)
-{
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
-    json_t *js = NULL;
-    if (htp_state != NULL) {
-        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
-        if (tx != NULL) {
-            htp_header_t *h = NULL;
-            h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                                                "Referer");
-            if (h != NULL) {
-                char *s = bstr_util_strdup_to_c(h->value);
-                if (s != NULL) {
-                    js = json_string(s);
-                    SCFree(s);
-                    if (js != NULL)
-                        return js;
-                }
-            }
-        }
-    }
-
-    return NULL;
-}
-
-static json_t *LogFileMetaGetUserAgent(const Packet *p, const File *ff)
-{
-    HtpState *htp_state = (HtpState *)p->flow->alstate;
-    json_t *js = NULL;
-    if (htp_state != NULL) {
-        htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, ff->txid);
-        if (tx != NULL) {
-            htp_header_t *h = NULL;
-            h = (htp_header_t *)htp_table_get_c(tx->request_headers,
-                                                "User-Agent");
-            if (h != NULL) {
-                char *s = bstr_util_strdup_to_c(h->value);
-                if (s != NULL) {
-                    js = json_string(s);
-                    SCFree(s);
-                    if (js != NULL)
-                        return js;
-                }
-            }
-        }
-    }
-
-    return NULL;
-}
-
 /**
  *  \internal
  *  \brief Write meta data on a single line json record
@@ -175,33 +83,24 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 {
     MemBuffer *buffer = (MemBuffer *)aft->buffer;
     json_t *js = CreateJSONHeader((Packet *)p, 0, "fileinfo"); //TODO const
+    json_t *hjs = NULL;
     if (unlikely(js == NULL))
         return;
 
     /* reset */
     MemBufferReset(buffer);
 
-    json_t *hjs = json_object();
-    if (unlikely(hjs == NULL)) {
-        json_decref(js);
-        return;
-    }
-
-    json_object_set_new(hjs, "app_proto", json_string(AppProtoToString(p->flow->alproto)));
     switch (p->flow->alproto) {
         case ALPROTO_HTTP:
-            json_object_set_new(hjs, "url", LogFileMetaGetUri(p, ff));
-            json_object_set_new(hjs, "hostname", LogFileMetaGetHost(p, ff));
-            json_object_set_new(hjs, "http_refer", LogFileMetaGetReferer(p, ff));
-            json_object_set_new(hjs, "http_user_agent", LogFileMetaGetUserAgent(p, ff));
-            json_object_set_new(js, "http", hjs);
+            hjs = JsonHttpAddMetadata(p->flow);
+            if (hjs)
+                json_object_set_new(js, "http", hjs);
             break;
     }
 
 
     json_t *fjs = json_object();
     if (unlikely(fjs == NULL)) {
-        json_decref(hjs);
         json_decref(js);
         return;
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -396,11 +396,10 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCReturnInt(TM_ECODE_OK);
 }
 
-json_t *JsonHttpAddMetadata(const Flow *f)
+json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id)
 {
     HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
-        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
         htp_tx_t *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_HTTP, htp_state, tx_id);
 
         if (tx) {

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -362,9 +362,6 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, ui
     if (http_ctx->flags & LOG_HTTP_EXTENDED)
         JsonHttpLogJSONExtended(hjs, tx);
 
-    /* tx id for correlation with alerts */
-    json_object_set_new(hjs, "tx_id", json_integer(tx_id));
-
     json_object_set_new(js, "http", hjs);
 }
 
@@ -376,7 +373,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     JsonHttpLogThread *jhl = (JsonHttpLogThread *)thread_data;
     MemBuffer *buffer = (MemBuffer *)jhl->buffer;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 1, "http"); //TODO const
+    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "http", tx_id); //TODO const
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -29,6 +29,7 @@ void TmModuleJsonHttpLogRegister (void);
 #ifdef HAVE_LIBJANSSON
 void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx);
 void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx);
+json_t *JsonHttpAddMetadata(const Flow *f);
 #endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -29,7 +29,7 @@ void TmModuleJsonHttpLogRegister (void);
 #ifdef HAVE_LIBJANSSON
 void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx);
 void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx);
-json_t *JsonHttpAddMetadata(const Flow *f);
+json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id);
 #endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -90,7 +90,7 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     MemBuffer *buffer = (MemBuffer *)jhl->buffer;
 
     json_t *sjs;
-    json_t *js = CreateJSONHeader((Packet *)p, 1, "smtp");
+    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "smtp", tx_id);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2015 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -117,11 +117,10 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
 
 }
 
-json_t *JsonSMTPAddMetadata(const Flow *f)
+json_t *JsonSMTPAddMetadata(const Flow *f, uint64_t tx_id)
 {
     SMTPState *smtp_state = (SMTPState *)FlowGetAppState(f);
     if (smtp_state) {
-        uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
         SMTPTransaction *tx = AppLayerParserGetTx(IPPROTO_TCP, ALPROTO_SMTP, smtp_state, tx_id);
 
         if (tx) {

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -227,7 +227,7 @@ static TmEcode JsonSmtpLogThreadInit(ThreadVars *t, void *initdata, void **data)
 
     if(initdata == NULL)
     {
-        SCLogDebug("Error getting context for HTTPLog.  \"initdata\" argument NULL");
+        SCLogDebug("Error getting context for SMTPLog.  \"initdata\" argument NULL");
         SCFree(aft);
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -58,6 +58,7 @@ static json_t *JsonSmtpDataLogger(ThreadVars *tv, void *thread_data, const Packe
 {
     json_t *sjs = json_object();
     SMTPTransaction *tx = vtx;
+    SMTPString *rcptto_str;
     if (sjs == NULL) {
         return NULL;
     }
@@ -68,6 +69,15 @@ static json_t *JsonSmtpDataLogger(ThreadVars *tv, void *thread_data, const Packe
     if (tx->mail_from) {
         json_object_set_new(sjs, "mail_from",
                             json_string((const char *)tx->mail_from));
+    }
+    if (!TAILQ_EMPTY(&tx->rcpt_to_list)) {
+        json_t *js_rcptto = json_array();
+        if (likely(js_rcptto != NULL)) {
+            TAILQ_FOREACH(rcptto_str, &tx->rcpt_to_list, next) {
+                json_array_append_new(js_rcptto, json_string((char *)rcptto_str->str));
+            }
+            json_object_set_new(sjs, "rcpt_to", js_rcptto);
+        }
     }
 
     return sjs;

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -206,6 +206,8 @@ static OutputCtx *OutputSmtpLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 
     email_ctx->file_ctx = ojc->file_ctx;
 
+    OutputEmailInitConf(conf, email_ctx);
+
     output_ctx->data = email_ctx;
     output_ctx->DeInit = OutputSmtpLogDeInitCtxSub;
 

--- a/src/output-json-smtp.h
+++ b/src/output-json-smtp.h
@@ -25,6 +25,6 @@
 #define __OUTPUT_JSON_SMTP_H__
 
 void TmModuleJsonSmtpLogRegister (void);
-json_t *JsonSMTPAddMetadata(const Flow *f);
+json_t *JsonSMTPAddMetadata(const Flow *f, uint64_t tx_id);
 
 #endif /* __OUTPUT_JSON_SMTP_H__ */

--- a/src/output-json-smtp.h
+++ b/src/output-json-smtp.h
@@ -25,5 +25,6 @@
 #define __OUTPUT_JSON_SMTP_H__
 
 void TmModuleJsonSmtpLogRegister (void);
+json_t *JsonSMTPAddMetadata(const Flow *f);
 
 #endif /* __OUTPUT_JSON_SMTP_H__ */

--- a/src/output-json-smtp.h
+++ b/src/output-json-smtp.h
@@ -25,6 +25,9 @@
 #define __OUTPUT_JSON_SMTP_H__
 
 void TmModuleJsonSmtpLogRegister (void);
+
+#ifdef HAVE_LIBJANSSON
 json_t *JsonSMTPAddMetadata(const Flow *f, uint64_t tx_id);
+#endif
 
 #endif /* __OUTPUT_JSON_SMTP_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -327,6 +327,18 @@ json_t *CreateJSONHeader(Packet *p, int direction_sensitive, char *event_type)
     return js;
 }
 
+json_t *CreateJSONHeaderWithTxId(Packet *p, int direction_sensitive, char *event_type, uint32_t tx_id)
+{
+    json_t *js = CreateJSONHeader(p, direction_sensitive, event_type);
+    if (unlikely(js == NULL))
+        return NULL;
+
+    /* tx id for correlation with other events */
+    json_object_set_new(js, "tx_id", json_integer(tx_id));
+
+    return js;
+}
+
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
 {
     char *js_s = json_dumps(js,

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -35,6 +35,7 @@ void TmModuleOutputJsonRegister (void);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 json_t *CreateJSONHeader(Packet *p, int direction_sensative, char *event_type);
+json_t *CreateJSONHeaderWithTxId(Packet *p, int direction_sensitive, char *event_type, uint32_t tx_id);
 TmEcode OutputJSON(json_t *js, void *data, uint64_t *count);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer);
 OutputCtx *OutputJsonInitCtx(ConfNode *);

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -277,6 +277,7 @@ void RunUnittests(int list_unittests, char *regex_arg)
     CudaBufferRegisterUnittests();
 #endif
     AppLayerUnittestsRegister();
+    MimeDecRegisterTests();
     if (list_unittests) {
         UtListTests(regex_arg);
     } else {

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -81,7 +81,6 @@
 /* Globally hold configuration data */
 static MimeDecConfig mime_dec_config = { 1, 1, 1, 0, MAX_HEADER_VALUE };
 
-#ifdef DEBUG
 /* Mime Parser String translation */
 static const char *StateFlags[] = { "NONE",
         "HEADER_READY",
@@ -93,7 +92,6 @@ static const char *StateFlags[] = { "NONE",
         "PARSE_DONE",
         "PARSE_ERROR",
         NULL };
-#endif
 
 /* URL executable file extensions */
 static const char *UrlExeExts[] = { ".exe",
@@ -2263,6 +2261,11 @@ static int ProcessMimeBody(const uint8_t *buf, uint32_t len,
     }
 
     return ret;
+}
+
+const char *MimeDecParseStateGetStatus(MimeDecParseState *state)
+{
+    return StateFlags[state->state_flag];
 }
 
 /**

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -297,6 +297,35 @@ MimeDecField * MimeDecAddField(MimeDecEntity *entity)
     return node;
 }
 
+
+/**
+ * \brief Searches for header fields with the specified name
+ *
+ * \param entity The entity to search
+ * \param name The header name (lowercase)
+ *
+ * \return number of items found
+ *
+ */
+int MimeDecFindFieldsForEach(const MimeDecEntity *entity, const char *name, int (*DataCallback)(const uint8_t *val, const size_t, void *data), void *data)
+{
+    MimeDecField *curr = entity->field_list;
+    int found = 0;
+
+    while (curr != NULL) {
+        /* name is stored lowercase */
+        if (strlen(name) == curr->name_len) {
+            if (SCMemcmp(curr->name, name, curr->name_len) == 0) {
+                if (DataCallback(curr->value, curr->value_len, data))
+                    found++;
+            }
+        }
+        curr = curr->next;
+    }
+
+    return found;
+}
+
 /**
  * \brief Searches for a header field with the specified name
  *

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -2437,8 +2437,10 @@ void MimeDecDeInitParser(MimeDecParseState *state)
     SCFree(state->hname);
     FreeDataValue(state->hvalue);
     FreeMimeDecStack(state->stack);
+#ifdef HAVE_NSS
     if (state->md5_ctx)
         HASH_Destroy(state->md5_ctx);
+#endif
     SCFree(state);
 }
 

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -2819,6 +2819,54 @@ static int MimeDecParseFullMsgTest01(void)
     return ret;
 }
 
+/* Test full message with linebreaks */
+static int MimeDecParseFullMsgTest02(void)
+{
+    int ret = MIME_DEC_OK;
+
+    uint32_t expected_count = 3;
+    uint32_t line_count = 0;
+
+    char msg[] = "From: Sender2\r\n"
+            "To: Recipient2\r\n"
+            "Subject: subject2\r\n"
+            "Content-Type: text/plain\r\n"
+            "\r\n"
+            "Line 1\r\n"
+            "Line 2\r\n"
+            "Line 3\r\n";
+
+    MimeDecEntity *entity = MimeDecParseFullMsg((uint8_t *)msg, strlen(msg), &line_count,
+            TestDataChunkCallback);
+
+    if (entity == NULL) {
+        SCLogInfo("Warning: Message failed to parse");
+        return -1;
+    }
+
+    MimeDecField *field = MimeDecFindField(entity, "subject");
+    if (field == NULL) {
+        SCLogInfo("Warning: Message failed to parse");
+        return -1;
+    }
+
+    if (memcmp(field->value, "subject2", sizeof("subject2")) != 0) {
+        SCLogInfo("Warning: failed to get subject");
+        return -1;
+    }
+
+
+    MimeDecFreeEntity(entity);
+
+    if (expected_count != line_count) {
+        SCLogInfo("Warning: Line count is invalid: expected - %d actual - %d",
+                expected_count, line_count);
+        return -1;
+    }
+
+    return ret;
+}
+
 static int MimeBase64DecodeTest01(void)
 {
     int ret = -1;
@@ -2936,6 +2984,7 @@ void MimeDecRegisterTests(void)
     UtRegisterTest("MimeDecParseLineTest01", MimeDecParseLineTest01, 0);
     UtRegisterTest("MimeDecParseLineTest02", MimeDecParseLineTest02, 0);
     UtRegisterTest("MimeDecParseFullMsgTest01", MimeDecParseFullMsgTest01, 0);
+    UtRegisterTest("MimeDecParseFullMsgTest02", MimeDecParseFullMsgTest02, 0);
     UtRegisterTest("MimeBase64DecodeTest01", MimeBase64DecodeTest01, 0);
     UtRegisterTest("MimeIsExeURLTest01", MimeIsExeURLTest01, 0);
     UtRegisterTest("MimeIsIpv4HostTest01", MimeIsIpv4HostTest01, 0);

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -79,7 +79,7 @@
 #define MAX_IP6_CHARS  39
 
 /* Globally hold configuration data */
-static MimeDecConfig mime_dec_config = { 1, 1, 1, MAX_HEADER_VALUE };
+static MimeDecConfig mime_dec_config = { 1, 1, 1, 0, MAX_HEADER_VALUE };
 
 #ifdef DEBUG
 /* Mime Parser String translation */
@@ -2182,7 +2182,7 @@ static int ProcessMimeBody(const uint8_t *buf, uint32_t len,
     uint32_t tlen;
 
 #ifdef HAVE_NSS
-    if (state->body_begin == 1 && (state->md5_ctx == NULL)) {
+    if (MimeDecGetConfig()->body_md5 && state->body_begin == 1 && (state->md5_ctx == NULL)) {
         state->md5_ctx = HASH_Create(HASH_AlgMD5);
         if (state->md5_ctx != NULL) {
             HASH_Begin(state->md5_ctx);

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -64,7 +64,7 @@
 #define ANOM_MALFORMED_MSG      64  /* Misc msg format errors found */
 #define ANOM_LONG_BOUNDARY     128  /* Boundary too long */
 
-/* Pubicly exposed size constants */
+/* Publicly exposed size constants */
 #define DATA_CHUNK_SIZE  3072  /* Should be divisible by 3 */
 #define LINEREM_SIZE      256
 

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -238,6 +238,7 @@ int MimeDecParseComplete(MimeDecParseState *state);
 int MimeDecParseLine(const uint8_t *line, const uint32_t len, MimeDecParseState *state);
 MimeDecEntity * MimeDecParseFullMsg(const uint8_t *buf, uint32_t blen, void *data,
         int (*DataChunkProcessorFunc)(const uint8_t *chunk, uint32_t len, MimeDecParseState *state));
+const char *MimeDecParseStateGetStatus(MimeDecParseState *state);
 
 /* Test functions */
 void MimeDecRegisterTests(void);

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -197,6 +197,10 @@ typedef struct MimeDecParseState {
     uint8_t bvremain[B64_BLOCK];  /**< Remainder from base64-decoded line */
     uint8_t bvr_len;  /**< Length of remainder from base64-decoded line */
     uint8_t data_chunk[DATA_CHUNK_SIZE];  /**< Buffer holding data chunk */
+#ifdef HAVE_NSS
+    HASHContext *md5_ctx;
+    uint8_t md5[MD5_LENGTH];
+#endif
     uint8_t state_flag;  /**<  Flag representing current state of parser */
     uint32_t data_chunk_len;  /**< Length of data chunk */
     int found_child;  /**< Flag indicating a child entity was found */

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -97,6 +97,7 @@ typedef struct MimeDecConfig {
     int decode_base64;  /**< Decode base64 bodies */
     int decode_quoted_printable;  /**< Decode quoted-printable bodies */
     int extract_urls;  /**< Extract and store URLs in data structure */
+    int body_md5;  /**< Compute md5 sum of body */
     uint32_t header_value_depth;  /**< Depth of which to store header values
                                        (Default is 2000) */
 } MimeDecConfig;

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -224,6 +224,7 @@ void MimeDecFreeUrl(MimeDecUrl *url);
 /* List functions */
 MimeDecField * MimeDecAddField(MimeDecEntity *entity);
 MimeDecField * MimeDecFindField(const MimeDecEntity *entity, const char *name);
+int MimeDecFindFieldsForEach(const MimeDecEntity *entity, const char *name, int (*DataCallback)(const uint8_t *val, const size_t, void *data), void *data);
 MimeDecEntity * MimeDecAddEntity(MimeDecEntity *parent);
 
 /* Helper functions */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -108,6 +108,7 @@ outputs:
             # http: yes              # enable dumping of http fields
             # tls: yes               # enable dumping of tls fields
             # ssh: yes               # enable dumping of ssh fields
+            # smtp: yes              # enable dumping of smtp fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -140,7 +140,8 @@ outputs:
         #- drop:
         #    alerts: no       # log alerts that caused drops
         - smtp:
-            #extended: yes
+            #extended: yes # enable this for extended logging information
+            # this includes: message-id, subject, x_mailer, user-agent
             # custom fields logging from the list:
             #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
             #  x-originating-ip, in-reply-to, references, importance, priority,

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -144,7 +144,7 @@ outputs:
             # custom fields logging from the list:
             #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
             #  x-originating-ip, in-reply-to, references, importance, priority,
-            #  sensitivity, organization, content-md5
+            #  sensitivity, organization, content-md5, date
             #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
             # output md5 of fields: body, subject
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -139,7 +139,18 @@ outputs:
             force-md5: no     # force logging of md5 checksums
         #- drop:
         #    alerts: no       # log alerts that caused drops
-        - smtp
+        - smtp:
+            #extended: yes
+            # custom fields logging from the list:
+            #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
+            #  x-originating-ip, in-reply-to, references, importance, priority,
+            #  sensitivity, organization, content-md5
+            #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
+            # output md5 of fields: body, subject
+            # for the body you need to set app-layer.protocols.smtp.mime.body-md5
+            # to yes
+            #md5: [body, subject]
+
         - ssh
         - stats:
             totals: yes       # stats for all threads merged together
@@ -1291,6 +1302,9 @@ app-layer:
 
         # Extract URLs and save in state data structure
         extract-urls: yes
+        # Set to yes to compute the md5 of the mail body. You will then
+        # be able to journalize it.
+        body-md5: no
       # Configure inspected-tracker for file_data keyword
       inspected-tracker:
         content-limit: 1000

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -141,7 +141,7 @@ outputs:
         #    alerts: no       # log alerts that caused drops
         - smtp:
             #extended: yes # enable this for extended logging information
-            # this includes: message-id, subject, x_mailer, user-agent
+            # this includes: bcc, message-id, subject, x_mailer, user-agent
             # custom fields logging from the list:
             #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
             #  x-originating-ip, in-reply-to, references, importance, priority,


### PR DESCRIPTION
This patchset is extending the SMTP logging and is also bringing some improvements and factorization in the JSON logging code.

Main work is the addition of extended and custom to SMTP/EMAIL fields logging. Another feature is the logging of some md5 fields. For instance, it is possible to output the md5 of a subject. This allow analysts to find similar mails without the need to get/read the real subject.

This patchset leads to events that can look like the following:
```json
{
  "timestamp": "2015-07-15T16:55:54.698185+0200",
  "flow_id": 37628720,
  "pcap_cnt": 22,
  "event_type": "smtp",
  "src_ip": "192.168.0.254",
  "src_port": 36403,
  "dest_ip": "192.168.0.5",
  "dest_port": 25,
  "proto": "TCP",
  "tx_id": 0,
  "smtp": {
    "helo": "tiger2",
    "mail_from": "<eric@tiger2>",
    "rcpt_to": [
      "<eric@regit.org>",
      "<eleblond@stamus-networks.com>",
      "<regit@regit.org>"
    ]
  },
  "email": {
    "status": "PARSE_DONE",
    "from": "Eric Leblond <eric@tiger2>",
    "to": [
      "eric@regit.org"
    ],
    "cc": [
      "eleblond@stamus-networks.com"
    ],
    "reply_to": "eleblond@stamus-networks.com",
    "message_id": "<20150715145539.GA631@tiger2>",
    "subject": "test header",
    "user_agent": "Mutt/1.5.23 (2014-03-12)",
    "subject_md5": "237128c9002cf596d755231d7f8c2f92",
    "body_md5": "8e509bb7159fcfb8bf80e139db57ab11"
  }
}
```

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/96
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/94

This PR replaces #1644  with no changes but 2 incremental commits to fix the build when libjansson is not available.