### PR TITLE
deltas for JSON stats logging.

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -706,6 +706,7 @@ static int StatsOutput(ThreadVars *tv)
             StatsRecord *r = &stats_table.tstats[offset];
             r->name = table[c].name;
             r->tm_name = sts->name;
+            r->pvalue = r->value;
 
             switch (e->type) {
                 case STATS_TYPE_AVERAGE:


### PR DESCRIPTION
Store previous value to pvalue variable per thread. It fixes the delta outputs in the JSON stats logging. 

I hope, I have resolved the issues from Pull Request 1630.