### PR TITLE
socket-permission: chmod for socket permission under linux

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -198,6 +198,15 @@ int UnixNew(UnixCommand * this)
         SCFree(sockettarget);
         return 0;
     }
+    /* chmod FTW for changing socket permissions */
+    ret = chmod(sockettarget, S_IRWXU|S_IRWXG);
+    if (ret == -1) {
+        int err = errno;
+        SCLogWarning(SC_ERR_INITIALIZATION,
+            "Unable to change permission on socket: %s (%d)",
+            strerror(err), err);
+    }
+
     SCFree(sockettarget);
     return 1;
 }


### PR DESCRIPTION
linux uses chmod (with the name of the socket as parameter) in order to set the permissions of a socket.

Branch created after first branch (fix-socket-permissions) failed to build, sorry about that