### PR TITLE
pfring pkt acq: removed reentrant flag

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -417,7 +417,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->checksum_mode = pfconf->checksum_mode;
 
-    opflag = PF_RING_REENTRANT | PF_RING_PROMISC;
+    opflag = PF_RING_PROMISC;
 
     /* if suri uses VLAN and if we have a recent kernel, we need
      * to use parsed_pkt to get VLAN info */


### PR DESCRIPTION
PF_RING_REENTRANT is not needed as each pfring socket is used by a single thread.