### PR TITLE
app-layer detect template: move more setup into detect module

### DIFF
--- a/scripts/setup-app-layer-detect.sh
+++ b/scripts/setup-app-layer-detect.sh
@@ -129,18 +129,6 @@ w
 EOF
 }
 
-function patch_detect_parse_c() {
-    filename="src/detect-parse.c"
-    echo "Patching ${filename}."
-    ed -s ${filename} > /dev/null <<EOF
-/\/\* Template\. \*\/
-.,+4t-
--4s/Template/${protoname}/g
-+1s/TEMPLATE/${protoname_upper}/g
-w
-EOF
-}
-
 function patch_detect_c() {
     filename="src/detect.c"
     echo "Patching ${filename}."
@@ -157,16 +145,6 @@ s/template/${protoname_lower}/g
 +
 s/TEMPLATE/${protoname_upper}/g
 +2
-/ALPROTO_TEMPLATE
-.,+3t-
--3
-.,+s/TEMPLATE/${protoname_upper}/g
-+
-s/template/${protoname_lower}/g
-+3
-/SIG_MASK_REQUIRE_TEMPLATE_STATE
-.t-
-s/TEMPLATE/${protoname_upper}/g
 /DetectTemplateBufferRegister
 t-
 s/Template/${protoname}/
@@ -206,7 +184,6 @@ patch_makefile_am
 patch_detect_engine_content_inspection_h
 patch_detect_engine_state_h
 patch_detect_engine_c
-patch_detect_parse_c
 patch_detect_c
 patch_detect_h
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1479,11 +1479,6 @@ static Signature *SigInitHelper(DetectEngineCtx *de_ctx, char *sigstr,
     if (sig->sm_lists[DETECT_SM_LIST_HRHHDMATCH])
         sig->flags |= SIG_FLAG_STATE_MATCH;
 
-    /* Template. */
-    if (sig->sm_lists[DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH]) {
-        sig->flags |= SIG_FLAG_STATE_MATCH;
-    }
-
     /* DNS */
     if (sig->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH])
         sig->flags |= SIG_FLAG_STATE_MATCH;

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -48,6 +48,9 @@ static int DetectTemplateBufferSetup(DetectEngineCtx *de_ctx, Signature *s,
 {
     s->list = DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH;
     s->alproto = ALPROTO_TEMPLATE;
+    s->flags |= SIG_FLAG_STATE_MATCH;
+    s->mask |= SIG_MASK_REQUIRE_TEMPLATE_STATE;
+    s->mask |= SIG_MASK_REQUIRE_FLOW;
     return 0;
 }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -2674,10 +2674,6 @@ static int SignatureCreateMask(Signature *s)
         s->mask |= SIG_MASK_REQUIRE_SMTP_STATE;
         SCLogDebug("sig requires smtp state");
     }
-    if (s->alproto == ALPROTO_TEMPLATE) {
-        s->mask |= SIG_MASK_REQUIRE_TEMPLATE_STATE;
-        SCLogDebug("sig requires template state");
-    }
 
     if ((s->mask & SIG_MASK_REQUIRE_DCE_STATE) ||
         (s->mask & SIG_MASK_REQUIRE_HTTP_STATE) ||
@@ -2685,7 +2681,6 @@ static int SignatureCreateMask(Signature *s)
         (s->mask & SIG_MASK_REQUIRE_DNS_STATE) ||
         (s->mask & SIG_MASK_REQUIRE_FTP_STATE) ||
         (s->mask & SIG_MASK_REQUIRE_SMTP_STATE) ||
-        (s->mask & SIG_MASK_REQUIRE_TEMPLATE_STATE) ||
         (s->mask & SIG_MASK_REQUIRE_TLS_STATE))
     {
         s->mask |= SIG_MASK_REQUIRE_FLOW;


### PR DESCRIPTION
Move the setting of some masks into the detect setup to limit code changes outside of the detect module.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/131
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/132
