### PR TITLE
lua: TLS lua output support

### DIFF
--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -81,6 +81,8 @@ enum {
 /* flags for file storage */
 #define SSL_AL_FLAG_STATE_STORED                0x40000
 
+#define SSL_AL_FLAG_STATE_LOGGED_LUA            0x80000
+
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 


### PR DESCRIPTION
Support TLS in lua output scripts (Feature #1568).
```lua
function init (args)
    local needs = {}
    needs["protocol"] = "tls"
    return needs
end

function setup (args)
    filename = SCLogPath() .. "/" .. "lua_tls.log"
    file = assert(io.open(filename, "a"))
end

function log (args)
    ts = SCPacketTimeString()
    ipver, srcip, dstip, proto, sp, dp = SCFlowTuple()

    version, subject, issuer, fingerprint = TlsGetCertInfo();
    if version == nil then
        return 0
    end

    file:write(ts .. " " .. srcip .. ":" .. sp .. " -> " .. dstip  ..
               ":" .. dp .. "  TLS: " .. "Subject='" .. subject ..
               "' " .. "Issuerdn='" .. issuer .. "\n")
    file:flush()
end

function deinit (args)
    file:close(file)
end
```