### PR TITLE
app-layer-tls: SNI extension support

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -119,6 +119,9 @@ SslConfig ssl_config;
 #define SSLV3_RECORD_HDR_LEN 5
 #define SSLV3_MESSAGE_HDR_LEN 4
 
+#define SSLV3_CLIENT_HELLO_VERSION_LEN 2
+#define SSLV3_CLIENT_HELLO_RANDOM_LEN 32
+
 /* TLS heartbeat protocol types */
 #define TLS_HB_REQUEST              1
 #define TLS_HB_RESPONSE             2
@@ -143,11 +146,101 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
     switch (ssl_state->curr_connp->handshake_type) {
         case SSLV3_HS_CLIENT_HELLO:
             ssl_state->flags |= SSL_AL_FLAG_STATE_CLIENT_HELLO;
+
+            /* skip version */
+            input += SSLV3_CLIENT_HELLO_VERSION_LEN;
+
+            /* skip random */
+            input += SSLV3_CLIENT_HELLO_RANDOM_LEN;
+
+            if ((input - initial_input) > input_len)
+                goto end;
+
+            /* skip session id */
+            uint8_t session_id_length = *(input++);
+
+            input += session_id_length;
+
+            if ((input + 1 - initial_input) > input_len)
+                goto end;
+
+            /* skip cipher suites */
+            uint16_t cipher_suites_length = ntohs(*(uint16_t *)input);
+            input += 2;
+
+            input += cipher_suites_length;
+
+            if ((input - initial_input) > input_len)
+                goto end;
+
+            /* skip compression methods */
+            uint8_t compression_methods_length = *(input++);
+
+            input += compression_methods_length;
+
+            if ((input + 1 - initial_input) > input_len)
+                goto end;
+
+            uint16_t extensions_len = ntohs(*(uint16_t *)input);
+            input += 2;
+
+            uint16_t processed_len = 0;
+            while (processed_len < extensions_len)
+            {
+                if ((input + 1 - initial_input) > input_len)
+                    goto end;
+
+                uint16_t ext_type = ntohs(*(uint16_t *)input);
+                input += 2;
+
+                if ((input + 1 - initial_input) > input_len)
+                    goto end;
+
+                uint16_t ext_len = ntohs(*(uint16_t *)input);
+                input += 2;
+
+
+                switch (ext_type) {
+                    case SSL_EXTENSION_SNI:
+                    {
+                        /* skip sni_list_length and sni_type */
+                        input += 3;
+
+                        if ((input + 1 - initial_input) > input_len)
+                            goto end;
+
+                        uint16_t sni_len = ntohs(*(uint16_t *)input);
+                        input += 2;
+
+                        size_t sni_strlen = sni_len + 1;
+                        ssl_state->curr_connp->sni = SCMalloc(sni_strlen);
+
+                        if (unlikely(ssl_state->curr_connp->sni == NULL))
+                            goto end;
+
+                        if ((input + sni_len - initial_input) > input_len)
+                            goto end;
+
+                        memcpy(ssl_state->curr_connp->sni, input,
+                               sni_strlen - 1);
+                        ssl_state->curr_connp->sni[sni_strlen-1] = 0;
+
+                        input += sni_len;
+                        break;
+                    }
+                    default:
+                    {
+                        input += ext_len;
+                        break;
+                    }
+                }
+                processed_len += ext_len + 4;
+            }
+end:
             break;
 
         case SSLV3_HS_SERVER_HELLO:
             ssl_state->flags |= SSL_AL_FLAG_STATE_SERVER_HELLO;
-
             break;
 
         case SSLV3_HS_SERVER_KEY_EXCHANGE:
@@ -1141,6 +1234,8 @@ void SSLStateFree(void *p)
         SCFree(ssl_state->client_connp.cert0_issuerdn);
     if (ssl_state->client_connp.cert0_fingerprint)
         SCFree(ssl_state->client_connp.cert0_fingerprint);
+    if (ssl_state->client_connp.sni)
+        SCFree(ssl_state->client_connp.sni);
 
     if (ssl_state->server_connp.trec)
         SCFree(ssl_state->server_connp.trec);
@@ -1150,6 +1245,8 @@ void SSLStateFree(void *p)
         SCFree(ssl_state->server_connp.cert0_issuerdn);
     if (ssl_state->server_connp.cert0_fingerprint)
         SCFree(ssl_state->server_connp.cert0_fingerprint);
+    if (ssl_state->server_connp.sni)
+        SCFree(ssl_state->server_connp.sni);
 
     /* Free certificate chain */
     while ((item = TAILQ_FIRST(&ssl_state->server_connp.certs))) {

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -86,7 +86,8 @@ enum {
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 
-
+/* extensions */
+#define SSL_EXTENSION_SNI                       0x0000
 
 /* SSL versions.  We'll use a unified format for all, with the top byte
  * holding the major version and the lower byte the minor version */
@@ -133,6 +134,9 @@ typedef struct SSLStateConnp_ {
     char *cert0_subject;
     char *cert0_issuerdn;
     char *cert0_fingerprint;
+
+    /* ssl server name indication extension */
+    char *sni;
 
     uint8_t *cert_input;
     uint32_t cert_input_len;

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -83,6 +83,9 @@ static void LogTlsLogExtended(LogTlsLogThread *aft, SSLState * state)
     if (state->server_connp.cert0_fingerprint != NULL) {
         MemBufferWriteString(aft->buffer, " SHA1='%s'", state->server_connp.cert0_fingerprint);
     }
+    if (state->client_connp.sni != NULL) {
+        MemBufferWriteString(aft->buffer, " SNI='%s'", state->client_connp.sni);
+    }
     switch (state->server_connp.version) {
         case TLS_VERSION_UNKNOWN:
             MemBufferWriteString(aft->buffer, " VERSION='UNDETERMINED'");

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -92,6 +92,12 @@ void JsonTlsLogJSONExtended(json_t *tjs, SSLState * state)
     json_object_set_new(tjs, "fingerprint",
                         json_string(state->server_connp.cert0_fingerprint));
 
+    /* tls.sni */
+    if (state->client_connp.sni) {
+        json_object_set_new(tjs, "sni",
+                            json_string(state->client_connp.sni));
+    }
+
     /* tls.version */
     switch (state->server_connp.version) {
         case TLS_VERSION_UNKNOWN:


### PR DESCRIPTION
Decode TLS client hello handshake to get server name from SNI extension. Add this value to tls-log (extended), output-json-tls (extended), and make it available to lua scripts through TlsGetSNI().

Fixed changes suggested in #1709.

https://redmine.openinfosecfoundation.org/issues/1134