### PR TITLE
[dev-flow-json-v1] decode: add flow memcap counter

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -403,6 +403,7 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
     dtv->counter_avg_pkt_size = StatsRegisterAvgCounter("decoder.avg_pkt_size", tv);
     dtv->counter_max_pkt_size = StatsRegisterMaxCounter("decoder.max_pkt_size", tv);
     dtv->counter_erspan = StatsRegisterMaxCounter("decoder.erspan", tv);
+    dtv->counter_flow_memcap = StatsRegisterCounter("flow.memcap", tv);
 
     dtv->counter_defrag_ipv4_fragments =
         StatsRegisterCounter("defrag.ipv4.fragments", tv);

--- a/src/decode.h
+++ b/src/decode.h
@@ -624,6 +624,8 @@ typedef struct DecodeThreadVars_
     uint16_t counter_defrag_ipv6_timeouts;
     uint16_t counter_defrag_max_hit;
 
+    uint16_t counter_flow_memcap;
+
     /* thread data for flow logging api: only used at forced
      * flow recycle during lookups */
     void *output_flow_thread_data;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -486,6 +486,11 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
 
             f = FlowGetUsedFlow(tv, dtv);
             if (f == NULL) {
+                /* max memcap reached, so increments the counter */
+                if (tv != NULL && dtv != NULL) {
+                    StatsIncr(tv, dtv->counter_flow_memcap);
+                }
+
                 /* very rare, but we can fail. Just giving up */
                 return NULL;
             }
@@ -495,6 +500,9 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
             /* now see if we can alloc a new flow */
             f = FlowAlloc();
             if (f == NULL) {
+                if (tv != NULL && dtv != NULL) {
+                    StatsIncr(tv, dtv->counter_flow_memcap);
+                }
                 return NULL;
             }
 


### PR DESCRIPTION
Comments in last PR addressed: https://github.com/inliniac/suricata/pull/1685

This adds a counter indicating how many times
the flow max memcap has been reached

Since there is no always a reference to FlowManagerThreadData,
the counter is put in DecodeThreadVars.

Currently when there is no counter increase in one call of FlowGetNew
because we don't have tv or dtv at the time of the call.

The following is a snippet of the generated EVE entry:
"flow":{"memcap":0,"spare":10000,"emerg_mode_entered":0,"emerg_mode_over":0,"tcp_reuse":0,"memuse":7085248}

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/68
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/67