### PR TITLE
util-debug: don't colorize if a redirect is used

### DIFF
--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -776,7 +776,7 @@ static inline SCLogOPIfaceCtx *SCLogInitConsoleOPIface(const char *log_format,
     }
     iface_ctx->log_level = tmp_log_level;
 
-    if (isatty(fileno(stdout))) {
+    if (isatty(fileno(stdout)) && isatty(fileno(stderr))) {
         iface_ctx->use_color = TRUE;
     }
 


### PR DESCRIPTION
It is better to disable the color mode when a redirect of stderr
is done to avoid getting colorized output in the generated file.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/101
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/99

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1562