### PR TITLE
lua: functions to force magic and md5 lookup on files

### DIFF
--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -666,6 +666,17 @@ static int LuaCallbackFileState(lua_State *luastate)
 }
 
 /** \internal
+ *  \brief wrapper to force magic lookup on all files from lua script
+    \retval cnt number of items placed on the stack
+ */
+static int LuaCallbackFileForceMagic(lua_State *luastate)
+{
+    FileForceMagicEnable();
+    lua_pushinteger(luastate, 1);
+    return 1;
+}
+
+/** \internal
  *  \brief fill lua stack with thread info
  *  \param luastate the lua state
  *  \param pa pointer to packet alert struct
@@ -743,6 +754,8 @@ int LuaRegisterFunctions(lua_State *luastate)
     lua_setglobal(luastate, "SCFileInfo");
     lua_pushcfunction(luastate, LuaCallbackFileState);
     lua_setglobal(luastate, "SCFileState");
+    lua_pushcfunction(luastate, LuaCallbackFileForceMagic);
+    lua_setglobal(luastate, "SCFileForceMagic");
 
     lua_pushcfunction(luastate, LuaCallbackThreadInfo);
     lua_setglobal(luastate, "SCThreadInfo");

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -677,6 +677,17 @@ static int LuaCallbackFileForceMagic(lua_State *luastate)
 }
 
 /** \internal
+ *  \brief wrapper to force md5 lookup on all files from lua script
+    \retval cnt number of items placed on the stack
+ */
+static int LuaCallbackFileForceMd5(lua_State *luastate)
+{
+    FileForceMd5Enable();
+    lua_pushinteger(luastate, 1);
+    return 1;
+}
+
+/** \internal
  *  \brief fill lua stack with thread info
  *  \param luastate the lua state
  *  \param pa pointer to packet alert struct
@@ -756,6 +767,8 @@ int LuaRegisterFunctions(lua_State *luastate)
     lua_setglobal(luastate, "SCFileState");
     lua_pushcfunction(luastate, LuaCallbackFileForceMagic);
     lua_setglobal(luastate, "SCFileForceMagic");
+    lua_pushcfunction(luastate, LuaCallbackFileForceMd5);
+    lua_setglobal(luastate, "SCFileForceMd5");
 
     lua_pushcfunction(luastate, LuaCallbackThreadInfo);
     lua_setglobal(luastate, "SCThreadInfo");


### PR DESCRIPTION
Added lua functions "SCFileForceMagic" and "SCFileForceMd5" to force magic and md5 lookup on all files. These functions are equivalent to setting "force-magic: yes" and "force-md5: yes" in suricata.yaml.

https://redmine.openinfosecfoundation.org/issues/1590

Example:
```lua
function init (args)
    local needs = {}
    needs['type'] = 'file'
    return needs
end

function setup (args)
    filename = SCLogPath() .. "/" .. "lua_file.log"
    file = assert(io.open(filename, "a"))
    SCFileForceMagic()
    SCFileForceMd5()
end

function log (args)
    fileid, txid, name, size, magic, md5 = SCFileInfo()
    file:write("filename='" .. name .. "' magic='" .. magic ..
               "' md5='" .. md5 .. "'\n")
    file:flush()
end

function deinit (args)
    file:close()
end
```