### PR TITLE
logging: fix modules ordering during logging for 2.0.x

### DIFF
--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -443,6 +443,7 @@ void TmModuleLogFilestoreRegister (void) {
     tmm_modules[TMM_FILESTORE].RegisterTests = NULL;
     tmm_modules[TMM_FILESTORE].cap_flags = 0;
     tmm_modules[TMM_FILESTORE].flags = TM_FLAG_LOGAPI_TM;
+    tmm_modules[TMM_FILESTORE].priority = 10;
 
     OutputRegisterFiledataModule(MODULE_NAME, "file", LogFilestoreLogInitCtx,
             LogFilestoreLogger);

--- a/src/tm-modules.h
+++ b/src/tm-modules.h
@@ -57,6 +57,8 @@ typedef struct TmModule_ {
                              the given TmModule */
     /* Other flags used by the module */
     uint8_t flags;
+    /* priority in the logging order, higher priority is runned first */
+    uint8_t priority;
 } TmModule;
 
 TmModule tmm_modules[TMM_SIZE];


### PR DESCRIPTION
This is a backport patch for 2.0.x to fix
modules ordering during logging.

Original patch is written by Eric Leblond,
the original commit message below:

With the previous code the order of the logging modules in the
YAML were determining which module was run first. This was not
wished and a consequences was that the EVE fileinfo module was
not correctly displaying the key 'stored' because it was
depending on a flag set alter by the filestore module.

This patch adds a priority file to the TmModule structure. The
higher the priority is set, the sooner the module is run in the
logging process. The RunModeOutput structure has also been
updated to contain the name of the original TmModule. Thus allowing
to define a priority for a RunModeOutput.

Currently only the filestore has a priority set. The rest of them is
set to the default value of zero.

Ticket: [1554](https://redmine.openinfosecfoundation.org/issues/1554)

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/84
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/83
