### PR TITLE
unix-manager: fix ressource leak when init fail

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -858,6 +858,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
         if (ConfGetBool("engine.init-failure-fatal", &failure_fatal) != 1) {
             SCLogDebug("ConfGetBool could not load the value.");
         }
+        SCFree(utd);
         if (failure_fatal) {
             exit(EXIT_FAILURE);
         } else {


### PR DESCRIPTION
Issue reported by coverity scan.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/131
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/129
