### PR TITLE
Enable direction sensitivity for TLS

### DIFF
--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -150,7 +150,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
     if (ssl_state->server_connp.cert0_issuerdn == NULL || ssl_state->server_connp.cert0_subject == NULL)
         goto end;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "tls");//TODO
+    json_t *js = CreateJSONHeader((Packet *)p, 1, "tls");
     if (unlikely(js == NULL))
         goto end;
 


### PR DESCRIPTION
When TLS is not treated as direction-sensitive and suricata runs in IPS mode,
the source and destination IPs/ports are reversed in the JSON log.