### PR TITLE
Threads rename v8 - Bug #1524

### DIFF
--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -118,8 +118,11 @@ void FlowDisableFlowManagerThread(void)
     /* flow manager thread(s) is/are a part of mgmt threads */
     tv = tv_root[TVT_MGMT];
 
-    while (tv != NULL) {
-        if (strncasecmp(tv->name, "FM", 2) == 0) {
+    while (tv != NULL) 
+    {
+        if (strncasecmp(tv->name, thread_name_flow_mgr,
+            strlen(thread_name_flow_mgr)) == 0) 
+        {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 
@@ -725,11 +728,12 @@ void FlowManagerThreadSpawn()
     StatsRegisterGlobalCounter("flow.memuse", FlowGetMemuse);
 
     uint32_t u;
-    for (u = 0; u < flowmgr_number; u++) {
+    for (u = 0; u < flowmgr_number; u++) 
+    {
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FM%02u", u+1);
+        snprintf(name, sizeof(name), "%s#%02u", thread_name_flow_mgr, u+1);
 
         tv_flowmgr = TmThreadCreateMgmtThreadByName(SCStrdup(name),
                 "FlowManager", 0);
@@ -885,11 +889,12 @@ void FlowRecyclerThreadSpawn()
 
 
     uint32_t u;
-    for (u = 0; u < flowrec_number; u++) {
+    for (u = 0; u < flowrec_number; u++) 
+    {
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FR%02u", u+1);
+        snprintf(name, sizeof(name), "%s#%02u", thread_name_flow_rec, u+1);
 
         tv_flowmgr = TmThreadCreateMgmtThreadByName(SCStrdup(name),
                 "FlowRecycler", 0);
@@ -939,8 +944,11 @@ void FlowDisableFlowRecyclerThread(void)
     /* flow recycler thread(s) is/are a part of mgmt threads */
     tv = tv_root[TVT_MGMT];
 
-    while (tv != NULL) {
-        if (strncasecmp(tv->name, "FR", 2) == 0) {
+    while (tv != NULL) 
+    {
+        if (strncasecmp(tv->name, thread_name_flow_rec, 
+            strlen(thread_name_flow_rec)) == 0) 
+        {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -119,7 +119,7 @@ void FlowDisableFlowManagerThread(void)
     tv = tv_root[TVT_MGMT];
 
     while (tv != NULL) {
-        if (strcasecmp(tv->name, "FlowManagerThread") == 0) {
+        if (strncasecmp(tv->name, "FM-", 3) == 0) {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 
@@ -729,9 +729,9 @@ void FlowManagerThreadSpawn()
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FlowManagerThread%02u", u+1);
+        snprintf(name, sizeof(name), "FM-%02u", u+1);
 
-        tv_flowmgr = TmThreadCreateMgmtThreadByName("FlowManagerThread",
+        tv_flowmgr = TmThreadCreateMgmtThreadByName(name,
                 "FlowManager", 0);
         BUG_ON(tv_flowmgr == NULL);
 
@@ -889,9 +889,9 @@ void FlowRecyclerThreadSpawn()
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FlowRecyclerThread%02u", u+1);
+        snprintf(name, sizeof(name), "FR-%02u", u+1);
 
-        tv_flowmgr = TmThreadCreateMgmtThreadByName("FlowRecyclerThread",
+        tv_flowmgr = TmThreadCreateMgmtThreadByName(name,
                 "FlowRecycler", 0);
         BUG_ON(tv_flowmgr == NULL);
 
@@ -940,7 +940,7 @@ void FlowDisableFlowRecyclerThread(void)
     tv = tv_root[TVT_MGMT];
 
     while (tv != NULL) {
-        if (strcasecmp(tv->name, "FlowRecyclerThread") == 0) {
+        if (strncasecmp(tv->name, "FR-", 3) == 0) {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -119,7 +119,7 @@ void FlowDisableFlowManagerThread(void)
     tv = tv_root[TVT_MGMT];
 
     while (tv != NULL) {
-        if (strncasecmp(tv->name, "FM-", 3) == 0) {
+        if (strncasecmp(tv->name, "FM", 2) == 0) {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 
@@ -729,9 +729,9 @@ void FlowManagerThreadSpawn()
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FM-%02u", u+1);
+        snprintf(name, sizeof(name), "FM%02u", u+1);
 
-        tv_flowmgr = TmThreadCreateMgmtThreadByName(name,
+        tv_flowmgr = TmThreadCreateMgmtThreadByName(SCStrdup(name),
                 "FlowManager", 0);
         BUG_ON(tv_flowmgr == NULL);
 
@@ -889,9 +889,9 @@ void FlowRecyclerThreadSpawn()
         ThreadVars *tv_flowmgr = NULL;
 
         char name[32] = "";
-        snprintf(name, sizeof(name), "FR-%02u", u+1);
+        snprintf(name, sizeof(name), "FR%02u", u+1);
 
-        tv_flowmgr = TmThreadCreateMgmtThreadByName(name,
+        tv_flowmgr = TmThreadCreateMgmtThreadByName(SCStrdup(name),
                 "FlowRecycler", 0);
         BUG_ON(tv_flowmgr == NULL);
 
@@ -940,7 +940,7 @@ void FlowDisableFlowRecyclerThread(void)
     tv = tv_root[TVT_MGMT];
 
     while (tv != NULL) {
-        if (strncasecmp(tv->name, "FR-", 3) == 0) {
+        if (strncasecmp(tv->name, "FR", 2) == 0) {
             TmThreadsSetFlag(tv, THV_KILL);
             cnt++;
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -479,7 +479,7 @@ int RunModeIdsAFPAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig,
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
-                              "DecodeAFP", "C",
+                              "DecodeAFP", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -521,7 +521,7 @@ int RunModeIdsAFPSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "W",
+                                    "DecodeAFP", thread_name_single,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -566,7 +566,7 @@ int RunModeIdsAFPWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "W",
+                                    "DecodeAFP", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -479,7 +479,7 @@ int RunModeIdsAFPAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig,
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
-                              "DecodeAFP", "RxAFP",
+                              "DecodeAFP", "C-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -521,7 +521,7 @@ int RunModeIdsAFPSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "AFPacket",
+                                    "DecodeAFP", "C-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -566,7 +566,7 @@ int RunModeIdsAFPWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "AFPacket",
+                                    "DecodeAFP", "W-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -479,7 +479,7 @@ int RunModeIdsAFPAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParseAFPConfig,
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
-                              "DecodeAFP", "C-",
+                              "DecodeAFP", "C",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -521,7 +521,7 @@ int RunModeIdsAFPSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "C-",
+                                    "DecodeAFP", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -566,7 +566,7 @@ int RunModeIdsAFPWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParseAFPConfig,
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
-                                    "DecodeAFP", "W-",
+                                    "DecodeAFP", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -85,7 +85,7 @@ int RunModeIdsErfDagSingle(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "W",
+        thread_name_single,
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
@@ -111,7 +111,7 @@ int RunModeIdsErfDagAutoFp(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "C",
+        thread_name_autofp,
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
@@ -137,7 +137,7 @@ int RunModeIdsErfDagWorkers(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "W",
+        thread_name_workers,
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -85,7 +85,7 @@ int RunModeIdsErfDagSingle(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "RxDAG",
+        "W",
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
@@ -111,7 +111,7 @@ int RunModeIdsErfDagAutoFp(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "RxDAG",
+        "C",
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
@@ -137,7 +137,7 @@ int RunModeIdsErfDagWorkers(void)
         DagConfigGetThreadCount,
         "ReceiveErfDag",
         "DecodeErfDag",
-        "RxDAG",
+        "W",
         NULL);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -204,12 +204,12 @@ static int NapatechInit(int runmode)
         case NT_RUNMODE_AUTOFP:
             ret = RunModeSetLiveCaptureAutoFp(NapatechConfigParser, NapatechGetThreadsCount,
                                               "NapatechStream", "NapatechDecode",
-                                              "RxNT", NULL);
+                                              "C-", NULL);
             break;
         case NT_RUNMODE_WORKERS:
             ret = RunModeSetLiveCaptureWorkers(NapatechConfigParser, NapatechGetThreadsCount,
                                                "NapatechStream", "NapatechDecode",
-                                               "RxNT", NULL);
+                                               "W-", NULL);
             break;
         default:
             ret = -1;

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -204,12 +204,12 @@ static int NapatechInit(int runmode)
         case NT_RUNMODE_AUTOFP:
             ret = RunModeSetLiveCaptureAutoFp(NapatechConfigParser, NapatechGetThreadsCount,
                                               "NapatechStream", "NapatechDecode",
-                                              "C", NULL);
+                                              thread_name_autofp, NULL);
             break;
         case NT_RUNMODE_WORKERS:
             ret = RunModeSetLiveCaptureWorkers(NapatechConfigParser, NapatechGetThreadsCount,
                                                "NapatechStream", "NapatechDecode",
-                                               "W", NULL);
+                                               thread_name_workers, NULL);
             break;
         default:
             ret = -1;

--- a/src/runmode-napatech.c
+++ b/src/runmode-napatech.c
@@ -204,12 +204,12 @@ static int NapatechInit(int runmode)
         case NT_RUNMODE_AUTOFP:
             ret = RunModeSetLiveCaptureAutoFp(NapatechConfigParser, NapatechGetThreadsCount,
                                               "NapatechStream", "NapatechDecode",
-                                              "C-", NULL);
+                                              "C", NULL);
             break;
         case NT_RUNMODE_WORKERS:
             ret = RunModeSetLiveCaptureWorkers(NapatechConfigParser, NapatechGetThreadsCount,
                                                "NapatechStream", "NapatechDecode",
-                                               "W-", NULL);
+                                               "W", NULL);
             break;
         default:
             ret = -1;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -372,7 +372,7 @@ int RunModeIdsNetmapAutoFp(void)
                               ParseNetmapConfig,
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
-                              "DecodeNetmap", "C",
+                              "DecodeNetmap", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -405,7 +405,7 @@ int RunModeIdsNetmapSingle(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "W",
+                                    "DecodeNetmap", thread_name_single,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -441,7 +441,7 @@ int RunModeIdsNetmapWorkers(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "W",
+                                    "DecodeNetmap", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -372,7 +372,7 @@ int RunModeIdsNetmapAutoFp(void)
                               ParseNetmapConfig,
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
-                              "DecodeNetmap", "RxNetmap",
+                              "DecodeNetmap", "C-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -405,7 +405,7 @@ int RunModeIdsNetmapSingle(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "NetmapPkt",
+                                    "DecodeNetmap", "C-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -441,7 +441,7 @@ int RunModeIdsNetmapWorkers(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "NetmapPkt",
+                                    "DecodeNetmap", "W-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -372,7 +372,7 @@ int RunModeIdsNetmapAutoFp(void)
                               ParseNetmapConfig,
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
-                              "DecodeNetmap", "C-",
+                              "DecodeNetmap", "C",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -405,7 +405,7 @@ int RunModeIdsNetmapSingle(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "C-",
+                                    "DecodeNetmap", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -441,7 +441,7 @@ int RunModeIdsNetmapWorkers(void)
                                     ParseNetmapConfig,
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
-                                    "DecodeNetmap", "W-",
+                                    "DecodeNetmap", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -184,7 +184,7 @@ int RunModeIdsNflogAutoFp(void)
                                       NflogConfigGeThreadsCount,
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
-                                      "C",
+                                      thread_name_autofp,
                                       live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -212,7 +212,7 @@ int RunModeIdsNflogSingle(void)
                                       NflogConfigGeThreadsCount,
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
-                                      "W",
+                                      thread_name_single,
                                       live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -240,7 +240,7 @@ int RunModeIdsNflogWorkers(void)
                                        NflogConfigGeThreadsCount,
                                        "ReceiveNFLOG",
                                        "DecodeNFLOG",
-                                       "W",
+                                       thread_name_workers,
                                        live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -184,7 +184,7 @@ int RunModeIdsNflogAutoFp(void)
                                       NflogConfigGeThreadsCount,
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
-                                      "RecvNFLOG",
+                                      "C",
                                       live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -212,7 +212,7 @@ int RunModeIdsNflogSingle(void)
                                       NflogConfigGeThreadsCount,
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
-                                      "RecvNFLOG",
+                                      "W",
                                       live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
@@ -240,7 +240,7 @@ int RunModeIdsNflogWorkers(void)
                                        NflogConfigGeThreadsCount,
                                        "ReceiveNFLOG",
                                        "DecodeNFLOG",
-                                       "RecvNFLOG",
+                                       "W",
                                        live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -62,6 +62,8 @@ void RunModeFilePcapRegister(void)
 int RunModeFilePcapSingle(void)
 {
     char *file = NULL;
+    char tname[TM_THREAD_NAME_MAX];
+    
     if (ConfGet("pcap-file.file", &file) == 0) {
         SCLogError(SC_ERR_RUNMODE, "Failed retrieving pcap-file from Conf");
         exit(EXIT_FAILURE);
@@ -72,8 +74,17 @@ int RunModeFilePcapSingle(void)
 
     PcapFileGlobalInit();
 
+    snprintf(tname, sizeof(tname), "%s#01", thread_name_single);
+    
+    char *thread_name = SCStrdup(tname);
+    if (unlikely(thread_name == NULL)) 
+    {
+        SCLogError(SC_ERR_RUNMODE, "failed to strdup thread name");
+        exit(EXIT_FAILURE);
+    }
+
     /* create the threads */
-    ThreadVars *tv = TmThreadCreatePacketHandler("PcapFile",
+    ThreadVars *tv = TmThreadCreatePacketHandler(thread_name,
                                                  "packetpool", "packetpool",
                                                  "packetpool", "packetpool",
                                                  "pktacqloop");
@@ -183,9 +194,17 @@ int RunModeFilePcapAutoFp(void)
         exit(EXIT_FAILURE);
     }
 
+    snprintf(tname, sizeof(tname), "%s#01", thread_name_autofp);
+    
+    char *thread_name = SCStrdup(tname);
+    if (unlikely(thread_name == NULL)) {
+        SCLogError(SC_ERR_RUNMODE, "failed to strdup thread name");
+        exit(EXIT_FAILURE);
+    }
+    
     /* create the threads */
     ThreadVars *tv_receivepcap =
-        TmThreadCreatePacketHandler("ReceivePcapFile",
+        TmThreadCreatePacketHandler(thread_name,
                                     "packetpool", "packetpool",
                                     queues, "flow",
                                     "pktacqloop");
@@ -217,12 +236,12 @@ int RunModeFilePcapAutoFp(void)
     }
 
     for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "Detect%d", thread+1);
+        snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
         snprintf(qname, sizeof(qname), "pickup%d", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
 
-        char *thread_name = SCStrdup(tname);
+        thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {
             SCLogError(SC_ERR_RUNMODE, "failed to strdup thread name");
             exit(EXIT_FAILURE);

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -242,7 +242,7 @@ int RunModeIdsPcapSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "PcapLive",
+                                    "DecodePcap", "C-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -283,7 +283,7 @@ int RunModeIdsPcapAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParsePcapConfig,
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
-                              "DecodePcap", "RxPcap",
+                              "DecodePcap", "C-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -315,7 +315,7 @@ int RunModeIdsPcapWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "RxPcap",
+                                    "DecodePcap", "W-",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -242,7 +242,7 @@ int RunModeIdsPcapSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "C-",
+                                    "DecodePcap", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -283,7 +283,7 @@ int RunModeIdsPcapAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParsePcapConfig,
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
-                              "DecodePcap", "C-",
+                              "DecodePcap", "C",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -315,7 +315,7 @@ int RunModeIdsPcapWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "W-",
+                                    "DecodePcap", "W",
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -242,7 +242,7 @@ int RunModeIdsPcapSingle(void)
     ret = RunModeSetLiveCaptureSingle(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "W",
+                                    "DecodePcap", thread_name_single,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -283,7 +283,7 @@ int RunModeIdsPcapAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(ParsePcapConfig,
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
-                              "DecodePcap", "C",
+                              "DecodePcap", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -315,7 +315,7 @@ int RunModeIdsPcapWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(ParsePcapConfig,
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
-                                    "DecodePcap", "W",
+                                    "DecodePcap", thread_name_workers,
                                     live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -433,7 +433,7 @@ int RunModeIdsPfringAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "C",
+                              "DecodePfring", thread_name_autofp,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -470,7 +470,7 @@ int RunModeIdsPfringSingle(void)
     ret = RunModeSetLiveCaptureSingle(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "W",
+                              "DecodePfring", thread_name_single,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -507,7 +507,7 @@ int RunModeIdsPfringWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "W",
+                              "DecodePfring", thread_name_workers,
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -433,7 +433,7 @@ int RunModeIdsPfringAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "C-",
+                              "DecodePfring", "C",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -470,7 +470,7 @@ int RunModeIdsPfringSingle(void)
     ret = RunModeSetLiveCaptureSingle(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "W-",
+                              "DecodePfring", "W",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -507,7 +507,7 @@ int RunModeIdsPfringWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "W-",
+                              "DecodePfring", "W",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -433,7 +433,7 @@ int RunModeIdsPfringAutoFp(void)
     ret = RunModeSetLiveCaptureAutoFp(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "RxPFR",
+                              "DecodePfring", "C-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -470,7 +470,7 @@ int RunModeIdsPfringSingle(void)
     ret = RunModeSetLiveCaptureSingle(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "RxPFR",
+                              "DecodePfring", "W-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
@@ -507,7 +507,7 @@ int RunModeIdsPfringWorkers(void)
     ret = RunModeSetLiveCaptureWorkers(tparser,
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
-                              "DecodePfring", "RxPFR",
+                              "DecodePfring", "W-",
                               live_dev);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -51,6 +51,14 @@
 
 int debuglog_enabled = 0;
 
+/* Runmode Global Thread Names */
+char *thread_name_autofp = "RX";
+char *thread_name_single = "W";
+char *thread_name_workers = "W";
+char *thread_name_verdict = "TX";
+char *thread_name_flow_mgr = "FM";
+char *thread_name_flow_rec = "FR";
+
 /**
  * \brief Holds description for a runmode.
  */

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -60,6 +60,14 @@ enum {
     RUNMODE_MAX,
 };
 
+/* Run Mode Global Thread Names */
+extern char *thread_name_autofp;
+extern char *thread_name_single;
+extern char *thread_name_workers;
+extern char *thread_name_verdict;
+extern char *thread_name_flow_mgr;
+extern char *thread_name_flow_rec;
+
 char *RunmodeGetActive(void);
 const char *RunModeGetMainMode(void);
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1657,6 +1657,7 @@ void TmThreadFree(ThreadVars *tv)
     }
 
     TmThreadsUnregisterThread(tv->id);
+    SCFree(tv->name);
     SCFree(tv);
 }
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -19,6 +19,9 @@
 #include "conf.h"
 #include "util-device.h"
 
+#define MAX_DEVNAME 12
+#define DEVNAME_CHUNCK 5
+
 /**
  * \file
  *
@@ -103,6 +106,28 @@ char *LiveGetDeviceName(int number)
     }
 
     return NULL;
+}
+
+/**
+ *  \brief Shorten a device name that is to long
+ *
+ *  \param device name from config and destination for modified
+ *
+ *  \retval None, is added to destination char *newdevname
+ */
+void LiveSafeDeviceName(const char *devname, char *newdevname)
+{
+    size_t devnamelen = strlen(devname);
+
+    if (devnamelen > MAX_DEVNAME) {
+        strncpy(newdevname, devname, DEVNAME_CHUNCK);
+        strncpy(newdevname+DEVNAME_CHUNCK, "...", 3);
+        strncpy(newdevname+8, devname+(devnamelen-DEVNAME_CHUNCK), DEVNAME_CHUNCK);
+        strncpy(newdevname+13, "\0", 1);
+        SCLogInfo("Shortening device name to: %s", newdevname);
+    } else {
+        strcpy(newdevname, devname);
+    }
 }
 
 /**

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -115,19 +115,27 @@ char *LiveGetDeviceName(int number)
  *
  *  \retval None, is added to destination char *newdevname
  */
-void LiveSafeDeviceName(const char *devname, char *newdevname)
+int LiveSafeDeviceName(const char *devname, char *newdevname, size_t destlen)
 {
     size_t devnamelen = strlen(devname);
 
+    // If we have to shorten the interface name
     if (devnamelen > MAX_DEVNAME) {
-        strncpy(newdevname, devname, DEVNAME_CHUNCK);
-        strncpy(newdevname+DEVNAME_CHUNCK, "...", 3);
-        strncpy(newdevname+8, devname+(devnamelen-DEVNAME_CHUNCK), DEVNAME_CHUNCK);
-        strncpy(newdevname+13, "\0", 1);
+    
+        // We need 13 chars to do this shortening
+        if (destlen < 13) {
+            return 1;
+        }
+    
+        size_t length;
+        length = strlcpy(newdevname, devname, DEVNAME_CHUNCK);
+        length = strlcat(newdevname, "...", DEVNAME_CHUNCK+3);
+        length = strlcat(newdevname, devname+(devnamelen-DEVNAME_CHUNCK), length+DEVNAME_CHUNCK);
         SCLogInfo("Shortening device name to: %s", newdevname);
     } else {
-        strcpy(newdevname, devname);
+        strlcpy(newdevname, devname, destlen);
     }
+    return 0;
 }
 
 /**

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -19,7 +19,7 @@
 #include "conf.h"
 #include "util-device.h"
 
-#define MAX_DEVNAME 11
+#define MAX_DEVNAME 10
 
 /**
  * \file
@@ -121,15 +121,15 @@ int LiveSafeDeviceName(const char *devname, char *newdevname, size_t destlen)
     /* If we have to shorten the interface name */
     if (devnamelen > MAX_DEVNAME) {
     
-        /* IF the dest length is over 11 chars long it will not do any
+        /* IF the dest length is over 10 chars long it will not do any
          * good for the shortening. The shortening is done due to the
-         * max length of pthread names (15 chars) and we use 2 chars
-         * for the threadname indicator eg. "W-" and one-two chars for 
+         * max length of pthread names (15 chars) and we use 3 chars
+         * for the threadname indicator eg. "W#-" and one-two chars for 
          * the thread number. And if the destination buffer is under
          * 6 chars there is point in shortening it since we must at
          * lest enter two periodes (.) into the string..
          */
-        if ((destlen-1) > 11 && (destlen-1) < 6) {
+        if ((destlen-1) > 10 && (destlen-1) < 6) {
             return 1;
         }
         

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -35,6 +35,7 @@ typedef struct LiveDevice_ {
 int LiveRegisterDevice(char *dev);
 int LiveGetDeviceCount(void);
 char *LiveGetDeviceName(int number);
+void LiveSafeDeviceName(const char *devname, char *newdevname);
 LiveDevice *LiveGetDevice(char *dev);
 int LiveBuildDeviceList(char * base);
 void LiveDeviceHasNoStats(void);

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -35,7 +35,7 @@ typedef struct LiveDevice_ {
 int LiveRegisterDevice(char *dev);
 int LiveGetDeviceCount(void);
 char *LiveGetDeviceName(int number);
-void LiveSafeDeviceName(const char *devname, char *newdevname);
+int LiveSafeDeviceName(const char *devname, char *newdevname, size_t destlen);
 LiveDevice *LiveGetDevice(char *dev);
 int LiveBuildDeviceList(char * base);
 void LiveDeviceHasNoStats(void);

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -536,7 +536,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "Recv-Q%s", cur_queue);
+        snprintf(tname, sizeof(tname), "RX-Q%s", cur_queue);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {
@@ -574,7 +574,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     }
     for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "Detect%d", thread+1);
+        snprintf(tname, sizeof(tname), "W%02d", thread+1);
         snprintf(qname, sizeof(qname), "pickup%d", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
@@ -629,7 +629,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
     /* create the threads */
     for (int i = 0; i < nqueue; i++) {
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "Verdict%d", i);
+        snprintf(tname, sizeof(tname), "TX%02d", i);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {
@@ -693,7 +693,7 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "Worker-Q%s", cur_queue);
+        snprintf(tname, sizeof(tname), "W-Q%s", cur_queue);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -191,6 +191,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         for (lthread = 0; lthread < nlive; lthread++) {
             char *live_dev = LiveGetDeviceName(lthread);
+            char visual_devname[14] = "";
             void *aconf;
             int threads_count;
 
@@ -209,6 +210,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
             threads_count = ModThreadsCount(aconf);
             for (thread = 0; thread < threads_count; thread++) {
+                LiveSafeDeviceName(live_dev, visual_devname);
                 snprintf(tname, sizeof(tname), "%s%s%d", thread_name,
                          live_dev, thread+1);
                 char *thread_name = SCStrdup(tname);
@@ -335,12 +337,15 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
     for (thread = 0; thread < threads_count; thread++) {
         char tname[TM_THREAD_NAME_MAX];
         char *n_thread_name = NULL;
+        char visual_devname[13] = "";
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
 
         if (single_mode) {
             snprintf(tname, sizeof(tname), "%s", thread_name);
         } else {
+            LiveSafeDeviceName(live_dev, visual_devname);
+            SCLogInfo("New dev name %s", visual_devname);
             snprintf(tname, sizeof(tname), "%s%s%d",
                      thread_name, live_dev, thread+1);
         }

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -191,7 +191,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         for (lthread = 0; lthread < nlive; lthread++) {
             char *live_dev = LiveGetDeviceName(lthread);
-            char visual_devname[14] = "";
+            char visual_devname[12] = "";
             int shortening_result;
             void *aconf;
             int threads_count;
@@ -211,7 +211,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
             threads_count = ModThreadsCount(aconf);
             for (thread = 0; thread < threads_count; thread++) {
-                shortening_result = LiveSafeDeviceName(live_dev, visual_devname, 13);
+                shortening_result = LiveSafeDeviceName(live_dev, visual_devname, sizeof(visual_devname));
                 if (shortening_result != 0) {
                     SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
                     exit(EXIT_FAILURE);
@@ -345,7 +345,7 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
     for (thread = 0; thread < threads_count; thread++) {
         char tname[TM_THREAD_NAME_MAX];
         char *n_thread_name = NULL;
-        char visual_devname[14] = "";
+        char visual_devname[12] = "";
         int shortening_result;
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
@@ -353,7 +353,7 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
         if (single_mode) {
             snprintf(tname, sizeof(tname), "%s", thread_name);
         } else {
-            shortening_result = LiveSafeDeviceName(live_dev, visual_devname, 13);
+            shortening_result = LiveSafeDeviceName(live_dev, visual_devname, sizeof(visual_devname));
             if (shortening_result != 0) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
                 exit(EXIT_FAILURE);

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -192,6 +192,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         for (lthread = 0; lthread < nlive; lthread++) {
             char *live_dev = LiveGetDeviceName(lthread);
             char visual_devname[14] = "";
+            int shortening_result;
             void *aconf;
             int threads_count;
 
@@ -210,9 +211,16 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
             threads_count = ModThreadsCount(aconf);
             for (thread = 0; thread < threads_count; thread++) {
-                LiveSafeDeviceName(live_dev, visual_devname);
+                shortening_result = LiveSafeDeviceName(live_dev, visual_devname, 13);
+                if (shortening_result != 0) {
+                    SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
+                    exit(EXIT_FAILURE);
+                }
+                
                 snprintf(tname, sizeof(tname), "%s%s%d", thread_name,
                          live_dev, thread+1);
+
+>>>>>>> Fixed string copy and cat functions and made shortening safer.
                 char *thread_name = SCStrdup(tname);
                 if (unlikely(thread_name == NULL)) {
                     SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate thread name");
@@ -337,15 +345,20 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
     for (thread = 0; thread < threads_count; thread++) {
         char tname[TM_THREAD_NAME_MAX];
         char *n_thread_name = NULL;
-        char visual_devname[13] = "";
+        char visual_devname[14] = "";
+        int shortening_result;
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
 
         if (single_mode) {
             snprintf(tname, sizeof(tname), "%s", thread_name);
         } else {
-            LiveSafeDeviceName(live_dev, visual_devname);
-            SCLogInfo("New dev name %s", visual_devname);
+            shortening_result = LiveSafeDeviceName(live_dev, visual_devname, 13);
+            if (shortening_result != 0) {
+                SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
+                exit(EXIT_FAILURE);
+            }
+
             snprintf(tname, sizeof(tname), "%s%s%d",
                      thread_name, live_dev, thread+1);
         }

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -147,7 +147,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         /* create the threads */
         for (thread = 0; thread < threads_count; thread++) {
-            snprintf(tname, sizeof(tname), "%s%02d", thread_name, thread+1);
+            snprintf(tname, sizeof(tname), "%s#%02d", thread_name, thread+1);
             char *thread_name = SCStrdup(tname);
             if (unlikely(thread_name == NULL)) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate thread name");
@@ -191,7 +191,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         for (lthread = 0; lthread < nlive; lthread++) {
             char *live_dev = LiveGetDeviceName(lthread);
-            char visual_devname[12] = "";
+            char visual_devname[11] = "";
             int shortening_result;
             void *aconf;
             int threads_count;
@@ -217,7 +217,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                     exit(EXIT_FAILURE);
                 }
                 
-                snprintf(tname, sizeof(tname), "%s%02d-%s", thread_name,
+                snprintf(tname, sizeof(tname), "%s#%02d-%s", thread_name,
                          thread+1, visual_devname);
 
                 char *thread_name = SCStrdup(tname);
@@ -258,7 +258,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     }
 
     for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "W%02d", thread+1);
+        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_workers, thread+1);
         snprintf(qname, sizeof(qname), "pickup%d", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
@@ -344,21 +344,21 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
     for (thread = 0; thread < threads_count; thread++) {
         char tname[TM_THREAD_NAME_MAX];
         char *n_thread_name = NULL;
-        char visual_devname[12] = "";
+        char visual_devname[11] = "";
         int shortening_result;
         ThreadVars *tv = NULL;
         TmModule *tm_module = NULL;
 
-        if (single_mode) {
-            snprintf(tname, sizeof(tname), "%s01", thread_name);
-        } else {
-            shortening_result = LiveSafeDeviceName(live_dev, visual_devname, sizeof(visual_devname));
-            if (shortening_result != 0) {
-                SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
-                exit(EXIT_FAILURE);
-            }
+        shortening_result = LiveSafeDeviceName(live_dev, visual_devname, sizeof(visual_devname));
+        if (shortening_result != 0) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
+            exit(EXIT_FAILURE);
+        }
             
-            snprintf(tname, sizeof(tname), "%s%02d-%s", thread_name,
+        if (single_mode) {
+            snprintf(tname, sizeof(tname), "%s#01-%s", thread_name, visual_devname);
+        } else {
+            snprintf(tname, sizeof(tname), "%s#%02d-%s", thread_name,
                      thread+1, visual_devname);
         }
         n_thread_name = SCStrdup(tname);
@@ -536,7 +536,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "RX-Q%s", cur_queue);
+        snprintf(tname, sizeof(tname), "%s-Q%s", thread_name_autofp, cur_queue);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {
@@ -574,7 +574,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     }
     for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "W%02d", thread+1);
+        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_workers, thread+1);
         snprintf(qname, sizeof(qname), "pickup%d", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
@@ -629,7 +629,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
     /* create the threads */
     for (int i = 0; i < nqueue; i++) {
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "TX%02d", i);
+        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_verdict, i);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {
@@ -693,7 +693,7 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
         memset(tname, 0, sizeof(tname));
-        snprintf(tname, sizeof(tname), "W-Q%s", cur_queue);
+        snprintf(tname, sizeof(tname), "%s-Q%s", thread_name_workers, cur_queue);
 
         char *thread_name = SCStrdup(tname);
         if (unlikely(thread_name == NULL)) {

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -147,7 +147,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         /* create the threads */
         for (thread = 0; thread < threads_count; thread++) {
-            snprintf(tname, sizeof(tname), "%s%d", thread_name, thread+1);
+            snprintf(tname, sizeof(tname), "%s%02d", thread_name, thread+1);
             char *thread_name = SCStrdup(tname);
             if (unlikely(thread_name == NULL)) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate thread name");
@@ -217,10 +217,9 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                     exit(EXIT_FAILURE);
                 }
                 
-                snprintf(tname, sizeof(tname), "%s%s%d", thread_name,
-                         live_dev, thread+1);
+                snprintf(tname, sizeof(tname), "%s%02d-%s", thread_name,
+                         thread+1, visual_devname);
 
->>>>>>> Fixed string copy and cat functions and made shortening safer.
                 char *thread_name = SCStrdup(tname);
                 if (unlikely(thread_name == NULL)) {
                     SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate thread name");
@@ -259,7 +258,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     }
 
     for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "Detect%d", thread+1);
+        snprintf(tname, sizeof(tname), "W%02d", thread+1);
         snprintf(qname, sizeof(qname), "pickup%d", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
@@ -351,16 +350,16 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
         TmModule *tm_module = NULL;
 
         if (single_mode) {
-            snprintf(tname, sizeof(tname), "%s", thread_name);
+            snprintf(tname, sizeof(tname), "%s01", thread_name);
         } else {
             shortening_result = LiveSafeDeviceName(live_dev, visual_devname, sizeof(visual_devname));
             if (shortening_result != 0) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Could not shorten long devicename: %s", live_dev);
                 exit(EXIT_FAILURE);
             }
-
-            snprintf(tname, sizeof(tname), "%s%s%d",
-                     thread_name, live_dev, thread+1);
+            
+            snprintf(tname, sizeof(tname), "%s%02d-%s", thread_name,
+                     thread+1, visual_devname);
         }
         n_thread_name = SCStrdup(tname);
         if (unlikely(n_thread_name == NULL)) {


### PR DESCRIPTION
Addressed feedback from #1648:
 * Enforced standard for offline pcap
 * Added interface name to single mode
 * Replace C with RX
 * Created global thread names
 * Added "#" in front of thread numbers