### PR TITLE
dns: response delta logging

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -172,6 +172,9 @@ typedef struct DNSTransaction_ {
 
     TAILQ_ENTRY(DNSTransaction_) next;
     DetectEngineState *de_state;
+
+    uint64_t request_usec_epoch;                    /**< usec since epoch */
+    uint32_t response_usec_offset;                  /**< response usec offset from request_usec_epoch */
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -113,6 +113,11 @@ static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
     json_object_del(js, "dns");
 }
 
+static inline uint64_t GetTimeDelta(DNSTransaction *tx)
+{
+    return tx->response_usec_offset;
+}
+
 static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, DNSAnswerEntry *entry)
 {
     MemBuffer *buffer = (MemBuffer *)aft->buffer;
@@ -130,6 +135,10 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
+
+    uint64_t delta = GetTimeDelta(tx);
+    if (delta > 0)
+        json_object_set_new(js, "response_time", json_integer(delta));
 
     /* we are logging an answer RR */
     if (entry != NULL) {
@@ -204,6 +213,10 @@ static void OutputFailure(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx,
     char rcode[16] = "";
     DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
     json_object_set_new(js, "rcode", json_string(rcode));
+
+    uint64_t delta = GetTimeDelta(tx);
+    if (delta > 0)
+        json_object_set_new(js, "response_time", json_integer(delta));
 
     /* no answer RRs, use query for rname */
     char *c;


### PR DESCRIPTION
Log the response time in microseconds as 'response_time' in JSON.

As #1750, but with more efficient storage. Instead of 32 bytes (2x struct timeval), this uses 12bytes per transaction.

Still only UDP.

PRscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/309
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/311