### PR TITLE
detect-tls-version: fix small resource leak

### DIFF
--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -201,6 +201,7 @@ DetectTlsVersionData *DetectTlsVersionParse (char *str)
             temp = TLS_VERSION_12;
         } else {
             SCLogError(SC_ERR_INVALID_VALUE, "Invalid value");
+            SCFree(orig);
             goto error;
         }
 


### PR DESCRIPTION
That fixes the leak from https://redmine.openinfosecfoundation.org/issues/1166 as in this case we jump into error and skip the SCFree(orig) which should still be called as orig was != NULL.

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/10
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/10