### PR TITLE
util-device: fix iface stats output

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1589,6 +1589,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
 
     /* Init is ok */
     AFPSwitchState(ptv, AFP_STATE_UP);
+    LiveDeviceIfaceWasSeen(ptv->livedev);
     return 0;
 
 frame_err:

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -309,6 +309,7 @@ ReceiveErfDagThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ewtn->tv = tv;
     *data = (void *)ewtn;
+    LiveDeviceIfaceWasSeen(ptv->livedev);
 
     SCLogInfo("Starting processing packets from stream: %d on DAG: %s",
         ewtn->dagstream, ewtn->dagname);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -662,6 +662,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
                      "Using mmap mode with GRO or LRO activated can lead to capture problems");
     }
 
+    LiveDeviceIfaceWasSeen(ntv->livedev);
     *data = (void *)ntv;
     aconf->DerefFunc(aconf);
     SCReturnInt(TM_ECODE_OK);

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -330,6 +330,7 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, void *initdata, void **data)
     ntv->datalen = T_DATA_SIZE;
 #undef T_DATA_SIZE
 
+    LiveDeviceIfaceWasSeen(ntv->livedev);
     *data = (void *)ntv;
 
     nflconfig->DerefFunc(nflconfig);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -528,6 +528,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
     ptv->capture_kernel_ifdrops = StatsRegisterCounter("capture.kernel_ifdrops",
             ptv->tv);
 
+    LiveDeviceIfaceWasSeen(ptv->livedev);
     *data = (void *)ptv;
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -554,6 +554,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
         }
     }
 
+    LiveDeviceIfaceWasSeen(ptv->livedev);
     *data = (void *)ptv;
     pfconf->DerefFunc(pfconf);
 

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -58,6 +58,7 @@ int LiveRegisterDevice(const char *dev)
     SC_ATOMIC_INIT(pd->drop);
     SC_ATOMIC_INIT(pd->invalid_checksums);
     pd->ignore_checksum = 0;
+    pd->seen = 0;
     TAILQ_INSERT_TAIL(&live_devices, pd, next);
 
     SCLogDebug("Device \"%s\" registered.", dev);
@@ -183,12 +184,16 @@ int LiveDeviceListClean()
 
     TAILQ_FOREACH_SAFE(pd, &live_devices, next, tpd) {
         if (live_devices_stats) {
-            SCLogNotice("Stats for '%s':  pkts: %" PRIu64", drop: %" PRIu64 " (%.2f%%), invalid chksum: %" PRIu64,
-                    pd->dev,
-                    SC_ATOMIC_GET(pd->pkts),
-                    SC_ATOMIC_GET(pd->drop),
-                    100 * (SC_ATOMIC_GET(pd->drop) * 1.0) / SC_ATOMIC_GET(pd->pkts),
-                    SC_ATOMIC_GET(pd->invalid_checksums));
+            if (pd->seen) {
+                SCLogNotice("Stats for '%s':  pkts: %" PRIu64", drop: %" PRIu64 " (%.2f%%), invalid chksum: %" PRIu64,
+                        pd->dev,
+                        SC_ATOMIC_GET(pd->pkts),
+                        SC_ATOMIC_GET(pd->drop),
+                        100 * (SC_ATOMIC_GET(pd->drop) * 1.0) / SC_ATOMIC_GET(pd->pkts),
+                        SC_ATOMIC_GET(pd->invalid_checksums));
+            } else {
+                SCLogNotice("Stats for '%s': The interface is not operational or recognized", pd->dev);
+            }
         }
         if (pd->dev)
             SCFree(pd->dev);
@@ -199,6 +204,11 @@ int LiveDeviceListClean()
     }
 
     SCReturnInt(TM_ECODE_OK);
+}
+
+void LiveDeviceIfaceWasSeen(LiveDevice *pd)
+{
+    pd->seen = 1;
 }
 
 #ifdef BUILD_UNIX_SOCKET

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -25,6 +25,7 @@
 typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
     int ignore_checksum;
+    int seen;
     SC_ATOMIC_DECLARE(uint64_t, pkts);
     SC_ATOMIC_DECLARE(uint64_t, drop);
     SC_ATOMIC_DECLARE(uint64_t, invalid_checksums);
@@ -40,6 +41,7 @@ int LiveBuildDeviceList(const char *base);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);
 int LiveBuildDeviceListCustom(const char *base, const char *itemname);
+void LiveDeviceIfaceWasSeen(LiveDevice *pd);
 
 #ifdef BUILD_UNIX_SOCKET
 TmEcode LiveDeviceIfaceStat(json_t *cmd, json_t *server_msg, void *data);


### PR DESCRIPTION
This permits to output stats per interface only if it exists.

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/91
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/90

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1648