### PR TITLE
pfring pkt acq: capture loop optimisation

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -295,7 +295,6 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
     struct pfring_pkthdr hdr;
     TmSlot *s = (TmSlot *)slot;
     time_t last_dump = 0;
-    struct timeval current_time;
 
     ptv->slot = s->slot_next;
 
@@ -350,10 +349,9 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
             }
 
             /* Trigger one dump of stats every second */
-            TimeGet(&current_time);
-            if (current_time.tv_sec != last_dump) {
+            if (p->ts.tv_sec != last_dump) {
                 PfringDumpCounters(ptv);
-                last_dump = current_time.tv_sec;
+                last_dump = p->ts.tv_sec;
             }
         } else {
             SCLogError(SC_ERR_PF_RING_RECV,"pfring_recv error  %" PRId32 "", r);


### PR DESCRIPTION
For each packet the capture module checks whether it is time to dump stats calling
TimeGet(). TimeGet() is an expensive function using gettimeofday() or SCSpinLock()
which affect performance. Since gettimeofday() is already called for setting packet
timestamp, it is more efficient to use the packet timestamp directly.