### PR TITLE
dns: response delta logging

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -172,6 +172,9 @@ typedef struct DNSTransaction_ {
 
     TAILQ_ENTRY(DNSTransaction_) next;
     DetectEngineState *de_state;
+
+    struct timeval request_ts;
+    struct timeval response_ts;
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -151,6 +151,11 @@ static int DNSUDPRequestParse(Flow *f, void *dstate,
         }
     }
 
+    if (dns_state != NULL && dns_state->curr != NULL) {
+        dns_state->curr->request_ts.tv_sec = f->lastts.tv_sec;
+        dns_state->curr->request_ts.tv_usec = f->lastts.tv_usec;
+    }
+
     SCReturnInt(1);
 bad_data:
 insufficient_data:
@@ -277,25 +282,30 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
         }
     }
 
-    /* parse rcode, e.g. "noerror" or "nxdomain" */
-    uint8_t rcode = ntohs(dns_header->flags) & 0x0F;
-    if (rcode <= DNS_RCODE_NOTZONE) {
-        SCLogDebug("rcode %u", rcode);
-        if (tx != NULL)
-            tx->rcode = rcode;
-    } else {
-        /* this is not invalid, rcodes can be user defined */
-        SCLogDebug("unexpected DNS rcode %u", rcode);
+    /* if we previously didn't have a tx, it could have been created by the
+     * above code, so lets check again */
+    if (tx == NULL) {
+        tx = DNSTransactionFindByTxId(dns_state, ntohs(dns_header->tx_id));
     }
-
-    if (ntohs(dns_header->flags) & 0x0080) {
-        SCLogDebug("recursion desired");
-        if (tx != NULL)
-            tx->recursion_desired = 1;
-    }
-
     if (tx != NULL) {
+        /* parse rcode, e.g. "noerror" or "nxdomain" */
+        uint8_t rcode = ntohs(dns_header->flags) & 0x0F;
+        if (rcode <= DNS_RCODE_NOTZONE) {
+            SCLogDebug("rcode %u", rcode);
+            tx->rcode = rcode;
+        } else {
+            /* this is not invalid, rcodes can be user defined */
+            SCLogDebug("unexpected DNS rcode %u", rcode);
+        }
+
+        if (ntohs(dns_header->flags) & 0x0080) {
+            SCLogDebug("recursion desired");
+            tx->recursion_desired = 1;
+        }
+
         tx->replied = 1;
+        tx->response_ts.tv_sec = f->lastts.tv_sec;
+        tx->response_ts.tv_usec = f->lastts.tv_usec;
     }
 
     SCReturnInt(1);

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -113,6 +113,22 @@ static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
     json_object_del(js, "dns");
 }
 
+static inline uint64_t GetTimeDelta(DNSTransaction *tx)
+{
+#define TIMER_IS_NUL(ts) \
+    ((ts)->tv_sec == 0 && (ts)->tv_usec == 0)
+
+    if (!TIMER_IS_NUL(&tx->request_ts) && timercmp(&tx->request_ts, &tx->response_ts, <=)) {
+        struct timeval delta;
+        timersub(&tx->response_ts, &tx->request_ts, &delta);
+        uint64_t usec = (delta.tv_sec * (uint64_t)1000000) + (delta.tv_usec);
+        return usec;
+    }
+    return 0;
+
+#undef TIMER_IS_NUL
+}
+
 static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, DNSAnswerEntry *entry)
 {
     MemBuffer *buffer = (MemBuffer *)aft->buffer;
@@ -130,6 +146,10 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
+
+    uint64_t delta = GetTimeDelta(tx);
+    if (delta > 0)
+        json_object_set_new(js, "response_time", json_integer(delta));
 
     /* we are logging an answer RR */
     if (entry != NULL) {
@@ -204,6 +224,10 @@ static void OutputFailure(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx,
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
+
+    uint64_t delta = GetTimeDelta(tx);
+    if (delta > 0)
+        json_object_set_new(js, "response_time", json_integer(delta));
 
     /* no answer RRs, use query for rname */
     char *c;


### PR DESCRIPTION
Log the response time in microseconds as 'response_time' in JSON.

UDP only for now.

Generally I wonder if this should be done in suri (as there is a cost in memory use). Maybe it belongs in postprocessing, e.g. logstash. @regit @jasonish

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/308
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/310