### PR TITLE
New PktAcqBreakLoop callback in TmModule

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -271,6 +271,7 @@ void TmModuleReceiveAFPRegister (void)
     tmm_modules[TMM_RECEIVEAFP].ThreadInit = ReceiveAFPThreadInit;
     tmm_modules[TMM_RECEIVEAFP].Func = NULL;
     tmm_modules[TMM_RECEIVEAFP].PktAcqLoop = ReceiveAFPLoop;
+    tmm_modules[TMM_RECEIVEAFP].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEAFP].ThreadExitPrintStats = ReceiveAFPThreadExitStats;
     tmm_modules[TMM_RECEIVEAFP].ThreadDeinit = NULL;
     tmm_modules[TMM_RECEIVEAFP].RegisterTests = NULL;

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -138,6 +138,7 @@ TmModuleReceiveErfDagRegister(void)
     tmm_modules[TMM_RECEIVEERFDAG].ThreadInit = ReceiveErfDagThreadInit;
     tmm_modules[TMM_RECEIVEERFDAG].Func = NULL;
     tmm_modules[TMM_RECEIVEERFDAG].PktAcqLoop = ReceiveErfDagLoop;
+    tmm_modules[TMM_RECEIVEERFDAG].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEERFDAG].ThreadExitPrintStats =
         ReceiveErfDagThreadExitStats;
     tmm_modules[TMM_RECEIVEERFDAG].ThreadDeinit = NULL;

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -81,6 +81,7 @@ TmModuleReceiveErfFileRegister(void)
     tmm_modules[TMM_RECEIVEERFFILE].ThreadInit = ReceiveErfFileThreadInit;
     tmm_modules[TMM_RECEIVEERFFILE].Func = NULL;
     tmm_modules[TMM_RECEIVEERFFILE].PktAcqLoop = ReceiveErfFileLoop;
+    tmm_modules[TMM_RECEIVEERFFILE].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEERFFILE].ThreadExitPrintStats =
         ReceiveErfFileThreadExitStats;
     tmm_modules[TMM_RECEIVEERFFILE].ThreadDeinit = NULL;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -158,6 +158,7 @@ void TmModuleReceiveIPFWRegister (void)
     tmm_modules[TMM_RECEIVEIPFW].ThreadInit = ReceiveIPFWThreadInit;
     tmm_modules[TMM_RECEIVEIPFW].Func = NULL;
     tmm_modules[TMM_RECEIVEIPFW].PktAcqLoop = ReceiveIPFWLoop;
+    tmm_modules[TMM_RECEIVEIPFW].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEIPFW].ThreadExitPrintStats = ReceiveIPFWThreadExitStats;
     tmm_modules[TMM_RECEIVEIPFW].ThreadDeinit = ReceiveIPFWThreadDeinit;
     tmm_modules[TMM_RECEIVEIPFW].cap_flags = SC_CAP_NET_ADMIN | SC_CAP_NET_RAW |

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -173,6 +173,7 @@ void TmModuleReceiveMpipeRegister (void)
     tmm_modules[TMM_RECEIVEMPIPE].ThreadInit = ReceiveMpipeThreadInit;
     tmm_modules[TMM_RECEIVEMPIPE].Func = NULL;
     tmm_modules[TMM_RECEIVEMPIPE].PktAcqLoop = ReceiveMpipeLoop;
+    tmm_modules[TMM_RECEIVEMPIPE].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEMPIPE].ThreadExitPrintStats = ReceiveMpipeThreadExitStats;
     tmm_modules[TMM_RECEIVEMPIPE].ThreadDeinit = NULL;
     tmm_modules[TMM_RECEIVEMPIPE].RegisterTests = NULL;

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -110,6 +110,7 @@ void TmModuleNapatechStreamRegister(void)
     tmm_modules[TMM_RECEIVENAPATECH].ThreadInit = NapatechStreamThreadInit;
     tmm_modules[TMM_RECEIVENAPATECH].Func = NULL;
     tmm_modules[TMM_RECEIVENAPATECH].PktAcqLoop = NapatechStreamLoop;
+    tmm_modules[TMM_RECEIVENAPATECH].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVENAPATECH].ThreadExitPrintStats = NapatechStreamThreadExitStats;
     tmm_modules[TMM_RECEIVENAPATECH].ThreadDeinit = NapatechStreamThreadDeinit;
     tmm_modules[TMM_RECEIVENAPATECH].RegisterTests = NULL;

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -1069,6 +1069,7 @@ void TmModuleReceiveNetmapRegister(void)
     tmm_modules[TMM_RECEIVENETMAP].ThreadInit = ReceiveNetmapThreadInit;
     tmm_modules[TMM_RECEIVENETMAP].Func = NULL;
     tmm_modules[TMM_RECEIVENETMAP].PktAcqLoop = ReceiveNetmapLoop;
+    tmm_modules[TMM_RECEIVENETMAP].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVENETMAP].ThreadExitPrintStats = ReceiveNetmapThreadExitStats;
     tmm_modules[TMM_RECEIVENETMAP].ThreadDeinit = ReceiveNetmapThreadDeinit;
     tmm_modules[TMM_RECEIVENETMAP].RegisterTests = NULL;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -117,6 +117,7 @@ void TmModuleReceiveNFLOGRegister (void)
     tmm_modules[TMM_RECEIVENFLOG].ThreadInit = ReceiveNFLOGThreadInit;
     tmm_modules[TMM_RECEIVENFLOG].Func = NULL;
     tmm_modules[TMM_RECEIVENFLOG].PktAcqLoop = ReceiveNFLOGLoop;
+    tmm_modules[TMM_RECEIVENFLOG].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVENFLOG].ThreadExitPrintStats = ReceiveNFLOGThreadExitStats;
     tmm_modules[TMM_RECEIVENFLOG].ThreadDeinit = ReceiveNFLOGThreadDeinit;
     tmm_modules[TMM_RECEIVENFLOG].RegisterTests = NULL;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -186,6 +186,7 @@ void TmModuleReceiveNFQRegister (void)
     tmm_modules[TMM_RECEIVENFQ].ThreadInit = ReceiveNFQThreadInit;
     tmm_modules[TMM_RECEIVENFQ].Func = NULL;
     tmm_modules[TMM_RECEIVENFQ].PktAcqLoop = ReceiveNFQLoop;
+    tmm_modules[TMM_RECEIVENFQ].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVENFQ].ThreadExitPrintStats = ReceiveNFQThreadExitStats;
     tmm_modules[TMM_RECEIVENFQ].ThreadDeinit = ReceiveNFQThreadDeinit;
     tmm_modules[TMM_RECEIVENFQ].RegisterTests = NULL;

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -114,6 +114,7 @@ void TmModuleReceivePcapFileRegister (void)
     tmm_modules[TMM_RECEIVEPCAPFILE].ThreadInit = ReceivePcapFileThreadInit;
     tmm_modules[TMM_RECEIVEPCAPFILE].Func = NULL;
     tmm_modules[TMM_RECEIVEPCAPFILE].PktAcqLoop = ReceivePcapFileLoop;
+    tmm_modules[TMM_RECEIVEPCAPFILE].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEPCAPFILE].ThreadExitPrintStats = ReceivePcapFileThreadExitStats;
     tmm_modules[TMM_RECEIVEPCAPFILE].ThreadDeinit = ReceivePcapFileThreadDeinit;
     tmm_modules[TMM_RECEIVEPCAPFILE].RegisterTests = NULL;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -128,6 +128,7 @@ void TmModuleReceivePcapRegister (void)
     tmm_modules[TMM_RECEIVEPCAP].ThreadInit = ReceivePcapThreadInit;
     tmm_modules[TMM_RECEIVEPCAP].Func = NULL;
     tmm_modules[TMM_RECEIVEPCAP].PktAcqLoop = ReceivePcapLoop;
+    tmm_modules[TMM_RECEIVEPCAP].PktAcqBreakLoop = NULL;
     tmm_modules[TMM_RECEIVEPCAP].ThreadExitPrintStats = ReceivePcapThreadExitStats;
     tmm_modules[TMM_RECEIVEPCAP].ThreadDeinit = NULL;
     tmm_modules[TMM_RECEIVEPCAP].RegisterTests = NULL;

--- a/src/tm-modules.h
+++ b/src/tm-modules.h
@@ -49,6 +49,9 @@ typedef struct TmModule_ {
 
     TmEcode (*PktAcqLoop)(ThreadVars *, void *, void *);
 
+    /** terminates the capture loop in PktAcqLoop */
+    TmEcode (*PktAcqBreakLoop)(ThreadVars *, void *);
+
     TmEcode (*Management)(ThreadVars *, void *);
 
     /** global Init/DeInit */

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1437,10 +1437,11 @@ again:
      * with all receive threads */
     while (tv) {
         int disable = 0;
+        TmModule *tm;
         /* obtain the slots for this TV */
         TmSlot *slots = tv->tm_slots;
         while (slots != NULL) {
-            TmModule *tm = TmModuleGetById(slots->tm_id);
+            tm = TmModuleGetById(slots->tm_id);
 
             if (tm->flags & TM_FLAG_RECEIVE_TM) {
                 disable = 1;
@@ -1469,6 +1470,9 @@ again:
             }
 
             /* we found a receive TV. Send it a KILL_PKTACQ signal. */
+            if (tm->PktAcqBreakLoop != NULL) {
+                tm->PktAcqBreakLoop(tv, SC_ATOMIC_GET(slots->slot_data));
+            }
             TmThreadsSetFlag(tv, THV_KILL_PKTACQ);
 
             if (tv->inq != NULL) {


### PR DESCRIPTION
This patch adds a new callback PktAcqBreakLoop() in TmModule to let packet acquisition modules define "break-loop" functions to terminate the capture loop. This is useful in case of blocking functions that need special actions to take place in order to stop the execution.