### PR TITLE
pfring pkt acq: keep running on 'pfring_set_cluster' failure when clu…

### DIFF
--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -109,6 +109,7 @@ void *OldParsePfringConfig(const char *iface)
     }
 
     strlcpy(pfconf->iface, iface, sizeof(pfconf->iface));
+    pfconf->flags = 0;
     pfconf->threads = 1;
     pfconf->cluster_id = 1;
 #ifdef HAVE_PFRING
@@ -143,6 +144,7 @@ void *OldParsePfringConfig(const char *iface)
         SCLogError(SC_ERR_INVALID_ARGUMENT,"Could not get cluster-id from config");
     } else {
         pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
     }
 
@@ -263,6 +265,7 @@ void *ParsePfringConfig(const char *iface)
     /* command line value has precedence */
     if (ConfGet("pfring.cluster-id", &tmpclusterid) == 1) {
         pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+        pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
         SCLogDebug("Going to use command-line provided cluster-id %" PRId32,
                    pfconf->cluster_id);
     } else {
@@ -278,6 +281,7 @@ void *ParsePfringConfig(const char *iface)
                        "Could not get cluster-id from config");
         } else {
             pfconf->cluster_id = (uint16_t)atoi(tmpclusterid);
+            pfconf->flags |= PFRING_CONF_FLAGS_CLUSTER;
             SCLogDebug("Going to use cluster-id %" PRId32, pfconf->cluster_id);
         }
     }

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -466,8 +466,11 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
         if (rc != 0) {
             SCLogError(SC_ERR_PF_RING_SET_CLUSTER_FAILED, "pfring_set_cluster "
                     "returned %d for cluster-id: %d", rc, ptv->cluster_id);
-            pfconf->DerefFunc(pfconf);
-            return TM_ECODE_FAILED;
+            if (rc != PF_RING_ERROR_NOT_SUPPORTED || (pfconf->flags & PFRING_CONF_FLAGS_CLUSTER)) {
+                /* cluster is mandatory as explicitly specified in the configuration */
+                pfconf->DerefFunc(pfconf);
+                return TM_ECODE_FAILED;
+            }
         }
     }
 

--- a/src/source-pfring.h
+++ b/src/source-pfring.h
@@ -31,8 +31,14 @@
 #include <pfring.h>
 #endif
 
+typedef enum {
+    PFRING_CONF_FLAGS_CLUSTER = 0x1
+} PfringIfaceConfigFlags;
+
 typedef struct PfringIfaceConfig_
 {
+    uint32_t flags;
+
     /* cluster param */
     int cluster_id;
 #ifdef HAVE_PFRING


### PR DESCRIPTION
…ster is not required

Suricata creates a pfring cluster with a default ID = 1 when not explicitly configured,
unless the device has prefix 'dna' or 'zc'. Since pf_ring also supports other cards
implementing kernel-bypass (cluster not supported), this is preventing those cards from
running on top of this module. This patch stops suricata on 'pfring_set_cluster' failure
only when error code != PF_RING_ERROR_NOT_SUPPORTED or cluster ID has not been explicitly
configured.