### PR TITLE
decode: add flow memcap counter

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -403,6 +403,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_avg_pkt_size = StatsRegisterAvgCounter("decoder.avg_pkt_size", tv);
     dtv->counter_max_pkt_size = StatsRegisterMaxCounter("decoder.max_pkt_size", tv);
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
+    dtv->counter_flow_memcap = StatsRegisterCounter("decoder.flow_failed", tv);
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -624,6 +624,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_timeouts;
     uint16_t counter_defrag_max_hit;
 
+    uint16_t counter_flow_memcap;
+
     /* thread data for flow logging api: only used at forced
      * flow recycle during lookups */
     void *output_flow_thread_data;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -486,6 +486,11 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
 
             f = FlowGetUsedFlow(tv, dtv);
             if (f == NULL) {
+                /* max memcap reached, so increments the counter */
+                if (tv != NULL && dtv != NULL) {
+                    StatsIncr(tv, dtv->counter_flow_memcap);
+                }
+
                 /* very rare, but we can fail. Just giving up */
                 return NULL;
             }

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -26,6 +26,7 @@
 
 #include "detect-engine-state.h"
 #include "tmqh-flow.h"
+#include "flow-manager.h"
 
 #define COPY_TIMESTAMP(src,dst) ((dst)->tv_sec = (src)->tv_sec, (dst)->tv_usec = (src)->tv_usec)
 


### PR DESCRIPTION
This adds a counter indicating how many times
the flow max memcap has been reached

Since there is no always a reference to FlowManagerThreadData,
the counter is put in DecodeThreadVars.

Currently when there is no counter increase in one call of FlowGetNew
because we don't have tv or dtv at the time of the call.

The following is a snippet of the generated EVE entry:
"decoder":{"pkts":9283,"bytes":8197970,"invalid":0,"ipv4":9283,"ipv6":0,"ethernet":9283,
"raw":0,"null":0,"sll":0,"tcp":9238,"udp":43,"sctp":0,"icmpv4":0,"icmpv6":0,"ppp":0,
"pppoe":0,"gre":0,"vlan":0,"vlan_qinq":0,"teredo":0,"ipv4_in_ipv6":0,"ipv6_in_ipv6":0,
"mpls":0,"avg_pkt_size":883,"max_pkt_size":1514,"erspan":0,"flow_failed":0}

flow_failed represents the new counter added.

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/67
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/66