### PR TITLE
conf: fail if sequence node set from command line - v1

### DIFF
--- a/src/conf-yaml-loader.c
+++ b/src/conf-yaml-loader.c
@@ -308,6 +308,12 @@ ConfYamlParse(yaml_parser_t *parser, ConfNode *parent, int inseq)
             SCLogDebug("event.type=YAML_SEQUENCE_START_EVENT; state=%d", state);
             if (ConfYamlParse(parser, node, 1) != 0)
                 goto fail;
+            if (node->final && !node->is_seq) {
+                SCLogError(SC_ERR_CONF_YAML_ERROR, "Error: Found node already "
+                    "set from command line. Setting of sequence nodes with "
+                    "--set is not supported.");
+                goto fail;
+            }
             node->is_seq = 1;
             state = CONF_KEY;
         }


### PR DESCRIPTION
One possible solution - better than a segv anyways:

It is currently not possible to set a sequence node from the
command line with --set. If done, the node will be setup as a map
with sequence nodes added causing issues at run time. For now
its best to just bail during initialization when this is seen.