### PR TITLE
fix http body pruning v2

### DIFF
--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -222,7 +222,7 @@ void HtpBodyPrune(HtpState *state, HtpBody *body, int direction)
         window = state->cfg->request_inspect_window;
     }
 
-    if (body->body_inspected < (min_size > window) ? min_size : window) {
+    if (body->body_inspected < ((min_size > window) ? min_size : window)) {
         SCReturn;
     }
 

--- a/src/app-layer-htp-file.c
+++ b/src/app-layer-htp-file.c
@@ -77,7 +77,7 @@
  *  \retval -2 not handling files on this flow
  */
 int HTPFileOpen(HtpState *s, uint8_t *filename, uint16_t filename_len,
-        uint8_t *data, uint32_t data_len, uint16_t txid, uint8_t direction)
+        uint8_t *data, uint32_t data_len, uint64_t txid, uint8_t direction)
 {
     int retval = 0;
     uint8_t flags = 0;

--- a/src/app-layer-htp-file.h
+++ b/src/app-layer-htp-file.h
@@ -25,7 +25,7 @@
 #ifndef __APP_LAYER_HTP_FILE_H__
 #define __APP_LAYER_HTP_FILE_H__
 
-int HTPFileOpen(HtpState *, uint8_t *, uint16_t, uint8_t *, uint32_t, uint16_t, uint8_t);
+int HTPFileOpen(HtpState *, uint8_t *, uint16_t, uint8_t *, uint32_t, uint64_t, uint8_t);
 int HTPFileStoreChunk(HtpState *, uint8_t *, uint32_t, uint8_t);
 int HTPFileClose(HtpState *, uint8_t *, uint32_t, uint8_t, uint8_t);
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -1827,6 +1827,7 @@ end:
     DetectEngineCleanHCBDBuffers(det_ctx);
     DetectEngineCleanHSBDBuffers(det_ctx);
     DetectEngineCleanHHDBuffers(det_ctx);
+    DetectEngineCleanSMTPBuffers(det_ctx);
 
     /* store the found sgh (or NULL) in the flow to save us from looking it
      * up again for the next packet. Also return any stream chunk we processed

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -873,7 +873,7 @@ void FileDisableStoringForTransaction(Flow *f, uint8_t direction, uint64_t tx_id
  *  \param fc file store
  *  \param file_id the file's id
  */
-void FileStoreFileById(FileContainer *fc, uint16_t file_id)
+void FileStoreFileById(FileContainer *fc, uint32_t file_id)
 {
     File *ptr = NULL;
 
@@ -888,7 +888,7 @@ void FileStoreFileById(FileContainer *fc, uint16_t file_id)
     }
 }
 
-void FileStoreAllFilesForTx(FileContainer *fc, uint16_t tx_id)
+void FileStoreAllFilesForTx(FileContainer *fc, uint64_t tx_id)
 {
     File *ptr = NULL;
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -62,7 +62,7 @@ typedef struct FileData_ {
 typedef struct File_ {
     uint16_t flags;
     uint64_t txid;                  /**< tx this file is part of */
-    unsigned int file_id;
+    uint32_t file_id;
     uint8_t *name;
     uint16_t name_len;
     int16_t state;
@@ -169,7 +169,7 @@ void FileDisableFilesize(Flow *f, uint8_t direction);
  */
 void FileDisableStoringForTransaction(Flow *f, uint8_t direction, uint64_t tx_id);
 
-void FlowFileDisableStoringForTransaction(struct Flow_ *f, uint16_t tx_id);
+void FlowFileDisableStoringForTransaction(struct Flow_ *f, uint64_t tx_id);
 void FilePrune(FileContainer *ffc);
 
 
@@ -184,8 +184,8 @@ int FileForceMd5(void);
 void FileForceTrackingEnable(void);
 
 void FileStoreAllFiles(FileContainer *);
-void FileStoreAllFilesForTx(FileContainer *, uint16_t);
-void FileStoreFileById(FileContainer *fc, uint16_t);
+void FileStoreAllFilesForTx(FileContainer *, uint64_t);
+void FileStoreFileById(FileContainer *fc, uint32_t);
 
 void FileTruncateAllOpenFiles(FileContainer *);
 


### PR DESCRIPTION
Fixes an issue in not properly cleaning up the HTTP body chunk list, leading to high memory use and in IPS mode stalls in connections due to excessive time needed to walk the chunk lists.

Should fix: https://redmine.openinfosecfoundation.org/issues/1632

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/324
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/326