### PR TITLE
app-layer-template: disable by default - v1

### DIFF
--- a/scripts/setup-app-layer-detect.sh
+++ b/scripts/setup-app-layer-detect.sh
@@ -34,9 +34,11 @@ function copy_template_file() {
 
     echo "Creating ${dst}."
 
-    sed -e "s/TEMPLATE/${protoname_upper}/g" \
+    sed -e '/TEMPLATE_START_REMOVE/,/TEMPLATE_END_REMOVE/d' \
+	-e "s/TEMPLATE/${protoname_upper}/g" \
 	-e "s/template/${protoname_lower}/g" \
-	-e "s/Template/${protoname}/g" > ${dst} < ${src}
+	-e "s/Template/${protoname}/g" \
+	> ${dst} < ${src}
 }
 
 function copy_templates() {

--- a/scripts/setup-app-layer-logger.sh
+++ b/scripts/setup-app-layer-logger.sh
@@ -38,9 +38,11 @@ function copy_template_file() {
 
     echo "Creating ${dst}."
     
-    sed -e "s/TEMPLATE/${protoname_upper}/g" \
+    sed -e '/TEMPLATE_START_REMOVE/,/TEMPLATE_END_REMOVE/d' \
+	-e "s/TEMPLATE/${protoname_upper}/g" \
 	-e "s/template/${protoname_lower}/g" \
-	-e "s/Template/${protoname}/g" > ${dst} < ${src}
+	-e "s/Template/${protoname}/g" \
+	> ${dst} < ${src}
 }
 
 function copy_templates() {

--- a/scripts/setup-app-layer.sh
+++ b/scripts/setup-app-layer.sh
@@ -37,9 +37,11 @@ function copy_template_file() {
 
     echo "Creating ${dst}."
     
-    sed -e "s/TEMPLATE/${protoname_upper}/g" \
+    sed -e '/TEMPLATE_START_REMOVE/,/TEMPLATE_END_REMOVE/d' \
+	-e "s/TEMPLATE/${protoname_upper}/g" \
 	-e "s/template/${protoname_lower}/g" \
-	-e "s/Template/${protoname}/g" > ${dst} < ${src}
+	-e "s/Template/${protoname}/g" \
+	> ${dst} < ${src}
 }
 
 function copy_app_layer_templates {

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -25,6 +25,7 @@
 
 #include "suricata-common.h"
 #include "stream.h"
+#include "conf.h"
 
 #include "util-unittest.h"
 
@@ -428,6 +429,12 @@ void RegisterTemplateParsers(void)
 {
     char *proto_name = "template";
 
+    /* TEMPLATE_START_REMOVE */
+    if (ConfGetNode("app-layer.protocols.template") == NULL) {
+        return;
+    }
+    /* TEMPLATE_END_REMOVE */
+
     /* Check if Template TCP detection is enabled. If it does not exist in
      * the configuration file then it will be enabled by default. */
     if (AppLayerProtoDetectConfProtoDetectionEnabled("tcp", proto_name)) {
@@ -481,8 +488,8 @@ void RegisterTemplateParsers(void)
             STREAM_TOSERVER, TemplateParseRequest);
 
         /* Register response parser for parsing frames from server to client. */
-        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_TEMPLATE, STREAM_TOCLIENT,
-            TemplateParseResponse);
+        AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_TEMPLATE,
+            STREAM_TOCLIENT, TemplateParseResponse);
 
         /* Register a function to be called by the application layer
          * when a transaction is to be freed. */
@@ -490,7 +497,8 @@ void RegisterTemplateParsers(void)
             TemplateStateTxFree);
 
         /* Register a function to return the current transaction count. */
-        AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TEMPLATE, TemplateGetTxCnt);
+        AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TEMPLATE,
+            TemplateGetTxCnt);
 
         /* Transaction handling. */
         AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP,

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -21,6 +21,7 @@
  */
 
 #include "suricata-common.h"
+#include "conf.h"
 #include "detect.h"
 #include "app-layer-template.h"
 
@@ -29,6 +30,10 @@ static void DetectTemplateBufferRegisterTests(void);
 
 void DetectTemplateBufferRegister(void)
 {
+    if (ConfGetNode("app-layer.protocols.template") == NULL) {
+        return;
+    }
+
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].name = "template_buffer";
     sigmatch_table[DETECT_AL_TEMPLATE_BUFFER].desc =
         "Template content modififier to match on the template buffers";

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -180,6 +180,10 @@ static TmEcode JsonTemplateLogThreadDeinit(ThreadVars *t, void *data)
 
 void TmModuleJsonTemplateLogRegister(void)
 {
+    if (ConfGetNode("app-layer.protocols.template") == NULL) {
+        return;
+    }
+
     tmm_modules[TMM_JSONTEMPLATELOG].name = "JsonTemplateLog";
     tmm_modules[TMM_JSONTEMPLATELOG].ThreadInit = JsonTemplateLogThreadInit;
     tmm_modules[TMM_JSONTEMPLATELOG].ThreadDeinit = JsonTemplateLogThreadDeinit;


### PR DESCRIPTION
Disables the app-layer templates by default if the app-layer template protocol configuration node doesn't exist.

The template setup scripts will remove this code on setup so new app-layer's are enabled by default like most other app-layer protocols.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/145
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/146