### PR TITLE
coccinelle: fix typo for strchrnul

### DIFF
--- a/qa/coccinelle/banned-functions.cocci
+++ b/qa/coccinelle/banned-functions.cocci
@@ -3,7 +3,7 @@ identifier i;
 position p1;
 @@
 
-\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strndup@i\|strchrdup@i\)(...)@p1
+\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strndup@i\|strchrnul@i\)(...)@p1
 
 @script:python@
 p1 << banned.p1;


### PR DESCRIPTION
This fixes a small typo within coccinelle banned functions