### PR TITLE
stream: fix logic problem in midstream

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -356,9 +356,11 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         alproto_masks = &f->probing_parser_toclient_alproto_masks;
         if (pp_port_dp != NULL) {
             SCLogDebug("toclient - Probing parser found for destination port %"PRIu16, f->dp);
-
-            /* found based on destination port, so use dp registration */
-            pe1 = pp_port_dp->dp;
+ 
+            /* Since we are analyzing the data in to_client direction
+             * and we consider inverted data, the port must be inverted
+             * to pick up the flow */
+            pe1 = pp_port_dp->sp;
         } else {
             SCLogDebug("toclient - No probing parser registered for dest port %"PRIu16,
                        f->dp);
@@ -368,7 +370,10 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         if (pp_port_sp != NULL) {
             SCLogDebug("toclient - Probing parser found for source port %"PRIu16, f->sp);
 
-            pe2 = pp_port_sp->sp;
+            /* Since we are analyzing the data in to_client direction
+             * and we consider inverted data, the port must be inverted
+             * to pick up the flow */
+            pe2 = pp_port_sp->dp;
         } else {
             SCLogDebug("toclient - No probing parser registered for source port %"PRIu16,
                         f->sp);


### PR DESCRIPTION
A patch worked with @regit 

When midstream is enabled, picked up flow are sent to app-layer
that has to recognize the flow.
The code is analyzing the data in to_server direction
and continue in to_client using the same approach.
In this case the port are not inverted although
we consider inverted data.
The result is that pe1 and pe2 are NULL due to the inversion.

To fix that error, the patch inverts source and destination ports
to pick up the connection when we are in to_client direction.

Consequences of the error was that all stream starting
with a to_client message where not picked up.

In the case of the modbus protocol where almost every packet is one command,
suricata was failing to pickup the connections as soon as it was starting
with a to_client message.
Run on forged pcap files have shown that, with this modification,
suricata is behaving correctly.

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/79
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/78