### PR TITLE
fix nfq_get_timestamp

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -473,7 +473,7 @@ int NFQSetupPkt (Packet *p, struct nfq_q_handle *qh, void *data)
     }
 
     ret = nfq_get_timestamp(tb, &p->ts);
-    if (ret != 0) {
+    if (ret != 0 || p->ts.tv_sec == 0) {
         memset (&p->ts, 0, sizeof(struct timeval));
         gettimeofday(&p->ts, NULL);
     }


### PR DESCRIPTION
Handle case when nfq_get_timestamp returns 0 for success, but timestamp is empty.