### PR TITLE
Unix manager fix rc2

### DIFF
--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -346,13 +346,15 @@ TmEcode UnixSocketPcapFilesCheck(void *data)
         unix_manager_file_task_running = 1;
         this->running = 1;
         if (ConfSet("pcap-file.file", cfile->filename) != 1) {
-            SCLogInfo("Can not set working file to '%s'", cfile->filename);
+            SCLogError(SC_ERR_INVALID_ARGUMENTS,
+                       "Can not set working file to '%s'", cfile->filename);
             PcapFilesFree(cfile);
             return TM_ECODE_FAILED;
         }
         if (cfile->output_dir) {
             if (ConfSet("default-log-dir", cfile->output_dir) != 1) {
-                SCLogInfo("Can not set output dir to '%s'", cfile->output_dir);
+                SCLogError(SC_ERR_INVALID_ARGUMENTS,
+                           "Can not set output dir to '%s'", cfile->output_dir);
                 PcapFilesFree(cfile);
                 return TM_ECODE_FAILED;
             }
@@ -361,7 +363,8 @@ TmEcode UnixSocketPcapFilesCheck(void *data)
             char tstr[16] = "";
             snprintf(tstr, sizeof(tstr), "%d", cfile->tenant_id);
             if (ConfSet("pcap-file.tenant-id", tstr) != 1) {
-                SCLogInfo("Can not set working tenant-id to '%s'", tstr);
+                SCLogError(SC_ERR_INVALID_ARGUMENTS,
+                           "Can not set working tenant-id to '%s'", tstr);
                 PcapFilesFree(cfile);
                 return TM_ECODE_FAILED;
             }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1108,6 +1108,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int build_info = 0;
     int conf_test = 0;
     int engine_analysis = 0;
+    int set_log_directory = 0;
     int ret = TM_ECODE_OK;
 
 #ifdef UNITTESTS
@@ -1580,6 +1581,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                         "exist. Shutting down the engine.", optarg, optarg);
                 return TM_ECODE_FAILED;
             }
+            set_log_directory = 1;
+
             break;
         case 'q':
 #ifdef NFQ
@@ -1711,6 +1714,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 
     if (suri->disabled_detect && suri->sig_file != NULL) {
         SCLogError(SC_ERR_INITIALIZATION, "can't use -s/-S when detection is disabled");
+        return TM_ECODE_FAILED;
+    }
+
+    if ((suri->run_mode == RUNMODE_UNIX_SOCKET) && set_log_directory) {
+        SCLogError(SC_ERR_INITIALIZATION, "can't use -l and unix socket runmode at the same time");
         return TM_ECODE_FAILED;
     }
 


### PR DESCRIPTION
This is a set of fixes for unix manager. First one fixes a race condition causing a segfault occuring at suricata start on some low profile and loaded systems. Third one causes suricata to exit when incompatible settings are used. Effect of using -l and unix socket runmode at the same time was the running mode not to be working at all without any warning to the user.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/128
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/120

Redmine ticket for 1st patch: https://redmine.openinfosecfoundation.org/issues/1645