### PR TITLE
asn1: fix memory leak

### DIFF
--- a/src/util-decode-asn1.c
+++ b/src/util-decode-asn1.c
@@ -373,13 +373,15 @@ void SCAsn1CtxDestroy(Asn1Ctx *ac)
     if (ac == NULL)
         return;
 
-    uint16_t i = 0;
-    for (; i < ac->cur_frame; i++) {
+    for (uint16_t i = 0; i < asn1_max_frames_config; i++) {
         Asn1Node *node = ASN1CTX_GET_NODE(ac, i);
-        if (node !=  NULL) {
-            SCFree(node);
+        if (node == NULL) {
+            break;
         }
+        SCFree(node);
     }
+
+    SCFree(ac->asn1_stack);
     SCFree(ac);
 }
 


### PR DESCRIPTION
As reported in issue #1395, fix 2 memory leaks when destroying
asn.1 decode contexts.

Fix of memory links confirmed with ASAN output.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/181
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/183
