### PR TITLE
json: fix missing includes in disable unix socket case

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -69,6 +69,7 @@
 #define MODULE_NAME "JsonAlertLog"
 
 #ifdef HAVE_LIBJANSSON
+#include <jansson.h>
 
 #define LOG_JSON_PAYLOAD 1
 #define LOG_JSON_PACKET 2

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -29,6 +29,7 @@
 
 void TmModuleJsonAlertLogRegister (void);
 #ifdef HAVE_LIBJANSSON
+#include <jansson.h>
 void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js);
 #endif /* HAVE_LIBJANSSON */
 

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -27,6 +27,7 @@
 void TmModuleJsonHttpLogRegister (void);
 
 #ifdef HAVE_LIBJANSSON
+#include <jansson.h>
 void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx);
 void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx);
 json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id);

--- a/src/output-json-smtp.h
+++ b/src/output-json-smtp.h
@@ -26,6 +26,7 @@
 
 void TmModuleJsonSmtpLogRegister (void);
 #ifdef HAVE_LIBJANSSON
+#include <jansson.h>
 json_t *JsonSMTPAddMetadata(const Flow *f, uint64_t tx_id);
 #endif
 

--- a/src/output-json-ssh.h
+++ b/src/output-json-ssh.h
@@ -28,6 +28,7 @@ void TmModuleJsonSshLogRegister (void);
 
 #ifdef HAVE_LIBJANSSON
 #include "app-layer-ssh.h"
+#include <jansson.h>
 
 void JsonSshLogJSON(json_t *js, SshState *tx);
 #endif

--- a/src/output-json-tls.h
+++ b/src/output-json-tls.h
@@ -28,6 +28,7 @@ void TmModuleJsonTlsLogRegister (void);
 
 #ifdef HAVE_LIBJANSSON
 #include "app-layer-ssl.h"
+#include <jansson.h>
 
 void JsonTlsLogJSONBasic(json_t *js, SSLState *ssl_state);
 void JsonTlsLogJSONExtended(json_t *js, SSLState *ssl_state);

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -28,6 +28,7 @@ void TmModuleOutputJsonRegister (void);
 
 #ifdef HAVE_LIBJANSSON
 
+#include <jansson.h>
 #include "suricata-common.h"
 #include "util-buffer.h"
 #include "util-logopenfile.h"

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -189,6 +189,7 @@ static inline void SCLogPrintToSyslog(int syslog_log_level, const char *msg)
 }
 
 #ifdef HAVE_LIBJANSSON
+#include <jansson.h>
 /**
  */
 int SCLogMessageJSON(struct timeval *tval, char *buffer, size_t buffer_size,


### PR DESCRIPTION
This PR fixes Issue 1641 (https://redmine.openinfosecfoundation.org/issues/1641) by adding the necessary includes.

Buildbot:
- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/9
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/9