### PR TITLE
Magic mgc loadfix 2

### DIFF
--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -329,6 +329,10 @@ static void *DetectFilemagicThreadInit(void *data)
             // check if filename is missing .mgc and try adding .mgc
             if(strncmp(filename + strlen(filename) - strlen(".mgc"), ".mgc", strlen(".mgc"))) {
                 filename_mgc = SCMalloc((strlen(filename) + strlen(".mgc") + 1));
+                if (unlikely(filename_mgc == NULL)) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for magic file check");
+                    goto error;
+                }
                 strlcpy(filename_mgc, filename, strlen(filename) + 1);
                 strlcat(filename_mgc, ".mgc", strlen(filename) + strlen(".mgc") + 1);
                 if ( (fd = fopen(filename_mgc, "r")) == NULL) {

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -46,6 +46,7 @@ int MagicInit(void)
     SCEnter();
 
     char *filename = NULL;
+    char *filename_mgc = NULL;
     FILE *fd = NULL;
 
     SCMutexInit(&g_magic_lock, NULL);
@@ -62,8 +63,21 @@ int MagicInit(void)
         SCLogInfo("using magic-file %s", filename);
 
         if ( (fd = fopen(filename, "r")) == NULL) {
-            SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
-            goto error;
+            // check if filename is missing .mgc and try adding .mgc
+            if(strncmp(filename + strlen(filename) - strlen(".mgc"), ".mgc", strlen(".mgc"))) {
+                filename_mgc = SCMalloc((strlen(filename) + strlen(".mgc") + 1));
+                strlcpy(filename_mgc, filename, strlen(filename) + 1);
+                strlcat(filename_mgc, ".mgc", strlen(filename) + strlen(".mgc") + 1);
+                if ( (fd = fopen(filename_mgc, "r")) == NULL) {
+                    SCLogWarning(SC_ERR_FOPEN, "Error opening file with additional mgc: \"%s\": %s", filename_mgc, strerror(errno));
+                    SCFree(filename_mgc);
+                    goto error;
+                }
+                SCFree(filename_mgc);
+            } else {
+                SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
+                goto error;
+            }
         }
         fclose(fd);
     }

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -66,6 +66,10 @@ int MagicInit(void)
             // check if filename is missing .mgc and try adding .mgc
             if(strncmp(filename + strlen(filename) - strlen(".mgc"), ".mgc", strlen(".mgc"))) {
                 filename_mgc = SCMalloc((strlen(filename) + strlen(".mgc") + 1));
+                if (unlikely(filename_mgc == NULL)) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate memory for magic file check");
+                    goto error;
+                }
                 strlcpy(filename_mgc, filename, strlen(filename) + 1);
                 strlcat(filename_mgc, ".mgc", strlen(filename) + strlen(".mgc") + 1);
                 if ( (fd = fopen(filename_mgc, "r")) == NULL) {


### PR DESCRIPTION
This fixes the Issue 873 as it copies the way magic_load checks for the .mgc file (by adding .mgc itself if the file is without .mgc in the config).

- Issue: https://redmine.openinfosecfoundation.org/issues/873
- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/4
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/4
