### PR TITLE
prelude: fix thread safeness

### DIFF
--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -114,6 +114,7 @@ typedef struct AlertPreludeCtx_ {
 typedef struct AlertPreludeThread_ {
     /** Pointer to the global context */
     AlertPreludeCtx *ctx;
+    idmef_analyzer_t *analyzer;
 } AlertPreludeThread;
 
 
@@ -130,24 +131,64 @@ static int SetupAnalyzer(idmef_analyzer_t *analyzer)
     SCEnter();
 
     ret = idmef_analyzer_new_model(analyzer, &string);
-    if (ret < 0)
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error creating analyzer model: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(ret);
-    prelude_string_set_constant(string, ANALYZER_MODEL);
+    }
+    ret = prelude_string_set_constant(string, ANALYZER_MODEL);
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting analyzer model: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
+        SCReturnInt(ret);
+    }
 
     ret = idmef_analyzer_new_class(analyzer, &string);
-    if (ret < 0)
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error creating analyzer class: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(ret);
-    prelude_string_set_constant(string, ANALYZER_CLASS);
+    }
+    ret = prelude_string_set_constant(string, ANALYZER_CLASS);
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting analyzer class: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
+        SCReturnInt(ret);
+    }
 
     ret = idmef_analyzer_new_manufacturer(analyzer, &string);
-    if (ret < 0)
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error creating analyzer manufacturer: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(ret);
-    prelude_string_set_constant(string, ANALYZER_MANUFACTURER);
+    }
+    ret = prelude_string_set_constant(string, ANALYZER_MANUFACTURER);
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting analyzer manufacturer: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
+        SCReturnInt(ret);
+    }
 
     ret = idmef_analyzer_new_version(analyzer, &string);
-    if (ret < 0)
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error creating analyzer version: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(ret);
-    prelude_string_set_constant(string, VERSION);
+    }
+    ret = prelude_string_set_constant(string, VERSION);
+    if (ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting analyzer version: %s.",
+                prelude_strsource(ret), prelude_strerror(ret));
+        SCReturnInt(ret);
+    }
 
     SCReturnInt(0);
 }
@@ -339,21 +380,24 @@ static int AddByteData(idmef_alert_t *alert, const char *meaning, const unsigned
 
     ret = idmef_additional_data_set_byte_string_ref(ad, data, size);
     if (ret < 0) {
-        SCLogDebug("%s: error setting byte string data: %s.",
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting byte string data: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
 
     ret = idmef_additional_data_new_meaning(ad, &str);
     if (ret < 0) {
-        SCLogDebug("%s: error creating additional-data meaning: %s.",
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error creating additional-data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
 
     ret = prelude_string_set_ref(str, meaning);
     if (ret < 0) {
-        SCLogDebug("%s: error setting byte string data meaning: %s.",
+        SCLogError(SC_ERR_INITIALIZATION,
+                "%s: error setting byte string data meaning: %s.",
                 prelude_strsource(ret), prelude_strerror(ret));
         SCReturnInt(-1);
     }
@@ -605,8 +649,7 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, void *initdata, void **data
 
     SCEnter();
 
-    if(initdata == NULL)
-    {
+    if (initdata == NULL) {
         SCLogDebug("Error getting context for Prelude.  \"initdata\" argument NULL");
         SCReturnInt(TM_ECODE_FAILED);
     }
@@ -618,6 +661,20 @@ static TmEcode AlertPreludeThreadInit(ThreadVars *t, void *initdata, void **data
 
     /** Use the Ouput Context */
     aun->ctx = ((OutputCtx *)initdata)->data;
+    
+    /** Create a per-thread idmef analyzer */
+    if (idmef_analyzer_new(&aun->analyzer) < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                   "Error creating idmef analyzer for Prelude.");
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+    
+    /** Setup the per-thread idmef analyzer */
+    if (SetupAnalyzer(aun->analyzer) < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                   "Error configuring idmef analyzer for Prelude.");
+        SCReturnInt(TM_ECODE_FAILED);
+    }
 
     *data = (void *)aun;
     SCReturnInt(TM_ECODE_OK);
@@ -640,6 +697,7 @@ static TmEcode AlertPreludeThreadDeinit(ThreadVars *t, void *data)
     }
 
     /* clear memory */
+    idmef_analyzer_destroy(aun->analyzer);
     memset(aun, 0, sizeof(AlertPreludeThread));
     SCFree(aun);
 
@@ -697,12 +755,19 @@ static OutputCtx *AlertPreludeInitCtx(ConfNode *conf)
 
     ret = prelude_client_set_flags(client, prelude_client_get_flags(client) | PRELUDE_CLIENT_FLAGS_ASYNC_TIMER|PRELUDE_CLIENT_FLAGS_ASYNC_SEND);
     if (ret < 0) {
-        SCLogDebug("Unable to set asynchronous send and timer.");
+        SCLogError(SC_ERR_INITIALIZATION,
+                   "Unable to set asynchronous send and timer.");
         prelude_client_destroy(client, PRELUDE_CLIENT_EXIT_STATUS_SUCCESS);
         SCReturnPtr(NULL, "AlertPreludeCtx");
     }
 
-    SetupAnalyzer(prelude_client_get_analyzer(client));
+    ret = SetupAnalyzer(prelude_client_get_analyzer(client));
+    if(ret < 0) {
+        SCLogError(SC_ERR_INITIALIZATION,
+                   "Unable to setup prelude client analyzer.");
+        prelude_client_destroy(client, PRELUDE_CLIENT_EXIT_STATUS_SUCCESS);
+        SCReturnPtr(NULL, "AlertPreludeCtx");
+    }
 
     ret = prelude_client_start(client);
     if (ret < 0) {
@@ -852,7 +917,7 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
         goto err;
     idmef_alert_set_create_time(alert, time);
 
-    idmef_alert_set_analyzer(alert, idmef_analyzer_ref(prelude_client_get_analyzer(apn->ctx->client)), IDMEF_LIST_PREPEND);
+    idmef_alert_set_analyzer(alert, idmef_analyzer_ref(apn->analyzer), IDMEF_LIST_PREPEND);
 
     /* finally, send event */
     prelude_client_send_idmef(apn->ctx->client, idmef);


### PR DESCRIPTION
Prelude analyzer is not thread safe so we need to have one
analyzer per thread.

PR builds:
- PR build: https://buildbot.openinfosecfoundation.org/builders/regit/builds/127
- PR pcaps: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/125

Redmine tickets: https://redmine.openinfosecfoundation.org/issues/1639