### PR TITLE
Per direction logging  - v3

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -1139,3 +1139,27 @@ void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size)
             snprintf(str, str_size, "%04x/%u", rcode, rcode);
     }
 }
+
+int DNSGetTxIsLogged(void *tx, uint8_t direction)
+{
+    DNSTransaction *dnstx = tx;
+    if (direction & STREAM_TOSERVER) {
+        return dnstx->request_logged;
+    }
+    else if (direction & STREAM_TOCLIENT) {
+        return dnstx->response_logged;
+    }
+    return 0;
+}
+
+void DNSSetTxIsLogged(void *tx, uint8_t direction)
+{
+    DNSTransaction *dnstx = tx;
+
+    if (direction & STREAM_TOSERVER) {
+        dnstx->request_logged = 1;
+    }
+    if (direction & STREAM_TOCLIENT) {
+        dnstx->response_logged = 1;
+    }
+}

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -172,6 +172,8 @@ typedef struct DNSTransaction_ {
 
     TAILQ_ENTRY(DNSTransaction_) next;
     DetectEngineState *de_state;
+    uint8_t request_logged;
+    uint8_t response_logged;
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */
@@ -235,6 +237,9 @@ void *DNSStateAlloc(void);
 void DNSStateFree(void *s);
 AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id);
 int DNSHasEvents(void *state);
+
+int DNSGetTxIsLogged(void *vtx, uint8_t direction);
+void DNSSetTxIsLogged(void *vtx, uint8_t direction);
 
 int DNSValidateRequestHeader(DNSState *, const DNSHeader *dns_header);
 int DNSValidateResponseHeader(DNSState *, const DNSHeader *dns_header);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -667,6 +667,9 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
+
+        AppLayerParserRegisterTxLogStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
+            DNSGetTxIsLogged, DNSSetTxIsLogged);
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -425,6 +425,9 @@ void RegisterDNSUDPParsers(void)
 
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);
 
+        AppLayerParserRegisterTxLogStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
+            DNSGetTxIsLogged, DNSSetTxIsLogged);
+
         DNSUDPConfigure();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -111,6 +111,9 @@ typedef struct AppLayerParserProtoCtx_
     DetectEngineState *(*GetTxDetectState)(void *tx);
     int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *);
 
+    int (*GetTxIsLogged)(void *tx, uint8_t direction);
+    void (*SetTxIsLogged)(void *tx, uint8_t direction);
+
     /* Indicates the direction the parser is ready to see the data
      * the first time for a flow.  Values accepted -
      * STREAM_TOSERVER, STREAM_TOCLIENT */
@@ -487,6 +490,20 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
+void AppLayerParserRegisterTxLogStateFuncs(uint8_t ipproto, AppProto alproto,
+    int (*GetTxIsLogged)(void *tx, uint8_t direction),
+    void (*SetTxIsLogged)(void *tx, uint8_t direction))
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].GetTxIsLogged =
+        GetTxIsLogged;
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetTxIsLogged =
+        SetTxIsLogged;
+
+    SCReturn;
+}
+
 /***** Get and transaction functions *****/
 
 void *AppLayerParserGetProtocolParserLocalStorage(uint8_t ipproto, AppProto alproto)
@@ -847,6 +864,32 @@ int AppLayerParserSetTxDetectState(uint8_t ipproto, AppProto alproto,
         SCReturnInt(-EBUSY);
     r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetTxDetectState(alstate, tx, s);
     SCReturnInt(r);
+}
+
+int AppLayerParserSupportsTxLogState(uint8_t ipproto, AppProto alproto)
+{
+    if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].GetTxIsLogged != NULL)
+        return TRUE;
+    return FALSE;
+}
+
+int AppLayerParserGetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx,
+    uint8_t direction)
+{
+    SCEnter();
+    int r;
+    r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].GetTxIsLogged(tx,
+        direction);
+    SCReturnInt(r);
+}
+
+void AppLayerParserSetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx,
+    uint8_t direction)
+{
+    SCEnter();
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetTxIsLogged(tx,
+        direction);
+    SCReturn;
 }
 
 /***** General *****/

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -146,6 +146,9 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+void AppLayerParserRegisterTxLogStateFuncs(uint8_t ipproto, AppProto alproto,
+    int (*GetTxIsLogged)(void *tx, uint8_t direction),
+    void (*SetTxIsLogged)(void *tx, uint8_t direction));
 
 /***** Get and transaction functions *****/
 
@@ -184,6 +187,9 @@ int AppLayerParserSupportsTxDetectState(uint8_t ipproto, AppProto alproto);
 int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
 DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);
 int AppLayerParserSetTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate, void *tx, DetectEngineState *s);
+int AppLayerParserSupportsTxLogState(uint8_t ipproto, AppProto alproto);
+int AppLayerParserGetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx, uint8_t direction);
+void AppLayerParserSetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx, uint8_t direction);
 
 /***** General *****/
 

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -166,7 +166,7 @@ static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *ds
 }
 
 static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p, Flow *f,
-    void *state, void *tx, uint64_t tx_id)
+    uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     LogDnsLogThread *aft = (LogDnsLogThread *)data;
     DNSTransaction *dns_tx = (DNSTransaction *)tx;

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -61,7 +61,7 @@ TmEcode LogHttpLogThreadDeinit(ThreadVars *, void *);
 void LogHttpLogExitPrintStats(ThreadVars *, void *);
 static void LogHttpLogDeInitCtx(OutputCtx *);
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 void TmModuleLogHttpLogRegister (void)
 {
@@ -515,7 +515,7 @@ end:
 
 }
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -250,7 +250,7 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
 
 }
 
-static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -258,24 +258,28 @@ static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
     DNSTransaction *tx = txptr;
     json_t *js;
 
-    DNSQueryEntry *query = NULL;
-    TAILQ_FOREACH(query, &tx->query_list, next) {
-        js = CreateJSONHeader((Packet *)p, 1, "dns");
+    if (flags & STREAM_TOSERVER) {
+        DNSQueryEntry *query = NULL;
+        TAILQ_FOREACH(query, &tx->query_list, next) {
+            js = CreateJSONHeader((Packet *)p, 1, "dns");
+            if (unlikely(js == NULL))
+                return TM_ECODE_OK;
+
+            LogQuery(td, js, tx, tx_id, query);
+
+            json_decref(js);
+        }
+    }
+
+    if (flags & STREAM_TOCLIENT) {
+        js = CreateJSONHeader((Packet *)p, 0, "dns");
         if (unlikely(js == NULL))
             return TM_ECODE_OK;
 
-        LogQuery(td, js, tx, tx_id, query);
+        LogAnswers(td, js, tx, tx_id);
 
         json_decref(js);
     }
-
-    js = CreateJSONHeader((Packet *)p, 0, "dns");
-    if (unlikely(js == NULL))
-        return TM_ECODE_OK;
-
-    LogAnswers(td, js, tx, tx_id);
-
-    json_decref(js);
 
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -365,7 +365,7 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, ui
     json_object_set_new(js, "http", hjs);
 }
 
-static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -83,7 +83,7 @@ static json_t *JsonSmtpDataLogger(const Flow *f, void *state, void *vtx, uint64_
     return sjs;
 }
 
-static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -53,7 +53,7 @@ typedef struct LogTemplateLogThread_ {
 } LogTemplateLogThread;
 
 static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
-    const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+    const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     TemplateTransaction *templatetx = tx;
     LogTemplateLogThread *thread = thread_data;

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -91,7 +91,7 @@ typedef struct LogLuaThreadCtx_ {
  *
  * NOTE: The flow (f) also referenced by p->flow is locked.
  */
-static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -118,17 +118,23 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
     }
 
     uint64_t total_txs = AppLayerParserGetTxCnt(p->proto, alproto, alstate);
-    uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
+    uint64_t min_tx_id = AppLayerParserGetTransactionLogId(f->alparser);
     int tx_progress_done_value_ts =
         AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
                                                        STREAM_TOSERVER);
     int tx_progress_done_value_tc =
         AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
                                                        STREAM_TOCLIENT);
-    int proto_logged = 0;
 
-    for (; tx_id < total_txs; tx_id++)
+    for (uint64_t tx_id = min_tx_id; tx_id < total_txs; tx_id++)
     {
+        int tx_progress;
+        int ts_ready = 0;
+        int tc_ready = 0;
+        int ts_logged = 0;
+        int tc_logged = 0;
+        int tx_log_done = 0;
+
         void *tx = AppLayerParserGetTx(p->proto, alproto, alstate, tx_id);
         if (tx == NULL) {
             SCLogDebug("tx is NULL not logging");
@@ -137,19 +143,21 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
 
         if (!(AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)))
         {
-            int tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                             tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
-            if (tx_progress < tx_progress_done_value_ts) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
-            }
+                tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
+                    tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
+                if (tx_progress == tx_progress_done_value_ts) {
+                    ts_ready = 1;
+                }
+                tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
+                    tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
+                if (tx_progress == tx_progress_done_value_tc) {
+                    tc_ready = 1;
+                }
+        }
 
-            tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                         tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
-            if (tx_progress < tx_progress_done_value_tc) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
-            }
+        if (!(ts_ready || tc_ready)) {
+            SCLogNotice("progress not for enough, not logging");
+            break;
         }
 
         // call each logger here (pseudo code)
@@ -157,16 +165,55 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
         store = op_thread_data->store;
         while (logger && store) {
             BUG_ON(logger->LogFunc == NULL);
-
             SCLogDebug("logger %p", logger);
-            if (logger->alproto == alproto) {
-                SCLogDebug("alproto match, logging tx_id %ju", tx_id);
+
+            if (logger->alproto != alproto) {
+                goto next;
+            }
+            SCLogDebug("alproto match, logging tx_id %ju", tx_id);
+
+            if (AppLayerParserSupportsTxLogState(p->proto, alproto)) {
+                ts_logged = AppLayerParserGetTxIsLogged(p->proto,
+                    alproto, tx, STREAM_TOSERVER);
+                tc_logged = AppLayerParserGetTxIsLogged(p->proto,
+                    alproto, tx, STREAM_TOCLIENT);
                 PACKET_PROFILING_TMM_START(p, logger->module_id);
-                logger->LogFunc(tv, store->thread_data, p, f, alstate, tx, tx_id);
+                if (ts_ready && !ts_logged) {
+                    logger->LogFunc(tv, store->thread_data, p, f,
+                        STREAM_TOSERVER, alstate, tx, tx_id);
+                    AppLayerParserSetTxIsLogged(p->proto, alproto, tx,
+                        STREAM_TOSERVER);
+                    ts_logged = 1;
+                }
+                if (tc_ready && !tc_logged) {
+                    logger->LogFunc(tv, store->thread_data, p, f,
+                        STREAM_TOCLIENT, alstate, tx, tx_id);
+                    AppLayerParserSetTxIsLogged(p->proto, alproto, tx,
+                        STREAM_TOCLIENT);
+                    tc_logged = 1;
+                }
                 PACKET_PROFILING_TMM_END(p, logger->module_id);
-                proto_logged = 1;
+                if (ts_logged && tc_logged && tx_id == min_tx_id) {
+                    tx_log_done = 1;
+                }
+            }
+            else if (ts_ready && tc_ready) {
+                PACKET_PROFILING_TMM_START(p, logger->module_id);
+                logger->LogFunc(tv, store->thread_data, p, f,
+                    STREAM_TOSERVER | STREAM_TOCLIENT, alstate, tx, tx_id);
+                ts_logged = tc_logged = 1;
+                tx_log_done = 1;
+                PACKET_PROFILING_TMM_END(p, logger->module_id);
             }
 
+            /* If neither direction was logged don't move onto to the
+             * next transaction. Prevents the log_id tracker from
+             * getting out of sync with whats actually been logged. */
+            if (!(ts_logged || tc_logged)) {
+                goto end;
+            }
+
+        next:
             logger = logger->next;
             store = store->next;
 
@@ -174,10 +221,10 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
             BUG_ON(logger != NULL && store == NULL);
         }
 
-        if (proto_logged) {
-            SCLogDebug("updating log tx_id %ju", tx_id);
+        if (tx_log_done) {
             AppLayerParserSetTransactionLogId(f->alparser);
         }
+
     }
 
 end:

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -29,7 +29,7 @@
 #include "decode.h"
 
 /** packet logger function pointer type */
-typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged


### PR DESCRIPTION
Another cut on per-direction logging based on feedback on the previous PRs: #1794, #1795.

Where per direction logging is required, the app-layer must now maintain some logging state. This state is not required if per-direction logging is not required, and is how existing loggers are handled.

The second commit converts DNS to per-direction logging and sees the following improvements:
- correct request timestamps
- correct ordering

Prscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/175
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/177
