### PR TITLE
RFC Only - Per direction TX logging with "pipelining" support.

### DIFF
--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -27,6 +27,7 @@
 
 #include "app-layer-events.h"
 #include "detect-engine-state.h"
+#include "output.h"
 #include "util-file.h"
 
 #define APP_LAYER_PARSER_EOF                    0x01
@@ -146,6 +147,9 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+void AppLayerParserRegisterOutputTxStateFuncs(uint8_t ipproto, AppProto alproto,
+    OutputTxState *(*GetTxOutputState)(void *tx),
+    void (*SetTxOutputState)(void *tx, OutputTxState *));
 
 /***** Get and transaction functions *****/
 
@@ -184,6 +188,9 @@ int AppLayerParserSupportsTxDetectState(uint8_t ipproto, AppProto alproto);
 int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
 DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);
 int AppLayerParserSetTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate, void *tx, DetectEngineState *s);
+int AppLayerParserSupportsTxOutputState(uint8_t ipproto, AppProto alproto);
+OutputTxState *AppLayerParserGetTxOutputState(uint8_t ipproto, AppProto alproto, void *tx);
+int AppLayerParserSetTxOutputState(uint8_t ipproto, AppProto alproto, void *tx, OutputTxState *s);
 
 /***** General *****/
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -154,8 +154,8 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
                                           void *local_data);
 
 
-uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate);
-void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate);
+uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate, uint8_t direction);
+void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate, uint8_t direction);
 uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint8_t direction);
 void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
                                 const uint8_t ipproto, const AppProto alproto, void *alstate,

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -166,7 +166,7 @@ static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *ds
 }
 
 static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p, Flow *f,
-    void *state, void *tx, uint64_t tx_id)
+    uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     LogDnsLogThread *aft = (LogDnsLogThread *)data;
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
@@ -355,7 +355,7 @@ void TmModuleLogDnsLogRegister (void)
     tmm_modules[TMM_LOGDNSLOG].flags = TM_FLAG_LOGAPI_TM;
 
     OutputRegisterTxModule(MODULE_NAME, "dns-log", LogDnsLogInitCtx,
-            ALPROTO_DNS, LogDnsLogger);
+            ALPROTO_DNS, LogDnsLogger, 0);
 
     /* enable the logger for the app layer */
     SCLogDebug("registered %s", MODULE_NAME);

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -61,7 +61,7 @@ TmEcode LogHttpLogThreadDeinit(ThreadVars *, void *);
 void LogHttpLogExitPrintStats(ThreadVars *, void *);
 static void LogHttpLogDeInitCtx(OutputCtx *);
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 void TmModuleLogHttpLogRegister (void)
 {
@@ -74,7 +74,7 @@ void TmModuleLogHttpLogRegister (void)
     tmm_modules[TMM_LOGHTTPLOG].flags = TM_FLAG_LOGAPI_TM;
 
     OutputRegisterTxModule(MODULE_NAME, "http-log", LogHttpLogInitCtx,
-            ALPROTO_HTTP, LogHttpLogger);
+            ALPROTO_HTTP, LogHttpLogger, 0);
 }
 
 #define LOG_HTTP_MAXN_NODES 64
@@ -515,7 +515,8 @@ end:
 
 }
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f,
+    uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -250,7 +250,7 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
 
 }
 
-static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 
@@ -426,9 +426,9 @@ void TmModuleJsonDnsLogRegister (void)
     tmm_modules[TMM_JSONDNSLOG].flags = TM_FLAG_LOGAPI_TM;
 
     OutputRegisterTxModule(MODULE_NAME, "dns-json-log", JsonDnsLogInitCtx,
-            ALPROTO_DNS, JsonDnsLogger);
+            ALPROTO_DNS, JsonDnsLogger, 0);
     OutputRegisterTxSubModule("eve-log", MODULE_NAME, "eve-log.dns", JsonDnsLogInitCtxSub,
-            ALPROTO_DNS, JsonDnsLogger);
+            ALPROTO_DNS, JsonDnsLogger, 0);
 }
 
 #else

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -365,7 +365,7 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, ui
     json_object_set_new(js, "http", hjs);
 }
 
-static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 
@@ -591,11 +591,11 @@ void TmModuleJsonHttpLogRegister (void)
 
     /* register as separate module */
     OutputRegisterTxModule("JsonHttpLog", "http-json-log", OutputHttpLogInit,
-            ALPROTO_HTTP, JsonHttpLogger);
+            ALPROTO_HTTP, JsonHttpLogger, 0);
 
     /* also register as child of eve-log */
     OutputRegisterTxSubModule("eve-log", "JsonHttpLog", "eve-log.http", OutputHttpLogInitSub,
-            ALPROTO_HTTP, JsonHttpLogger);
+            ALPROTO_HTTP, JsonHttpLogger, 0);
 }
 
 #else

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -83,7 +83,7 @@ static json_t *JsonSmtpDataLogger(const Flow *f, void *state, void *vtx, uint64_
     return sjs;
 }
 
-static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;
@@ -268,15 +268,12 @@ void TmModuleJsonSmtpLogRegister (void) {
     tmm_modules[TMM_JSONSMTPLOG].flags = TM_FLAG_LOGAPI_TM;
 
     /* register as separate module */
-    OutputRegisterTxModule("JsonSmtpLog", "smtp-json-log",
-                               OutputSmtpLogInit, ALPROTO_SMTP,
-                               JsonSmtpLogger);
+    OutputRegisterTxModule("JsonSmtpLog", "smtp-json-log", OutputSmtpLogInit,
+        ALPROTO_SMTP, JsonSmtpLogger, 0);
 
     /* also register as child of eve-log */
-    OutputRegisterTxSubModule("eve-log", "JsonSmtpLog",
-                                  "eve-log.smtp",
-                                  OutputSmtpLogInitSub, ALPROTO_SMTP,
-                                  JsonSmtpLogger);
+    OutputRegisterTxSubModule("eve-log", "JsonSmtpLog", "eve-log.smtp",
+        OutputSmtpLogInitSub, ALPROTO_SMTP, JsonSmtpLogger, 0);
 }
 
 #else

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -53,7 +53,7 @@ typedef struct LogTemplateLogThread_ {
 } LogTemplateLogThread;
 
 static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
-    const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+    const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     TemplateTransaction *templatetx = tx;
     LogTemplateLogThread *thread = thread_data;
@@ -193,7 +193,7 @@ void TmModuleJsonTemplateLogRegister(void)
 
     /* Register as an eve sub-module. */
     OutputRegisterTxSubModule("eve-log", "JsonTemplateLog", "eve-log.template",
-        OutputTemplateLogInitSub, ALPROTO_TEMPLATE, JsonTemplateLogger);
+        OutputTemplateLogInitSub, ALPROTO_TEMPLATE, JsonTemplateLogger, 0);
 
     SCLogNotice("Template JSON logger registered.");
 }

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -91,7 +91,7 @@ typedef struct LogLuaThreadCtx_ {
  *
  * NOTE: The flow (f) also referenced by p->flow is locked.
  */
-static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -51,11 +51,12 @@ typedef struct OutputTxLogger_ {
     struct OutputTxLogger_ *next;
     const char *name;
     TmmId module_id;
+    int directional;
 } OutputTxLogger;
 
 static OutputTxLogger *list = NULL;
 
-int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *output_ctx)
+int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *output_ctx, int directional)
 {
     int module_id = TmModuleGetIdByName(name);
     if (module_id < 0)
@@ -71,6 +72,7 @@ int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
     op->output_ctx = output_ctx;
     op->name = name;
     op->module_id = (TmmId) module_id;
+    op->directional = directional;
 
     if (list == NULL)
         list = op;
@@ -118,17 +120,25 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
     }
 
     uint64_t total_txs = AppLayerParserGetTxCnt(p->proto, alproto, alstate);
-    uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
     int tx_progress_done_value_ts =
         AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
                                                        STREAM_TOSERVER);
     int tx_progress_done_value_tc =
         AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
                                                        STREAM_TOCLIENT);
-    int proto_logged = 0;
+
+    uint64_t tx_id_ts = AppLayerParserGetTransactionLogId(f->alparser,
+        STREAM_TOSERVER);
+    uint64_t tx_id_tc = AppLayerParserGetTransactionLogId(f->alparser,
+        STREAM_TOCLIENT);
+    uint64_t tx_id = MIN(tx_id_ts, tx_id_tc);
 
     for (; tx_id < total_txs; tx_id++)
     {
+        int ts_ready = 0;
+        int tc_ready = 0;
+        int proto_logged = 0;
+
         void *tx = AppLayerParserGetTx(p->proto, alproto, alstate, tx_id);
         if (tx == NULL) {
             SCLogDebug("tx is NULL not logging");
@@ -138,18 +148,40 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
         if (!(AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)))
         {
             int tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                             tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
-            if (tx_progress < tx_progress_done_value_ts) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
+                tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
+            if (tx_progress == tx_progress_done_value_ts) {
+                ts_ready = 1;
             }
 
             tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                         tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
-            if (tx_progress < tx_progress_done_value_tc) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
+                tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
+            if (tx_progress == tx_progress_done_value_tc) {
+                tc_ready = 1;
             }
+        }
+
+        if (!(ts_ready || tc_ready)) {
+            SCLogNotice("progress not for enough, not logging");
+            break;
+        }
+
+        /* Prevent the processing of one direction getting farther
+         * ahead than the other.
+         *
+         * This is possible if over lapping transactions happen where
+         * a response for a newer TX is seen before the response for
+         * an older TX.
+         *
+         * This basically serializes the logging in transaction order,
+         * but loses the order the messages may have been seen on the
+         * wire, but is consistent with the behaviour prior to
+         * per-direction TX logging.
+         */
+        if (tc_ready && tx_id > tx_id_tc) {
+            break;
+        }
+        if (ts_ready && tx_id > tx_id_ts) {
+            break;
         }
 
         // call each logger here (pseudo code)
@@ -158,15 +190,45 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
         while (logger && store) {
             BUG_ON(logger->LogFunc == NULL);
 
-            SCLogDebug("logger %p", logger);
-            if (logger->alproto == alproto) {
-                SCLogDebug("alproto match, logging tx_id %ju", tx_id);
-                PACKET_PROFILING_TMM_START(p, logger->module_id);
-                logger->LogFunc(tv, store->thread_data, p, f, alstate, tx, tx_id);
-                PACKET_PROFILING_TMM_END(p, logger->module_id);
-                proto_logged = 1;
+            /* Immediately skip to next if this logger is not
+             * directional and both sides are not ready. */
+            if (!logger->directional) {
+                if (!(ts_ready && tc_ready)) {
+                    goto next;
+                }
             }
 
+            SCLogDebug("logger %p", logger);
+            if (logger->alproto == alproto) {
+
+                SCLogDebug("alproto match, logging tx_id %ju", tx_id);
+
+                PACKET_PROFILING_TMM_START(p, logger->module_id);
+                if (logger->directional) {
+                    SCLogInfo("Logging directional TX: "
+                        "ts_ready: %d; tc_ready: %d; tx_id: %"PRIu64"; "
+                        "tx_id_ts: %"PRIu64"; tx_id_tc: %"PRIu64,
+                        ts_ready, tc_ready, tx_id, tx_id_ts, tx_id_tc);
+                    if (ts_ready && tx_id_ts <= tx_id) {
+                        logger->LogFunc(tv, store->thread_data, p, f,
+                            STREAM_TOSERVER, alstate, tx, tx_id);
+                        proto_logged = 1;
+                    }
+                    if (tc_ready && tx_id_tc <= tx_id) {
+                        logger->LogFunc(tv, store->thread_data, p, f,
+                            STREAM_TOCLIENT, alstate, tx, tx_id);
+                        proto_logged = 1;
+                    }
+                }
+                else {
+                    logger->LogFunc(tv, store->thread_data, p, f, 0, alstate,
+                        tx, tx_id);
+                    proto_logged = 1;
+                }
+                PACKET_PROFILING_TMM_END(p, logger->module_id);
+            }
+
+        next:
             logger = logger->next;
             store = store->next;
 
@@ -176,7 +238,12 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
 
         if (proto_logged) {
             SCLogDebug("updating log tx_id %ju", tx_id);
-            AppLayerParserSetTransactionLogId(f->alparser);
+            if (ts_ready && tx_id_ts <= tx_id) {
+                AppLayerParserSetTransactionLogId(f->alparser, STREAM_TOSERVER);
+            }
+            if (tc_ready && tx_id_tc <= tx_id) {
+                AppLayerParserSetTransactionLogId(f->alparser, STREAM_TOCLIENT);
+            }
         }
     }
 

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -29,14 +29,14 @@
 #include "decode.h"
 
 /** packet logger function pointer type */
-typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged
  */
 //typedef int (*TxLogCondition)(ThreadVars *, const Packet *);
 
-int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *);
+int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *, int directional);
 
 void TmModuleTxLoggerRegister (void);
 

--- a/src/output.c
+++ b/src/output.c
@@ -160,7 +160,7 @@ error:
 void
 OutputRegisterTxModule(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
-    TxLogger TxLogFunc)
+    TxLogger TxLogFunc, int directional)
 {
     if (unlikely(TxLogFunc == NULL)) {
         goto error;
@@ -176,6 +176,7 @@ OutputRegisterTxModule(const char *name, const char *conf_name,
     module->InitFunc = InitFunc;
     module->TxLogFunc = TxLogFunc;
     module->alproto = alproto;
+    module->directional = directional;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
     SCLogDebug("Tx logger \"%s\" registered.", name);
@@ -188,7 +189,7 @@ error:
 void
 OutputRegisterTxSubModule(const char *parent_name, const char *name,
     const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
-    AppProto alproto, TxLogger TxLogFunc)
+    AppProto alproto, TxLogger TxLogFunc, int directional)
 {
     if (unlikely(TxLogFunc == NULL)) {
         goto error;
@@ -205,6 +206,7 @@ OutputRegisterTxSubModule(const char *parent_name, const char *name,
     module->InitSubFunc = InitFunc;
     module->TxLogFunc = TxLogFunc;
     module->alproto = alproto;
+    module->directional = directional;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
     SCLogDebug("Tx logger \"%s\" registered.", name);

--- a/src/output.h
+++ b/src/output.h
@@ -25,6 +25,7 @@
 #define __OUTPUT_H__
 
 #include "suricata.h"
+#include "conf.h"
 #include "tm-threads.h"
 
 #define DEFAULT_LOG_MODE_APPEND     "yes"
@@ -64,6 +65,13 @@ typedef struct OutputModule_ {
 
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
+
+#define OUTPUT_TX_STATE_FLAG_TOSERVER_LOGGED 0x01
+#define OUTPUT_TX_STATE_FLAG_TOCLIENT_LOGGED 0x02
+
+typedef struct OutputTxState_ {
+    uint8_t flags;
+} OutputTxState;
 
 void OutputRegisterModule(const char *, const char *, OutputCtx *(*)(ConfNode *));
 

--- a/src/output.h
+++ b/src/output.h
@@ -56,6 +56,12 @@ typedef struct OutputModule_ {
     AppProto alproto;
     enum OutputStreamingType stream_type;
 
+    /* If module is a tx logger, and directional is true, the
+     * TxLogFunc will be called per direction when each direction is
+     * complete rather than waiting for both sides of the Tx to be
+     * complete. */
+    int directional;
+
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
 
@@ -70,10 +76,10 @@ void OutputRegisterPacketSubModule(const char *parent_name, const char *name,
 
 void OutputRegisterTxModule(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
-    TxLogger TxLogFunc);
+    TxLogger TxLogFunc, int directional);
 void OutputRegisterTxSubModule(const char *parent_name, const char *name,
     const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
-    AppProto alproto, TxLogger TxLogFunc);
+    AppProto alproto, TxLogger TxLogFunc, int directional);
 
 void OutputRegisterFileModule(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), FileLogger FileLogFunc);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -582,7 +582,7 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
     } else if (module->TxLogFunc) {
         SCLogDebug("%s is a tx logger", module->name);
         OutputRegisterTxLogger(module->name, module->alproto,
-                module->TxLogFunc, output_ctx);
+                module->TxLogFunc, output_ctx, module->directional);
 
         /* need one instance of the tx logger module */
         if (tx_logger_module == NULL) {


### PR DESCRIPTION
I took a look into what it would take to log sequential requests before responses were seen and retain support for overlapping transactions. Some extra book-keeping is required for the counters. For instance, we don't want to increment a counter until the earliest transaction is finished. Overlapping transactions messed this up as we'd never iterate over the lower transactions again.

So to make this happen we delay incrementing the log_id counters, but need to also set a flag on a transaction to flag if its been logged or not. This will allow us to handle something like:

REQ 1
REQ 2
RSP 2
REQ 1

Or (as can be in async messaging protocols):

REQ 1
RSP 2
REQ 2
RSP 1

Or even,

REQ 1
REQ 2
REQ 3
RSP 1
RSP 2
RSP 3

(http pipelining for example).

This is due for some refactoring, but I was after thoughts on the extra bookkeeping required to make this happen.  I didn't see another way than creating another set of callbacks into the protocol specific app-layer to retrieve and set the extra per tx data.

It would probably be a bit cleaner if we didn't have to worry about directional vs non-directional loggers, and let the logger choose to ignore the direction. For example, the current DNS and HTTP loggers could ignore on direction TO_SERVER and just handle the TO_CLIENT case.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/169
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/171

