### PR TITLE
magic: prefer brew magic on OS X if exists

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,9 @@
             CFLAGS="${CFLAGS} -DOS_DARWIN"
             CPPFLAGS="${CPPFLAGS} -I/opt/local/include"
             LDFLAGS="${LDFLAGS} -L/opt/local/lib"
+	    if test -e /usr/local/share/misc/magic.mgc; then
+	       e_magic_file=/usr/local/share/misc/magic
+	    fi
             ;;
         *-*-linux*)
             #for now do nothing


### PR DESCRIPTION
I'm not sure if this is the best way to do this, but on OS X, magic.h doesn't exist by default.  One way to add it is libmagic from homebrew, however, the path to magic has to be updated as Suricata will fail if it loads the magic file included by OS X.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/134
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/135