### PR TITLE
file-store: add force-filestore configuration option to enable writin…

### DIFF
--- a/src/log-file.c
+++ b/src/log-file.c
@@ -416,6 +416,12 @@ static OutputCtx *LogFileLogInitCtx(ConfNode *conf)
     output_ctx->data = logfile_ctx;
     output_ctx->DeInit = LogFileLogDeInitCtx;
 
+    const char *force_filestore = ConfNodeLookupChildValue(conf, "force-filestore");
+    if (force_filestore != NULL && ConfValIsTrue(force_filestore)) {
+        FileForceFilestoreEnable();
+        SCLogInfo("forcing filestore of all files");
+    }
+
     const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");
     if (force_magic != NULL && ConfValIsTrue(force_magic)) {
         FileForceMagicEnable();

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -458,6 +458,12 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
         }
     }
 
+    const char *force_filestore = ConfNodeLookupChildValue(conf, "force-filestore");
+    if (force_filestore != NULL && ConfValIsTrue(force_filestore)) {
+        FileForceFilestoreEnable();
+        SCLogInfo("forcing filestore of all files");
+    }
+
     const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");
     if (force_magic != NULL && ConfValIsTrue(force_magic)) {
         FileForceMagicEnable();

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -258,6 +258,12 @@ OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
     output_file_ctx->file_ctx = ojc->file_ctx;
 
     if (conf) {
+        const char *force_filestore = ConfNodeLookupChildValue(conf, "force-filestore");
+        if (force_filestore != NULL && ConfValIsTrue(force_filestore)) {
+            FileForceFilestoreEnable();
+            SCLogInfo("forcing filestore of all files");
+        }
+
         const char *force_magic = ConfNodeLookupChildValue(conf, "force-magic");
         if (force_magic != NULL && ConfValIsTrue(force_magic)) {
             FileForceMagicEnable();

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -36,6 +36,11 @@
 #include "app-layer-parser.h"
 #include "util-validate.h"
 
+/** \brief switch to force filestore on all files
+ *         regardless of the rules.
+ */
+static int g_file_force_filestore = 0;
+
 /** \brief switch to force magic checks on all files
  *         regardless of the rules.
  */
@@ -55,6 +60,11 @@ static int g_file_force_tracking = 0;
 static void FileFree(File *);
 static void FileDataFree(FileData *);
 
+void FileForceFilestoreEnable(void)
+{
+    g_file_force_filestore = 1;
+}
+
 void FileForceMagicEnable(void)
 {
     g_file_force_magic = 1;
@@ -63,6 +73,11 @@ void FileForceMagicEnable(void)
 void FileForceMd5Enable(void)
 {
     g_file_force_md5 = 1;
+}
+
+int FileForceFilestore(void)
+{
+    return g_file_force_filestore;
 }
 
 int FileForceMagic(void)
@@ -534,7 +549,7 @@ File *FileOpenFile(FileContainer *ffc, uint8_t *name,
         SCReturnPtr(NULL, "File");
     }
 
-    if (flags & FILE_STORE) {
+    if (flags & FILE_STORE || g_file_force_filestore) {
         ff->flags |= FILE_STORE;
     } else if (flags & FILE_NOSTORE) {
         SCLogDebug("not storing this file");

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -172,6 +172,8 @@ void FileDisableStoringForTransaction(Flow *f, uint8_t direction, uint64_t tx_id
 void FlowFileDisableStoringForTransaction(struct Flow_ *f, uint16_t tx_id);
 void FilePrune(FileContainer *ffc);
 
+void FileForceFilestoreEnable(void);
+int FileForceFilestore(void);
 
 void FileDisableMagic(Flow *f, uint8_t);
 void FileForceMagicEnable(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -348,6 +348,7 @@ outputs:
       log-dir: files    # directory to store the files
       force-magic: no   # force logging magic on all stored files
       force-md5: no     # force logging of md5 checksums
+      force-filestore: no # force storing of all files
       #waldo: file.waldo # waldo file to store the file_id across runs
 
   # output module to log files tracked in a easily parsable json format


### PR DESCRIPTION
file-store: add force-filestore configuration option to enable writing all
                extracted files to filesystem.

This adds support for force-filestore keyword in suricata.yaml to enable writing all reconstructed files to the filesystem without needing to include filestore rules in the configuration.

This would probably never get used on live traffic, but is quite useful to extract a combination of logs and files when processing pcaps.