### PR TITLE
Config fix

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2226,6 +2226,11 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    if (suri.run_mode == RUNMODE_DUMP_CONFIG) {
+        ConfDump();
+        exit(EXIT_SUCCESS);
+    }
+
     /* Since our config is now loaded we can finish configurating the
      * logging module. */
     SCLogLoadConfig(suri.daemon, suri.verbose);
@@ -2233,11 +2238,6 @@ int main(int argc, char **argv)
     SCPrintVersion();
 
     UtilCpuPrintSummary();
-
-    if (suri.run_mode == RUNMODE_DUMP_CONFIG) {
-        ConfDump();
-        exit(EXIT_SUCCESS);
-    }
 
     if (PostConfLoadedSetup(&suri) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -50,7 +50,7 @@ host-mode: auto
 
 # Default pid file.
 # Will use this file if no --pidfile in command options.
-#pid-file: /var/run/suricata.pid
+#pid-file: @e_rundir@suricata.pid
 
 # Daemon working directory
 # Suricata will change directory to this one if provided
@@ -980,7 +980,7 @@ logging:
       # type: json
   - file:
       enabled: no
-      filename: /var/log/suricata.log
+      filename: @e_logdir@suricata.log
       # type: json
   - syslog:
       enabled: no


### PR DESCRIPTION
Two patches related to configuration. First one is cleaning dump-config and the next one is using some built at configure path instead of using hardcoded one.

PR scripts:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/117
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/115