### PR TITLE
output-json: fix regression on log prefix handling

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -356,6 +356,9 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer *buffer)
                             json_string(file_ctx->sensor_name));
     }
 
+    if (file_ctx->prefix)
+        MemBufferWriteRaw(buffer, file_ctx->prefix, file_ctx->prefix_len);
+
     int r = json_dump_callback(js, MemBufferCallback, buffer,
             JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
 #ifdef JSON_ESCAPE_SLASH
@@ -496,6 +499,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
         const char *prefix = ConfNodeLookupChildValue(conf, "prefix");
         if (prefix != NULL)
         {
+            SCLogInfo("Using prefix '%s' for JSON message", prefix);
             json_ctx->file_ctx->prefix = SCStrdup(prefix);
             if (json_ctx->file_ctx->prefix == NULL)
             {
@@ -503,6 +507,7 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                     "Failed to allocate memory for eve-log.prefix setting.");
                 exit(EXIT_FAILURE);
             }
+            json_ctx->file_ctx->prefix_len = strlen(prefix);
         }
 
         if (json_ctx->json_out == LOGFILE_TYPE_FILE ||

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -519,8 +519,10 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
     SCMutexDestroy(&lf_ctx->fp_mutex);
 
-    if (lf_ctx->prefix != NULL)
+    if (lf_ctx->prefix != NULL) {
         SCFree(lf_ctx->prefix);
+        lf_ctx->prefix_len = 0;
+    }
 
     if(lf_ctx->filename != NULL)
         SCFree(lf_ctx->filename);

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -102,6 +102,7 @@ typedef struct LogFileCtx_ {
     /**< Used by some alert loggers like the unified ones that append
      * the date onto the end of files. */
     char *prefix;
+    size_t prefix_len;
 
     /** Generic size_limit and size_current
      * They must be common to the threads accesing the same file */


### PR DESCRIPTION
The log prefix option was not anymore honored due to a regression
caused by some recent code.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/120
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/118
