### PR TITLE
Issue 1592: Fix deadlock in thread restart

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2155,6 +2155,8 @@ int main(int argc, char **argv)
 
     SC_ATOMIC_INIT(engine_stage);
 
+    TmInitThreadManager();
+    
     /* initialize the logging subsys */
     SCLogInitLogModule(NULL);
 

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -77,11 +77,18 @@ static int SetCPUAffinity(uint16_t cpu);
 ThreadVars *tv_root[TVT_MAX] = { NULL };
 
 /* lock to protect tv_root */
-SCMutex tv_root_lock = SCMUTEX_INITIALIZER;
+SCMutex tv_root_lock;
+SCMutexAttr tv_root_lock_attr;
 
 /* Action On Failure(AOF).  Determines how the engine should behave when a
  * thread encounters a failure.  Defaults to restart the failed thread */
 uint8_t tv_aof = THV_RESTART_THREAD;
+
+void TmInitThreadManager() {
+    pthread_mutexattr_init(&tv_root_lock_attr);
+    pthread_mutexattr_settype(&tv_root_lock_attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&tv_root_lock, &tv_root_lock_attr);    
+}
 
 /**
  * \brief Check if a thread flag is set.

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -80,6 +80,7 @@ extern ThreadVars *tv_root[TVT_MAX];
 
 extern SCMutex tv_root_lock;
 
+void TmInitThreadManager();
 void TmSlotSetFuncAppend(ThreadVars *, TmModule *, void *);
 void TmSlotSetFuncAppendDelayed(ThreadVars *, TmModule *, void *, int delayed);
 TmSlot *TmSlotGetSlotForTM(int);


### PR DESCRIPTION
This fixes an issues where when a thread dies and attempts to be
restarted, a deadlock ensues as the thread attempts to lock the same
mutex (tv_root_lock) twice.

Specifically, TmThreadCheckThreadState() takes a lock on tv_root_lock as
it iterates through the list of threads and performs a check as to the
state of the thread.  If the thread has failed, it will attempt to
potentially restart the thread calling TmThreadRestartThread() which
subsequently calls TmThreadSpawn() which eventually calls
TmThreadAppend().  TmThreadAppend() also attempts to take a lock on
tv_root_mutex.  Since the lock was already taken by
TmThreadCheckThreadState(), a deadlock ensues.

The potential fix is to change tv_root_mutex from a normal mutex into
a recursive mutex so the same thread can lock tv_root_mutex multiple
times (this looked safe when testing).  However, there are a number
of functions that are either called once or never called that interact
with tv_root_mutex as well (example TmThreadAppend() is only called
from TmThreadSpawn() and TmThreadRestart() isn't called at all).
In both of these cases, since the function interacts with
tv_root_mutex, they create a lock.  We may want to revisit this in
general but the proposed fix should unblock the initial issue.

The change requires an explicit initialization function which is
now called in Suricata's main().