### PR TITLE
Misc improvements

### DIFF
--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -51,6 +51,7 @@
 
 #define LOG_STATS_TOTALS  (1<<0)
 #define LOG_STATS_THREADS (1<<1)
+#define LOG_STATS_NULLS   (1<<2)
 
 TmEcode LogStatsLogThreadInit(ThreadVars *, void *, void **);
 TmEcode LogStatsLogThreadDeinit(ThreadVars *, void *);
@@ -106,6 +107,9 @@ int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *st)
     if (aft->statslog_ctx->flags & LOG_STATS_TOTALS) {
         for (u = 0; u < st->nstats; u++) {
             if (st->stats[u].name == NULL)
+                continue;
+
+            if (!(aft->statslog_ctx->flags & LOG_STATS_NULLS) && st->stats[u].value == 0)
                 continue;
 
             char line[1024];
@@ -238,6 +242,7 @@ OutputCtx *LogStatsLogInitCtx(ConfNode *conf)
     if (conf != NULL) {
         const char *totals = ConfNodeLookupChildValue(conf, "totals");
         const char *threads = ConfNodeLookupChildValue(conf, "threads");
+        const char *nulls = ConfNodeLookupChildValue(conf, "null-values");
         SCLogDebug("totals %s threads %s", totals, threads);
 
         if (totals != NULL && ConfValIsFalse(totals)) {
@@ -245,6 +250,9 @@ OutputCtx *LogStatsLogInitCtx(ConfNode *conf)
         }
         if (threads != NULL && ConfValIsTrue(threads)) {
             statslog_ctx->flags |= LOG_STATS_THREADS;
+        }
+        if (nulls != NULL && ConfValIsTrue(nulls)) {
+            statslog_ctx->flags |= LOG_STATS_NULLS;
         }
         SCLogDebug("statslog_ctx->flags %08x", statslog_ctx->flags);
     }

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -92,6 +92,10 @@ void AFPDerefConfig(void *conf)
     }
 }
 
+/* if cluster id is not set, assign it automagically, uniq value per
+ * interface. */
+static int cluster_id_auto = 1;
+
 /**
  * \brief extract information from config file
  *
@@ -192,7 +196,7 @@ void *ParseAFPConfig(const char *iface)
         if (rss_queues > 0) {
             if (rss_queues < aconf->threads) {
                 aconf->threads = rss_queues;
-                SCLogInfo("More core than RSS queues, using %d threads for interface %s",
+                SCLogInfo("More cores than RSS queues, using %d threads for interface %s",
                           aconf->threads, iface);
             }
         }
@@ -252,14 +256,15 @@ void *ParseAFPConfig(const char *iface)
     (void) SC_ATOMIC_ADD(aconf->ref, aconf->threads);
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-id", &tmpclusterid) != 1) {
-        SCLogError(SC_ERR_INVALID_ARGUMENT,"Could not get cluster-id from config");
+        aconf->cluster_id = (uint16_t)(cluster_id_auto++);
     } else {
         aconf->cluster_id = (uint16_t)atoi(tmpclusterid);
         SCLogDebug("Going to use cluster-id %" PRId32, aconf->cluster_id);
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "cluster-type", &tmpctype) != 1) {
-        SCLogError(SC_ERR_GET_CLUSTER_TYPE_FAILED,"Could not get cluster-type from config");
+        /* default to our safest choice: flow hashing + defrag enabled */
+        aconf->cluster_type = PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG;
     } else if (strcmp(tmpctype, "cluster_round_robin") == 0) {
         SCLogInfo("Using round-robin cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -513,7 +513,7 @@ int RunModeIdsAFPAutoFp(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsAFPAutoFp initialised");
+    SCLogDebug("RunModeIdsAFPAutoFp initialised");
 #endif /* HAVE_AF_PACKET */
 
     SCReturnInt(0);
@@ -555,7 +555,7 @@ int RunModeIdsAFPSingle(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsAFPSingle initialised");
+    SCLogDebug("RunModeIdsAFPSingle initialised");
 
 #endif /* HAVE_AF_PACKET */
     SCReturnInt(0);
@@ -600,7 +600,7 @@ int RunModeIdsAFPWorkers(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsAFPWorkers initialised");
+    SCLogDebug("RunModeIdsAFPWorkers initialised");
 
 #endif /* HAVE_AF_PACKET */
     SCReturnInt(0);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1702,9 +1702,9 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
     ptv->cluster_id = 1;
     /* We only set cluster info if the number of reader threads is greater than 1 */
     if (afpconfig->threads > 1) {
-            ptv->cluster_id = afpconfig->cluster_id;
-            ptv->cluster_type = afpconfig->cluster_type;
-            ptv->threads = afpconfig->threads;
+        ptv->cluster_id = afpconfig->cluster_id;
+        ptv->cluster_type = afpconfig->cluster_type;
+        ptv->threads = afpconfig->threads;
     }
 #endif
     ptv->flags = afpconfig->flags;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1073,7 +1073,7 @@ static int AFPSynchronizeStart(AFPThreadVars *ptv)
             }
         /* no packets */
         } else if (r == 0 && AFPPeersListStarted()) {
-            SCLogInfo("Starting to read on %s", ptv->tv->name);
+            SCLogDebug("Starting to read on %s", ptv->tv->name);
             return 1;
         } else if (r < 0) { /* only exit on error */
             SCLogWarning(SC_ERR_AFP_READ, "poll failed with retval %d", r);
@@ -1154,7 +1154,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
         AFPPeersListReachedInc();
     }
     if (ptv->afp_state == AFP_STATE_UP) {
-        SCLogInfo("Thread %s using socket %d", tv->name, ptv->socket);
+        SCLogDebug("Thread %s using socket %d", tv->name, ptv->socket);
         AFPSynchronizeStart(ptv);
     }
 
@@ -1570,8 +1570,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
         ptv->frame_offset = 0;
     }
 
-    SCLogInfo("Using interface '%s' via socket %d", (char *)devname, ptv->socket);
-
+    SCLogDebug("Using interface '%s' via socket %d", (char *)devname, ptv->socket);
 
     ptv->datalink = AFPGetDevLinktype(ptv->socket, ptv->iface);
     switch (ptv->datalink) {

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1720,23 +1720,6 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
             ptv->tv);
 #endif
 
-    char *active_runmode = RunmodeGetActive();
-
-    if (active_runmode && !strcmp("workers", active_runmode)) {
-        ptv->flags |= AFP_ZERO_COPY;
-        SCLogInfo("Enabling zero copy mode");
-    } else {
-        /* If we are using copy mode we need a lock */
-        ptv->flags |= AFP_SOCK_PROTECT;
-    }
-
-    /* If we are in RING mode, then we can use ZERO copy
-     * by using the data release mechanism */
-    if (ptv->flags & AFP_RING_MODE) {
-        ptv->flags |= AFP_ZERO_COPY;
-        SCLogInfo("Enabling zero copy mode by using data release call");
-    }
-
     ptv->copy_mode = afpconfig->copy_mode;
     if (ptv->copy_mode != AFP_COPY_MODE_NONE) {
         strlcpy(ptv->out_iface, afpconfig->out_iface, AFP_IFACE_NAME_LENGTH);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1860,18 +1860,21 @@ TmEcode DecodeAFP(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packet
     }
 
     /* call the decoder */
-    switch(p->datalink) {
-        case LINKTYPE_LINUX_SLL:
-            DecodeSll(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
-            break;
+    switch (p->datalink) {
         case LINKTYPE_ETHERNET:
             DecodeEthernet(tv, dtv, p,GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
+            break;
+        case LINKTYPE_LINUX_SLL:
+            DecodeSll(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         case LINKTYPE_PPP:
             DecodePPP(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         case LINKTYPE_RAW:
             DecodeRaw(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
+            break;
+        case LINKTYPE_NULL:
+            DecodeNull(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         default:
             SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodeAFP", p->datalink);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1134,25 +1134,22 @@ static int ParseCommandLinePcapLive(SCInstance *suri, const char *optarg)
 {
     memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
 
-    if (optarg == NULL) {
-        SCLogError(SC_ERR_INITIALIZATION, "no option argument (optarg) for -i");
-        return TM_ECODE_FAILED;
-    }
+    if (optarg != NULL) {
+        /* some windows shells require escaping of the \ in \Device. Otherwise
+         * the backslashes are stripped. We put them back here. */
+        if (strlen(optarg) > 9 && strncmp(optarg, "DeviceNPF", 9) == 0) {
+            snprintf(suri->pcap_dev, sizeof(suri->pcap_dev), "\\Device\\NPF%s", optarg+9);
+        } else {
+            strlcpy(suri->pcap_dev, optarg, ((strlen(optarg) < sizeof(suri->pcap_dev)) ? (strlen(optarg)+1) : (sizeof(suri->pcap_dev))));
+            PcapTranslateIPToDevice(suri->pcap_dev, sizeof(suri->pcap_dev));
+        }
 
-    /* some windows shells require escaping of the \ in \Device. Otherwise
-     * the backslashes are stripped. We put them back here. */
-    if (strlen(optarg) > 9 && strncmp(optarg, "DeviceNPF", 9) == 0) {
-        snprintf(suri->pcap_dev, sizeof(suri->pcap_dev), "\\Device\\NPF%s", optarg+9);
-    } else {
-        strlcpy(suri->pcap_dev, optarg, ((strlen(optarg) < sizeof(suri->pcap_dev)) ? (strlen(optarg)+1) : (sizeof(suri->pcap_dev))));
-        PcapTranslateIPToDevice(suri->pcap_dev, sizeof(suri->pcap_dev));
-    }
-
-    if (strcmp(suri->pcap_dev, optarg) != 0) {
-        SCLogInfo("translated %s to pcap device %s", optarg, suri->pcap_dev);
-    } else if (strlen(suri->pcap_dev) > 0 && isdigit((unsigned char)suri->pcap_dev[0])) {
-        SCLogError(SC_ERR_PCAP_TRANSLATE, "failed to find a pcap device for IP %s", optarg);
-        return TM_ECODE_FAILED;
+        if (strcmp(suri->pcap_dev, optarg) != 0) {
+            SCLogInfo("translated %s to pcap device %s", optarg, suri->pcap_dev);
+        } else if (strlen(suri->pcap_dev) > 0 && isdigit((unsigned char)suri->pcap_dev[0])) {
+            SCLogError(SC_ERR_PCAP_TRANSLATE, "failed to find a pcap device for IP %s", optarg);
+            return TM_ECODE_FAILED;
+        }
     }
 
     if (suri->run_mode == RUNMODE_UNKNOWN) {
@@ -1340,29 +1337,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
 #endif /* HAVE_NFLOG */
             } else if (strcmp((long_opts[option_index]).name , "pcap") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_PCAP_DEV;
-                    if (optarg) {
-                        LiveRegisterDevice(optarg);
-                        memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
-                        strlcpy(suri->pcap_dev, optarg,
-                                ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
-                                 (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                    }
-                } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
-#ifdef OS_WIN32
-                    SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
-                            "support is not (yet) supported on Windows.");
-                    return TM_ECODE_FAILED;
-#else
-                    SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
-                            "multiple pcap devices to get packets is experimental.");
-                    LiveRegisterDevice(optarg);
-#endif
-                } else {
-                    SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
-                            "has been specified");
-                    usage(argv[0]);
+                if (ParseCommandLinePcapLive(suri, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
             } else if(strcmp((long_opts[option_index]).name, "init-errors-fatal") == 0) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1551,6 +1551,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             suri->run_mode = RUNMODE_PRINT_USAGE;
             return TM_ECODE_OK;
         case 'i':
+            if (optarg == NULL) {
+                SCLogError(SC_ERR_INITIALIZATION, "no option argument (optarg) for -i");
+                return TM_ECODE_FAILED;
+            }
 #ifdef HAVE_AF_PACKET
             if (ParseCommandLineAfpacket(suri, optarg) != TM_ECODE_OK) {
                 return TM_ECODE_FAILED;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1095,6 +1095,41 @@ static void SCPrintElapsedTime(SCInstance *suri)
     SCLogInfo("time elapsed %.3fs", (float)milliseconds/(float)1000);
 }
 
+static int ParseCommandLineAfpacket(SCInstance *suri, const char *optarg)
+{
+#ifdef HAVE_AF_PACKET
+    if (suri->run_mode == RUNMODE_UNKNOWN) {
+        suri->run_mode = RUNMODE_AFP_DEV;
+        if (optarg) {
+            LiveRegisterDevice(optarg);
+            memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
+            strlcpy(suri->pcap_dev, optarg,
+                    ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
+                     (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
+        }
+    } else if (suri->run_mode == RUNMODE_AFP_DEV) {
+        SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
+                "multiple devices to get packets is experimental.");
+        if (optarg) {
+            LiveRegisterDevice(optarg);
+        } else {
+            SCLogInfo("Multiple af-packet option without interface on each is useless");
+        }
+    } else {
+        SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
+                "has been specified");
+        usage(suri->progname);
+        return TM_ECODE_FAILED;
+    }
+    return TM_ECODE_OK;
+#else
+    SCLogError(SC_ERR_NO_AF_PACKET,"AF_PACKET not enabled. On Linux "
+            "host, make sure to pass --enable-af-packet to "
+            "configure when building.");
+    return TM_ECODE_FAILED;
+#endif
+}
+
 static int ParseCommandLinePcapLive(SCInstance *suri, const char *optarg)
 {
     memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
@@ -1259,38 +1294,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
 #endif /* HAVE_PFRING */
             }
-            else if (strcmp((long_opts[option_index]).name , "af-packet") == 0){
-#ifdef HAVE_AF_PACKET
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_AFP_DEV;
-                    if (optarg) {
-                        LiveRegisterDevice(optarg);
-                        memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
-                        strlcpy(suri->pcap_dev, optarg,
-                                ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
-                                 (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                    }
-                } else if (suri->run_mode == RUNMODE_AFP_DEV) {
-                    SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
-                            "multiple devices to get packets is experimental.");
-                    if (optarg) {
-                        LiveRegisterDevice(optarg);
-                    } else {
-                        SCLogInfo("Multiple af-packet option without interface on each is useless");
-                        break;
-                    }
-                } else {
-                    SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
-                            "has been specified");
-                    usage(argv[0]);
+            else if (strcmp((long_opts[option_index]).name , "af-packet") == 0)
+            {
+                if (ParseCommandLineAfpacket(suri, optarg) != TM_ECODE_OK) {
                     return TM_ECODE_FAILED;
                 }
-#else
-                SCLogError(SC_ERR_NO_AF_PACKET,"AF_PACKET not enabled. On Linux "
-                        "host, make sure to pass --enable-af-packet to "
-                        "configure when building.");
-                return TM_ECODE_FAILED;
-#endif
             } else if (strcmp((long_opts[option_index]).name , "netmap") == 0){
 #ifdef HAVE_NETMAP
                 if (suri->run_mode == RUNMODE_UNKNOWN) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1551,9 +1551,15 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             suri->run_mode = RUNMODE_PRINT_USAGE;
             return TM_ECODE_OK;
         case 'i':
+#ifdef HAVE_AF_PACKET
+            if (ParseCommandLineAfpacket(suri, optarg) != TM_ECODE_OK) {
+                return TM_ECODE_FAILED;
+            }
+#else
             if (ParseCommandLinePcapLive(suri, optarg) != TM_ECODE_OK) {
                 return TM_ECODE_FAILED;
             }
+#endif
             break;
         case 'l':
             if (optarg == NULL) {

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1095,6 +1095,53 @@ static void SCPrintElapsedTime(SCInstance *suri)
     SCLogInfo("time elapsed %.3fs", (float)milliseconds/(float)1000);
 }
 
+static int ParseCommandLinePcapLive(SCInstance *suri, const char *optarg)
+{
+    memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
+
+    if (optarg == NULL) {
+        SCLogError(SC_ERR_INITIALIZATION, "no option argument (optarg) for -i");
+        return TM_ECODE_FAILED;
+    }
+
+    /* some windows shells require escaping of the \ in \Device. Otherwise
+     * the backslashes are stripped. We put them back here. */
+    if (strlen(optarg) > 9 && strncmp(optarg, "DeviceNPF", 9) == 0) {
+        snprintf(suri->pcap_dev, sizeof(suri->pcap_dev), "\\Device\\NPF%s", optarg+9);
+    } else {
+        strlcpy(suri->pcap_dev, optarg, ((strlen(optarg) < sizeof(suri->pcap_dev)) ? (strlen(optarg)+1) : (sizeof(suri->pcap_dev))));
+        PcapTranslateIPToDevice(suri->pcap_dev, sizeof(suri->pcap_dev));
+    }
+
+    if (strcmp(suri->pcap_dev, optarg) != 0) {
+        SCLogInfo("translated %s to pcap device %s", optarg, suri->pcap_dev);
+    } else if (strlen(suri->pcap_dev) > 0 && isdigit((unsigned char)suri->pcap_dev[0])) {
+        SCLogError(SC_ERR_PCAP_TRANSLATE, "failed to find a pcap device for IP %s", optarg);
+        return TM_ECODE_FAILED;
+    }
+
+    if (suri->run_mode == RUNMODE_UNKNOWN) {
+        suri->run_mode = RUNMODE_PCAP_DEV;
+        LiveRegisterDevice(suri->pcap_dev);
+    } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
+#ifdef OS_WIN32
+        SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
+                "support is not (yet) supported on Windows.");
+        return TM_ECODE_FAILED;
+#else
+        SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
+                "multiple pcap devices to get packets is experimental.");
+        LiveRegisterDevice(suri->pcap_dev);
+#endif
+    } else {
+        SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
+                "has been specified");
+        usage(suri->progname);
+        return TM_ECODE_FAILED;
+    }
+    return TM_ECODE_OK;
+}
+
 static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 {
     int opt;
@@ -1521,46 +1568,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             suri->run_mode = RUNMODE_PRINT_USAGE;
             return TM_ECODE_OK;
         case 'i':
-            memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
-
-            if (optarg == NULL) {
-                SCLogError(SC_ERR_INITIALIZATION, "no option argument (optarg) for -i");
-                return TM_ECODE_FAILED;
-            }
-
-            /* some windows shells require escaping of the \ in \Device. Otherwise
-             * the backslashes are stripped. We put them back here. */
-            if (strlen(optarg) > 9 && strncmp(optarg, "DeviceNPF", 9) == 0) {
-                snprintf(suri->pcap_dev, sizeof(suri->pcap_dev), "\\Device\\NPF%s", optarg+9);
-            } else {
-                strlcpy(suri->pcap_dev, optarg, ((strlen(optarg) < sizeof(suri->pcap_dev)) ? (strlen(optarg)+1) : (sizeof(suri->pcap_dev))));
-                PcapTranslateIPToDevice(suri->pcap_dev, sizeof(suri->pcap_dev));
-            }
-
-            if (strcmp(suri->pcap_dev, optarg) != 0) {
-                SCLogInfo("translated %s to pcap device %s", optarg, suri->pcap_dev);
-            } else if (strlen(suri->pcap_dev) > 0 && isdigit((unsigned char)suri->pcap_dev[0])) {
-                SCLogError(SC_ERR_PCAP_TRANSLATE, "failed to find a pcap device for IP %s", optarg);
-                return TM_ECODE_FAILED;
-            }
-
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_PCAP_DEV;
-                LiveRegisterDevice(suri->pcap_dev);
-            } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
-#ifdef OS_WIN32
-                SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
-                        "support is not (yet) supported on Windows.");
-                return TM_ECODE_FAILED;
-#else
-                SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
-                        "multiple pcap devices to get packets is experimental.");
-                LiveRegisterDevice(suri->pcap_dev);
-#endif
-            } else {
-                SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
-                                                     "has been specified");
-                usage(argv[0]);
+            if (ParseCommandLinePcapLive(suri, optarg) != TM_ECODE_OK) {
                 return TM_ECODE_FAILED;
             }
             break;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2150,6 +2150,7 @@ int main(int argc, char **argv)
     SCInstance suri;
 
     SCInstanceInit(&suri);
+    suri.progname = argv[0];
 
     sc_set_caps = FALSE;
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -155,6 +155,7 @@ typedef struct SCInstance_ {
     struct timeval start_time;
 
     char *log_dir;
+    const char *progname; /**< pointer to argv[0] */
 } SCInstance;
 
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -42,7 +42,7 @@ static int live_devices_stats = 1;
  *  \retval 0 on success.
  *  \retval -1 on failure.
  */
-int LiveRegisterDevice(char *dev)
+int LiveRegisterDevice(const char *dev)
 {
     LiveDevice *pd = SCMalloc(sizeof(LiveDevice));
     if (unlikely(pd == NULL)) {
@@ -113,7 +113,7 @@ char *LiveGetDeviceName(int number)
  *  \retval ptr pointer to the string containing the device
  *  \retval NULL on error
  */
-LiveDevice *LiveGetDevice(char *name)
+LiveDevice *LiveGetDevice(const char *name)
 {
     int i = 0;
     LiveDevice *pd;
@@ -136,12 +136,12 @@ LiveDevice *LiveGetDevice(char *name)
 
 
 
-int LiveBuildDeviceList(char * runmode)
+int LiveBuildDeviceList(const char *runmode)
 {
     return LiveBuildDeviceListCustom(runmode, "interface");
 }
 
-int LiveBuildDeviceListCustom(char * runmode, char * itemname)
+int LiveBuildDeviceListCustom(const char *runmode, const char *itemname)
 {
     ConfNode *base = ConfGetNode(runmode);
     ConfNode *child;

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -32,14 +32,14 @@ typedef struct LiveDevice_ {
 } LiveDevice;
 
 
-int LiveRegisterDevice(char *dev);
+int LiveRegisterDevice(const char *dev);
 int LiveGetDeviceCount(void);
 char *LiveGetDeviceName(int number);
-LiveDevice *LiveGetDevice(char *dev);
-int LiveBuildDeviceList(char * base);
+LiveDevice *LiveGetDevice(const char *dev);
+int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);
-int LiveBuildDeviceListCustom(char * base, char * itemname);
+int LiveBuildDeviceListCustom(const char *base, const char *itemname);
 
 #ifdef BUILD_UNIX_SOCKET
 TmEcode LiveDeviceIfaceStat(json_t *cmd, json_t *server_msg, void *data);

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -157,6 +157,7 @@ int GetIfaceOffloading(const char *pcap_dev)
     int fd;
     struct ethtool_value ethv;
     int ret = 0;
+    char *lro = "unset", *gro = "unset";
 
     fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (fd == -1) {
@@ -175,10 +176,8 @@ int GetIfaceOffloading(const char *pcap_dev)
         return -1;
     } else {
         if (ethv.data) {
-            SCLogInfo("Generic Receive Offload is set on %s", pcap_dev);
+            gro = "SET";
             ret = 1;
-        } else {
-            SCLogInfo("Generic Receive Offload is unset on %s", pcap_dev);
         }
     }
 
@@ -194,15 +193,13 @@ int GetIfaceOffloading(const char *pcap_dev)
         return -1;
     } else {
         if (ethv.data & ETH_FLAG_LRO) {
-            SCLogInfo("Large Receive Offload is set on %s", pcap_dev);
+            lro = "SET";
             ret = 1;
-        } else {
-            SCLogInfo("Large Receive Offload is unset on %s", pcap_dev);
         }
     }
 
     close(fd);
-
+    SCLogInfo("NIC offloading on %s: GRO: %s, LRO: %s", pcap_dev, gro, lro);
     return ret;
 #else
     /* ioctl is not defined, let's pretend returning 0 is ok */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -315,6 +315,7 @@ outputs:
       filename: stats.log
       totals: yes       # stats for all threads merged together
       threads: no       # per thread stats
+      #null-values: yes  # print counters that have value 0
 
   # a line based alerts log similar to fast.log into syslog
   - syslog:


### PR DESCRIPTION
Some misc things:
- when using -i, use afpacket if available
- afpacket output cleanups
- afpacket: no more warnings for missing cluster values, use sane defaults
- stats.log: option to suppress 0 values, enabled by default

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/303
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/305

Btw, https://redmine.openinfosecfoundation.org/issues/1591 affects this, -i on unsupported linktypes now fails. Need to check if afpacket supports a link first maybe.

cc: @regit @pevma @jasonish 