### PR TITLE
Bugfix for detect-engine.luajit-states

### DIFF
--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -192,10 +192,17 @@ int DetectLuajitSetupStatesPool(int num, int reloads)
     if (luajit_states == NULL) {
         int cnt = 0;
         char *conf_val = NULL;
+        ConfNode *denode = NULL;
+        ConfNode *decnf = ConfGetNode("detect-engine");
+        if (decnf != NULL) {
+            TAILQ_FOREACH(denode, &decnf->head, next) {
+                if (strcmp(denode->val, "luajit-states") == 0) {
+                    (void)ConfGetChildValueInt(denode, "luajit-states", &cnt);
+                }
+            }
+        }
 
-        if ((ConfGet("detect-engine.luajit-states", &conf_val)) == 1) {
-            cnt = (int)atoi(conf_val);
-        } else {
+        if (cnt == 0) {
             int cpus = UtilCpuGetNumProcessorsOnline();
             if (cpus == 0) {
                 cpus = 10;


### PR DESCRIPTION
detect-engine is a list, and luajit-states was looked up as a map.