### PR TITLE
output-json: add app_proto key in root

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -108,6 +108,8 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             break;
     }
 
+    json_object_set_new(js, "app_proto",
+            json_string(AppProtoToString(p->flow->alproto)));
 
     json_t *fjs = json_object();
     if (unlikely(fjs == NULL)) {

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -188,7 +188,7 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
         return;
     }
 
-    json_object_set_new(hjs, "app_proto", json_string(AppProtoToString(f->alproto)));
+    json_object_set_new(js, "app_proto", json_string(AppProtoToString(f->alproto)));
 
     json_object_set_new(hjs, "pkts_toserver",
             json_integer(f->todstpktcnt));

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -194,7 +194,7 @@ static void JsonNetFlowLogJSONToServer(JsonNetFlowLogThread *aft, json_t *js, Fl
         return;
     }
 
-    json_object_set_new(hjs, "app_proto",
+    json_object_set_new(js, "app_proto",
             json_string(AppProtoToString(f->alproto_ts ? f->alproto_ts : f->alproto)));
 
     json_object_set_new(hjs, "pkts",
@@ -243,7 +243,7 @@ static void JsonNetFlowLogJSONToClient(JsonNetFlowLogThread *aft, json_t *js, Fl
         return;
     }
 
-    json_object_set_new(hjs, "app_proto",
+    json_object_set_new(js, "app_proto",
             json_string(AppProtoToString(f->alproto_tc ? f->alproto_tc : f->alproto)));
 
     json_object_set_new(hjs, "pkts",


### PR DESCRIPTION
By adding the key in the root of *flow and fileinfo  events it
will be possible to get all events for one application layer by
using a 'event_type:proto OR app_proto:proto' filter. This will
permit to the analyst to get a good view of events related to
one protocol.

This patch also fixes a regression in file logging where app_proto
was available before 94dbd303e4744a40f3761265be7c73a7a4754764 create
the regression.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/125
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/123

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1614