### PR TITLE
Ruleset stats v1.2

### DIFF
--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -887,6 +887,19 @@ static void DetectEngineCtxFreeThreadKeywordData(DetectEngineCtx *de_ctx)
     de_ctx->keyword_list = NULL;
 }
 
+static void DetectEngineCtxFreeFailedSigs(DetectEngineCtx *de_ctx)
+{
+    SigString *item = de_ctx->sig_stat.failed_sigs;
+    while (item) {
+        SigString *next = item->next;
+        SCFree(item->filename);
+        SCFree(item->sig_str);
+        SCFree(item);
+        item = next;
+    }
+    de_ctx->sig_stat.failed_sigs = NULL;
+}
+
 /**
  * \brief Free a DetectEngineCtx::
  *
@@ -941,6 +954,7 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
 
     DetectEngineCtxFreeThreadKeywordData(de_ctx);
     SRepDestroy(de_ctx);
+    DetectEngineCtxFreeFailedSigs(de_ctx);
 
     /* if we have a config prefix, remove the config from the tree */
     if (strlen(de_ctx->config_prefix) > 0) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -769,6 +769,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
         goto error;
 
     memset(de_ctx,0,sizeof(DetectEngineCtx));
+    memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (minimal) {
         de_ctx->minimal = 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -290,6 +290,69 @@ char *DetectLoadCompleteSigPath(const DetectEngineCtx *de_ctx, char *sig_file)
     return path;
 }
 
+static SigString *SigStringAlloc(void)
+{
+    SigString *sigstr = SCMalloc(sizeof(SigString));
+    if (unlikely(sigstr == NULL))
+        return NULL;
+
+    sigstr->line = 0;
+    sigstr->next = NULL;
+
+    return sigstr;
+}
+
+static int SigStringAddSig(SigString *sig, const char *sig_file,
+                           const char *sig_str, int line)
+{
+    if (sig_file == NULL || sig_str == NULL) {
+        return 0;
+    }
+
+    sig->filename = SCStrdup(sig_file);
+    if (sig->filename == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        return 0;
+    }
+
+    sig->sig_str = SCStrdup(sig_str);
+    if (sig->sig_str == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        return 0;
+    }
+
+    sig->line = line;
+
+    return 1;
+}
+
+static int SigStringAppend(SigString **list, const char *sig_file,
+                           const char *sig_str, int line)
+{
+    SigString *item = SigStringAlloc();
+    if (item == NULL) {
+        return 0;
+    }
+
+    if (!SigStringAddSig(item, sig_file, sig_str, line)) {
+        SCFree(item);
+        return 0;
+    }
+
+    if (*list == NULL) {
+        *list = item;
+    } else {
+        SigString *tmpptr = *list;
+        while (tmpptr->next != NULL) {
+            tmpptr = tmpptr->next;
+        }
+        tmpptr->next = item;
+    }
+    item = item->next;
+
+    return 1;
+}
+
 /**
  *  \brief Load a file with signatures
  *  \param de_ctx Pointer to the detection engine context
@@ -371,6 +434,10 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
                 EngineAnalysisRulesFailure(line, sig_file, lineno - multiline);
             }
             bad++;
+            if (!SigStringAppend(&de_ctx->sig_stat.failed_sigs, sig_file, line, (lineno - multiline))) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Error adding sig \"%s\" from "
+                     "file %s at line %"PRId32"", line, sig_file, lineno - multiline);
+            }
         }
         multiline = 0;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -445,14 +445,12 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     ConfNode *rule_files;
     ConfNode *file = NULL;
-    SigFileLoaderStat sig_stat;
+    SigFileLoaderStat *sig_stat = &de_ctx->sig_stat;
     int ret = 0;
     char *sfile = NULL;
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
-
-    memset(&sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.rule-files",
@@ -477,7 +475,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 TAILQ_FOREACH(file, &rule_files->head, next) {
                     sfile = DetectLoadCompleteSigPath(de_ctx, file->val);
                     good_sigs = bad_sigs = 0;
-                    ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
+                    ret = ProcessSigFiles(de_ctx, sfile, sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
                     if (ret != 0 || good_sigs == 0) {
@@ -492,7 +490,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     /* If a Signature file is specified from commandline, parse it too */
     if (sig_file != NULL) {
-        ret = ProcessSigFiles(de_ctx, sig_file, &sig_stat, &good_sigs, &bad_sigs);
+        ret = ProcessSigFiles(de_ctx, sig_file, sig_stat, &good_sigs, &bad_sigs);
 
         if (ret != 0) {
             if (de_ctx->failure_fatal == 1) {
@@ -510,9 +508,9 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     /* now we should have signatures to work with */
-    if (sig_stat.good_sigs_total <= 0) {
-        if (sig_stat.total_files > 0) {
-           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat.total_files);
+    if (sig_stat->good_sigs_total <= 0) {
+        if (sig_stat->total_files > 0) {
+           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat->total_files);
         } else {
             SCLogInfo("No signatures supplied.");
             goto end;
@@ -520,10 +518,10 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     } else {
         /* we report the total of files and rules successfully loaded and failed */
         SCLogInfo("%" PRId32 " rule files processed. %" PRId32 " rules successfully loaded, %" PRId32 " rules failed",
-            sig_stat.total_files, sig_stat.good_sigs_total, sig_stat.bad_sigs_total);
+            sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
     }
 
-    if ((sig_stat.bad_sigs_total || sig_stat.bad_files) && de_ctx->failure_fatal) {
+    if ((sig_stat->bad_sigs_total || sig_stat->bad_files) && de_ctx->failure_fatal) {
         ret = -1;
         goto end;
     }
@@ -539,6 +537,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
+    gettimeofday(&de_ctx->last_reload, NULL);
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();

--- a/src/detect.h
+++ b/src/detect.h
@@ -547,8 +547,16 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+typedef struct SigString_ {
+    char *filename;
+    char *sig_str;
+    int line;
+    struct SigString_ *next;
+} SigString;
+
 /** \brief Signature loader statistics */
 typedef struct SigFileLoaderStat_ {
+    SigString *failed_sigs;
     int bad_files;
     int total_files;
     int good_sigs_total;

--- a/src/detect.h
+++ b/src/detect.h
@@ -547,6 +547,14 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+/** \brief Signature loader statistics */
+typedef struct SigFileLoaderStat_ {
+    int bad_files;
+    int total_files;
+    int good_sigs_total;
+    int bad_sigs_total;
+} SigFileLoaderStat;
+
 typedef struct DetectEngineThreadKeywordCtxItem_ {
     void *(*InitFunc)(void *);
     void (*FreeFunc)(void *);
@@ -715,6 +723,12 @@ typedef struct DetectEngineCtx_ {
 
     /** id of loader thread 'owning' this de_ctx */
     int loader_id;
+
+    /** time of last ruleset reload */
+    struct timeval last_reload;
+
+    /** signatures stats */
+    SigFileLoaderStat sig_stat;
 
 } DetectEngineCtx;
 
@@ -1090,14 +1104,6 @@ typedef struct DetectEngineMasterCtx_ {
     DetectEngineTenantMapping *tenant_mapping_list;
 
 } DetectEngineMasterCtx;
-
-/** \brief Signature loader statistics */
-typedef struct SigFileLoaderStat_ {
-    int bad_files;
-    int total_files;
-    int good_sigs_total;
-    int bad_sigs_total;
-} SigFileLoaderStat;
 
 /** Remember to add the options in SignatureIsIPOnly() at detect.c otherwise it wont be part of a signature group */
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -28,6 +28,7 @@
 #include "detect.h"
 #include "pkt-var.h"
 #include "conf.h"
+#include "detect-engine.h"
 
 #include "threads.h"
 #include "threadvars.h"
@@ -45,6 +46,7 @@
 #include "util-crypt.h"
 
 #include "output-json.h"
+#include "output-json-stats.h"
 
 #define MODULE_NAME "JsonStatsLog"
 
@@ -65,6 +67,90 @@ typedef struct JsonStatsLogThread_ {
     MemBuffer *buffer;
 } JsonStatsLogThread;
 
+static json_t *OutputDetectEngineStats2Json(const DetectEngineCtx *de_ctx,
+                                            const int output_type)
+{
+    struct timeval last_reload;
+    char timebuf[64];
+    SigFileLoaderStat *sig_stat = NULL;
+
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        return NULL;
+    }
+
+    if (output_type == LAST_RELOAD || output_type == BOTH) {
+        last_reload = de_ctx->last_reload;
+        CreateIsoTimeString(&last_reload, timebuf, sizeof(timebuf));
+        json_object_set_new(jdata, "last_reload", json_string(timebuf));
+    }
+
+    sig_stat = &de_ctx->sig_stat;
+    if ((output_type == RULESET || output_type == BOTH) && sig_stat != NULL) {
+        json_object_set_new(jdata, "rules_loaded",
+                            json_integer(sig_stat->good_sigs_total));
+        json_object_set_new(jdata, "rules_failed",
+                            json_integer(sig_stat->bad_sigs_total));
+    }
+
+    return jdata;
+}
+
+static TmEcode OutputTenancyStats2Json(int output_type, json_t **jdata)
+{
+    *jdata = json_object();
+    if (*jdata == NULL) {
+        return TM_ECODE_FAILED;
+    }
+
+    DetectEngineCtx *list = DetectEngineGetCurrent();
+    if (list == NULL) {
+        return TM_ECODE_FAILED;
+    }
+
+    if (list->minimal) {
+        json_object_set_new(*jdata, "message", json_string("Detect engine is not yet ready"));
+        return TM_ECODE_FAILED;
+    }
+
+    json_t *js_tenant_list = json_array();
+
+    if (js_tenant_list == NULL) {
+        json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+        return TM_ECODE_FAILED;
+    }
+
+    while(list) {
+        json_t *js_tenant = json_object();
+        if (js_tenant == NULL) {
+            json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+            json_decref(js_tenant_list);
+            return TM_ECODE_FAILED;
+        }
+        json_object_set_new(js_tenant, "id", json_integer(list->tenant_id));
+
+        json_t *js_stats = OutputDetectEngineStats2Json(list, output_type);
+        if (js_stats == NULL) {
+            json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+            return TM_ECODE_FAILED;
+        }
+        json_object_update_missing(js_tenant, js_stats);
+        json_array_append_new(js_tenant_list, js_tenant);
+        list = list->next;
+    }
+
+    *jdata = js_tenant_list;
+    return TM_ECODE_OK;
+}
+
+TmEcode OutputTenancyStatsLastReload(json_t **jdata) {
+    return OutputTenancyStats2Json(LAST_RELOAD, jdata);
+}
+
+TmEcode OutputTenancyStatsRuleset(json_t **jdata) {
+    return OutputTenancyStats2Json(RULESET, jdata);
+}
+
 static json_t *OutputStats2Json(json_t *js, const char *key)
 {
     void *iter;
@@ -83,6 +169,16 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     json_t *value = json_object_iter_value(iter);
     if (value == NULL) {
         value = json_object();
+        /* When multi-tenancy is disabled, we put engine stats
+           under detect object.
+           Otherwise, we'll have a proper object 'tenancy' */
+        if (!DetectEngineMultiTenantEnabled() && !strncmp(s, "detect", 6)) {
+            json_t *js_engine =
+                OutputDetectEngineStats2Json(DetectEngineGetCurrent(), BOTH);
+            if (js_engine != NULL) {
+                json_object_set_new(value, "engine", js_engine);
+            }
+        }
         json_object_set_new(js, s, value);
     }
     if (s2 != NULL) {
@@ -119,6 +215,19 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
     /* Uptime, in seconds. */
     json_object_set_new(js_stats, "uptime",
         json_integer((int)difftime(tval.tv_sec, st->start_time)));
+
+    /* tenancy stats */
+    if (DetectEngineMultiTenantEnabled()) {
+        json_t *js_tenancy = json_object();
+        if (js_tenancy == NULL) {
+            return 0;
+        }
+
+        TmEcode retval = OutputTenancyStats2Json(BOTH, &js_tenancy);
+        if (retval == TM_ECODE_OK) {
+            json_object_set_new(js_stats, "tenancy", js_tenancy);
+        }
+    }
 
     uint32_t u = 0;
     if (aft->statslog_ctx->flags & JSON_STATS_TOTALS) {

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -24,6 +24,16 @@
 #ifndef __OUTPUT_JSON_COUNTERS_H__
 #define __OUTPUT_JSON_COUNTERS_H__
 
+enum {
+    LAST_RELOAD = 0,
+    RULESET,
+    BOTH
+};
+
 void TmModuleJsonStatsLogRegister (void);
+#ifdef HAVE_LIBJANSSON
+TmEcode OutputTenancyStatsLastReload(json_t **jdata);
+TmEcode OutputTenancyStatsRuleset(json_t **jdata);
+#endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_COUNTERS_H__ */

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -649,16 +649,28 @@ TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
     SCReturnInt(TM_ECODE_OK);
 }
 
-TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+TmEcode UnixManagerReloadRulesWrapper(json_t *cmd, json_t *server_msg, void *data, int wait)
 {
     SCEnter();
     DetectEngineReloadStart();
 
-    while (DetectEngineReloadIsDone() == 0)
-        usleep(100);
+    if (wait) {
+        while (DetectEngineReloadIsDone() == 0)
+            usleep(100);
+    }
 
     json_object_set_new(server_msg, "message", json_string("done"));
     SCReturnInt(TM_ECODE_OK);
+}
+
+TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 1);
+}
+
+TmEcode UnixManagerNonBlockingReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 0);
 }
 
 TmEcode UnixManagerLastReloadCommand(json_t *cmd,
@@ -942,6 +954,7 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("non-blocking-reload-rules", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -29,6 +29,8 @@
 #include "runmodes.h"
 #include "conf.h"
 
+#include "output-json-stats.h"
+
 #include "util-privs.h"
 #include "util-debug.h"
 #include "util-signal.h"
@@ -659,6 +661,47 @@ TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
+TmEcode UnixManagerLastReloadCommand(json_t *cmd,
+                                     json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval = TM_ECODE_OK;
+    json_t *jdata = NULL;
+
+    retval = OutputTenancyStatsLastReload(&jdata);
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    if (retval == TM_ECODE_FAILED) {
+        json_object_set_new(server_msg, "message", jdata);
+        SCReturnInt(retval);
+    }
+
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
+
+TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
+                                       json_t *server_msg, void *data)
+{
+    SCEnter();
+    json_t *jdata = NULL;
+    TmEcode retval = TM_ECODE_OK;
+
+    retval = OutputTenancyStatsRuleset(&jdata);
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    if (retval == TM_ECODE_FAILED) {
+        json_object_set_new(server_msg, "message", jdata);
+        SCReturnInt(retval);
+    }
+
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(TM_ECODE_OK);
+}
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -899,6 +942,8 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("last-reload", UnixManagerLastReloadCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -714,6 +714,39 @@ TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
     json_object_set_new(server_msg, "message", jdata);
     SCReturnInt(TM_ECODE_OK);
 }
+
+TmEcode UnixManagerShowFailedRules(json_t *cmd,
+                                   json_t *server_msg, void *data)
+{
+    SCEnter();
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    SigString *sigs_str = de_ctx->sig_stat.failed_sigs;
+    json_t *js_sigs_array = json_array();
+
+    if (js_sigs_array == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
+    while (sigs_str != NULL) {
+        json_t *jdata = json_object();
+        if (jdata == NULL) {
+            json_object_set_new(server_msg, "message", json_string("Unable to get the sig"));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+
+        json_object_set_new(jdata, "rule", json_string(sigs_str->sig_str));
+        json_object_set_new(jdata, "filename", json_string(sigs_str->filename));
+        json_object_set_new(jdata, "line", json_integer(sigs_str->line));
+        json_array_append_new(js_sigs_array, jdata);
+
+        sigs_str = sigs_str->next;
+    }
+
+    json_object_set_new(server_msg, "message", js_sigs_array);
+    SCReturnInt(TM_ECODE_OK);
+}
+
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -957,6 +990,7 @@ static TmEcode UnixManager(ThreadVars *th_v, void *thread_data)
     UnixManagerRegisterCommand("non-blocking-reload-rules", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
+    UnixManagerRegisterCommand("show-failed-rules", UnixManagerShowFailedRules, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);


### PR DESCRIPTION
A patchset updated that aims at improving information regarding ruleset returned to the user by suricata.
This addresses all comments in the last PR: https://github.com/inliniac/suricata/pull/1710
Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1585

First feature is an update on stats JSON with information added about the ruleset so user can know and monitor how much rules are loaded and failed.

    "detect":{"engine":{"last_reload":"2015-10-13T09:59:48.044996+0200","rules_loaded":17184,"rules_failed":0},"alert":28}

Other changes are related to unix socket with some new commands:

- last-reload
- ruleset-stats: display information about number of loaded and failed rules
- show-failed-rules: display a list of failed rules (dc53401 for more details)

This PR also contains a patch implementing a non blocking reload command in unix socket. As we can know with this patchset when reload is done we can also have an asynchronous command.

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/73
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/72