### PR TITLE
rules-reload: fix reload with -s or -S

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2340,7 +2340,7 @@ static int reloads = 0;
  *  \retval -1 error
  *  \retval 0 ok
  */
-int DetectEngineReload(const char *filename)
+int DetectEngineReload(const char *filename, SCInstance *suri)
 {
     DetectEngineCtx *new_de_ctx = NULL;
     DetectEngineCtx *old_de_ctx = NULL;
@@ -2377,7 +2377,8 @@ int DetectEngineReload(const char *filename)
         DetectEngineDeReference(&old_de_ctx);
         return -1;
     }
-    if (SigLoadSignatures(new_de_ctx, NULL, 0) != 0) {
+    if (SigLoadSignatures(new_de_ctx,
+                          suri->sig_file, suri->sig_file_exclusive) != 0) {
         DetectEngineCtxFree(new_de_ctx);
         DetectEngineDeReference(&old_de_ctx);
         return -1;

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -75,7 +75,7 @@ void DetectEnginePruneFreeList(void);
 int DetectEngineMoveToFreeList(DetectEngineCtx *de_ctx);
 DetectEngineCtx *DetectEngineReference(DetectEngineCtx *);
 void DetectEngineDeReference(DetectEngineCtx **de_ctx);
-int DetectEngineReload(const char *filename);
+int DetectEngineReload(const char *filename, SCInstance *suri);
 int DetectEngineEnabled(void);
 int DetectEngineMTApply(void);
 int DetectEngineMultiTenantEnabled(void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2379,7 +2379,7 @@ int main(int argc, char **argv)
 
     if (suri.delayed_detect) {
         /* force 'reload', this will load the rules and swap engines */
-        DetectEngineReload(NULL);
+        DetectEngineReload(NULL, &suri);
 
         if (suri.sig_file != NULL)
             UtilSignalHandlerSetup(SIGUSR2, SignalHandlerSigusr2SigFileStartup);
@@ -2412,10 +2412,10 @@ int main(int argc, char **argv)
         }
 
         if (sigusr2_count > 0) {
-            DetectEngineReload(conf_filename);
+            DetectEngineReload(conf_filename, &suri);
             sigusr2_count--;
         } else if (DetectEngineReloadIsStart()) {
-            DetectEngineReload(conf_filename);
+            DetectEngineReload(conf_filename, &suri);
             DetectEngineReloadSetDone();
         }
 


### PR DESCRIPTION
When using the -S or -s option, the reload was causing the specified
rules file to be forgotten and the default rules to be loaded at
reload time.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/115
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/113