### PR TITLE
file-magic: improve libmagic handling on *nix systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,8 @@
     fi
     echo -n "installation for $host OS... "
 
-    e_magic_file="/usr/share/file/magic"
+    e_magic_file=""
+    e_magic_file_comment="#"
     case "$host" in
         *-*-*freebsd*)
             LUA_PC_NAME="lua-5.1"
@@ -216,14 +217,12 @@
             CFLAGS="${CFLAGS} -DOS_FREEBSD"
             CPPFLAGS="${CPPFLAGS} -I/usr/local/include -I/usr/local/include/libnet11"
             LDFLAGS="${LDFLAGS} -L/usr/local/lib -L/usr/local/lib/libnet11"
-            e_magic_file="/usr/share/misc/magic"
             ;;
         *-*-openbsd*)
             LUA_PC_NAME="lua51"
             CFLAGS="${CFLAGS} -D__OpenBSD__"
             CPPFLAGS="${CPPFLAGS} -I/usr/local/include -I/usr/local/include/libnet-1.1"
             LDFLAGS="${LDFLAGS} -L/usr/local/lib -I/usr/local/lib/libnet-1.1"
-            e_magic_file="/usr/local/share/misc/magic.mgc"
             ;;
         *darwin*|*Darwin*)
             LUA_PC_NAME="lua-5.1"
@@ -1803,6 +1802,7 @@ if test "$WINDOWS_PATH" = "yes"; then
   e_sysconfdir="$e_winbase\\\\"
   e_sysconfrulesdir="$e_winbase\\\\rules\\\\"
   e_magic_file="$e_winbase\\\\magic.mgc"
+  e_magic_file_comment=""
   e_logdir="$e_winbase\\\\log"
   e_logfilesdir="$e_logdir\\\\files"
   e_logcertsdir="$e_logdir\\\\certs"
@@ -1824,6 +1824,7 @@ AC_SUBST(e_sysconfrulesdir)
 AC_SUBST(e_localstatedir)
 AC_DEFINE_UNQUOTED([CONFIG_DIR],["$e_sysconfdir"],[Our CONFIG_DIR])
 AC_SUBST(e_magic_file)
+AC_SUBST(e_magic_file_comment)
 
 EXPAND_VARIABLE(prefix, CONFIGURE_PREFIX)
 EXPAND_VARIABLE(sysconfdir, CONFIGURE_SYSCONDIR)

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -322,13 +322,20 @@ static void *DetectFilemagicThreadInit(void *data)
 
     (void)ConfGet("magic-file", &filename);
     if (filename != NULL) {
-        SCLogInfo("using magic-file %s", filename);
-
-        if ( (fd = fopen(filename, "r")) == NULL) {
-            SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
-            goto error;
+        if (strncmp(filename,"",strlen(filename)) == 0) {
+            // set filename to NULL on *nix systems so magic_load uses system default path (see man libmagic)
+            SCLogInfo("using system default magic-file");
+            filename = NULL;
         }
-        fclose(fd);
+        else {
+            SCLogInfo("using magic-file %s", filename);
+
+            if ( (fd = fopen(filename, "r")) == NULL) {
+                SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
+                goto error;
+            }
+            fclose(fd);
+        }
     }
 
     if (magic_load(t->ctx, filename) != 0) {

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -58,14 +58,23 @@ int MagicInit(void)
     }
 
     (void)ConfGet("magic-file", &filename);
-    if (filename != NULL) {
-        SCLogInfo("using magic-file %s", filename);
 
-        if ( (fd = fopen(filename, "r")) == NULL) {
-            SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
-            goto error;
+
+    if (filename != NULL) {
+        if (strncmp(filename,"",strlen(filename)) == 0) {
+            // set filename to NULL on *nix systems so magic_load uses system default path (see man libmagic)
+            SCLogInfo("using system default magic-file");
+            filename = NULL;
         }
-        fclose(fd);
+        else {
+            SCLogInfo("using magic-file %s", filename);
+
+            if ( (fd = fopen(filename, "r")) == NULL) {
+                SCLogWarning(SC_ERR_FOPEN, "Error opening file: \"%s\": %s", filename, strerror(errno));
+                goto error;
+            }
+            fclose(fd);
+        }
     }
 
     if (magic_load(g_magic_ctx, filename) != 0) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -395,7 +395,7 @@ outputs:
 
 # Magic file. The extension .mgc is added to the value here.
 #magic-file: /usr/share/file/magic
-magic-file: @e_magic_file@
+@e_magic_file_comment@magic-file: @e_magic_file@
 
 # When running in NFQ inline mode, it is possible to use a simulated
 # non-terminal NFQUEUE verdict.


### PR DESCRIPTION
This fixes https://redmine.openinfosecfoundation.org/issues/873 without changing the code too much.
So for *nix systems we can skip setting magic-file since it will load the system default which might differ between distributions and libmagic (file) package versions. We just need to set it properly on Windows.

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/5
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/5