### PR TITLE
In configuration test mode, check signatures if 'delayed-detect' is enabled

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2304,7 +2304,8 @@ int main(int argc, char **argv)
                     "detection engine contexts failed.");
             exit(EXIT_FAILURE);
         }
-        if (suri.delayed_detect || (mt_enabled && !default_tenant)) {
+        if ((suri.delayed_detect || (mt_enabled && !default_tenant)) &&
+            (suri.run_mode != RUNMODE_CONF_TEST)) {
             de_ctx = DetectEngineCtxInitMinimal();
         } else {
             de_ctx = DetectEngineCtxInit();


### PR DESCRIPTION
When 'detection-engine.delayed-detect' option was set to 'yes', suricata didn't check signatures validity in configuration test mode. IMHO, it looks like a bug.