### PR TITLE
unix manager: log client's version with debug level

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -334,7 +334,7 @@ int UnixCommandAccept(UnixCommand *this)
         close(client);
         return 0;
     } else {
-        SCLogInfo("Unix socket: client version: \"%s\"",
+        SCLogDebug("Unix socket: client version: \"%s\"",
                 json_string_value(version));
     }
 


### PR DESCRIPTION
As (dis)connects are already logged as a debug events, this one
should do the same.