### PR TITLE
modbus: disable by default - v1

### DIFF
--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1427,21 +1427,13 @@ void RegisterModbusParsers(void)
                                           STREAM_TOSERVER,
                                           ModbusProbingParser);
         } else {
-            /* if we have no config, we enable the default port 502 */
+            /* If there is no app-layer section for Modbus, silently
+             * leave it disabled. */
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                                                 proto_name, ALPROTO_MODBUS,
                                                 0, sizeof(ModbusHeader),
                                                 ModbusProbingParser)) {
-                SCLogWarning(SC_ERR_MODBUS_CONFIG, "no Modbus TCP config found, "
-                                                "enabling Modbus detection on "
-                                                "port 502.");
-
-                AppLayerProtoDetectPPRegister(IPPROTO_TCP,
-                                              "502",
-                                              ALPROTO_MODBUS,
-                                              0, sizeof(ModbusHeader),
-                                              STREAM_TOSERVER,
-                                              ModbusProbingParser);
+                return;
             }
         }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1171,7 +1171,7 @@ rule-files:
  - smtp-events.rules    # available in suricata sources under rules dir
  - dns-events.rules     # available in suricata sources under rules dir
  - tls-events.rules     # available in suricata sources under rules dir
- - modbus-events.rules  # available in suricata sources under rules dir
+# - modbus-events.rules  # available in suricata sources under rules dir
  - app-layer-events.rules  # available in suricata sources under rules dir
 
 classification-file: @e_sysconfdir@classification.config
@@ -1350,7 +1350,7 @@ app-layer:
       # If the limit is reached, app-layer-event:modbus.flooded; will match.
       #request-flood: 500
 
-      enabled: yes
+      enabled: no
       detection-ports:
         dp: 502
       # According to MODBUS Messaging on TCP/IP Implementation Guide V1.0b, it 


### PR DESCRIPTION
Disable modbus by default, including the case where no modbus configuration is provided.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1615

Possible issue: Without this PR, Modbus configures itself with sane defaults (assuming you want modbus enabled) if the configuration is not provided.  Now there is no way to say "yes, enable modbus with a default sane configuration" - the user must enable it and make sure the detection-ports is correct.  This is probably not specific to Modbus, but to any app-layer protocol we may want to ship by default.

Buildbot output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/160
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/161
