### PR TITLE
detect: denote the max detection list; fix issue 1674.

### DIFF
--- a/src/detect-base64-data.c
+++ b/src/detect-base64-data.c
@@ -186,6 +186,10 @@ end:
     return retval;
 }
 
+/**
+ * Test that the rule fails to load if the detection list is changed
+ * after base64_data.
+ */
 static int DetectBase64DataSetupTest03(void)
 {
     DetectEngineCtx *de_ctx = NULL;
@@ -221,6 +225,38 @@ end:
     return retval;
 }
 
+/**
+ * Test that the list can be changed to post-detection lists after the
+ * base64 keyword.
+ */
+static int DetectBase64DataSetupTest04(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+    int retval = 0;
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->sig_list = SigInit(de_ctx,
+        "alert tcp any any -> any any (msg:\"some b64thing\"; flow:established,from_server; file_data; content:\"sometext\"; fast_pattern; base64_decode:relative; base64_data; content:\"foobar\"; nocase; tag:session,120,seconds; sid:1111111; rev:1;)");
+    if (de_ctx->sig_list == NULL) {
+        printf("SigInit failed: ");
+        goto end;
+    }
+
+    retval = 1;
+end:
+    if (de_ctx != NULL) {
+        SigGroupCleanup(de_ctx);
+        SigCleanSignatures(de_ctx);
+        DetectEngineCtxFree(de_ctx);
+    }
+    return retval;
+}
+
 #endif
 
 static void DetectBase64DataRegisterTests(void)
@@ -231,6 +267,8 @@ static void DetectBase64DataRegisterTests(void)
     UtRegisterTest("DetectBase64DataSetupTest02", DetectBase64DataSetupTest02,
         1);
     UtRegisterTest("DetectBase64DataSetupTest03", DetectBase64DataSetupTest03,
+        1);
+    UtRegisterTest("DetectBase64DataSetupTest04", DetectBase64DataSetupTest04,
         1);
 #endif /* UNITTESTS */
 }

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1320,9 +1320,8 @@ int SigValidate(DetectEngineCtx *de_ctx, Signature *s)
     }
 
     if (s->sm_lists[DETECT_SM_LIST_BASE64_DATA] != NULL) {
-        int list;
         uint16_t idx = s->sm_lists[DETECT_SM_LIST_BASE64_DATA]->idx;
-        for (list = 0; list < DETECT_SM_LIST_MAX; list++) {
+        for (int list = 0; list < DETECT_SM_LIST_DETECT_MAX; list++) {
             if (list != DETECT_SM_LIST_BASE64_DATA &&
                 s->sm_lists[list] != NULL) {
                 if (s->sm_lists[list]->idx > idx) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -116,7 +116,6 @@ enum DetectSigmatchListEnum {
 
     DETECT_SM_LIST_AMATCH,
     DETECT_SM_LIST_DMATCH,
-    DETECT_SM_LIST_TMATCH,
 
     DETECT_SM_LIST_FILEMATCH,
 
@@ -130,8 +129,14 @@ enum DetectSigmatchListEnum {
 
     DETECT_SM_LIST_TEMPLATE_BUFFER_MATCH,
 
+    /* Demarcation between detection and post-detection lists. All
+     * detection lists must come before this. */
+    DETECT_SM_LIST_DETECT_MAX,
+
     /* list for post match actions: flowbit set, flowint increment, etc */
     DETECT_SM_LIST_POSTMATCH,
+
+    DETECT_SM_LIST_TMATCH, /**< post-detection tagging */
 
     /* lists for alert thresholding and suppression */
     DETECT_SM_LIST_SUPPRESS,


### PR DESCRIPTION
Possible solution for Redmine issue 1674.

Denotes the max detection list so that rule validation can
allow post-detection lists to come after base64_data, but
disallow detection lists to come after it.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1674

Buildbot appears to be down.