### PR TITLE
json-stats: add per app-layer stats

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -283,7 +283,7 @@ static DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id
 /** \internal
  *  \brief Free a DNS TX
  *  \param tx DNS TX to free */
-static void DNSTransactionFree(DNSTransaction *tx, DNSState *state)
+void DNSTransactionFree(DNSTransaction *tx, DNSState *state)
 {
     SCEnter();
 
@@ -419,33 +419,6 @@ void *DNSStateAlloc(void)
 
     TAILQ_INIT(&dns_state->tx_list);
     return s;
-}
-
-void DNSStateFree(void *s)
-{
-    SCEnter();
-    if (s) {
-        DNSState *dns_state = (DNSState *) s;
-
-        DNSTransaction *tx = NULL;
-        while ((tx = TAILQ_FIRST(&dns_state->tx_list))) {
-            TAILQ_REMOVE(&dns_state->tx_list, tx, next);
-            DNSTransactionFree(tx, dns_state);
-        }
-
-        if (dns_state->buffer != NULL) {
-            DNSDecrMemcap(0xffff, dns_state); /** TODO update if/once we alloc
-                                               *  in a smarter way */
-            SCFree(dns_state->buffer);
-        }
-
-        BUG_ON(dns_state->tx_with_detect_state_cnt > 0);
-
-        DNSDecrMemcap(sizeof(DNSState), dns_state);
-        BUG_ON(dns_state->memuse > 0);
-        SCFree(s);
-    }
-    SCReturn;
 }
 
 /** \brief Validation checks for DNS request header

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -224,6 +224,7 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction);
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 
 void DNSStateTransactionFree(void *state, uint64_t tx_id);
+void DNSTransactionFree(DNSTransaction *tx, DNSState *state);
 DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id);
 
 int DNSStateHasTxDetectState(void *alstate);
@@ -232,7 +233,6 @@ int DNSSetTxDetectState(void *alstate, void *vtx, DetectEngineState *s);
 
 void DNSSetEvent(DNSState *s, uint8_t e);
 void *DNSStateAlloc(void);
-void DNSStateFree(void *s);
 AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id);
 int DNSHasEvents(void *state);
 
@@ -255,5 +255,8 @@ uint16_t DNSUdpResponseGetNameByOffset(const uint8_t * const input, const uint32
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
+
+void DNSRegisterCounter(void);
+uint64_t DNSStateGetStateCnt(void);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -58,6 +58,25 @@ struct DNSTcpHeader_ {
 } __attribute__((__packed__));
 typedef struct DNSTcpHeader_ DNSTcpHeader;
 
+SC_ATOMIC_DECLARE(uint64_t, dns_tcp_global_tx_cnt);
+
+/* global counter functions */
+static inline void DNSTCPSetGlobalTxCounter(void)
+{
+    SC_ATOMIC_ADD(dns_tcp_global_tx_cnt, 1);
+}
+
+static inline uint64_t DNSTCPGetGlobalTxCnt(void)
+{
+    return SC_ATOMIC_GET(dns_tcp_global_tx_cnt);
+}
+
+static void DNSTCPRegisterGlobalTxCounter(void)
+{
+    SC_ATOMIC_INIT(dns_tcp_global_tx_cnt);
+    StatsRegisterGlobalCounter("app-layer.dns_tcp", DNSTCPGetGlobalTxCnt);
+}
+
 /** \internal
  *  \param input_len at least enough for the DNSTcpHeader
  */
@@ -608,6 +627,35 @@ static uint16_t DNSTcpProbingParser(uint8_t *input, uint32_t ilen, uint32_t *off
     return ALPROTO_DNS;
 }
 
+static void DNSTCPStateFree(void *s)
+{
+    SCEnter();
+
+    if (s) {
+        DNSState *dns_state = (DNSState *) s;
+
+        DNSTransaction *tx = NULL;
+        while ((tx = TAILQ_FIRST(&dns_state->tx_list))) {
+            TAILQ_REMOVE(&dns_state->tx_list, tx, next);
+            DNSTransactionFree(tx, dns_state);
+            DNSTCPSetGlobalTxCounter();
+        }
+
+        if (dns_state->buffer != NULL) {
+            DNSDecrMemcap(0xffff, dns_state); /** TODO update if/once we alloc
+                                               *  in a smarter way */
+            SCFree(dns_state->buffer);
+        }
+
+        BUG_ON(dns_state->tx_with_detect_state_cnt > 0);
+
+        DNSDecrMemcap(sizeof(DNSState), dns_state);
+        BUG_ON(dns_state->memuse > 0);
+        SCFree(s);
+    }
+    SCReturn;
+}
+
 void RegisterDNSTCPParsers(void)
 {
     char *proto_name = "dns";
@@ -650,7 +698,7 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterParser(IPPROTO_TCP , ALPROTO_DNS, STREAM_TOCLIENT,
                                      DNSTCPResponseParse);
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_DNS, DNSStateAlloc,
-                                         DNSStateFree);
+                                         DNSTCPStateFree);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_DNS,
                                          DNSStateTransactionFree);
 
@@ -667,6 +715,7 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
+        DNSTCPRegisterGlobalTxCounter();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -50,6 +50,25 @@
 
 #include "app-layer-dns-udp.h"
 
+SC_ATOMIC_DECLARE(uint64_t, dns_udp_global_tx_cnt);
+
+/* global counter functions */
+static inline void DNSUDPSetGlobalTxCounter(void)
+{
+    SC_ATOMIC_ADD(dns_udp_global_tx_cnt, 1);
+}
+
+static inline uint64_t DNSUDPGetGlobalTxCnt(void)
+{
+    return SC_ATOMIC_GET(dns_udp_global_tx_cnt);
+}
+
+static void DNSUDPRegisterGlobalTxCounter(void)
+{
+    SC_ATOMIC_INIT(dns_udp_global_tx_cnt);
+    StatsRegisterGlobalCounter("app-layer.dns_udp", DNSUDPGetGlobalTxCnt);
+}
+
 /** \internal
  *  \brief Parse DNS request packet
  */
@@ -362,6 +381,34 @@ static void DNSUDPConfigure(void)
     DNSConfigSetGlobalMemcap(global_memcap);
 }
 
+static void DNSUDPStateFree(void *s)
+{
+    SCEnter();
+    if (s) {
+        DNSState *dns_state = (DNSState *) s;
+
+        DNSTransaction *tx = NULL;
+        while ((tx = TAILQ_FIRST(&dns_state->tx_list))) {
+            TAILQ_REMOVE(&dns_state->tx_list, tx, next);
+            DNSTransactionFree(tx, dns_state);
+            DNSUDPSetGlobalTxCounter();
+        }
+
+        if (dns_state->buffer != NULL) {
+            DNSDecrMemcap(0xffff, dns_state); /** TODO update if/once we alloc
+                                               *  in a smarter way */
+            SCFree(dns_state->buffer);
+        }
+
+        BUG_ON(dns_state->tx_with_detect_state_cnt > 0);
+
+        DNSDecrMemcap(sizeof(DNSState), dns_state);
+        BUG_ON(dns_state->memuse > 0);
+        SCFree(s);
+    }
+    SCReturn;
+}
+
 void RegisterDNSUDPParsers(void)
 {
     char *proto_name = "dns";
@@ -404,7 +451,7 @@ void RegisterDNSUDPParsers(void)
         AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_DNS, STREAM_TOCLIENT,
                                      DNSUDPResponseParse);
         AppLayerParserRegisterStateFuncs(IPPROTO_UDP, ALPROTO_DNS, DNSStateAlloc,
-                                         DNSStateFree);
+                                         DNSUDPStateFree);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_UDP, ALPROTO_DNS,
                                          DNSStateTransactionFree);
 
@@ -426,6 +473,7 @@ void RegisterDNSUDPParsers(void)
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);
 
         DNSUDPConfigure();
+        DNSUDPRegisterGlobalTxCounter();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -91,6 +91,8 @@ static uint64_t htp_state_memuse = 0;
 static uint64_t htp_state_memcnt = 0;
 #endif
 
+SC_ATOMIC_DECLARE(uint64_t, htp_global_tx_cnt);
+
 SCEnumCharMap http_decoder_event_table[ ] = {
     { "UNKNOWN_ERROR",
         HTTP_DECODER_EVENT_UNKNOWN_ERROR},
@@ -231,6 +233,23 @@ static int HTPLookupPersonality(const char *str)
     }
 
     return -1;
+}
+
+/* global counter functions */
+static inline void HTPSetGlobalTxCounter(void)
+{
+    SC_ATOMIC_ADD(htp_global_tx_cnt, 1);
+}
+
+static inline uint64_t HTPGetGlobalTxCnt(void)
+{
+    return SC_ATOMIC_GET(htp_global_tx_cnt);
+}
+
+static void HTPRegisterGlobalTxCounter(void)
+{
+    SC_ATOMIC_INIT(htp_global_tx_cnt);
+    StatsRegisterGlobalCounter("app-layer.http", HTPGetGlobalTxCnt);
 }
 
 void HTPSetEvent(HtpState *s, HtpTxUserData *htud, uint8_t e)
@@ -417,6 +436,7 @@ static void HTPStateTransactionFree(void *state, uint64_t id)
             tx->response_progress = HTP_RESPONSE_COMPLETE;
         }
         htp_tx_destroy(tx);
+        HTPSetGlobalTxCounter();
     }
 }
 
@@ -2753,7 +2773,6 @@ static int HTPRegisterPatternsForProtocolDetection(void)
 void RegisterHTPParsers(void)
 {
     SCEnter();
-
     char *proto_name = "http";
 
     /** HTTP */
@@ -2792,6 +2811,7 @@ void RegisterHTPParsers(void)
         SC_ATOMIC_INIT(htp_config_flags);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_HTTP, STREAM_TOSERVER);
         HTPConfigure();
+        HTPRegisterGlobalTxCounter();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);


### PR DESCRIPTION
This adds adds the number of application layer transactions handled
by the supported protocols.

In some application layer, like ssh, we don't have a transaction,
so we count the number of the states.

The output added in EVE will be:
"app-layer": { "http": 234, "stmp": 12, "ssh": 22, "dns": 2000 }

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1657
Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/92
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/91