### PR TITLE
Dev mixed mode v3

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -147,7 +147,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
         }
 
         char *action = "";
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -220,7 +220,7 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -278,7 +278,7 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -340,7 +340,7 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
             continue;
         }
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -1410,8 +1410,8 @@ int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix)
     struct timeval ts;
     memset(&ts, 0x00, sizeof(struct timeval));
 
-    extern int run_mode;
-    if (run_mode == RUNMODE_UNITTEST)
+    extern RunModesList runmodeslist;
+    if (runmodeslist.run_mode[0] == RUNMODE_UNITTEST)
         TimeGet(&ts);
     else
         gettimeofday(&ts, NULL);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -176,7 +176,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 TcpStream *opposing_stream = NULL;
                 if (stream == &ssn->client) {
                     opposing_stream = &ssn->server;
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOSERVER;
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     } else {
@@ -185,7 +185,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     }
                 } else {
                     opposing_stream = &ssn->client;
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOCLIENT;
                         p->flowflags |= FLOW_PKT_TOSERVER;
                     } else {
@@ -203,7 +203,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     ret = StreamTcpReassembleAppLayer(tv, ra_ctx, ssn,
                                                       opposing_stream, p);
                 if (stream == &ssn->client) {
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOCLIENT;
                         p->flowflags |= FLOW_PKT_TOSERVER;
                     } else {
@@ -211,7 +211,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     }
                 } else {
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOSERVER;
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     } else {

--- a/src/decode.c
+++ b/src/decode.c
@@ -231,6 +231,16 @@ inline int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datale
     return 0;
 }
 
+int PacketModeIsIPS(const Packet *p)
+{
+    return (p->pkt_mode == IPS);
+}
+
+int PacketModeIsIDS(const Packet *p)
+{
+    return (p->pkt_mode == IDS);
+}
+
 /**
  *  \brief Copy data to Packet payload and set packet length
  *
@@ -275,6 +285,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->ts.tv_usec = parent->ts.tv_usec;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
 
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL)
@@ -345,8 +356,10 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
     p->recursion_level = parent->recursion_level; /* NOT incremented */
     p->ts.tv_sec = parent->ts.tv_sec;
     p->ts.tv_usec = parent->ts.tv_usec;
-    p->datalink = DLT_RAW;
+    p->datalink = DLT_RAW; 
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
+
     /* tell new packet it's part of a tunnel */
     SET_TUNNEL_PKT(p);
     p->vlan_id[0] = parent->vlan_id[0];

--- a/src/decode.h
+++ b/src/decode.h
@@ -351,6 +351,14 @@ typedef struct PktProfiling_ {
 /* forward declartion since Packet struct definition requires this */
 struct PacketQueue_;
 
+/*
+   since a pkt could come from different runmodes, we need to set
+   a mode to be able to do an action later.
+   (e.g. if a pkt come from NFQ, pkt_mode will be set to IPS and
+         it means that we'll be able to drop it.)
+*/
+enum PktMode {IDS, IPS, AUTO};
+
 /* sizes of the members:
  * src: 17 bytes
  * dst: 17 bytes
@@ -400,6 +408,8 @@ typedef struct Packet_
     struct Flow_ *flow;
 
     struct timeval ts;
+
+    enum PktMode pkt_mode;
 
     union {
         /* nfq stuff */
@@ -874,6 +884,8 @@ int PacketCallocExtPkt(Packet *p, int datalen);
 int PacketCopyData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketSetData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datalen);
+int PacketModeIsIPS(const Packet *p);
+int PacketModeIsIDS(const Packet *p);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
 
 DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1047,7 +1047,7 @@ static uint8_t DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
         }
     }
 
-    if (run_mode == RUNMODE_UNITTEST) {
+    if (runmodeslist.run_mode[0] == RUNMODE_UNITTEST) {
         de_ctx->sgh_mpm_context = ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL;
     }
 

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -27,10 +27,10 @@
  */
 
 #include "suricata-common.h"
-
+#include "suricata.h"
 #include "runmodes.h"
 
-extern int run_mode;
+extern RunModesList runmodeslist;
 
 #include "decode.h"
 
@@ -91,7 +91,7 @@ int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, char *replacestr)
         goto error;
     }
 
-    switch (run_mode) {
+    switch (runmodeslist.run_mode[0]) {
         case RUNMODE_NFQ:
         case RUNMODE_IPFW:
             break;
@@ -339,15 +339,15 @@ int DetectReplaceLongPatternMatchTestWrp(char *sig, uint32_t sid, char *sig_rep,
     uint16_t psize = sizeof(raw_eth_pkt);
 
     /* would be unittest */
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
     ret = DetectReplaceLongPatternMatchTest(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt),
                              sig, sid, p, &psize);
     if (ret == 1) {
         SCLogDebug("replace: test1 phase1");
         ret = DetectReplaceLongPatternMatchTest(p, psize, sig_rep, sid_rep, NULL, NULL);
     }
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
     return ret;
 }
 
@@ -374,15 +374,15 @@ int DetectReplaceLongPatternMatchTestUDPWrp(char *sig, uint32_t sid, char *sig_r
     uint8_t p[sizeof(raw_eth_pkt)];
     uint16_t psize = sizeof(raw_eth_pkt);
 
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
     ret = DetectReplaceLongPatternMatchTest(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt),
                              sig, sid, p, &psize);
     if (ret == 1) {
         SCLogDebug("replace: test1 phase1 ok: %" PRIuMAX" vs %d",(uintmax_t)sizeof(raw_eth_pkt),psize);
         ret = DetectReplaceLongPatternMatchTest(p, psize, sig_rep, sid_rep, NULL, NULL);
     }
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
     return ret;
 }
 
@@ -573,8 +573,8 @@ static int DetectReplaceMatchTest15(void)
  */
 static int DetectReplaceParseTest01(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -593,7 +593,7 @@ static int DetectReplaceParseTest01(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -607,8 +607,8 @@ static int DetectReplaceParseTest01(void)
  */
 static int DetectReplaceParseTest02(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -627,7 +627,7 @@ static int DetectReplaceParseTest02(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -642,8 +642,8 @@ static int DetectReplaceParseTest02(void)
  */
 static int DetectReplaceParseTest03(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -662,7 +662,7 @@ static int DetectReplaceParseTest03(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -676,8 +676,8 @@ static int DetectReplaceParseTest03(void)
  */
 static int DetectReplaceParseTest04(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -696,7 +696,7 @@ static int DetectReplaceParseTest04(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -710,8 +710,8 @@ static int DetectReplaceParseTest04(void)
  */
 static int DetectReplaceParseTest05(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -730,7 +730,7 @@ static int DetectReplaceParseTest05(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -744,8 +744,8 @@ static int DetectReplaceParseTest05(void)
  */
 static int DetectReplaceParseTest06(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -764,7 +764,7 @@ static int DetectReplaceParseTest06(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -778,8 +778,8 @@ static int DetectReplaceParseTest06(void)
  */
 static int DetectReplaceParseTest07(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -798,7 +798,7 @@ static int DetectReplaceParseTest07(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -459,7 +459,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 de_ctx->config_prefix);
     }
 
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodeGetCurrent(0) == RUNMODE_ENGINE_ANALYSIS) {
         fp_engine_analysis_set = SetupFPAnalyzer();
         rule_engine_analysis_set = SetupRuleAnalyzer();
     }
@@ -539,7 +539,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodeGetCurrent(0) == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();
         }

--- a/src/detect.c
+++ b/src/detect.c
@@ -666,7 +666,7 @@ static StreamMsg *SigMatchSignaturesGetSmsg(Flow *f, Packet *p, uint8_t flags)
         TcpSession *ssn = (TcpSession *)f->protoctx;
 
         /* at stream eof, or in inline mode, inspect all smsg's */
-        if ((flags & STREAM_EOF) || StreamTcpInlineMode()) {
+        if ((flags & STREAM_EOF) || StreamTcpInlineMode(p)) {
             if (p->flowflags & FLOW_PKT_TOSERVER) {
                 smsg = ssn->toserver_smsg_head;
                 /* deref from the ssn */
@@ -11505,6 +11505,7 @@ static int SigTestDropFlow03(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->pkt_mode = IPS;
     f.alproto = ALPROTO_HTTP;
 
     StreamTcpInitConfig(TRUE);

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -278,8 +278,8 @@ static int LogDropLogNetFilter (ThreadVars *tv, const Packet *p, void *data)
  */
 static int LogDropCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
-        SCLogDebug("engine is not running in inline mode, so returning");
+    if (!PacketModeIsIPS(p)) {
+        SCLogDebug("packet is not running in inline mode, so returning");
         return FALSE;
     }
     if (PKT_IS_PSEUDOPKT(p)) {
@@ -374,6 +374,7 @@ int LogDropLogTest01()
 
     memset(&th_v, 0, sizeof(th_v));
     p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
+    p->pkt_mode = IPS;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -142,7 +142,7 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
     char *action = "allowed";
     if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
         action = "blocked";
-    } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+    } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
         action = "blocked";
     }
 
@@ -274,7 +274,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
                 MemBufferReset(payload);
 
-                if (!EngineModeIsIPS()) {
+                if (!PacketModeIsIPS(p)) {
                     if (p->flowflags & FLOW_PKT_TOSERVER) {
                         flag = FLOW_PKT_TOCLIENT;
                     } else {
@@ -401,7 +401,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         char *action = "allowed";
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "blocked";
         }
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -150,7 +150,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
                 continue;
             }
             if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
-               ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
+               ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)))
             {
                 AlertJsonHeader(p, pa, js);
                 logged = 1;
@@ -362,8 +362,8 @@ static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
  */
 static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
-        SCLogDebug("engine is not running in inline mode, so returning");
+    if (!PacketModeIsIPS(p)) {
+        SCLogDebug("packet is not running in inline mode, so returning");
         return FALSE;
     }
     if (PKT_IS_PSEUDOPKT(p)) {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -378,7 +378,7 @@ int AFPConfigGeThreadsCount(void *conf)
 
 int AFPRunModeIsIPS()
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_AFP_DEV);
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -395,7 +395,7 @@ int AFPRunModeIsIPS()
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        char *live_dev = LiveGetDeviceName(ldev);
+        char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -425,7 +425,7 @@ int AFPRunModeIsIPS()
     if (has_ids && has_ips) {
         SCLogInfo("AF_PACKET mode using IPS and IDS mode");
         for (ldev = 0; ldev < nlive; ldev++) {
-            char *live_dev = LiveGetDeviceName(ldev);
+            char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;
@@ -480,7 +480,7 @@ int RunModeIdsAFPAutoFp(void)
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
                               "DecodeAFP", "RxAFP",
-                              live_dev);
+                              live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -522,7 +522,7 @@ int RunModeIdsAFPSingle(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", "AFPacket",
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -567,7 +567,7 @@ int RunModeIdsAFPWorkers(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", "AFPacket",
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -86,7 +86,7 @@ int RunModeIdsErfDagSingle(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
         exit(EXIT_FAILURE);
@@ -112,7 +112,7 @@ int RunModeIdsErfDagAutoFp(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
         exit(EXIT_FAILURE);
@@ -138,7 +138,7 @@ int RunModeIdsErfDagWorkers(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");
         exit(EXIT_FAILURE);

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -373,7 +373,7 @@ int RunModeIdsNetmapAutoFp(void)
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
                               "DecodeNetmap", "RxNetmap",
-                              live_dev);
+                              live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -406,7 +406,7 @@ int RunModeIdsNetmapSingle(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", "NetmapPkt",
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -442,7 +442,7 @@ int RunModeIdsNetmapWorkers(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", "NetmapPkt",
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -185,7 +185,7 @@ int RunModeIdsNflogAutoFp(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       "RecvNFLOG",
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -213,7 +213,7 @@ int RunModeIdsNflogSingle(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       "RecvNFLOG",
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -241,7 +241,7 @@ int RunModeIdsNflogWorkers(void)
                                        "ReceiveNFLOG",
                                        "DecodeNFLOG",
                                        "RecvNFLOG",
-                                       live_dev);
+                                       live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nfq.c
+++ b/src/runmode-nfq.c
@@ -74,7 +74,8 @@ int RunModeIpsNFQAutoFp(void)
     ret = RunModeSetIPSAutoFp(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }
@@ -94,7 +95,8 @@ int RunModeIpsNFQWorker(void)
     ret = RunModeSetIPSWorker(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -243,7 +243,7 @@ int RunModeIdsPcapSingle(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", "PcapLive",
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -284,7 +284,7 @@ int RunModeIdsPcapAutoFp(void)
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
                               "DecodePcap", "RxPcap",
-                              live_dev);
+                              live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -316,7 +316,7 @@ int RunModeIdsPcapWorkers(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", "RxPcap",
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -397,7 +397,7 @@ static int GetDevAndParser(char **live_dev, ConfigIfaceParserFunc *parser)
         if (*live_dev == NULL) {
             if (ConfGet("pfring.interface", live_dev) == 1) {
                 SCLogInfo("Using interface %s", *live_dev);
-                LiveRegisterDevice(*live_dev);
+                LiveRegisterDevice(*live_dev, RUNMODE_PFRING);
             } else {
                 SCLogInfo("No interface found, problem incoming");
                 *live_dev = NULL;
@@ -434,7 +434,7 @@ int RunModeIdsPfringAutoFp(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -471,7 +471,7 @@ int RunModeIdsPfringSingle(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -508,7 +508,7 @@ int RunModeIdsPfringWorkers(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -188,9 +188,9 @@ char *RunmodeGetActive(void)
  *
  * \return a string containing the current running mode
  */
-const char *RunModeGetMainMode(void)
+const char *RunModeGetMainMode(int index)
 {
-    int mainmode = RunmodeGetCurrent();
+    int mainmode = RunmodeGetCurrent(index);
 
     return RunModeTranslateModeToName(mainmode);
 }

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -24,7 +24,7 @@
 #define __RUNMODES_H__
 
 /* Run mode */
-enum {
+enum RunModes {
     RUNMODE_UNKNOWN = 0,
     RUNMODE_PCAP_DEV,
     RUNMODE_PCAP_FILE,

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -61,7 +61,7 @@ enum RunModes {
 };
 
 char *RunmodeGetActive(void);
-const char *RunModeGetMainMode(void);
+const char *RunModeGetMainMode(int index);
 
 void RunModeListRunmodes(void);
 void RunModeDispatch(int, const char *);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1682,7 +1682,7 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
     strlcpy(ptv->iface, afpconfig->iface, AFP_IFACE_NAME_LENGTH);
     ptv->iface[AFP_IFACE_NAME_LENGTH - 1]= '\0';
 
-    ptv->livedev = LiveGetDevice(ptv->iface);
+    ptv->livedev = LiveGetDevice(ptv->iface, RUNMODE_AFP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -533,7 +533,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     ntv->checksum_mode = aconf->checksum_mode;
     ntv->copy_mode = aconf->copy_mode;
 
-    ntv->livedev = LiveGetDevice(aconf->iface_name);
+    ntv->livedev = LiveGetDevice(aconf->iface_name, RUNMODE_NETMAP);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         goto error_ntv;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -288,7 +288,7 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCLogDebug("NFLOG netlink queue timeout can't be set to %d",
                     ntv->qtimeout);
 
-    ntv->livedev = LiveGetDevice(nflconfig->numgroup);
+    ntv->livedev = LiveGetDevice(nflconfig->numgroup, RUNMODE_NFLOG);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
 	    SCFree(ntv);

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -155,6 +155,7 @@ static int NFLOGCallback(struct nflog_g_handle *gh, struct nfgenmsg *msg,
         return -1;
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
+    p->pkt_mode = IDS;
 
     ph = nflog_get_msg_packet_hdr(nfa);
     if (ph != NULL) {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -823,7 +823,7 @@ int NFQRegisterQueue(char *queue)
     nq->queue_num = queue_num;
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
-    LiveRegisterDevice(queue);
+    LiveRegisterDevice(queue, RUNMODE_NFQ);
 
     SCLogDebug("Queue \"%s\" registered.", queue);
     return 0;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -505,6 +505,7 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     }
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
+    p->pkt_mode = IPS;
     p->nfq_v.nfq_index = ntv->nfq_index;
     ret = NFQSetupPkt(p, qh, (void *)nfa);
     if (ret == -1) {

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -41,6 +41,7 @@
 #include "util-checksum.h"
 #include "util-ioctl.h"
 #include "tmqh-packetpool.h"
+#include "runmodes.h"
 
 #ifdef __SC_CUDA_SUPPORT__
 
@@ -383,7 +384,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->tv = tv;
 
-    ptv->livedev = LiveGetDevice(pcapconfig->iface);
+    ptv->livedev = LiveGetDevice(pcapconfig->iface, RUNMODE_PCAP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);
@@ -551,7 +552,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->tv = tv;
 
-    ptv->livedev = LiveGetDevice(pcapconfig->iface);
+    ptv->livedev = LiveGetDevice(pcapconfig->iface, RUNMODE_PCAP);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCReturnInt(TM_ECODE_FAILED);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -408,7 +408,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ptv->livedev = LiveGetDevice(pfconf->iface);
+    ptv->livedev = LiveGetDevice(pfconf->iface, RUNMODE_PFRING);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -41,9 +41,14 @@ extern int stream_inline;
  *  \retval 0 no
  *  \retval 1 yes
  */
-int StreamTcpInlineMode(void)
+int StreamTcpInlineMode(Packet *p)
 {
-    return stream_inline;
+    if (stream_inline == IDS)
+        return 0;
+    else if (stream_inline == IPS)
+        return 1;
+    else /* implied AUTO */
+        return (stream_inline && PacketModeIsIPS(p));
 }
 
 /**

--- a/src/stream-tcp-inline.h
+++ b/src/stream-tcp-inline.h
@@ -26,7 +26,7 @@
 
 #include "stream-tcp-private.h"
 
-int StreamTcpInlineMode(void);
+int StreamTcpInlineMode(Packet *p);
 int StreamTcpInlineSegmentCompare(TcpSegment *, TcpSegment *);
 void StreamTcpInlineSegmentReplacePacket(Packet *, TcpSegment *);
 

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1283,7 +1283,7 @@ static int HandleSegmentStartsBeforeListSegment(ThreadVars *tv, TcpReassemblyThr
             StreamTcpSetEvent(p, STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA);
         }
 
-        if (StreamTcpInlineMode()) {
+        if (StreamTcpInlineMode(p)) {
             if (StreamTcpInlineSegmentCompare(seg, list_seg) != 0) {
                 StreamTcpInlineSegmentReplacePacket(p, list_seg);
             }
@@ -1481,7 +1481,7 @@ static int HandleSegmentStartsAtSameListSegment(ThreadVars *tv, TcpReassemblyThr
             StreamTcpSetEvent(p, STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA);
         }
 
-        if (StreamTcpInlineMode()) {
+        if (StreamTcpInlineMode(p)) {
             if (StreamTcpInlineSegmentCompare(list_seg, seg) != 0) {
                 StreamTcpInlineSegmentReplacePacket(p, list_seg);
             }
@@ -1688,7 +1688,7 @@ static int HandleSegmentStartsAfterListSegment(ThreadVars *tv, TcpReassemblyThre
             StreamTcpSetEvent(p, STREAM_REASSEMBLY_OVERLAP_DIFFERENT_DATA);
         }
 
-        if (StreamTcpInlineMode()) {
+        if (StreamTcpInlineMode(p)) {
             if (StreamTcpInlineSegmentCompare(list_seg, seg) != 0) {
                 StreamTcpInlineSegmentReplacePacket(p, list_seg);
             }
@@ -1979,7 +1979,7 @@ static uint8_t StreamGetAppLayerFlags(TcpSession *ssn, TcpStream *stream,
         flag |= STREAM_EOF;
     }
 
-    if (StreamTcpInlineMode() == 0) {
+    if (StreamTcpInlineMode(p) == 0) {
         if (p->flowflags & FLOW_PKT_TOSERVER) {
             flag |= STREAM_TOCLIENT;
         } else {
@@ -2565,7 +2565,7 @@ int DoHandleGap(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
     if (unlikely(SEQ_GT(seg->seq, next_seq))) {
         /* we've run into a sequence gap */
 
-        if (StreamTcpInlineMode()) {
+        if (StreamTcpInlineMode(p)) {
             /* don't conclude it's a gap until we see that the data
              * that is missing was acked. */
             if (SEQ_GT(seg->seq,stream->last_ack) && ssn->state != TCP_CLOSED)
@@ -2688,7 +2688,7 @@ static inline int DoReassemble(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 "ra_base_seq %" PRIu32 ", last_ack %"PRIu32, seg->seq,
                 seg->payload_len, rd->ra_base_seq, stream->last_ack);
 
-        if (StreamTcpInlineMode() == 0) {
+        if (StreamTcpInlineMode(p) == 0) {
             /* handle segments partly before ra_base_seq */
             if (SEQ_GT(rd->ra_base_seq, seg->seq)) {
                 payload_offset = (rd->ra_base_seq + 1) - seg->seq;
@@ -2995,7 +2995,7 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
         /* if in inline mode, we process all segments regardless of whether
          * they are ack'd or not. In non-inline, we process only those that
          * are at least partly ack'd. */
-        if (StreamTcpInlineMode() == 0 && SEQ_GEQ(seg->seq, stream->last_ack))
+        if (StreamTcpInlineMode(p) == 0 && SEQ_GEQ(seg->seq, stream->last_ack))
             break;
 
         SCLogDebug("seg %p, SEQ %"PRIu32", LEN %"PRIu16", SUM %"PRIu32,
@@ -3053,7 +3053,7 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
     /* if no data was sent to the applayer, we send it a empty 'nudge'
      * when in inline mode */
-    if (StreamTcpInlineMode() && rd.data_sent == 0 && ssn->state > TCP_ESTABLISHED) {
+    if (StreamTcpInlineMode(p) && rd.data_sent == 0 && ssn->state > TCP_ESTABLISHED) {
         SCLogDebug("sending empty eof message");
         /* send EOF to app layer */
         AppLayerHandleTCPData(tv, ra_ctx, p, p->flow, ssn, stream,
@@ -3392,7 +3392,7 @@ int StreamTcpReassembleHandleSegmentUpdateACK (ThreadVars *tv,
     SCLogDebug("stream->seg_list %p", stream->seg_list);
 
     int r = 0;
-    if (!(StreamTcpInlineMode())) {
+    if (!(StreamTcpInlineMode(p))) {
         if (StreamTcpReassembleAppLayer(tv, ra_ctx, ssn, stream, p) < 0)
             r = -1;
         if (StreamTcpReassembleRaw(ra_ctx, ssn, stream, p) < 0)
@@ -3442,7 +3442,7 @@ int StreamTcpReassembleHandleSegment(ThreadVars *tv, TcpReassemblyThreadCtx *ra_
 
     /* in stream inline mode even if we have no data we call the reassembly
      * functions to handle EOF */
-    if (StreamTcpInlineMode()) {
+    if (StreamTcpInlineMode(p)) {
         int r = 0;
         if (StreamTcpReassembleAppLayer(tv, ra_ctx, ssn, stream, p) < 0)
             r = -1;
@@ -8464,6 +8464,7 @@ static int StreamTcpReassembleInlineTest10(void)
     p->tcph->th_seq = htonl(7);
     p->flow = f;
     p->flowflags |= FLOW_PKT_TOSERVER;
+    p->pkt_mode = IPS;
 
     SCMutexLock(&f->m);
     if (StreamTcpUTAddSegmentWithPayload(&tv, ra_ctx, &ssn.server,  2, stream_payload1, 2) == -1) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -120,7 +120,7 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 SC_ATOMIC_DECLARE(uint64_t, st_memuse);
 
 /* stream engine running in "inline" mode. */
-int stream_inline = 0;
+enum PktMode stream_inline;
 
 void TmModuleStreamTcpRegister (void)
 {
@@ -422,7 +422,7 @@ void StreamTcpInitConfig(char quiet)
                 "enabled" : "disabled");
     }
 
-    int inl = 0;
+    int inl = IDS;
 
 
     char *temp_stream_inline_str;
@@ -430,13 +430,10 @@ void StreamTcpInitConfig(char quiet)
         /* checking for "auto" and falling back to boolean to provide
          * backward compatibility */
         if (strcmp(temp_stream_inline_str, "auto") == 0) {
-            if (EngineModeIsIPS()) {
-                stream_inline = 1;
-            } else {
-                stream_inline = 0;
-            }
+            stream_inline = AUTO;
         } else if (ConfGetBool("stream.inline", &inl) == 1) {
-            stream_inline = inl;
+            if (inl == IPS)
+                stream_inline = IPS;
         }
     }
 
@@ -4679,7 +4676,7 @@ error:
         ReCalculateChecksum(p);
     }
 
-    if (StreamTcpInlineMode()) {
+    if (StreamTcpInlineMode(p)) {
         PACKET_DROP(p);
     }
     SCReturnInt(-1);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -147,7 +147,7 @@ static inline int StreamTcpCheckFlowDrops(Packet *p)
      * the IP only module, or from a reassembled msg and/or from an
      * applayer detection, then drop the rest of the packets of the
      * same stream and avoid inspecting it any further */
-    if (EngineModeIsIPS() && (p->flow->flags & FLOW_ACTION_DROP))
+    if (PacketModeIsIPS(p) && (p->flow->flags & FLOW_ACTION_DROP))
         return 1;
 
     return 0;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1180,7 +1180,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     strlcpy(suri->pcap_dev, optarg,
                             ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                              (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                    LiveRegisterDevice(optarg);
+                    LiveRegisterDevice(optarg, RUNMODE_PFRING);
                 }
 #else
                 SCLogError(SC_ERR_NO_PF_RING,"PF_RING not enabled. Make sure "
@@ -1217,7 +1217,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_AFP_DEV;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1227,7 +1227,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple devices to get packets is experimental.");
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
                     } else {
                         SCLogInfo("Multiple af-packet option without interface on each is useless");
                         break;
@@ -1249,7 +1249,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_NETMAP;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_NETMAP);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1259,7 +1259,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple devices to get packets is experimental.");
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_NETMAP);
                     } else {
                         SCLogInfo("Multiple netmap option without interface on each is useless");
                         break;
@@ -1288,7 +1288,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_PCAP_DEV;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_PCAP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1302,7 +1302,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #else
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple pcap devices to get packets is experimental.");
-                    LiveRegisterDevice(optarg);
+                    LiveRegisterDevice(optarg, RUNMODE_PCAP_DEV);
 #endif
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
@@ -1434,7 +1434,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     usage(argv[0]);
                     return TM_ECODE_FAILED;
                 }
-                LiveRegisterDevice(optarg);
+                LiveRegisterDevice(optarg, RUNMODE_DAG);
 #else
                 SCLogError(SC_ERR_DAG_REQUIRED, "libdag and a DAG card are required"
 						" to receieve packets using --dag.");
@@ -1474,7 +1474,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_MPIPE);
                     }
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
@@ -1546,7 +1546,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_PCAP_DEV;
-                LiveRegisterDevice(suri->pcap_dev);
+                LiveRegisterDevice(suri->pcap_dev, RUNMODE_PCAP_DEV);
             } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
                 SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
@@ -1555,7 +1555,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #else
                 SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                         "multiple pcap devices to get packets is experimental.");
-                LiveRegisterDevice(suri->pcap_dev);
+                LiveRegisterDevice(suri->pcap_dev, RUNMODE_PCAP_DEV);
 #endif
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -92,6 +92,8 @@
                                      packets. */
 #define SURICATA_DONE    (1 << 2)   /**< packets capture ended */
 
+#define RUNMODES_MAX     2
+
 /* Engine stage/status*/
 enum {
     SURICATA_INIT = 0,
@@ -126,8 +128,14 @@ PacketQueue trans_q[256];
 
 SCDQDataQueue data_queues[256];
 
+typedef struct RunModesList_ {
+    int run_mode[RUNMODES_MAX];
+    int runmodes_cnt;
+    int enable_mixed_mode;
+} RunModesList;
+
 typedef struct SCInstance_ {
-    int run_mode;
+    RunModesList runmodeslist;
 
     char pcap_dev[128];
     char *sig_file;
@@ -188,10 +196,10 @@ void SignalHandlerSigusr2EngineShutdown(int);
 void SignalHandlerSigusr2Idle(int sig);
 
 int RunmodeIsUnittests(void);
-int RunmodeGetCurrent(void);
+int RunmodeGetCurrent(int index);
 int IsRuleReloadSet(int quiet);
 
-extern int run_mode;
+extern RunModesList runmodeslist;
 
 #endif /* __SURICATA_H__ */
 

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -643,7 +643,7 @@ TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
                                       json_t *server_msg, void *data)
 {
     SCEnter();
-    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode()));
+    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode(0)));
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -42,7 +42,7 @@ static int live_devices_stats = 1;
  *  \retval 0 on success.
  *  \retval -1 on failure.
  */
-int LiveRegisterDevice(char *dev)
+int LiveRegisterDevice(char *dev, enum RunModes runmode)
 {
     LiveDevice *pd = SCMalloc(sizeof(LiveDevice));
     if (unlikely(pd == NULL)) {
@@ -54,6 +54,8 @@ int LiveRegisterDevice(char *dev)
         SCFree(pd);
         return -1;
     }
+    pd->runmode = runmode;
+
     SC_ATOMIC_INIT(pd->pkts);
     SC_ATOMIC_INIT(pd->drop);
     SC_ATOMIC_INIT(pd->invalid_checksums);
@@ -69,13 +71,15 @@ int LiveRegisterDevice(char *dev)
  *
  *  \retval cnt the number of registered devices
  */
-int LiveGetDeviceCount(void)
+int LiveGetDeviceCount(enum RunModes runmode)
 {
     int i = 0;
     LiveDevice *pd;
 
     TAILQ_FOREACH(pd, &live_devices, next) {
-        i++;
+        if (runmode == pd->runmode) {
+            i++;
+        }
     }
 
     return i;
@@ -89,17 +93,19 @@ int LiveGetDeviceCount(void)
  *  \retval ptr pointer to the string containing the device
  *  \retval NULL on error
  */
-char *LiveGetDeviceName(int number)
+char *LiveGetDeviceName(int number, enum RunModes runmode)
 {
     int i = 0;
     LiveDevice *pd;
 
     TAILQ_FOREACH(pd, &live_devices, next) {
-        if (i == number) {
+        if (i == number && runmode == pd->runmode) {
             return pd->dev;
         }
 
-        i++;
+        if (runmode == pd->runmode) {
+            i++;
+        }
     }
 
     return NULL;
@@ -113,7 +119,7 @@ char *LiveGetDeviceName(int number)
  *  \retval ptr pointer to the string containing the device
  *  \retval NULL on error
  */
-LiveDevice *LiveGetDevice(char *name)
+LiveDevice *LiveGetDevice(char *name, enum RunModes runmode)
 {
     int i = 0;
     LiveDevice *pd;
@@ -124,11 +130,13 @@ LiveDevice *LiveGetDevice(char *name)
     }
 
     TAILQ_FOREACH(pd, &live_devices, next) {
-        if (!strcmp(name, pd->dev)) {
+        if (!strcmp(name, pd->dev) && runmode == pd->runmode) {
             return pd;
         }
 
-        i++;
+        if (runmode == pd->runmode) {
+            i++;
+        }
     }
 
     return NULL;
@@ -136,12 +144,12 @@ LiveDevice *LiveGetDevice(char *name)
 
 
 
-int LiveBuildDeviceList(char * runmode)
+int LiveBuildDeviceList(char * runmode, enum RunModes run_mode)
 {
-    return LiveBuildDeviceListCustom(runmode, "interface");
+    return LiveBuildDeviceListCustom(runmode, "interface", run_mode);
 }
 
-int LiveBuildDeviceListCustom(char * runmode, char * itemname)
+int LiveBuildDeviceListCustom(char * runmode, char * itemname, enum RunModes run_mode)
 {
     ConfNode *base = ConfGetNode(runmode);
     ConfNode *child;
@@ -158,7 +166,7 @@ int LiveBuildDeviceListCustom(char * runmode, char * itemname)
                     break;
                 SCLogInfo("Adding %s %s from config file",
                           itemname, subchild->val);
-                LiveRegisterDevice(subchild->val);
+                LiveRegisterDevice(subchild->val, run_mode);
                 i++;
             }
         }

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -20,10 +20,12 @@
 
 #include "queue.h"
 #include "unix-manager.h"
+#include "runmodes.h"
 
 /** storage for live device names */
 typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
+    enum RunModes runmode; /**< the runmode (e.g. "RUNMODE_NFLOG") */
     int ignore_checksum;
     SC_ATOMIC_DECLARE(uint64_t, pkts);
     SC_ATOMIC_DECLARE(uint64_t, drop);
@@ -32,14 +34,14 @@ typedef struct LiveDevice_ {
 } LiveDevice;
 
 
-int LiveRegisterDevice(char *dev);
-int LiveGetDeviceCount(void);
-char *LiveGetDeviceName(int number);
-LiveDevice *LiveGetDevice(char *dev);
-int LiveBuildDeviceList(char * base);
+int LiveRegisterDevice(char *dev, enum RunModes runmode);
+int LiveGetDeviceCount(enum RunModes runmode);
+char *LiveGetDeviceName(int number, enum RunModes runmode);
+LiveDevice *LiveGetDevice(char *dev, enum RunModes runmode);
+int LiveBuildDeviceList(char * base, enum RunModes runmode);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);
-int LiveBuildDeviceListCustom(char * base, char * itemname);
+int LiveBuildDeviceListCustom(char * base, char * itemname, enum RunModes runmode);
 
 #ifdef BUILD_UNIX_SOCKET
 TmEcode LiveDeviceIfaceStat(json_t *cmd, json_t *server_msg, void *data);

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -71,7 +71,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
 
     capng_clear(CAPNG_SELECT_BOTH);
 
-    switch (run_mode) {
+    switch (runmodeslist.run_mode[0]) {
         case RUNMODE_PCAP_DEV:
         case RUNMODE_AFP_DEV:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -104,7 +104,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
@@ -112,7 +112,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     int thread = 0;
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     int thread_max = TmThreadGetNbThreads(DETECT_CPU_SET);
     /* always create at least one thread */
     if (thread_max == 0)
@@ -190,7 +190,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         int lthread;
 
         for (lthread = 0; lthread < nlive; lthread++) {
-            char *live_dev = LiveGetDeviceName(lthread);
+            char *live_dev = LiveGetDeviceName(lthread, runmode);
             void *aconf;
             int threads_count;
 
@@ -412,9 +412,9 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     void *aconf;
     int ldev;
 
@@ -428,7 +428,7 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                 exit(EXIT_FAILURE);
             }
         } else {
-            live_dev_c = LiveGetDeviceName(ldev);
+            live_dev_c = LiveGetDeviceName(ldev, runmode);
             aconf = ConfigParser(live_dev_c);
         }
         RunModeSetLiveCaptureWorkersForDevice(ModThreadsCount,
@@ -447,9 +447,9 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     void *aconf;
 
     if (nlive > 1) {
@@ -461,7 +461,7 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
     if (live_dev != NULL) {
         aconf = ConfigParser(live_dev);
     } else {
-        char *live_dev_c = LiveGetDeviceName(0);
+        char *live_dev_c = LiveGetDeviceName(0, runmode);
         aconf = ConfigParser(live_dev_c);
         /* \todo Set threads number in config to 1 */
     }
@@ -482,7 +482,8 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name)
+                        char *decode_mod_name,
+                        int runmode)
 {
     SCEnter();
     char tname[TM_THREAD_NAME_MAX];
@@ -494,8 +495,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nqueue = LiveGetDeviceCount();
-
+    int nqueue = LiveGetDeviceCount(runmode);
     int thread_max = TmThreadGetNbThreads(DETECT_CPU_SET);
     /* always create at least one thread */
     if (thread_max == 0)
@@ -513,7 +513,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     for (int i = 0; i < nqueue; i++) {
     /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);
@@ -534,6 +534,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
+
         TmModule *tm_module = TmModuleGetByName(recv_mod_name);
         if (tm_module == NULL) {
             SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName failed for %s", recv_mod_name);
@@ -659,18 +660,19 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
         char *recv_mod_name,
         char *verdict_mod_name,
-        char *decode_mod_name)
+        char *decode_mod_name,
+        int runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     ThreadVars *tv = NULL;
     TmModule *tm_module = NULL;
     char *cur_queue = NULL;
 
-    int nqueue = LiveGetDeviceCount();
+    int nqueue = LiveGetDeviceCount(runmode);
 
     for (int i = 0; i < nqueue; i++) {
         /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);

--- a/src/util-runmodes.h
+++ b/src/util-runmodes.h
@@ -34,35 +34,37 @@ int RunModeSetLiveCaptureAuto(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name);
+                        char *decode_mod_name,
+                        int runmode);
 
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name);
+                        char *decode_mod_name,
+                        int runmode);
 
 char *RunmodeAutoFpCreatePickupQueuesString(int n);
 


### PR DESCRIPTION
This permits to run suricata in mixed-mode.
It's only a preview, so it will need more work.

The idea is to replace single run_mode with a structure named RunModesList,
which represents the runmodes that will be run in an array.
Currently it's possibile to run two runmodes of the following:
AF_PACKET, Nfqueue, Nflog.

It means that if you try to run, for example, PF_RING and AF_PACKET, it won't work.

Updates:
- declare runmode as enum and not int
- rename enum mode to enum PktMode

Last PR: https://github.com/inliniac/suricata/pull/1698

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/72
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/71