### PR TITLE
flash decompression v2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -436,6 +436,74 @@
 
 # libraries
 
+  # zlib
+    AC_ARG_WITH(zlib_includes,
+            [  --with-zlib-includes=DIR  zlib include directory],
+            [with_zlib_includes="$withval"],[with_zlib_includes=no])
+    AC_ARG_WITH(zlib_libraries,
+            [  --with-zlib-libraries=DIR    zlib library directory],
+            [with_zlib_libraries="$withval"],[with_zlib_libraries="no"])
+
+    if test "$with_zlib_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_zlib_includes}"
+    fi
+
+    AC_CHECK_HEADER(zlib.h,,ZLIB="no")
+
+    if test "$with_zlib_libraries" != "no"; then
+        LDFLAGS="${LDFLAGS}  -L${with_zlib_libraries}"
+    fi
+
+    # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+    # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+    ZLIB=""
+    TMPLIBS="${LIBS}"
+    AC_CHECK_LIB(z,inflate,,ZLIB="no")
+
+    if test "$ZLIB" = "no"; then
+        echo
+        echo "   ERROR!  zlib library not found, go get it"
+        echo
+        exit 1
+    fi
+    LIBS="${TMPLIBS} -lz"
+
+  # liblzma
+    AC_ARG_WITH(liblzma_includes,
+            [  --with-liblzma-includes=DIR  liblzma include directory],
+            [with_liblzma_includes="$withval"],[with_liblzma_includes=no])
+    AC_ARG_WITH(liblzma_libraries,
+            [  --with-liblzma-libraries=DIR    liblzma library directory],
+            [with_liblzma_libraries="$withval"],[with_liblzma_libraries="no"])
+
+    if test "$with_liblzma_includes" != "no"; then
+        CPPFLAGS="${CPPFLAGS} -I${with_liblzma_includes}"
+    fi
+
+    AC_CHECK_HEADER(lzma.h,,LIBLZMA="no")
+
+    if test "$with_liblzma_libraries" != "no"; then
+        LDFLAGS="${LDFLAGS}  -L${with_liblzma_libraries}"
+    fi
+
+    # To prevent duping the lib link we reset LIBS after this check. Setting action-if-found to NULL doesn't seem to work
+    # see: http://blog.flameeyes.eu/2008/04/29/i-consider-ac_check_lib-harmful
+    LIBLZMA=""
+    TMPLIBS="${LIBS}"
+    AC_CHECK_LIB(lzma,lzma_code,,LIBLZMA="no")
+
+    if test "$LIBLZMA" = "no"; then
+        echo
+        echo "   Warning! liblzma library not found, you will not be"
+        echo "   able to decompress flash file compressed with lzma."
+        echo
+        enable_liblzma=no
+    else
+        enable_liblzma=yes
+        AC_DEFINE([HAVE_LIBLZMA],[1],[liblzma available])
+        LIBS="${TMPLIBS} -llzma"
+    fi
+
     AC_MSG_CHECKING([for Mpipe])
     AC_COMPILE_IFELSE(
         [AC_LANG_PROGRAM([[#include <gxio/mpipe.h>]])],
@@ -1851,6 +1919,8 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   libnspr support:                         ${enable_nspr}
   libjansson support:                      ${enable_jansson}
   hiredis support:                         ${enable_hiredis}
+  liblzma support:                         ${enable_liblzma}
+
   Prelude support:                         ${enable_prelude}
   PCRE jit:                                ${pcre_jit_available}
   LUA support:                             ${enable_lua}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -340,6 +340,8 @@ util-device.c util-device.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \
 util-file.c util-file.h \
+util-file-decompression.c util-file-decompression.h \
+util-file-flash-decompression.c util-file-flash-decompression.h \
 util-fix_checksum.c util-fix_checksum.h \
 util-fmemopen.c util-fmemopen.h \
 util-hash.c util-hash.h \

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2499,6 +2499,52 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                     cfg_prec->http_body_inline = 0;
                 }
             }
+        } else if (strcasecmp("decompression-swf", p->name) == 0) {
+            ConfNode *pval;
+
+            TAILQ_FOREACH(pval, &p->head, next) {
+                if (strcasecmp("enabled", pval->name) == 0) {
+                    if (ConfValIsTrue(pval->val)) {
+                        cfg_prec->decomp_swf_enabled = 1;
+                    } else if (ConfValIsFalse(pval->val)) {
+                        cfg_prec->decomp_swf_enabled = 0;
+                    } else {
+                        WarnInvalidConfEntry("decompression-swf.enabled", "%s", "no");
+                    }
+                } else if (strcasecmp("type", pval->name) == 0) {
+                    if (strcasecmp("no", pval->val) == 0) {
+                        cfg_prec->decomp_swf_type = HTTP_DECOMP_FLASH_NONE;
+                    } else if (strcasecmp("deflate", pval->val) == 0) {
+                        cfg_prec->decomp_swf_type = HTTP_DECOMP_FLASH_ZLIB;
+                    } else if (strcasecmp("lzma", pval->val) == 0) {
+                        cfg_prec->decomp_swf_type = HTTP_DECOMP_FLASH_LZMA;
+                    } else if (strcasecmp("both", pval->val) == 0) {
+                        cfg_prec->decomp_swf_type = HTTP_DECOMP_FLASH_BOTH;
+                    } else {
+                        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                                   "Invalid entry for "
+                                   "decompression-swf.type: %s - "
+                                   "Killing engine", pval->val);
+                        exit(EXIT_FAILURE);
+                    }
+                } else if (strcasecmp("compress-depth", pval->name) == 0) {
+                    if (ParseSizeStringU32(pval->val, &cfg_prec->decomp_swf_compress_depth) < 0) {
+                        SCLogError(SC_ERR_SIZE_PARSE,
+                                   "Error parsing decompression-swf.compression-depth "
+                                   "from conf file - %s. Killing engine", p->val);
+                        exit(EXIT_FAILURE);
+                    }
+                } else if (strcasecmp("decompress-depth", pval->name) == 0) {
+                    if (ParseSizeStringU32(pval->val, &cfg_prec->decomp_swf_decompress_depth) < 0) {
+                        SCLogError(SC_ERR_SIZE_PARSE,
+                                   "Error parsing decompression-swf.decompression-depth "
+                                   "from conf file - %s. Killing engine", p->val);
+                        exit(EXIT_FAILURE);
+                    }
+                } else {
+                    SCLogWarning(SC_ERR_UNKNOWN_VALUE, "Ignoring unknown param %s", pval->name);
+                }
+            }
         } else {
             SCLogWarning(SC_ERR_UNKNOWN_VALUE, "LIBHTP Ignoring unknown "
                          "default config: %s", p->name);
@@ -2576,7 +2622,7 @@ void HTPConfigure(void)
 
         HTPConfigSetDefaultsPhase1(htprec);
         HTPConfigParseParameters(htprec, s, cfgtree);
-        HTPConfigSetDefaultsPhase2(s->name, htprec);
+        HTPConfigSetDefaultsPhase2(s->name, htprec); 
     }
 
     SCReturn;

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -132,6 +132,14 @@ enum {
     HTTP_DECODER_EVENT_MULTIPART_INVALID_HEADER,
 };
 
+/* decompression swf type setting */
+enum {
+    HTTP_DECOMP_FLASH_NONE = 0,
+    HTTP_DECOMP_FLASH_ZLIB,
+    HTTP_DECOMP_FLASH_LZMA,
+    HTTP_DECOMP_FLASH_BOTH,
+};
+
 #define HTP_PCRE_NONE           0x00    /**< No pcre executed yet */
 #define HTP_PCRE_DONE           0x01    /**< Flag to indicate that pcre has
                                              done some inspection in the
@@ -158,6 +166,12 @@ typedef struct HTPCfgRec_ {
     int                 randomize;
     int                 randomize_range;
     int                 http_body_inline;
+
+    /* flash decompression */
+    int                 decomp_swf_enabled;
+    int                 decomp_swf_type;
+    uint32_t            decomp_swf_decompress_depth;
+    uint32_t            decomp_swf_compress_depth;
 } HTPCfgRec;
 
 /** Struct used to hold chunks of a body on a request */

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -54,6 +54,7 @@
 
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
+#include "util-file-decompression.h"
 #include "app-layer.h"
 #include "app-layer-htp.h"
 #include "app-layer-htp-mem.h"
@@ -318,9 +319,11 @@ int DetectEngineRunHttpServerBodyMpm(DetectEngineCtx *de_ctx,
                                      HtpState *htp_state, uint8_t flags,
                                      void *tx, uint64_t idx)
 {
+    int ret = 0;
     uint32_t cnt = 0;
     uint32_t buffer_len = 0;
     uint32_t stream_start_offset = 0;
+    uint8_t *decompressed_buffer = NULL;
     uint8_t *buffer = DetectEngineHSBDGetBufferForTX(tx, idx,
                                                      de_ctx, det_ctx,
                                                      f, htp_state,
@@ -330,9 +333,30 @@ int DetectEngineRunHttpServerBodyMpm(DetectEngineCtx *de_ctx,
     if (buffer_len == 0)
         goto end;
 
+    if (htp_state->cfg->decomp_swf_enabled) {
+        int file_swf_type = FileIsFlashFile(buffer, buffer_len);
+        if (file_swf_type == FILE_FLASH_ZLIB_COMPRESSION ||
+            file_swf_type == FILE_FLASH_LZMA_COMPRESSION)
+        {
+            ret = FileDecompressFlashFile(buffer, &buffer_len,
+                                          &decompressed_buffer,
+                                          det_ctx,
+                                          htp_state->cfg->decomp_swf_type,
+                                          htp_state->cfg->decomp_swf_decompress_depth,
+                                          htp_state->cfg->decomp_swf_compress_depth);
+            if (ret == 1) {
+                buffer = decompressed_buffer;
+            }
+        }
+    }
+
     cnt = HttpServerBodyPatternSearch(det_ctx, buffer, buffer_len, flags);
 
  end:
+    if (ret == 1) {
+        SCFree(decompressed_buffer);
+    }
+
     return cnt;
 }
 
@@ -344,8 +368,10 @@ int DetectEngineInspectHttpServerBody(ThreadVars *tv,
                                       void *tx, uint64_t tx_id)
 {
     HtpState *htp_state = (HtpState *)alstate;
+    int ret = 0;
     uint32_t buffer_len = 0;
     uint32_t stream_start_offset = 0;
+    uint8_t *decompressed_buffer = NULL;
     uint8_t *buffer = DetectEngineHSBDGetBufferForTX(tx, tx_id,
                                                      de_ctx, det_ctx,
                                                      f, htp_state,
@@ -354,6 +380,23 @@ int DetectEngineInspectHttpServerBody(ThreadVars *tv,
                                                      &stream_start_offset);
     if (buffer_len == 0)
         goto end;
+
+    if (htp_state->cfg->decomp_swf_enabled) {
+        int file_swf_type = FileIsFlashFile(buffer, buffer_len);
+        if (file_swf_type == FILE_FLASH_ZLIB_COMPRESSION ||
+            file_swf_type == FILE_FLASH_LZMA_COMPRESSION)
+        {
+            ret = FileDecompressFlashFile(buffer, &buffer_len,
+                                          &decompressed_buffer,
+                                          det_ctx,
+                                          htp_state->cfg->decomp_swf_type,
+                                          htp_state->cfg->decomp_swf_decompress_depth,
+                                          htp_state->cfg->decomp_swf_compress_depth);
+            if (ret == 1) {
+                buffer = decompressed_buffer;
+            }
+        }
+    }
 
     det_ctx->buffer_offset = 0;
     det_ctx->discontinue_matching = 0;
@@ -364,6 +407,11 @@ int DetectEngineInspectHttpServerBody(ThreadVars *tv,
                                           buffer_len,
                                           stream_start_offset,
                                           DETECT_ENGINE_CONTENT_INSPECTION_MODE_HSBD, NULL);
+
+   if (ret == 1) {
+        SCFree(decompressed_buffer);
+    }
+
     if (r == 1)
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
 
@@ -4418,6 +4466,1548 @@ libhtp:\n\
     const char *sig = "alert http any any -> any any (file_data; content:\"bccd\"; depth:4; sid:1;)";
     return RunTest(steps, sig, yaml);
 }
+
+static int DetectEngineHttpServerBodyFileDataTest19(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest20(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: no\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest21(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: deflate\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest22(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: lzma\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x0a, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest23(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','x','-','s','h','o','c','k','w','a','v','e','-','f','l','a','s','h', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x43, 0x57, 0x53, 0x01, 0xcb, 0x6c, 0x00, 0x00, 0x78, 0xda, 0xad, 0xbd, 0x07, 0x98, 0x55, 0x55,
+        0x9e, 0xee, 0xbd, 0x4f, 0xd8, 0xb5, 0x4e, 0x15, 0xc1, 0xc2, 0x80, 0x28, 0x86, 0xd2, 0x2e, 0x5a,
+        0xdb, 0x46, 0xd9, 0x39, 0x38, 0xdd, 0x4e, 0x1b, 0xa8, 0x56, 0x5b, 0xc5, 0x6b, 0xe8, 0x76, 0xfa,
+        0x0e, 0xc2, 0x8e, 0x50, 0x76, 0x51, 0xc5, 0x54, 0x15, 0x88, 0x73, 0xc3, 0xd0, 0x88, 0x39, 0x81,
+        0x98, 0x63, 0x91, 0x93, 0x8a, 0x82, 0x89, 0x60, 0x00, 0xcc, 0xb1, 0x00, 0x01, 0x73, 0xce, 0x39,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"CWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest24(void)
+{
+#ifdef HAVE_LIBLZMA
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe,
+        0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37,
+        0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0,
+        0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59, 0x56, 0x06, 0x08, 0xe9,
+        0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+#else
+    return 1;
+#endif /* HAVE_LIBLZMA */
+}
+
+static int DetectEngineHttpServerBodyFileDataTest25(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: no\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20, 0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19,
+        0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05,
+        0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2,
+        0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0, 0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59,
+        0x56, 0x06, 0x08, 0xe9, 0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest26(void)
+{
+#ifdef HAVE_LIBLZMA
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: lzma\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '1', '0', '3', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61, 0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe,
+        0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b, 0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37,
+        0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1, 0xfc, 0x9e, 0x64, 0xda, 0x6c, 0x11, 0x21, 0x33, 0xed, 0xa0,
+        0x0e, 0x76, 0x70, 0xa0, 0xcd, 0x98, 0x2e, 0x76, 0x80, 0xf0, 0xe0, 0x59, 0x56, 0x06, 0x08, 0xe9,
+        0xca, 0xeb, 0xa2, 0xc6, 0xdb, 0x5a, 0x86
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"FWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+#else
+    return 1;
+#endif /* HAVE_LIBLZMA */
+}
+
+static int DetectEngineHttpServerBodyFileDataTest27(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: deflate\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x17, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61,
+        0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b,
+        0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
+
+static int DetectEngineHttpServerBodyFileDataTest28(void)
+{
+    char input[] = "\
+%YAML 1.1\n\
+---\n\
+libhtp:\n\
+\n\
+  default-config:\n\
+\n\
+    decompression-swf:\n\
+      enabled: yes\n\
+      type: both\n\
+      compress-depth: 0\n\
+      decompress-depth: 0\n\
+";
+
+    ConfCreateContextBackup();
+    ConfInit();
+    HtpConfigCreateBackup();
+
+    ConfYamlLoadString(input, strlen(input));
+    HTPConfigure();
+
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /file.swf HTTP/1.0\r\n"
+        "Host: www.openinfosecfoundation.org\r\n"
+        "User-Agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] = {
+        'H', 'T', 'T', 'P', '/', '1', '.', '1', ' ', '2', '0', '0', 'o', 'k', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'L', 'e', 'n', 'g', 't', 'h', ':', ' ', '8', '0', 0x0d, 0x0a,
+        'C', 'o', 'n', 't', 'e', 'n', 't', '-', 'T', 'y', 'p', 'e', ':', ' ',
+        'a','p','p','l','i','c','a','t','i','o','n','/','o','c','t','e','t','-','s','t','r','e','a','m', 0x0d, 0x0a,
+        0x0d, 0x0a,
+        0x5a, 0x57, 0x53, 0x01, 0x5c, 0x24, 0x00, 0x00, 0xb7, 0x21, 0x00, 0x00, 0x5d, 0x00, 0x00, 0x20,
+        0x00, 0x00, 0x3b, 0xff, 0xfc, 0x8e, 0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85,
+        0x19, 0xfa, 0xdf, 0xe7, 0x66, 0x08, 0xa0, 0x3d, 0x3e, 0x85, 0xf5, 0x75, 0x6f, 0xd0, 0x7e, 0x61,
+        0x35, 0x1b, 0x1a, 0x8b, 0x16, 0x4d, 0xdf, 0x05, 0x32, 0xfe, 0xa4, 0x4c, 0x46, 0x49, 0xb7, 0x7b,
+        0x6b, 0x75, 0xf9, 0x2b, 0x5c, 0x37, 0x29, 0x0b, 0x91, 0x37, 0x01, 0x37, 0x0e, 0xe9, 0xf2, 0xe1,
+    };
+    uint32_t http_len2 = sizeof(http_buf2);
+    int result = 0;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
+                               "(flow:established,from_server; "
+                               "file_data; content:\"ZWS\"; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        goto end;
+    }
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    if ((PacketAlertCheck(p1, 1))) {
+        printf("sid 1 matched but shouldn't have\n");
+        goto end;
+    }
+
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    if (!(PacketAlertCheck(p2, 1))) {
+        printf("sid 1 didn't match but should have");
+        goto end;
+    }
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    HTPFreeConfig();
+    HtpConfigRestoreBackup();
+    ConfRestoreContextBackup();
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p1, 1);
+    UTHFreePackets(&p2, 1);
+    return result;
+}
 #endif /* UNITTESTS */
 
 void DetectEngineHttpServerBodyRegisterTests(void)
@@ -4505,7 +6095,26 @@ void DetectEngineHttpServerBodyRegisterTests(void)
                   DetectEngineHttpServerBodyFileDataTest17, 1);
     UtRegisterTest("DetectEngineHttpServerBodyFileDataTest18",
                   DetectEngineHttpServerBodyFileDataTest18, 1);
-
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest19",
+                  DetectEngineHttpServerBodyFileDataTest19, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest20",
+                  DetectEngineHttpServerBodyFileDataTest20, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest21",
+                  DetectEngineHttpServerBodyFileDataTest21, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest22",
+                  DetectEngineHttpServerBodyFileDataTest22, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest23",
+                  DetectEngineHttpServerBodyFileDataTest23, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest24",
+                  DetectEngineHttpServerBodyFileDataTest24, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest25",
+                  DetectEngineHttpServerBodyFileDataTest25, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest26",
+                  DetectEngineHttpServerBodyFileDataTest26, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest27",
+                  DetectEngineHttpServerBodyFileDataTest27, 1);
+    UtRegisterTest("DetectEngineHttpServerBodyFileDataTest28",
+                  DetectEngineHttpServerBodyFileDataTest28, 1);
 #endif /* UNITTESTS */
 
     return;

--- a/src/detect.h
+++ b/src/detect.h
@@ -28,6 +28,8 @@
 
 #include "flow.h"
 
+#include "app-layer-events.h"
+
 #include "detect-engine-proto.h"
 #include "detect-reference.h"
 
@@ -882,6 +884,9 @@ typedef struct DetectEngineThreadCtx_ {
      *  thread safety issues */
     void **keyword_ctxs_array;
     int keyword_ctxs_size;
+
+    AppLayerDecoderEvents *decoder_events;
+    uint16_t events;
 
 #ifdef PROFILING
     struct SCProfileData_ *rule_perf_data;

--- a/src/util-file-decompression.c
+++ b/src/util-file-decompression.c
@@ -1,0 +1,233 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ * \brief Decompress files transfered via HTTP corresponding to file_data
+ * keyword.
+ *
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "app-layer-htp.h"
+
+#include "util-file-decompression.h"
+#include "util-file-flash-decompression.h"
+#include "util-misc.h"
+#include "util-print.h"
+
+#define FLASH_ZLIB_MIN_VERSION    0x06
+#define FLASH_LZMA_MIN_VERSION    0x0D
+
+SCEnumCharMap file_decoder_event_table[ ] = {
+    { "NO MEMORY",                  FILE_DECODER_EVENT_NO_MEM },
+    { "NO FLASH SUPPORT",           FILE_DECODER_EVENT_NO_FLASH_SUPPORT },
+    { "INVALID FLASH VERSION",      FILE_DECODER_EVENT_INVALID_FLASH_VERSION },
+    { "Z_STREAM_END",               FILE_DECODER_EVENT_Z_STREAM_END },
+    { "Z_OK",                       FILE_DECODER_EVENT_Z_OK },
+    { "Z_DATA_ERROR",               FILE_DECODER_EVENT_Z_DATA_ERROR },
+    { "Z_STREAM_ERROR",             FILE_DECODER_EVENT_Z_STREAM_ERROR },
+    { "Z_BUF_ERROR",                FILE_DECODER_EVENT_Z_BUF_ERROR },
+    { "Z_UNKNOWN_ERROR",            FILE_DECODER_EVENT_Z_UNKNOWN_ERROR },
+    { "LZMA_DECODER_ERROR",         FILE_DECODER_EVENT_LZMA_DECODER_ERROR },
+    { "LZMA_STREAM_END",            FILE_DECODER_EVENT_LZMA_STREAM_END },
+    { "LZMA_OK",                    FILE_DECODER_EVENT_LZMA_OK },
+    { "LZMA_MEMLIMIT_ERROR",        FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR },
+    { "LZMA_OPTIONS_ERROR",         FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR },
+    { "LZMA_FORMAT_ERROR",          FILE_DECODER_EVENT_LZMA_FORMAT_ERROR },
+    { "LZMA_DATA_ERROR",            FILE_DECODER_EVENT_LZMA_DATA_ERROR },
+    { "LZMA_BUF_ERROR",             FILE_DECODER_EVENT_LZMA_BUF_ERROR },
+    { "LZMA_UNKNOWN_ERROR",         FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR },
+    { NULL,                         -1 },
+};
+
+int FileIsFlashFile(const uint8_t *buffer, uint32_t buffer_len)
+{
+    if (buffer_len >= 3 && buffer[1] == 'W' && buffer[2] == 'S') {
+        if (buffer[0] == 'F')
+            return FILE_FLASH_NO_COMPRESSION;
+        else if (buffer[0] == 'C')
+            return FILE_FLASH_ZLIB_COMPRESSION;
+        else if (buffer[0] == 'Z')
+            return FILE_FLASH_LZMA_COMPRESSION;
+        else
+            return FILE_IS_NOT_FLASH;
+    }
+
+    return FILE_IS_NOT_FLASH;
+}
+
+int FileDecompressFlashFile(const uint8_t *buffer, uint32_t *buffer_len,
+                            uint8_t **decompressed_buffer,
+                            DetectEngineThreadCtx *det_ctx,
+                            int swf_type,
+                            uint32_t decompress_depth,
+                            uint32_t compress_depth)
+{
+    int r = 0;
+    uint32_t buf_len = *buffer_len;
+    uint8_t *compressed_data = NULL;
+    uint8_t *decompressed_data = *decompressed_buffer;
+
+    int compression_type = FileIsFlashFile(buffer, buf_len);
+    if (compression_type == FILE_FLASH_NO_COMPRESSION) {
+        return 0;
+    }
+
+    int offset = 0;
+    if (compression_type == FILE_FLASH_ZLIB_COMPRESSION) {
+        /* compressed data start from the 4th bytes */
+        offset = 8;
+    } else if (compression_type == FILE_FLASH_LZMA_COMPRESSION) {
+        /* compressed data start from the 17th bytes */
+        offset = 17;
+    }
+
+    /* if compress_depth is 0, keep the buffer length */
+    uint32_t compressed_data_len = (compress_depth == 0) ? (buf_len - offset) : compress_depth;
+
+    /* get flash decompressed file length */
+    uint32_t decompressed_swf_len = FileGetFlashDecompressedLen(buffer);
+    if (decompressed_swf_len == 0) {
+        decompressed_swf_len = MIN_SWF_LEN;
+    }
+
+    /* if decompress_depth is 0, keep the flash file length */
+    uint32_t decompressed_data_len = (decompress_depth == 0) ? decompressed_swf_len : decompress_depth;
+    decompressed_data = SCMalloc(decompressed_data_len + 8);
+    if (decompressed_data == NULL) {
+        FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_NO_MEM);
+        return 0;
+    }
+
+    /* get file flash version */
+    uint8_t flash_version = FileGetFlashVersion(buffer, buf_len);
+
+    /*
+     * FWS format
+     * | 4 bytes         | 4 bytes    | n bytes |
+     * | 'FWS' + version | script len | data    |
+     */
+    memcpy(decompressed_data, "FWS", 3);
+    memcpy(decompressed_data + 3, &flash_version, 1);
+    memcpy(decompressed_data + 4, &decompressed_swf_len, 4);
+
+    if ((swf_type == HTTP_DECOMP_FLASH_ZLIB || swf_type == HTTP_DECOMP_FLASH_BOTH) &&
+        compression_type == FILE_FLASH_ZLIB_COMPRESSION)
+    {
+        if (flash_version < FLASH_ZLIB_MIN_VERSION) {
+            FileDecompressionSetEvent(det_ctx,
+                                      FILE_DECODER_EVENT_INVALID_FLASH_VERSION);
+            return 0;
+        }
+
+        compressed_data = SCMalloc(compressed_data_len);
+        if (compressed_data == NULL) {
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_NO_MEM);
+            return 0;
+        }
+
+        /* put compressed data */
+        memcpy(compressed_data, buffer + offset, compressed_data_len);
+
+        r = FileDecompressFlashZlibData(det_ctx,
+                                        compressed_data, compressed_data_len,
+                                        decompressed_data + 8, decompressed_data_len);
+        SCFree(compressed_data);
+        if (r == 0)
+            return 0;
+
+    } else if ((swf_type == HTTP_DECOMP_FLASH_LZMA || swf_type == HTTP_DECOMP_FLASH_BOTH) &&
+               compression_type == FILE_FLASH_LZMA_COMPRESSION)
+    {
+        if (flash_version < FLASH_LZMA_MIN_VERSION) {
+            FileDecompressionSetEvent(det_ctx,
+                                      FILE_DECODER_EVENT_INVALID_FLASH_VERSION);
+            return 0;
+        }
+        /* we need to setup the lzma header */
+        /*
+         * | 5 bytes         | 8 bytes             | n bytes         |
+         * | LZMA properties | Uncompressed length | Compressed data |
+         */
+        compressed_data_len += 13;
+        compressed_data = SCMalloc(compressed_data_len);
+        if (compressed_data == NULL) {
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_NO_MEM);
+            return 0;
+        }
+        /* put lzma properties */
+        memcpy(compressed_data, buffer + 12, 5);
+        /* put lzma end marker */
+        memset(compressed_data + 5, 0xFF, 8);
+        /* put compressed data */
+        memcpy(compressed_data + 13, buffer + offset, compressed_data_len - 13);
+
+        r = FileDecompressFlashLzmaData(det_ctx,
+                                        compressed_data, compressed_data_len,
+                                        decompressed_data + 8, decompressed_data_len);
+        SCFree(compressed_data);
+        if (r == 0)
+            return 0;
+    } else {
+        return 0;
+    }
+
+    *buffer_len = decompressed_data_len;
+    *decompressed_buffer = decompressed_data;
+
+    return 1;
+}
+
+int FileDecompressionGetEventInfo(const char *event_name, int *event_id,
+                                  AppLayerEventType *event_type)
+{
+    *event_id = SCMapEnumNameToValue(event_name, file_decoder_event_table);
+    if (*event_id == -1) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%s\" not present in "
+                   "file's enum map table.",  event_name);
+        /* this should be treated as fatal */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+    
+}
+
+int FileDecompressionHasEvents(DetectEngineThreadCtx *det_ctx)
+{
+    return (det_ctx->events > 0);
+}
+
+AppLayerDecoderEvents *FileDecompressionGetEvent(DetectEngineThreadCtx *det_ctx)
+{
+    return det_ctx->decoder_events;
+}
+
+void FileDecompressionSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e)
+{
+    AppLayerDecoderEventsSetEventRaw(&det_ctx->decoder_events, e);
+    det_ctx->events++;
+}
+
+

--- a/src/util-file-decompression.h
+++ b/src/util-file-decompression.h
@@ -1,0 +1,71 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ *
+ */
+
+#ifndef __UTIL_FILE_DECOMPRESSION_H__
+#define __UTIL_FILE_DECOMPRESSION_H__
+
+#include "detect.h"
+
+enum {
+    FILE_IS_NOT_FLASH = 0,
+    FILE_FLASH_NO_COMPRESSION,
+    FILE_FLASH_ZLIB_COMPRESSION,
+    FILE_FLASH_LZMA_COMPRESSION,
+};
+
+enum {
+    FILE_DECODER_EVENT_NO_MEM,
+    FILE_DECODER_EVENT_NO_FLASH_SUPPORT,
+    FILE_DECODER_EVENT_INVALID_FLASH_VERSION,
+    FILE_DECODER_EVENT_Z_STREAM_END,
+    FILE_DECODER_EVENT_Z_OK,
+    FILE_DECODER_EVENT_Z_DATA_ERROR,
+    FILE_DECODER_EVENT_Z_STREAM_ERROR,
+    FILE_DECODER_EVENT_Z_BUF_ERROR,
+    FILE_DECODER_EVENT_Z_UNKNOWN_ERROR,
+    FILE_DECODER_EVENT_LZMA_DECODER_ERROR,
+    FILE_DECODER_EVENT_LZMA_STREAM_END,
+    FILE_DECODER_EVENT_LZMA_OK,
+    FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR,
+    FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR,
+    FILE_DECODER_EVENT_LZMA_FORMAT_ERROR,
+    FILE_DECODER_EVENT_LZMA_DATA_ERROR,
+    FILE_DECODER_EVENT_LZMA_BUF_ERROR,
+    FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR,
+};
+
+int FileIsFlashFile(const uint8_t *buffer, uint32_t buffer_len);
+int FileDecompressFlashFile(const uint8_t *buffer, uint32_t *buffer_len,
+                            uint8_t **decompressed_buffer,
+                            DetectEngineThreadCtx *det_ctx,
+                            int swf_type,
+                            uint32_t decompress_depth, uint32_t compress_depth);
+
+int FileDecompressionGetEventInfo(const char *event_name, int *event_id,
+                                  AppLayerEventType *event_type);
+int FileDecompressionHasEvents(DetectEngineThreadCtx *det_ctx);
+AppLayerDecoderEvents *FileDecompressionGetEvent(DetectEngineThreadCtx *det_ctx);
+void FileDecompressionSetEvent(DetectEngineThreadCtx *det_ctx, uint8_t e);
+
+#endif /* __UTIL_FILE_DECOMPRESSION_H__ */

--- a/src/util-file-flash-decompression.c
+++ b/src/util-file-flash-decompression.c
@@ -1,0 +1,182 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ */
+
+
+#include "suricata.h"
+#include "suricata-common.h"
+
+#include "app-layer-htp.h"
+
+#include "util-file-decompression.h"
+#include "util-file-flash-decompression.h"
+#include "util-misc.h"
+#include "util-print.h"
+
+#include <zlib.h>
+
+#ifdef HAVE_LIBLZMA
+#include <lzma.h>
+#endif
+
+/*
+ * Return uncompressed file length
+ * in little-endian order
+ */
+uint32_t FileGetFlashDecompressedLen(const uint8_t *buffer)
+{
+    int a = buffer[4];
+    int b = buffer[5];
+    int c = buffer[6];
+    int d = buffer[7];
+
+    uint32_t value = (((a & 0xff) << 24) | ((b & 0xff) << 16) | ((c & 0xff) << 8) | (d & 0xff));
+
+    return (((value >> 24) & 0x000000FF) | ((value >> 8) & 0x0000FF00) |
+            ((value << 8) & 0x00FF0000) | ((value << 24) & 0xFF000000));
+}
+
+uint8_t FileGetFlashVersion(const uint8_t *buffer, const uint32_t buffer_len)
+{
+    if (buffer_len >= 3)
+        return buffer[3];
+
+    return 0;
+}
+
+/* CWS format */
+/*
+ * | 4 bytes         | 4 bytes    | n bytes         |
+ * | 'CWS' + version | script len | compressed data |
+ */
+int FileDecompressFlashZlibData(DetectEngineThreadCtx *det_ctx,
+                                uint8_t *compressed_data, uint32_t compressed_data_len,
+                                uint8_t *decompressed_data, uint32_t decompressed_data_len)
+{
+    int ret = 1;
+    z_stream infstream;
+    infstream.zalloc = Z_NULL;
+    infstream.zfree = Z_NULL;
+    infstream.opaque = Z_NULL;
+
+    infstream.avail_in = (uInt)compressed_data_len;
+    infstream.next_in = (Bytef *)compressed_data;
+    infstream.avail_out = (uInt)decompressed_data_len;
+    infstream.next_out = (Bytef *)decompressed_data;
+
+    inflateInit(&infstream);
+    int result = inflate(&infstream, Z_NO_FLUSH);
+    switch(result) {
+        case Z_STREAM_END:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_STREAM_END);
+            break;
+        case Z_OK:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_OK);
+            break;
+        case Z_DATA_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_DATA_ERROR);
+            ret = 0;
+            break;
+        case Z_STREAM_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_STREAM_ERROR);
+            ret = 0;
+            break;
+        case Z_BUF_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_BUF_ERROR);
+            ret = 0;
+            break;
+        default:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_Z_UNKNOWN_ERROR);
+            ret = 0;
+            break;
+    }
+    inflateEnd(&infstream);
+
+    return ret;
+}
+
+/* ZWS format */
+/*
+ * | 4 bytes         | 4 bytes    | 4 bytes        | 5 bytes    | n bytes   | 6 bytes         |
+ * | 'ZWS' + version | script len | compressed len | LZMA props | LZMA data | LZMA end marker |
+ */
+int FileDecompressFlashLzmaData(DetectEngineThreadCtx *det_ctx,
+                                uint8_t *compressed_data, uint32_t compressed_data_len,
+                                uint8_t *decompressed_data, uint32_t decompressed_data_len)
+{
+#ifdef HAVE_LIBLZMA
+    int ret = 1;
+    lzma_stream strm = LZMA_STREAM_INIT;
+    lzma_ret result = lzma_alone_decoder(&strm, UINT64_MAX /* memlimit */);
+    if (result != LZMA_OK) {
+        FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_DECODER_ERROR);
+        return 0;
+    }
+
+    strm.avail_in = compressed_data_len;
+    strm.next_in = compressed_data;
+    strm.avail_out = decompressed_data_len;
+    strm.next_out = decompressed_data;
+
+    result = lzma_code(&strm, LZMA_RUN);
+    switch(result) {
+        case LZMA_STREAM_END:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_STREAM_END);
+            break;
+        case LZMA_OK:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_OK);
+            break;
+        case LZMA_MEMLIMIT_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_MEMLIMIT_ERROR);
+            ret = 0;
+            break;
+        case LZMA_OPTIONS_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_OPTIONS_ERROR);
+            ret = 0;
+            break;
+        case LZMA_FORMAT_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_FORMAT_ERROR);
+            ret = 0;
+            break;
+        case LZMA_DATA_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_DATA_ERROR);
+            ret = 0;
+            break;
+        case LZMA_BUF_ERROR:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_BUF_ERROR);
+            ret = 0;
+            break;
+        default:
+            FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_LZMA_UNKNOWN_ERROR);
+            ret = 0;
+            break;
+    }
+
+    lzma_end(&strm);
+    return ret;
+#else
+    FileDecompressionSetEvent(det_ctx, FILE_DECODER_EVENT_NO_FLASH_SUPPORT);
+    return 0;
+#endif /* HAVE_LIBLZMA */
+}
+
+

--- a/src/util-file-flash-decompression.h
+++ b/src/util-file-flash-decompression.h
@@ -1,0 +1,39 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/** \file
+ *
+ * \author Giuseppe Longo <giuseppe@glongo.it>
+ *
+ *
+ */
+
+#ifndef __UTIL_FILE_FLASH_DECOMPRESSION_H__
+#define __UTIL_FILE_FLASH_DECOMPRESSION_H__
+
+#define MIN_SWF_LEN    1000
+
+uint8_t FileGetFlashVersion(const uint8_t *buffer, const uint32_t buffer_len);
+uint32_t FileGetFlashDecompressedLen(const uint8_t *buffer);
+int FileDecompressFlashZlibData(DetectEngineThreadCtx *det_ctx,
+                                uint8_t *compressed_data, uint32_t compressed_data_len,
+                                uint8_t *decompressed_data, uint32_t decompressed_data_len);
+int FileDecompressFlashLzmaData(DetectEngineThreadCtx *det_ctx,
+                                uint8_t *compressed_data, uint32_t compressed_data_len,
+                                uint8_t *decompressed_data, uint32_t decompressed_data_len);
+
+#endif /* __UTIL_FILE_FLASH_DECOMPRESSION_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1381,7 +1381,6 @@ app-layer:
     http:
       enabled: yes
       # memcap: 64mb
-
       ###########################################################################
       # Configure libhtp.
       #
@@ -1451,6 +1450,20 @@ app-layer:
 
            # auto will use http-body-inline mode in IPS mode, yes or no set it statically
            http-body-inline: auto
+
+           # Decompress SWF files.
+           # 2 types: 'deflate', 'lzma', 'both' will decompress deflate and lzma
+           # compress-depth:
+           # Specifies the maximum amount of data to decompress,
+           # set 0 for unlimited.
+           # decompress-depth:
+           # Specifies the maximum amount of decompressed data to obtain,
+           # set 0 for unlimited.
+           decompression-swf:
+             enabled: yes
+             type: both
+             compress-depth: 0
+             decompress-depth: 0
 
            # Take a random value for inspection sizes around the specified value.
            # This lower the risk of some evasion technics but could lead


### PR DESCRIPTION
This adds new decompression API for flash files compressed with zlib/lzma.

This PR adds events handling for detect engine.
Currently, events functions are added but they are not used
since equivalent register functions for app layer are missing.

Updates:
Comment of last PR addressed: https://github.com/inliniac/suricata/pull/1642

Ticket: [1600](https://redmine.openinfosecfoundation.org/issues/1600)

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/83
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/82