### PR TITLE
json: fix malformed output

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -345,7 +345,7 @@ static int MemBufferCallback(const char *str, size_t size, void *data)
         MemBufferExpand(&memb, OUTPUT_BUFFER_SIZE);
     }
 #endif
-    MemBufferWriteString(memb, "%s", str);
+    MemBufferWriteRaw(memb, str, size);
     return 0;
 }
 


### PR DESCRIPTION
Even though the json output callback is called with a null terminated
string, it's not useable directly. The size parameter to the callback
might be a lot smaller than the string size. Libjansson gives the size
up to the first point that needs escaping.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/312
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/314