### PR TITLE
Midstream fix v2

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -345,7 +345,8 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
             SCLogDebug("toserver - Probing parser found for source port %"PRIu16, f->sp);
 
             /* found based on source port, so use sp registration */
-            pe2 = pp_port_sp->sp;
+            pe2 = pp_port_sp->dp;
+            f->reverted = 1;
         } else {
             SCLogDebug("toserver - No probing parser registered for source port %"PRIu16,
                     f->sp);
@@ -356,7 +357,7 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         alproto_masks = &f->probing_parser_toclient_alproto_masks;
         if (pp_port_dp != NULL) {
             SCLogDebug("toclient - Probing parser found for destination port %"PRIu16, f->dp);
-
+ 
             /* found based on destination port, so use dp registration */
             pe1 = pp_port_dp->dp;
         } else {
@@ -368,7 +369,9 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         if (pp_port_sp != NULL) {
             SCLogDebug("toclient - Probing parser found for source port %"PRIu16, f->sp);
 
-            pe2 = pp_port_sp->sp;
+            /* found based on source port, so use sp registration */
+            pe2 = pp_port_sp->dp;
+            f->reverted = 1;
         } else {
             SCLogDebug("toclient - No probing parser registered for source port %"PRIu16,
                         f->sp);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -905,7 +905,13 @@ int AppLayerParserParse(AppLayerParserThreadCtx *alp_tctx, Flow *f, AppProto alp
     /* invoke the recursive parser, but only on data. We may get empty msgs on EOF */
     if (input_len > 0 || (flags & STREAM_EOF)) {
         /* invoke the parser */
-        if (p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
+        int dir;
+        if (f->reverted) {
+            dir = (flags & STREAM_TOSERVER) ? 1 : 0;
+        } else {
+            dir = (flags & STREAM_TOSERVER) ? 0 : 1;
+        }
+        if (p->Parser[dir](f, alstate, pstate,
                 input, input_len,
                 alp_tctx->alproto_local_storage[f->protomap][alproto]) < 0)
         {

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -91,6 +91,7 @@
         (f)->probing_parser_toserver_alproto_masks = 0; \
         (f)->probing_parser_toclient_alproto_masks = 0; \
         (f)->flags = 0; \
+        (f)->reverted = 0; \
         (f)->lastts.tv_sec = 0; \
         (f)->lastts.tv_usec = 0; \
         (f)->protoctx = NULL; \

--- a/src/flow.h
+++ b/src/flow.h
@@ -338,6 +338,8 @@ typedef struct Flow_
 
     uint32_t flags;
 
+    uint8_t reverted;
+
     /* time stamp of last update (last packet). Set/updated under the
      * flow and flow hash row locks, safe to read under either the
      * flow lock or flow hash row lock. */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -5071,6 +5071,11 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
     return ret;
 }
 
+int StreamTcpMidstreamIsEnabled()
+{
+    return (stream_config.midstream == TRUE);
+}
+
 TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 {
     SCEnter();

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -221,6 +221,7 @@ static inline int StreamNeedsReassembly(TcpSession *ssn, int direction)
     }
 }
 
+int StreamTcpMidstreamIsEnabled(void);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
 int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,


### PR DESCRIPTION
A work from @glongo and me, aiming at improving midstream. When working with modbus traffic, suricata is not able to picked up a large part of sessions when midstream is enable. This is due to the fact, it does not manage to pick all sessions starting with data in to_client side. This is a real problem for modbus protocol where session last forever and you can not really restart an industrial system when you restart suricata.

This patchset fixes this and it has shown some results on both real (test environment) and simulated (manually altered pcap) modbus traffic.

Regarding the main patch, I tend to think we should maybe completely invert the src and dest in the flow when the application layer detected it is reverted. This may lead to bigger, intrusive changes so I've decided to propose this code and discuss if now as a later solution.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/123
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/121