### PR TITLE
Fix install permissions for configuration files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,11 +15,11 @@ install-data-am:
 install-full: install install-conf install-rules
 
 install-conf:
-	install -d "$(DESTDIR)$(e_sysconfdir)"
-	@test -e "$(DESTDIR)$(e_sysconfdir)/suricata.yaml" || install -m 600 "$(top_srcdir)/suricata.yaml" "$(DESTDIR)$(e_sysconfdir)"
-	@test -e "$(DESTDIR)$(e_sysconfdir)/classification.config" || install -m 600 "$(top_srcdir)/classification.config" "$(DESTDIR)$(e_sysconfdir)"
-	@test -e "$(DESTDIR)$(e_sysconfdir)/reference.config" || install -m 600 "$(top_srcdir)/reference.config" "$(DESTDIR)$(e_sysconfdir)"
-	@test -e "$(DESTDIR)$(e_sysconfdir)/threshold.config" || install -m 600 "$(top_srcdir)/threshold.config" "$(DESTDIR)$(e_sysconfdir)"
+	install -m 755 -d "$(DESTDIR)$(e_sysconfdir)"
+	@test -e "$(DESTDIR)$(e_sysconfdir)/suricata.yaml" || install -m 644 "$(top_srcdir)/suricata.yaml" "$(DESTDIR)$(e_sysconfdir)"
+	@test -e "$(DESTDIR)$(e_sysconfdir)/classification.config" || install -m 644 "$(top_srcdir)/classification.config" "$(DESTDIR)$(e_sysconfdir)"
+	@test -e "$(DESTDIR)$(e_sysconfdir)/reference.config" || install -m 644 "$(top_srcdir)/reference.config" "$(DESTDIR)$(e_sysconfdir)"
+	@test -e "$(DESTDIR)$(e_sysconfdir)/threshold.config" || install -m 644 "$(top_srcdir)/threshold.config" "$(DESTDIR)$(e_sysconfdir)"
 	install -d "$(DESTDIR)$(e_logfilesdir)"
 	install -d "$(DESTDIR)$(e_logcertsdir)"
 	install -d "$(DESTDIR)$(e_rundir)"
@@ -36,12 +36,12 @@ endif
 else
 	@echo "UNABLE to load ruleset wget or curl are not installed on system."
 endif
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)decoder-events.rules" || install -m 600 "$(top_srcdir)/rules/decoder-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)stream-events.rules" || install -m 600 "$(top_srcdir)/rules/stream-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)smtp-events.rules" || install -m 600 "$(top_srcdir)/rules/smtp-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)http-events.rules" || install -m 600 "$(top_srcdir)/rules/http-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)dns-events.rules" || install -m 600 "$(top_srcdir)/rules/dns-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
-	@test -e "$(DESTDIR)$(e_sysconfrulesdir)modbus-events.rules" || install -m 600 "$(top_srcdir)/rules/modbus-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)decoder-events.rules" || install -m 644 "$(top_srcdir)/rules/decoder-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)stream-events.rules" || install -m 644 "$(top_srcdir)/rules/stream-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)smtp-events.rules" || install -m 644 "$(top_srcdir)/rules/smtp-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)http-events.rules" || install -m 644 "$(top_srcdir)/rules/http-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)dns-events.rules" || install -m 644 "$(top_srcdir)/rules/dns-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
+	@test -e "$(DESTDIR)$(e_sysconfrulesdir)modbus-events.rules" || install -m 644 "$(top_srcdir)/rules/modbus-events.rules" "$(DESTDIR)$(e_sysconfrulesdir)"
 	@echo ""
 	@echo "You can now start suricata by running as root something like '$(DESTDIR)$(bindir)/suricata -c $(DESTDIR)$(e_sysconfdir)/suricata.yaml -i eth0'."
 	@echo ""


### PR DESCRIPTION
When suricata runs under non-root account with 'delayed-detect' enabled,
it can not load signatures properly due to insufficient access rights.
With disabled 'delayed-detect' everything works fine because privileges
are dropped after signatures loading.

So let's change configuration dir/files access rights a bit.