### PR TITLE
Mixed mode v7

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -147,7 +147,7 @@ int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)
         }
 
         char *action = "";
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-syslog.c
+++ b/src/alert-syslog.c
@@ -220,7 +220,7 @@ static TmEcode AlertSyslogIPv4(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -278,7 +278,7 @@ static TmEcode AlertSyslogIPv6(ThreadVars *tv, const Packet *p, void *data)
         PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
         PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";
@@ -340,7 +340,7 @@ static TmEcode AlertSyslogDecoderEvent(ThreadVars *tv, const Packet *p, void *da
             continue;
         }
 
-        if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "[Drop] ";
         } else if (pa->action & ACTION_DROP) {
             action = "[wDrop] ";

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -1410,8 +1410,8 @@ int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix)
     struct timeval ts;
     memset(&ts, 0x00, sizeof(struct timeval));
 
-    extern int run_mode;
-    if (run_mode == RUNMODE_UNITTEST)
+    extern RunModesList runmodeslist;
+    if (RunmodeGetPrimary(&runmodeslist) == RUNMODE_UNITTEST)
         TimeGet(&ts);
     else
         gettimeofday(&ts, NULL);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -176,7 +176,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                 TcpStream *opposing_stream = NULL;
                 if (stream == &ssn->client) {
                     opposing_stream = &ssn->server;
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOSERVER;
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     } else {
@@ -185,7 +185,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     }
                 } else {
                     opposing_stream = &ssn->client;
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOCLIENT;
                         p->flowflags |= FLOW_PKT_TOSERVER;
                     } else {
@@ -203,7 +203,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     ret = StreamTcpReassembleAppLayer(tv, ra_ctx, ssn,
                                                       opposing_stream, p);
                 if (stream == &ssn->client) {
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOCLIENT;
                         p->flowflags |= FLOW_PKT_TOSERVER;
                     } else {
@@ -211,7 +211,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     }
                 } else {
-                    if (StreamTcpInlineMode()) {
+                    if (StreamTcpInlineMode(p)) {
                         p->flowflags &= ~FLOW_PKT_TOSERVER;
                         p->flowflags |= FLOW_PKT_TOCLIENT;
                     } else {

--- a/src/decode.c
+++ b/src/decode.c
@@ -231,6 +231,16 @@ inline int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datale
     return 0;
 }
 
+int PacketModeIsIPS(const Packet *p)
+{
+    return (p->pkt_mode == PKT_MODE_IPS);
+}
+
+int PacketModeIsIDS(const Packet *p)
+{
+    return (p->pkt_mode == PKT_MODE_IDS);
+}
+
 /**
  *  \brief Copy data to Packet payload and set packet length
  *
@@ -275,6 +285,7 @@ Packet *PacketTunnelPktSetup(ThreadVars *tv, DecodeThreadVars *dtv, Packet *pare
     p->ts.tv_usec = parent->ts.tv_usec;
     p->datalink = DLT_RAW;
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
 
     /* set the root ptr to the lowest layer */
     if (parent->root != NULL)
@@ -345,8 +356,10 @@ Packet *PacketDefragPktSetup(Packet *parent, uint8_t *pkt, uint16_t len, uint8_t
     p->recursion_level = parent->recursion_level; /* NOT incremented */
     p->ts.tv_sec = parent->ts.tv_sec;
     p->ts.tv_usec = parent->ts.tv_usec;
-    p->datalink = DLT_RAW;
+    p->datalink = DLT_RAW; 
     p->tenant_id = parent->tenant_id;
+    p->pkt_mode = parent->pkt_mode;
+
     /* tell new packet it's part of a tunnel */
     SET_TUNNEL_PKT(p);
     p->vlan_id[0] = parent->vlan_id[0];

--- a/src/decode.h
+++ b/src/decode.h
@@ -351,6 +351,14 @@ typedef struct PktProfiling_ {
 /* forward declartion since Packet struct definition requires this */
 struct PacketQueue_;
 
+/*
+   since a pkt could come from different runmodes, we need to set
+   a mode to be able to do an action later.
+   (e.g. if a pkt come from NFQ, pkt_mode will be set to IPS and
+         it means that we'll be able to drop it.)
+*/
+enum PktMode {PKT_MODE_IDS, PKT_MODE_IPS, PKT_MODE_AUTO};
+
 /* sizes of the members:
  * src: 17 bytes
  * dst: 17 bytes
@@ -400,6 +408,8 @@ typedef struct Packet_
     struct Flow_ *flow;
 
     struct timeval ts;
+
+    enum PktMode pkt_mode;
 
     union {
         /* nfq stuff */
@@ -876,6 +886,8 @@ int PacketCallocExtPkt(Packet *p, int datalen);
 int PacketCopyData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketSetData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datalen);
+int PacketModeIsIPS(const Packet *p);
+int PacketModeIsIDS(const Packet *p);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
 
 DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1048,7 +1048,7 @@ static uint8_t DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
         }
     }
 
-    if (run_mode == RUNMODE_UNITTEST) {
+    if (RunmodeGetPrimary(&runmodeslist) == RUNMODE_UNITTEST) {
         de_ctx->sgh_mpm_context = ENGINE_SGH_MPM_FACTORY_CONTEXT_FULL;
     }
 

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -27,10 +27,10 @@
  */
 
 #include "suricata-common.h"
-
+#include "suricata.h"
 #include "runmodes.h"
 
-extern int run_mode;
+extern RunModesList runmodeslist;
 
 #include "decode.h"
 
@@ -91,17 +91,20 @@ int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, char *replacestr)
         goto error;
     }
 
-    switch (run_mode) {
-        case RUNMODE_NFQ:
-        case RUNMODE_IPFW:
-            break;
-        default:
-            SCLogWarning(SC_ERR_RUNMODE,
-                         "Can't use 'replace' keyword in non IPS mode: %s",
-                         s->sig_str);
-            /* this is a success, having the alert is interesting */
-            return 0;
-    }
+    int i;
+    for (i = 0; i < RunmodeGetNumber(&runmodeslist); i++) {
+        switch (RunmodeGetCurrent(&runmodeslist, i)) {
+			case RUNMODE_NFQ:
+			case RUNMODE_IPFW:
+				break;
+			default:
+				SCLogWarning(SC_ERR_RUNMODE,
+					         "Can't use 'replace' keyword in non IPS mode: %s",
+						     s->sig_str);
+				/* this is a success, having the alert is interesting */
+				return 0;
+		}
+	}
 
     /* add to the latest "content" keyword from either dmatch or pmatch */
     pm =  SigMatchGetLastSMFromLists(s, 2,
@@ -339,15 +342,15 @@ int DetectReplaceLongPatternMatchTestWrp(char *sig, uint32_t sid, char *sig_rep,
     uint16_t psize = sizeof(raw_eth_pkt);
 
     /* would be unittest */
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
     ret = DetectReplaceLongPatternMatchTest(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt),
                              sig, sid, p, &psize);
     if (ret == 1) {
         SCLogDebug("replace: test1 phase1");
         ret = DetectReplaceLongPatternMatchTest(p, psize, sig_rep, sid_rep, NULL, NULL);
     }
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
     return ret;
 }
 
@@ -374,15 +377,15 @@ int DetectReplaceLongPatternMatchTestUDPWrp(char *sig, uint32_t sid, char *sig_r
     uint8_t p[sizeof(raw_eth_pkt)];
     uint16_t psize = sizeof(raw_eth_pkt);
 
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
     ret = DetectReplaceLongPatternMatchTest(raw_eth_pkt, (uint16_t)sizeof(raw_eth_pkt),
                              sig, sid, p, &psize);
     if (ret == 1) {
         SCLogDebug("replace: test1 phase1 ok: %" PRIuMAX" vs %d",(uintmax_t)sizeof(raw_eth_pkt),psize);
         ret = DetectReplaceLongPatternMatchTest(p, psize, sig_rep, sid_rep, NULL, NULL);
     }
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
     return ret;
 }
 
@@ -573,8 +576,8 @@ static int DetectReplaceMatchTest15(void)
  */
 static int DetectReplaceParseTest01(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -593,7 +596,7 @@ static int DetectReplaceParseTest01(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -607,8 +610,8 @@ static int DetectReplaceParseTest01(void)
  */
 static int DetectReplaceParseTest02(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -627,7 +630,7 @@ static int DetectReplaceParseTest02(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -642,8 +645,8 @@ static int DetectReplaceParseTest02(void)
  */
 static int DetectReplaceParseTest03(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -662,7 +665,7 @@ static int DetectReplaceParseTest03(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -676,8 +679,8 @@ static int DetectReplaceParseTest03(void)
  */
 static int DetectReplaceParseTest04(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -696,7 +699,7 @@ static int DetectReplaceParseTest04(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -710,8 +713,8 @@ static int DetectReplaceParseTest04(void)
  */
 static int DetectReplaceParseTest05(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -730,7 +733,7 @@ static int DetectReplaceParseTest05(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -744,8 +747,8 @@ static int DetectReplaceParseTest05(void)
  */
 static int DetectReplaceParseTest06(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -764,7 +767,7 @@ static int DetectReplaceParseTest06(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
@@ -778,8 +781,8 @@ static int DetectReplaceParseTest06(void)
  */
 static int DetectReplaceParseTest07(void)
 {
-    int run_mode_backup = run_mode;
-    run_mode = RUNMODE_NFQ;
+    int run_mode_backup = runmodeslist.run_mode[0];
+    runmodeslist.run_mode[0] = RUNMODE_NFQ;
 
     DetectEngineCtx *de_ctx = NULL;
     int result = 1;
@@ -798,7 +801,7 @@ static int DetectReplaceParseTest07(void)
     }
 
  end:
-    run_mode = run_mode_backup;
+    runmodeslist.run_mode[0] = run_mode_backup;
 
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);

--- a/src/detect.c
+++ b/src/detect.c
@@ -668,7 +668,7 @@ static StreamMsg *SigMatchSignaturesGetSmsg(Flow *f, Packet *p, uint8_t flags)
         TcpSession *ssn = (TcpSession *)f->protoctx;
 
         /* at stream eof, or in inline mode, inspect all smsg's */
-        if ((flags & STREAM_EOF) || StreamTcpInlineMode()) {
+        if ((flags & STREAM_EOF) || StreamTcpInlineMode(p)) {
             if (p->flowflags & FLOW_PKT_TOSERVER) {
                 smsg = ssn->toserver_smsg_head;
                 /* deref from the ssn */
@@ -11511,6 +11511,7 @@ static int SigTestDropFlow03(void)
     p2->flowflags |= FLOW_PKT_TOSERVER;
     p2->flowflags |= FLOW_PKT_ESTABLISHED;
     p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->pkt_mode = PKT_MODE_IPS;
     f.alproto = ALPROTO_HTTP;
 
     StreamTcpInitConfig(TRUE);

--- a/src/detect.c
+++ b/src/detect.c
@@ -453,6 +453,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
+    extern RunModesList runmodeslist;
 
     memset(&sig_stat, 0, sizeof(SigFileLoaderStat));
 
@@ -461,7 +462,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 de_ctx->config_prefix);
     }
 
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodeGetPrimary(&runmodeslist) == RUNMODE_ENGINE_ANALYSIS) {
         fp_engine_analysis_set = SetupFPAnalyzer();
         rule_engine_analysis_set = SetupRuleAnalyzer();
     }
@@ -541,7 +542,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
-    if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodeGetPrimary(&runmodeslist) == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();
         }

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -282,8 +282,8 @@ static int LogDropLogNetFilter (ThreadVars *tv, const Packet *p, void *data)
  */
 static int LogDropCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
-        SCLogDebug("engine is not running in inline mode, so returning");
+    if (!PacketModeIsIPS(p)) {
+        SCLogDebug("packet is not running in inline mode, so returning");
         return FALSE;
     }
     if (PKT_IS_PSEUDOPKT(p)) {
@@ -378,6 +378,7 @@ int LogDropLogTest01()
 
     memset(&th_v, 0, sizeof(th_v));
     p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
+    p->pkt_mode = PKT_MODE_IPS;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
     if (de_ctx == NULL) {

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -143,7 +143,7 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
     char *action = "allowed";
     if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
         action = "blocked";
-    } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+    } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
         action = "blocked";
     }
 
@@ -394,7 +394,7 @@ static int AlertJsonDecoderEvent(ThreadVars *tv, JsonAlertLogThread *aft, const 
         char *action = "allowed";
         if (pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) {
             action = "blocked";
-        } else if ((pa->action & ACTION_DROP) && EngineModeIsIPS()) {
+        } else if ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)) {
             action = "blocked";
         }
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -154,7 +154,7 @@ static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
                 continue;
             }
             if ((pa->action & (ACTION_REJECT|ACTION_REJECT_DST|ACTION_REJECT_BOTH)) ||
-               ((pa->action & ACTION_DROP) && EngineModeIsIPS()))
+               ((pa->action & ACTION_DROP) && PacketModeIsIPS(p)))
             {
                 AlertJsonHeader(p, pa, js);
                 logged = 1;
@@ -366,8 +366,8 @@ static int JsonDropLogger(ThreadVars *tv, void *thread_data, const Packet *p)
  */
 static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
 {
-    if (!EngineModeIsIPS()) {
-        SCLogDebug("engine is not running in inline mode, so returning");
+    if (!PacketModeIsIPS(p)) {
+        SCLogDebug("packet is not running in inline mode, so returning");
         return FALSE;
     }
     if (PKT_IS_PSEUDOPKT(p)) {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -399,7 +399,7 @@ int AFPConfigGeThreadsCount(void *conf)
 
 int AFPRunModeIsIPS()
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_AFP_DEV);
     int ldev;
     ConfNode *if_root;
     ConfNode *if_default = NULL;
@@ -416,7 +416,7 @@ int AFPRunModeIsIPS()
     if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
 
     for (ldev = 0; ldev < nlive; ldev++) {
-        char *live_dev = LiveGetDeviceName(ldev);
+        char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
         if (live_dev == NULL) {
             SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
             return 0;
@@ -446,7 +446,7 @@ int AFPRunModeIsIPS()
     if (has_ids && has_ips) {
         SCLogInfo("AF_PACKET mode using IPS and IDS mode");
         for (ldev = 0; ldev < nlive; ldev++) {
-            char *live_dev = LiveGetDeviceName(ldev);
+            char *live_dev = LiveGetDeviceName(ldev, RUNMODE_AFP_DEV);
             if (live_dev == NULL) {
                 SCLogError(SC_ERR_INVALID_VALUE, "Problem with config file");
                 return 0;
@@ -501,7 +501,7 @@ int RunModeIdsAFPAutoFp(void)
                               AFPConfigGeThreadsCount,
                               "ReceiveAFP",
                               "DecodeAFP", "RxAFP",
-                              live_dev);
+                              live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -543,7 +543,7 @@ int RunModeIdsAFPSingle(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", "AFPacket",
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -588,7 +588,7 @@ int RunModeIdsAFPWorkers(void)
                                     AFPConfigGeThreadsCount,
                                     "ReceiveAFP",
                                     "DecodeAFP", "AFPacket",
-                                    live_dev);
+                                    live_dev, RUNMODE_AFP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-erf-dag.c
+++ b/src/runmode-erf-dag.c
@@ -86,7 +86,7 @@ int RunModeIdsErfDagSingle(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG single runmode failed to start");
         exit(EXIT_FAILURE);
@@ -112,7 +112,7 @@ int RunModeIdsErfDagAutoFp(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG autofp runmode failed to start");
         exit(EXIT_FAILURE);
@@ -138,7 +138,7 @@ int RunModeIdsErfDagWorkers(void)
         "ReceiveErfDag",
         "DecodeErfDag",
         "RxDAG",
-        NULL);
+        NULL, RUNMODE_DAG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "DAG workers runmode failed to start");
         exit(EXIT_FAILURE);

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -373,7 +373,7 @@ int RunModeIdsNetmapAutoFp(void)
                               NetmapConfigGeThreadsCount,
                               "ReceiveNetmap",
                               "DecodeNetmap", "RxNetmap",
-                              live_dev);
+                              live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -406,7 +406,7 @@ int RunModeIdsNetmapSingle(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", "NetmapPkt",
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -442,7 +442,7 @@ int RunModeIdsNetmapWorkers(void)
                                     NetmapConfigGeThreadsCount,
                                     "ReceiveNetmap",
                                     "DecodeNetmap", "NetmapPkt",
-                                    live_dev);
+                                    live_dev, RUNMODE_NETMAP);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nflog.c
+++ b/src/runmode-nflog.c
@@ -185,7 +185,7 @@ int RunModeIdsNflogAutoFp(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       "RecvNFLOG",
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -213,7 +213,7 @@ int RunModeIdsNflogSingle(void)
                                       "ReceiveNFLOG",
                                       "DecodeNFLOG",
                                       "RecvNFLOG",
-                                      live_dev);
+                                      live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);
@@ -241,7 +241,7 @@ int RunModeIdsNflogWorkers(void)
                                        "ReceiveNFLOG",
                                        "DecodeNFLOG",
                                        "RecvNFLOG",
-                                       live_dev);
+                                       live_dev, RUNMODE_NFLOG);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-nfq.c
+++ b/src/runmode-nfq.c
@@ -74,7 +74,8 @@ int RunModeIpsNFQAutoFp(void)
     ret = RunModeSetIPSAutoFp(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }
@@ -94,7 +95,8 @@ int RunModeIpsNFQWorker(void)
     ret = RunModeSetIPSWorker(NFQGetThread,
             "ReceiveNFQ",
             "VerdictNFQ",
-            "DecodeNFQ");
+            "DecodeNFQ",
+            RUNMODE_NFQ);
 #endif /* NFQ */
     return ret;
 }

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -243,7 +243,7 @@ int RunModeIdsPcapSingle(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", "PcapLive",
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -284,7 +284,7 @@ int RunModeIdsPcapAutoFp(void)
                               PcapConfigGeThreadsCount,
                               "ReceivePcap",
                               "DecodePcap", "RxPcap",
-                              live_dev);
+                              live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -316,7 +316,7 @@ int RunModeIdsPcapWorkers(void)
                                     PcapConfigGeThreadsCount,
                                     "ReceivePcap",
                                     "DecodePcap", "RxPcap",
-                                    live_dev);
+                                    live_dev, RUNMODE_PCAP_DEV);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Unable to start runmode");
         exit(EXIT_FAILURE);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -401,7 +401,7 @@ static int GetDevAndParser(char **live_dev, ConfigIfaceParserFunc *parser)
         if (*live_dev == NULL) {
             if (ConfGet("pfring.interface", live_dev) == 1) {
                 SCLogInfo("Using interface %s", *live_dev);
-                LiveRegisterDevice(*live_dev);
+                LiveRegisterDevice(*live_dev, RUNMODE_PFRING);
             } else {
                 SCLogInfo("No interface found, problem incoming");
                 *live_dev = NULL;
@@ -438,7 +438,7 @@ int RunModeIdsPfringAutoFp(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -475,7 +475,7 @@ int RunModeIdsPfringSingle(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);
@@ -512,7 +512,7 @@ int RunModeIdsPfringWorkers(void)
                               PfringConfigGeThreadsCount,
                               "ReceivePfring",
                               "DecodePfring", "RxPFR",
-                              live_dev);
+                              live_dev, RUNMODE_PFRING);
     if (ret != 0) {
         SCLogError(SC_ERR_RUNMODE, "Runmode start failed");
         exit(EXIT_FAILURE);

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -49,6 +49,8 @@
 
 #include "source-pfring.h"
 
+extern RunModesList runmodeslist;
+
 int debuglog_enabled = 0;
 
 /**
@@ -188,9 +190,9 @@ char *RunmodeGetActive(void)
  *
  * \return a string containing the current running mode
  */
-const char *RunModeGetMainMode(void)
+const char *RunModeGetMainMode(int index)
 {
-    int mainmode = RunmodeGetCurrent();
+    int mainmode = RunmodeGetCurrent(&runmodeslist, index);
 
     return RunModeTranslateModeToName(mainmode);
 }

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -24,7 +24,7 @@
 #define __RUNMODES_H__
 
 /* Run mode */
-enum {
+enum RunModes {
     RUNMODE_UNKNOWN = 0,
     RUNMODE_PCAP_DEV,
     RUNMODE_PCAP_FILE,

--- a/src/runmodes.h
+++ b/src/runmodes.h
@@ -61,7 +61,7 @@ enum RunModes {
 };
 
 char *RunmodeGetActive(void);
-const char *RunModeGetMainMode(void);
+const char *RunModeGetMainMode(int index);
 
 void RunModeListRunmodes(void);
 void RunModeDispatch(int, const char *);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -782,6 +782,7 @@ int AFPReadFromRing(AFPThreadVars *ptv)
             SCReturnInt(AFP_FAILURE);
         }
         PKT_SET_SRC(p, PKT_SRC_WIRE);
+        p->pkt_mode = PKT_MODE_AUTO;
 
         /* Suricata will treat packet so telling it is busy, this
          * status will be reset to 0 (ie TP_STATUS_KERNEL) in the release

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1682,7 +1682,7 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
     strlcpy(ptv->iface, afpconfig->iface, AFP_IFACE_NAME_LENGTH);
     ptv->iface[AFP_IFACE_NAME_LENGTH - 1]= '\0';
 
-    ptv->livedev = LiveGetDevice(ptv->iface);
+    ptv->livedev = LiveGetDevice(ptv->iface, RUNMODE_AFP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -813,7 +813,7 @@ static int MpipeReceiveOpenEgress(char *out_iface, int iface_idx,
                                   MpipeIfaceConfig *mpipe_conf[])
 {
     int channel;
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(RUNMODE_MPIPE);
     int result;
 
     /* Initialize an equeue */
@@ -908,7 +908,7 @@ TmEcode ReceiveMpipeThreadInit(ThreadVars *tv, void *initdata, void **data)
     /* Initialize and configure mPIPE, which is only done by one core. */
 
     if (strcmp(link_name, "multi") == 0) {
-        int nlive = LiveGetDeviceCount();
+        int nlive = LiveGetDeviceCount(RUNMODE_MPIPE);
         int instance = gxio_mpipe_link_instance(LiveGetDeviceName(0));
         for (int i = 1; i < nlive; i++) {
             link_name = LiveGetDeviceName(i);

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -533,7 +533,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     ntv->checksum_mode = aconf->checksum_mode;
     ntv->copy_mode = aconf->copy_mode;
 
-    ntv->livedev = LiveGetDevice(aconf->iface_name);
+    ntv->livedev = LiveGetDevice(aconf->iface_name, RUNMODE_NETMAP);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         goto error_ntv;

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -288,7 +288,7 @@ TmEcode ReceiveNFLOGThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCLogDebug("NFLOG netlink queue timeout can't be set to %d",
                     ntv->qtimeout);
 
-    ntv->livedev = LiveGetDevice(nflconfig->numgroup);
+    ntv->livedev = LiveGetDevice(nflconfig->numgroup, RUNMODE_NFLOG);
     if (ntv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
 	    SCFree(ntv);

--- a/src/source-nflog.c
+++ b/src/source-nflog.c
@@ -155,6 +155,7 @@ static int NFLOGCallback(struct nflog_g_handle *gh, struct nfgenmsg *msg,
         return -1;
 
     PKT_SET_SRC(p, PKT_SRC_WIRE);
+    p->pkt_mode = PKT_MODE_IDS;
 
     ph = nflog_get_msg_packet_hdr(nfa);
     if (ph != NULL) {

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -823,7 +823,7 @@ int NFQRegisterQueue(char *queue)
     nq->queue_num = queue_num;
     receive_queue_num++;
     SCMutexUnlock(&nfq_init_lock);
-    LiveRegisterDevice(queue);
+    LiveRegisterDevice(queue, RUNMODE_NFQ);
 
     SCLogDebug("Queue \"%s\" registered.", queue);
     return 0;

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -505,6 +505,7 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     }
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
+    p->pkt_mode = PKT_MODE_IPS;
     p->nfq_v.nfq_index = ntv->nfq_index;
     ret = NFQSetupPkt(p, qh, (void *)nfa);
     if (ret == -1) {

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -41,6 +41,7 @@
 #include "util-checksum.h"
 #include "util-ioctl.h"
 #include "tmqh-packetpool.h"
+#include "runmodes.h"
 
 #ifdef __SC_CUDA_SUPPORT__
 
@@ -383,7 +384,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->tv = tv;
 
-    ptv->livedev = LiveGetDevice(pcapconfig->iface);
+    ptv->livedev = LiveGetDevice(pcapconfig->iface, RUNMODE_PCAP_DEV);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);
@@ -551,7 +552,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->tv = tv;
 
-    ptv->livedev = LiveGetDevice(pcapconfig->iface);
+    ptv->livedev = LiveGetDevice(pcapconfig->iface, RUNMODE_PCAP);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -421,7 +421,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
-    ptv->livedev = LiveGetDevice(pfconf->iface);
+    ptv->livedev = LiveGetDevice(pfconf->iface, RUNMODE_PFRING);
     if (ptv->livedev == NULL) {
         SCLogError(SC_ERR_INVALID_VALUE, "Unable to find Live device");
         SCFree(ptv);

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -41,9 +41,14 @@ extern int stream_inline;
  *  \retval 0 no
  *  \retval 1 yes
  */
-int StreamTcpInlineMode(void)
+int StreamTcpInlineMode(const Packet *p)
 {
-    return stream_inline;
+    if (stream_inline == PKT_MODE_IDS)
+        return 0;
+    else if (stream_inline == PKT_MODE_IPS)
+        return 1;
+    else /* implied AUTO */
+        return (stream_inline && PacketModeIsIPS(p));
 }
 
 /**

--- a/src/stream-tcp-inline.h
+++ b/src/stream-tcp-inline.h
@@ -26,7 +26,7 @@
 
 #include "stream-tcp-private.h"
 
-int StreamTcpInlineMode(void);
+int StreamTcpInlineMode(const Packet *p);
 int StreamTcpInlineSegmentCompare(TcpSegment *, TcpSegment *);
 void StreamTcpInlineSegmentReplacePacket(Packet *, TcpSegment *);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -120,7 +120,7 @@ uint64_t StreamTcpReassembleMemuseGlobalCounter(void);
 SC_ATOMIC_DECLARE(uint64_t, st_memuse);
 
 /* stream engine running in "inline" mode. */
-int stream_inline = 0;
+enum PktMode stream_inline;
 
 void TmModuleStreamTcpRegister (void)
 {
@@ -424,19 +424,14 @@ void StreamTcpInitConfig(char quiet)
 
     int inl = 0;
 
-
     char *temp_stream_inline_str;
     if (ConfGet("stream.inline", &temp_stream_inline_str) == 1) {
         /* checking for "auto" and falling back to boolean to provide
          * backward compatibility */
         if (strcmp(temp_stream_inline_str, "auto") == 0) {
-            if (EngineModeIsIPS()) {
-                stream_inline = 1;
-            } else {
-                stream_inline = 0;
-            }
+            stream_inline = PKT_MODE_AUTO;
         } else if (ConfGetBool("stream.inline", &inl) == 1) {
-            stream_inline = inl;
+            stream_inline = PKT_MODE_IPS;
         }
     }
 
@@ -4679,7 +4674,7 @@ error:
         ReCalculateChecksum(p);
     }
 
-    if (StreamTcpInlineMode()) {
+    if (StreamTcpInlineMode(p)) {
         PACKET_DROP(p);
     }
     SCReturnInt(-1);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -147,7 +147,7 @@ static inline int StreamTcpCheckFlowDrops(Packet *p)
      * the IP only module, or from a reassembled msg and/or from an
      * applayer detection, then drop the rest of the packets of the
      * same stream and avoid inspecting it any further */
-    if (EngineModeIsIPS() && (p->flow->flags & FLOW_ACTION_DROP))
+    if (PacketModeIsIPS(p) && (p->flow->flags & FLOW_ACTION_DROP))
         return 1;
 
     return 0;

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1183,7 +1183,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     strlcpy(suri->pcap_dev, optarg,
                             ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                              (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                    LiveRegisterDevice(optarg);
+                    LiveRegisterDevice(optarg, RUNMODE_PFRING);
                 }
 #else
                 SCLogError(SC_ERR_NO_PF_RING,"PF_RING not enabled. Make sure "
@@ -1220,7 +1220,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_AFP_DEV;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1230,7 +1230,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple devices to get packets is experimental.");
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
                     } else {
                         SCLogInfo("Multiple af-packet option without interface on each is useless");
                         break;
@@ -1252,7 +1252,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_NETMAP;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_NETMAP);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1262,7 +1262,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple devices to get packets is experimental.");
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_NETMAP);
                     } else {
                         SCLogInfo("Multiple netmap option without interface on each is useless");
                         break;
@@ -1291,7 +1291,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 if (suri->run_mode == RUNMODE_UNKNOWN) {
                     suri->run_mode = RUNMODE_PCAP_DEV;
                     if (optarg) {
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_PCAP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
@@ -1305,7 +1305,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #else
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple pcap devices to get packets is experimental.");
-                    LiveRegisterDevice(optarg);
+                    LiveRegisterDevice(optarg, RUNMODE_PCAP_DEV);
 #endif
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
@@ -1440,7 +1440,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     usage(argv[0]);
                     return TM_ECODE_FAILED;
                 }
-                LiveRegisterDevice(optarg);
+                LiveRegisterDevice(optarg, RUNMODE_DAG);
 #else
                 SCLogError(SC_ERR_DAG_REQUIRED, "libdag and a DAG card are required"
 						" to receieve packets using --dag.");
@@ -1480,7 +1480,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                         strlcpy(suri->pcap_dev, optarg,
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
-                        LiveRegisterDevice(optarg);
+                        LiveRegisterDevice(optarg, RUNMODE_MPIPE);
                     }
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
@@ -1552,7 +1552,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 
             if (suri->run_mode == RUNMODE_UNKNOWN) {
                 suri->run_mode = RUNMODE_PCAP_DEV;
-                LiveRegisterDevice(suri->pcap_dev);
+                LiveRegisterDevice(suri->pcap_dev, RUNMODE_PCAP_DEV);
             } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
                 SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
@@ -1561,7 +1561,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #else
                 SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                         "multiple pcap devices to get packets is experimental.");
-                LiveRegisterDevice(suri->pcap_dev);
+                LiveRegisterDevice(suri->pcap_dev, RUNMODE_PCAP_DEV);
 #endif
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -219,7 +219,7 @@ SC_ATOMIC_DECLARE(unsigned int, engine_stage);
 volatile uint8_t suricata_ctl_flags = 0;
 
 /** Run mode selected */
-int run_mode = RUNMODE_UNKNOWN;
+RunModesList runmodeslist = { {RUNMODE_UNKNOWN, RUNMODE_UNKNOWN}, 0};
 
 /** Engine mode: inline (ENGINE_MODE_IPS) or just
   * detection mode (ENGINE_MODE_IDS by default) */
@@ -262,15 +262,52 @@ void EngineModeSetIDS(void)
 
 int RunmodeIsUnittests(void)
 {
-    if (run_mode == RUNMODE_UNITTEST)
+    if (RunmodeGetPrimary(&runmodeslist) == RUNMODE_UNITTEST)
         return 1;
 
     return 0;
 }
 
-int RunmodeGetCurrent(void)
+int RunmodeGetCurrent(const RunModesList *runmodes, int index)
 {
-    return run_mode;
+    return runmodes->run_mode[index];
+}
+
+int RunmodeGetNumber(const RunModesList *runmodes)
+{
+    return runmodes->runmodes_cnt;
+}
+
+static int RunmodeIsUnknown(const RunModesList *runmodes)
+{
+    return (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_UNKNOWN);
+}
+
+/* When we are in mixed mode, we check if a runmode
+ *  isn't alredy specified to prevent to assign it twice
+ */
+static int RunmodeIsAlreadyRan(const RunModesList *runmodes,
+                               const enum RunModes run_mode)
+{
+    int i;
+
+    for (i = 0; i < runmodes->runmodes_cnt; i++) {
+        if (runmodes->run_mode[i] == run_mode) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int RunmodeGetPrimary(const RunModesList *runmodes)
+{
+    return runmodes->run_mode[0];
+}
+
+int RunmodeGetSecondary(const RunModesList *runmodes)
+{
+    return runmodes->run_mode[1];
 }
 
 static void SignalHandlerSigint(/*@unused@*/ int sig)
@@ -939,7 +976,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
     /* run the selected runmode */
     if (run_mode == RUNMODE_PCAP_DEV) {
         if (strlen(pcap_dev) == 0) {
-            int ret = LiveBuildDeviceList("pcap");
+            int ret = LiveBuildDeviceList("pcap", RUNMODE_PCAP_DEV);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for pcap");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -953,7 +990,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("mpipe.inputs");
+            int ret = LiveBuildDeviceList("mpipe.inputs", RUNMODE_TILERA_MPIPE);
             if (ret == 0) {
                 fprintf(stderr, "ERROR: No interface found in config for mpipe\n");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -970,7 +1007,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
             }
         } else {
             /* not an error condition if we have a 1.0 config */
-            LiveBuildDeviceList("pfring");
+            LiveBuildDeviceList("pfring", RUNMODE_PFRING);
         }
     } else if (run_mode == RUNMODE_AFP_DEV) {
         /* iface has been set on command line */
@@ -980,7 +1017,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("af-packet");
+            int ret = LiveBuildDeviceList("af-packet", RUNMODE_AFP_DEV);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for af-packet");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -999,7 +1036,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
                 SCReturnInt(TM_ECODE_FAILED);
             }
         } else {
-            int ret = LiveBuildDeviceList("netmap");
+            int ret = LiveBuildDeviceList("netmap", RUNMODE_NETMAP);
             if (ret == 0) {
                 SCLogError(SC_ERR_INITIALIZATION, "No interface found in config for netmap");
                 SCReturnInt(TM_ECODE_FAILED);
@@ -1012,7 +1049,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
 #endif
 #ifdef HAVE_NFLOG
     } else if (run_mode == RUNMODE_NFLOG) {
-        int ret = LiveBuildDeviceListCustom("nflog", "group");
+        int ret = LiveBuildDeviceListCustom("nflog", "group", RUNMODE_NFLOG);
         if (ret == 0) {
             SCLogError(SC_ERR_INITIALIZATION, "No group found in config for nflog");
             SCReturnInt(TM_ECODE_FAILED);
@@ -1025,7 +1062,9 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
 
 static void SCInstanceInit(SCInstance *suri)
 {
-    suri->run_mode = RUNMODE_UNKNOWN;
+    suri->runmodeslist.run_mode[0] = RUNMODE_UNKNOWN;
+    suri->runmodeslist.run_mode[1] = RUNMODE_UNKNOWN;
+    suri->runmodeslist.runmodes_cnt = 0; 
 
     memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
     suri->sig_file = NULL;
@@ -1112,6 +1151,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int set_log_directory = 0;
     int ret = TM_ECODE_OK;
 
+    RunModesList *runmodes = &suri->runmodeslist;
+
 #ifdef UNITTESTS
     coverage_unittests = 0;
     g_ut_modules = 0;
@@ -1177,7 +1218,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             if (strcmp((long_opts[option_index]).name , "pfring") == 0 ||
                 strcmp((long_opts[option_index]).name , "pfring-int") == 0) {
 #ifdef HAVE_PFRING
-                suri->run_mode = RUNMODE_PFRING;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PFRING;
                 if (optarg != NULL) {
                     memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                     strlcpy(suri->pcap_dev, optarg,
@@ -1217,8 +1258,17 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
             else if (strcmp((long_opts[option_index]).name , "af-packet") == 0){
 #ifdef HAVE_AF_PACKET
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_AFP_DEV;
+                if (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_UNKNOWN) {
+                    if (!RunmodeIsAlreadyRan(runmodes, RUNMODE_AFP_DEV)) {
+                        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_AFP_DEV; 
+                    } else {
+                        SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
+                            "multiple devices to get packets is experimental.");
+                        if (!optarg) {
+                            SCLogInfo("Multiple af-packet option without interface on each is useless");
+                            break;
+                        }
+                    }
                     if (optarg) {
                         LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
@@ -1226,14 +1276,13 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
                     }
-                } else if (suri->run_mode == RUNMODE_AFP_DEV) {
-                    SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
-                            "multiple devices to get packets is experimental.");
-                    if (optarg) {
-                        LiveRegisterDevice(optarg, RUNMODE_AFP_DEV);
+                    if (runmodes->runmodes_cnt < RUNMODES_MAX) {
+                        runmodes->runmodes_cnt++;
                     } else {
-                        SCLogInfo("Multiple af-packet option without interface on each is useless");
-                        break;
+                        SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
+                                   "Maximum number of runmodes reached");
+                        usage(argv[0]);
+                        return TM_ECODE_FAILED;
                     }
                 } else {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
@@ -1249,8 +1298,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif
             } else if (strcmp((long_opts[option_index]).name , "netmap") == 0){
 #ifdef HAVE_NETMAP
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_NETMAP;
+                if (RunmodeIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_NETMAP;
                     if (optarg) {
                         LiveRegisterDevice(optarg, RUNMODE_NETMAP);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
@@ -1258,7 +1307,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
                     }
-                } else if (suri->run_mode == RUNMODE_NETMAP) {
+                } else if (runmodes->run_mode[0] == RUNMODE_NETMAP) {
                     SCLogWarning(SC_WARN_PCAP_MULTI_DEV_EXPERIMENTAL, "using "
                             "multiple devices to get packets is experimental.");
                     if (optarg) {
@@ -1279,17 +1328,25 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif
             } else if (strcmp((long_opts[option_index]).name, "nflog") == 0) {
 #ifdef HAVE_NFLOG
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_NFLOG;
-                    LiveBuildDeviceListCustom("nflog", "group");
+                if (RunmodeIsUnknown(runmodes)) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_NFLOG; 
+                    LiveBuildDeviceListCustom("nflog", "group", RUNMODE_NFLOG);
+                    if (runmodes->runmodes_cnt < RUNMODES_MAX) {
+                        runmodes->runmodes_cnt++;
+                    } else {
+                        SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
+                                   "Maximum number of runmodes reached");
+                        usage(argv[0]);
+                        return TM_ECODE_FAILED;
+                    }
                 }
 #else
                 SCLogError(SC_ERR_NFLOG_NOSUPPORT, "NFLOG not enabled.");
                 return TM_ECODE_FAILED;
 #endif /* HAVE_NFLOG */
             } else if (strcmp((long_opts[option_index]).name , "pcap") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_PCAP_DEV;
+                if (RunmodeIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PCAP_DEV;
                     if (optarg) {
                         LiveRegisterDevice(optarg, RUNMODE_PCAP_DEV);
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
@@ -1297,7 +1354,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                                 ((strlen(optarg) < sizeof(suri->pcap_dev)) ?
                                  (strlen(optarg) + 1) : sizeof(suri->pcap_dev)));
                     }
-                } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
+                } else if (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
                     SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
                             "support is not (yet) supported on Windows.");
@@ -1323,8 +1380,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 }
 #ifdef BUILD_UNIX_SOCKET
             } else if (strcmp((long_opts[option_index]).name , "unix-socket") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_UNIX_SOCKET;
+                if (RunmodeIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_UNIX_SOCKET;
                     if (optarg) {
                         if (ConfSetFinal("unix-command.filename", optarg) != 1) {
                             fprintf(stderr, "ERROR: Failed to set unix-command.filename.\n");
@@ -1345,7 +1402,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
             else if(strcmp((long_opts[option_index]).name, "list-unittests") == 0) {
 #ifdef UNITTESTS
-                suri->run_mode = RUNMODE_LIST_UNITTEST;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_UNITTEST;
 #else
                 fprintf(stderr, "ERROR: Unit tests not enabled. Make sure to pass --enable-unittests to configure when building.\n");
                 return TM_ECODE_FAILED;
@@ -1357,7 +1414,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
 #endif /* UNITTESTS */
             } else if (strcmp((long_opts[option_index]).name, "list-runmodes") == 0) {
-                suri->run_mode = RUNMODE_LIST_RUNMODES;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_RUNMODES;
                 return TM_ECODE_OK;
             } else if (strcmp((long_opts[option_index]).name, "list-keywords") == 0) {
                 if (optarg) {
@@ -1372,15 +1429,15 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
 #ifdef OS_WIN32
             else if(strcmp((long_opts[option_index]).name, "service-install") == 0) {
-                suri->run_mode = RUNMODE_INSTALL_SERVICE;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_INSTALL_SERVICE;
                 return TM_ECODE_OK;
             }
             else if(strcmp((long_opts[option_index]).name, "service-remove") == 0) {
-                suri->run_mode = RUNMODE_REMOVE_SERVICE;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_REMOVE_SERVICE;
                 return TM_ECODE_OK;
             }
             else if(strcmp((long_opts[option_index]).name, "service-change-params") == 0) {
-                suri->run_mode = RUNMODE_CHANGE_SERVICE_PARAMS;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_CHANGE_SERVICE_PARAMS;
                 return TM_ECODE_OK;
             }
 #endif /* OS_WIN32 */
@@ -1423,7 +1480,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* HAVE_LIBCAP_NG */
             }
             else if (strcmp((long_opts[option_index]).name, "erf-in") == 0) {
-                suri->run_mode = RUNMODE_ERF_FILE;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_ERF_FILE;
                 if (ConfSetFinal("erf-file.file", optarg) != 1) {
                     fprintf(stderr, "ERROR: Failed to set erf-file.file\n");
                     return TM_ECODE_FAILED;
@@ -1431,10 +1488,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             }
             else if (strcmp((long_opts[option_index]).name, "dag") == 0) {
 #ifdef HAVE_DAG
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_DAG;
+                if (RunmodesIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_DAG;
                 }
-                else if (suri->run_mode != RUNMODE_DAG) {
+                else if (runmodes->run_mode[runmodes->runmodes_cnt] != RUNMODE_DAG) {
                     SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
                         "more than one run mode has been specified");
                     usage(argv[0]);
@@ -1449,7 +1506,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 		}
         else if (strcmp((long_opts[option_index]).name, "napatech") == 0) {
 #ifdef HAVE_NAPATECH
-            suri->run_mode = RUNMODE_NAPATECH;
+            runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_NAPATECH;
 #else
             SCLogError(SC_ERR_NAPATECH_REQUIRED, "libntapi and a Napatech adapter are required"
                                                  " to capture packets using --napatech.");
@@ -1468,13 +1525,13 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* HAVE_PCAP_SET_BUFF */
             }
             else if(strcmp((long_opts[option_index]).name, "build-info") == 0) {
-                suri->run_mode = RUNMODE_PRINT_BUILDINFO;
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PRINT_BUILDINFO;
                 return TM_ECODE_OK;
             }
 #ifdef HAVE_MPIPE
             else if(strcmp((long_opts[option_index]).name , "mpipe") == 0) {
-                if (suri->run_mode == RUNMODE_UNKNOWN) {
-                    suri->run_mode = RUNMODE_TILERA_MPIPE;
+                if (RunmodesIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_TILERA_MPIPE;
                     if (optarg != NULL) {
                         memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
                         strlcpy(suri->pcap_dev, optarg,
@@ -1524,7 +1581,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
 #endif /* OS_WIN32 */
         case 'h':
-            suri->run_mode = RUNMODE_PRINT_USAGE;
+            runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PRINT_USAGE;
             return TM_ECODE_OK;
         case 'i':
             memset(suri->pcap_dev, 0, sizeof(suri->pcap_dev));
@@ -1550,10 +1607,10 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 return TM_ECODE_FAILED;
             }
 
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_PCAP_DEV;
+            if (RunmodeIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PCAP_DEV;
                 LiveRegisterDevice(suri->pcap_dev, RUNMODE_PCAP_DEV);
-            } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
+            } else if (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
                 SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "
                         "support is not (yet) supported on Windows.");
@@ -1591,12 +1648,22 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'q':
 #ifdef NFQ
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_NFQ;
+            if (RunmodeIsUnknown(runmodes)) {
+                if (!RunmodeIsAlreadyRan(runmodes, RUNMODE_NFQ)) {
+                    runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_NFQ; 
+                }
                 EngineModeSetIPS();
                 if (NFQRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
-            } else if (suri->run_mode == RUNMODE_NFQ) {
+                if (runmodes->runmodes_cnt < RUNMODES_MAX) {
+                    runmodes->runmodes_cnt++;
+                } else {
+                    SCLogError(SC_ERR_MULTIPLE_RUN_MODE,
+                               "Maximum number of runmodes reached");
+                    usage(argv[0]);
+                    return TM_ECODE_FAILED;
+                }
+            } else if (RunmodeIsAlreadyRan(runmodes, RUNMODE_NFQ)) {
                 if (NFQRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
@@ -1612,12 +1679,12 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'd':
 #ifdef IPFW
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_IPFW;
+            if (RunmodeIsUnknown(runmodes)) {
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_IPFW;
                 EngineModeSetIPS();
                 if (IPFWRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
-            } else if (suri->run_mode == RUNMODE_IPFW) {
+            } else if (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_IPFW) {
                 if (IPFWRegisterQueue(optarg) == -1)
                     return TM_ECODE_FAILED;
             } else {
@@ -1632,8 +1699,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif /* IPFW */
             break;
         case 'r':
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_PCAP_FILE;
+            if (RunmodeIsUnknown(runmodes) && !runmodes->runmodes_cnt) {
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PCAP_FILE;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode "
                                                      "has been specified");
@@ -1662,8 +1729,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             break;
         case 'u':
 #ifdef UNITTESTS
-            if (suri->run_mode == RUNMODE_UNKNOWN) {
-                suri->run_mode = RUNMODE_UNITTEST;
+            if (runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_UNKNOWN) {
+                runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_UNITTEST;
             } else {
                 SCLogError(SC_ERR_MULTIPLE_RUN_MODE, "more than one run mode has"
                                                      " been specified");
@@ -1684,7 +1751,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
 #endif
             break;
         case 'V':
-            suri->run_mode = RUNMODE_PRINT_VERSION;
+            runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_PRINT_VERSION;
             return TM_ECODE_OK;
         case 'F':
             if (optarg == NULL) {
@@ -1722,25 +1789,25 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         return TM_ECODE_FAILED;
     }
 
-    if ((suri->run_mode == RUNMODE_UNIX_SOCKET) && set_log_directory) {
+    if ((runmodes->run_mode[runmodes->runmodes_cnt] == RUNMODE_UNIX_SOCKET) && set_log_directory) {
         SCLogError(SC_ERR_INITIALIZATION, "can't use -l and unix socket runmode at the same time");
         return TM_ECODE_FAILED;
     }
 
     if (list_app_layer_protocols)
-        suri->run_mode = RUNMODE_LIST_APP_LAYERS;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_APP_LAYERS;
     if (list_cuda_cards)
-        suri->run_mode = RUNMODE_LIST_CUDA_CARDS;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_CUDA_CARDS;
     if (list_keywords)
-        suri->run_mode = RUNMODE_LIST_KEYWORDS;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_KEYWORDS;
     if (list_unittests)
-        suri->run_mode = RUNMODE_LIST_UNITTEST;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_LIST_UNITTEST;
     if (dump_config)
-        suri->run_mode = RUNMODE_DUMP_CONFIG;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_DUMP_CONFIG;
     if (conf_test)
-        suri->run_mode = RUNMODE_CONF_TEST;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_CONF_TEST;
     if (engine_analysis)
-        suri->run_mode = RUNMODE_ENGINE_ANALYSIS;
+        runmodes->run_mode[runmodes->runmodes_cnt] = RUNMODE_ENGINE_ANALYSIS;
 
     ret = SetBpfString(optind, argv);
     if (ret != TM_ECODE_OK)
@@ -1864,7 +1931,7 @@ static int InitSignalHandler(SCInstance *suri)
 int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
 {
     /* Treat internal running mode */
-    switch(suri->run_mode) {
+    switch(RunmodeGetPrimary(&suri->runmodeslist)) {
         case RUNMODE_LIST_KEYWORDS:
             ListKeywords(suri->keyword_info);
             return TM_ECODE_DONE;
@@ -1918,19 +1985,43 @@ int StartInternalRunMode(SCInstance *suri, int argc, char **argv)
 
 static int FinalizeRunMode(SCInstance *suri, char **argv)
 {
-    switch (suri->run_mode) {
+    switch (RunmodeGetPrimary(&suri->runmodeslist)) {
         case RUNMODE_PCAP_FILE:
         case RUNMODE_ERF_FILE:
         case RUNMODE_ENGINE_ANALYSIS:
             suri->offline = 1;
+            break;
+        case RUNMODE_PCAP_DEV:
+        case RUNMODE_PFRING:
+        case RUNMODE_NFQ:
+        case RUNMODE_NFLOG:
+        case RUNMODE_IPFW:
+        case RUNMODE_DAG:
+        case RUNMODE_AFP_DEV:
+        case RUNMODE_NETMAP:
+        case RUNMODE_TILERA_MPIPE:
+        case RUNMODE_UNITTEST:
+        case RUNMODE_NAPATECH:
+        case RUNMODE_UNIX_SOCKET:
+        case RUNMODE_USER_MAX:
+        case RUNMODE_LIST_KEYWORDS:
+        case RUNMODE_LIST_APP_LAYERS:
+        case RUNMODE_LIST_CUDA_CARDS:
+        case RUNMODE_LIST_RUNMODES:
+        case RUNMODE_PRINT_VERSION:
+        case RUNMODE_PRINT_BUILDINFO:
+        case RUNMODE_PRINT_USAGE:
+        case RUNMODE_DUMP_CONFIG:
+        case RUNMODE_CONF_TEST:
+        case RUNMODE_LIST_UNITTEST:
+        case RUNMODE_MAX:
             break;
         case RUNMODE_UNKNOWN:
             usage(argv[0]);
             return TM_ECODE_FAILED;
     }
     /* Set the global run mode */
-    run_mode = suri->run_mode;
-
+    runmodeslist = suri->runmodeslist;
 
     return TM_ECODE_OK;
 }
@@ -1992,23 +2083,27 @@ static int ConfigGetCaptureValue(SCInstance *suri)
     if ((ConfGet("default-packet-size", &temp_default_packet_size)) != 1) {
         int lthread;
         int nlive;
-        switch (suri->run_mode) {
-            case RUNMODE_PCAP_DEV:
-            case RUNMODE_AFP_DEV:
-            case RUNMODE_NETMAP:
-            case RUNMODE_PFRING:
-                nlive = LiveGetDeviceCount();
-                for (lthread = 0; lthread < nlive; lthread++) {
-                    char *live_dev = LiveGetDeviceName(lthread);
-                    unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(live_dev);
-                    if (iface_max_packet_size > default_packet_size)
-                        default_packet_size = iface_max_packet_size;
-                }
-                if (default_packet_size)
-                    break;
-                /* fall through */
-            default:
-                default_packet_size = DEFAULT_PACKET_SIZE;
+        int i;
+        for (i = 0; i < RunmodeGetNumber(&suri->runmodeslist); i++) {
+            enum RunModes runmode = RunmodeGetCurrent(&suri->runmodeslist, i);
+            switch (runmode) {
+                case RUNMODE_PCAP_DEV:
+                case RUNMODE_AFP_DEV:
+                case RUNMODE_NETMAP:
+                case RUNMODE_PFRING:
+                    nlive = LiveGetDeviceCount(runmode);
+                    for (lthread = 0; lthread < nlive; lthread++) {
+                        char *live_dev = LiveGetDeviceName(lthread, runmode);
+                        unsigned int iface_max_packet_size = GetIfaceMaxPacketSize(live_dev);
+                        if (iface_max_packet_size > default_packet_size)
+                            default_packet_size = iface_max_packet_size;
+                    }
+                    if (default_packet_size)
+                        break;
+                    /* fall through */
+                default:
+                    default_packet_size = DEFAULT_PACKET_SIZE;
+            }
         }
     } else {
         if (ParseSizeStringU32(temp_default_packet_size, &default_packet_size) < 0) {
@@ -2091,17 +2186,17 @@ static int PostConfLoadedSetup(SCInstance *suri)
     }
 
 #ifdef NFQ
-    if (suri->run_mode == RUNMODE_NFQ)
+    if (RunmodeGetPrimary(&suri->runmodeslist) == RUNMODE_NFQ || RunmodeGetSecondary(&suri->runmodeslist) == RUNMODE_NFQ)
         NFQInitConfig(FALSE);
 #endif
 
     /* Load the Host-OS lookup. */
     SCHInfoLoadFromConfig();
-    if (suri->run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri->runmodeslist) != RUNMODE_UNIX_SOCKET) {
         DefragInit();
     }
 
-    if (suri->run_mode == RUNMODE_ENGINE_ANALYSIS) {
+    if (RunmodeGetPrimary(&suri->runmodeslist) == RUNMODE_ENGINE_ANALYSIS) {
         SCLogInfo("== Carrying out Engine Analysis ==");
         char *temp = NULL;
         if (ConfGet("engine-analysis", &temp) == 0) {
@@ -2120,7 +2215,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
     CIDRInit();
     SigParsePrepare();
 #ifdef PROFILING
-    if (suri->run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri->runmodeslist) != RUNMODE_UNIX_SOCKET) {
         SCProfilingRulesGlobalInit();
         SCProfilingKeywordsGlobalInit();
         SCProfilingInit();
@@ -2215,7 +2310,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (suri.run_mode == RUNMODE_UNITTEST)
+    if (RunmodeGetPrimary(&suri.runmodeslist) == RUNMODE_UNITTEST)
         RunUnittests(0, suri.regex_arg);
 
 #ifdef __SC_CUDA_SUPPORT__
@@ -2224,7 +2319,7 @@ int main(int argc, char **argv)
     CudaBufferInit();
 #endif
 
-    if (!CheckValidDaemonModes(suri.daemon, suri.run_mode)) {
+    if (!CheckValidDaemonModes(suri.daemon, RunmodeGetPrimary(&suri.runmodeslist))) {
         exit(EXIT_FAILURE);
     }
 
@@ -2232,7 +2327,7 @@ int main(int argc, char **argv)
     GlobalInits();
     TimeInit();
     SupportFastPatternForSigMatchTypes();
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         StatsInit();
     }
 
@@ -2245,7 +2340,7 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
-    if (suri.run_mode == RUNMODE_DUMP_CONFIG) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) == RUNMODE_DUMP_CONFIG) {
         ConfDump();
         exit(EXIT_SUCCESS);
     }
@@ -2258,8 +2353,11 @@ int main(int argc, char **argv)
 
     UtilCpuPrintSummary();
 
-    if (ParseInterfacesList(suri.run_mode, suri.pcap_dev) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
+    int i;
+    for (i = 0; i < RunmodeGetNumber(&suri.runmodeslist); i++) {
+        if (ParseInterfacesList(RunmodeGetCurrent(&suri.runmodeslist, i), suri.pcap_dev) != TM_ECODE_OK) {
+            exit(EXIT_FAILURE);
+        }
     }
 
     if (PostConfLoadedSetup(&suri) != TM_ECODE_OK) {
@@ -2284,7 +2382,7 @@ int main(int argc, char **argv)
     }
 
     HostInitConfig(HOST_VERBOSE);
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         FlowInitConfig(FLOW_VERBOSE);
         StreamTcpInitConfig(STREAM_VERBOSE);
         IPPairInitConfig(IPPAIR_VERBOSE);
@@ -2310,7 +2408,7 @@ int main(int argc, char **argv)
             exit(EXIT_FAILURE);
         }
         if ((suri.delayed_detect || (mt_enabled && !default_tenant)) &&
-            (suri.run_mode != RUNMODE_CONF_TEST)) {
+            (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_CONF_TEST)) {
             de_ctx = DetectEngineCtxInitMinimal();
         } else {
             de_ctx = DetectEngineCtxInit();
@@ -2329,7 +2427,7 @@ int main(int argc, char **argv)
         if (!de_ctx->minimal) {
             if (LoadSignatures(de_ctx, &suri) != TM_ECODE_OK)
                 exit(EXIT_FAILURE);
-            if (suri.run_mode == RUNMODE_ENGINE_ANALYSIS) {
+            if (RunmodeGetPrimary(&suri.runmodeslist) == RUNMODE_ENGINE_ANALYSIS) {
                 exit(EXIT_SUCCESS);
             }
         }
@@ -2348,20 +2446,25 @@ int main(int argc, char **argv)
 
     SCDropMainThreadCaps(suri.userid, suri.groupid);
 
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         RunModeInitializeOutputs();
         StatsSetupPostConfig();
     }
 
-    if(suri.run_mode == RUNMODE_CONF_TEST){
+    if(RunmodeGetPrimary(&suri.runmodeslist) == RUNMODE_CONF_TEST){
         SCLogNotice("Configuration provided was successfully loaded. Exiting.");
         exit(EXIT_SUCCESS);
     }
 
-    RunModeDispatch(suri.run_mode, suri.runmode_custom_mode);
+    RunModeDispatch(RunmodeGetPrimary(&suri.runmodeslist), suri.runmode_custom_mode);
+    for (i = 1; i < RunmodeGetNumber(&suri.runmodeslist); i++) {
+        if (suri.runmodeslist.run_mode[i] != RUNMODE_UNKNOWN) {
+            RunModeDispatch(suri.runmodeslist.run_mode[i], suri.runmode_custom_mode);
+        }
+    }
 
     /* In Unix socket runmode, Flow manager is started on demand */
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         /* Spawn the unix socket manager thread */
         int unix_socket = 0;
         if (ConfGetBool("unix-command.enabled", &unix_socket) != 1)
@@ -2457,7 +2560,7 @@ int main(int argc, char **argv)
 
     UnixSocketKillSocketThread();
 
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         /* First we need to disable the flow manager thread */
         FlowDisableFlowManagerThread();
     }
@@ -2466,7 +2569,7 @@ int main(int argc, char **argv)
     /* Disable packet acquisition first */
     TmThreadDisableReceiveThreads();
 
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         /* we need a packet pool for FlowForceReassembly */
         PacketPoolInit();
 
@@ -2480,7 +2583,7 @@ int main(int argc, char **argv)
 
     /* before TmThreadKillThreads, as otherwise that kills it
      * but more slowly */
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         FlowDisableFlowRecyclerThread();
     }
 
@@ -2488,7 +2591,7 @@ int main(int argc, char **argv)
     TmThreadKillThreads();
 
 
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         /* destroy the packet pool for flow reassembly after all
          * the other threads are gone. */
         PacketPoolDestroy();
@@ -2531,7 +2634,7 @@ int main(int argc, char **argv)
     OutputDeregisterAll();
     TimeDeinit();
     SCProtoNameDeInit();
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         DefragDestroy();
     }
     if (!suri.disabled_detect) {
@@ -2552,7 +2655,7 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef PROFILING
-    if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
+    if (RunmodeGetPrimary(&suri.runmodeslist) != RUNMODE_UNIX_SOCKET) {
         if (profiling_rules_enabled)
             SCProfilingDump();
         SCProfilingDestroy();

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -68,6 +68,7 @@
 #include "suricata-common.h"
 #include "packet-queue.h"
 #include "data-queue.h"
+#include "runmodes.h"
 
 /* the name of our binary */
 #define PROG_NAME "Suricata"
@@ -91,6 +92,8 @@
 #define SURICATA_KILL    (1 << 1)   /**< shut down asap, discarding outstanding
                                      packets. */
 #define SURICATA_DONE    (1 << 2)   /**< packets capture ended */
+
+#define RUNMODES_MAX     2
 
 /* Engine stage/status*/
 enum {
@@ -126,8 +129,13 @@ PacketQueue trans_q[256];
 
 SCDQDataQueue data_queues[256];
 
+typedef struct RunModesList_ {
+    enum RunModes run_mode[RUNMODES_MAX];
+    int runmodes_cnt;
+} RunModesList;
+
 typedef struct SCInstance_ {
-    int run_mode;
+    RunModesList runmodeslist;
 
     char pcap_dev[128];
     char *sig_file;
@@ -187,11 +195,14 @@ void SignalHandlerSigusr2(int);
 void SignalHandlerSigusr2EngineShutdown(int);
 void SignalHandlerSigusr2Idle(int sig);
 
+int RunmodeGetPrimary(const RunModesList *runmodes);
+int RunmodeGetSecondary(const RunModesList *runmodes);
+int RunmodeGetNumber(const RunModesList *runmodes);
 int RunmodeIsUnittests(void);
-int RunmodeGetCurrent(void);
+int RunmodeGetCurrent(const RunModesList *runmodes, int index);
 int IsRuleReloadSet(int quiet);
 
-extern int run_mode;
+extern RunModesList runmodeslist;
 
 #endif /* __SURICATA_H__ */
 

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -643,7 +643,7 @@ TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
                                       json_t *server_msg, void *data)
 {
     SCEnter();
-    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode()));
+    json_object_set_new(server_msg, "message", json_string(RunModeGetMainMode(0)));
     SCReturnInt(TM_ECODE_OK);
 }
 

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -20,10 +20,12 @@
 
 #include "queue.h"
 #include "unix-manager.h"
+#include "runmodes.h"
 
 /** storage for live device names */
 typedef struct LiveDevice_ {
     char *dev;  /**< the device (e.g. "eth0") */
+    enum RunModes runmode; /**< the runmode (e.g. "RUNMODE_NFLOG") */
     int ignore_checksum;
     SC_ATOMIC_DECLARE(uint64_t, pkts);
     SC_ATOMIC_DECLARE(uint64_t, drop);
@@ -31,15 +33,14 @@ typedef struct LiveDevice_ {
     TAILQ_ENTRY(LiveDevice_) next;
 } LiveDevice;
 
-
-int LiveRegisterDevice(const char *dev);
-int LiveGetDeviceCount(void);
-char *LiveGetDeviceName(int number);
-LiveDevice *LiveGetDevice(const char *dev);
-int LiveBuildDeviceList(const char *base);
+int LiveRegisterDevice(char *dev, enum RunModes runmode);
+int LiveGetDeviceCount(enum RunModes runmode);
+char *LiveGetDeviceName(int number, enum RunModes runmode);
+LiveDevice *LiveGetDevice(char *dev, enum RunModes runmode);
+int LiveBuildDeviceList(char * base, enum RunModes runmode);
 void LiveDeviceHasNoStats(void);
 int LiveDeviceListClean(void);
-int LiveBuildDeviceListCustom(const char *base, const char *itemname);
+int LiveBuildDeviceListCustom(char * base, char * itemname, enum RunModes runmode);
 
 #ifdef BUILD_UNIX_SOCKET
 TmEcode LiveDeviceIfaceStat(json_t *cmd, json_t *server_msg, void *data);

--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -71,7 +71,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
 
     capng_clear(CAPNG_SELECT_BOTH);
 
-    switch (run_mode) {
+    switch (runmodeslist.run_mode[0]) {
         case RUNMODE_PCAP_DEV:
         case RUNMODE_AFP_DEV:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
@@ -87,6 +87,31 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
                     CAP_NET_ADMIN,          /* needed for nfqueue inline mode */
                     -1);
+            break;
+        case RUNMODE_ERF_FILE:
+        case RUNMODE_ENGINE_ANALYSIS:
+        case RUNMODE_NFLOG:
+        case RUNMODE_IPFW:
+        case RUNMODE_DAG:
+        case RUNMODE_PCAP_FILE:
+        case RUNMODE_NETMAP:
+        case RUNMODE_TILERA_MPIPE:
+        case RUNMODE_UNITTEST:
+        case RUNMODE_NAPATECH:
+        case RUNMODE_UNIX_SOCKET:
+        case RUNMODE_USER_MAX:
+        case RUNMODE_LIST_KEYWORDS:
+        case RUNMODE_LIST_APP_LAYERS:
+        case RUNMODE_LIST_CUDA_CARDS:
+        case RUNMODE_LIST_RUNMODES:
+        case RUNMODE_PRINT_VERSION:
+        case RUNMODE_PRINT_BUILDINFO:
+        case RUNMODE_PRINT_USAGE:
+        case RUNMODE_DUMP_CONFIG:
+        case RUNMODE_CONF_TEST:
+        case RUNMODE_LIST_UNITTEST:
+        case RUNMODE_MAX:
+        case RUNMODE_UNKNOWN:
             break;
     }
 

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -104,7 +104,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
@@ -112,7 +112,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     int thread = 0;
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     int thread_max = TmThreadGetNbThreads(DETECT_CPU_SET);
     /* always create at least one thread */
     if (thread_max == 0)
@@ -190,7 +190,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         int lthread;
 
         for (lthread = 0; lthread < nlive; lthread++) {
-            char *live_dev = LiveGetDeviceName(lthread);
+            char *live_dev = LiveGetDeviceName(lthread, runmode);
             void *aconf;
             int threads_count;
 
@@ -412,9 +412,9 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     void *aconf;
     int ldev;
 
@@ -428,7 +428,7 @@ int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc ConfigParser,
                 exit(EXIT_FAILURE);
             }
         } else {
-            live_dev_c = LiveGetDeviceName(ldev);
+            live_dev_c = LiveGetDeviceName(ldev, runmode);
             aconf = ConfigParser(live_dev_c);
         }
         RunModeSetLiveCaptureWorkersForDevice(ModThreadsCount,
@@ -447,9 +447,9 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev)
+                              const char *live_dev, int runmode)
 {
-    int nlive = LiveGetDeviceCount();
+    int nlive = LiveGetDeviceCount(runmode);
     void *aconf;
 
     if (nlive > 1) {
@@ -461,7 +461,7 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
     if (live_dev != NULL) {
         aconf = ConfigParser(live_dev);
     } else {
-        char *live_dev_c = LiveGetDeviceName(0);
+        char *live_dev_c = LiveGetDeviceName(0, runmode);
         aconf = ConfigParser(live_dev_c);
         /* \todo Set threads number in config to 1 */
     }
@@ -482,7 +482,8 @@ int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc ConfigParser,
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name)
+                        char *decode_mod_name,
+                        int runmode)
 {
     SCEnter();
     char tname[TM_THREAD_NAME_MAX];
@@ -494,8 +495,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
-    int nqueue = LiveGetDeviceCount();
-
+    int nqueue = LiveGetDeviceCount(runmode);
     int thread_max = TmThreadGetNbThreads(DETECT_CPU_SET);
     /* always create at least one thread */
     if (thread_max == 0)
@@ -513,7 +513,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 
     for (int i = 0; i < nqueue; i++) {
     /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);
@@ -534,6 +534,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
+
         TmModule *tm_module = TmModuleGetByName(recv_mod_name);
         if (tm_module == NULL) {
             SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName failed for %s", recv_mod_name);
@@ -659,18 +660,19 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
         char *recv_mod_name,
         char *verdict_mod_name,
-        char *decode_mod_name)
+        char *decode_mod_name,
+        int runmode)
 {
     char tname[TM_THREAD_NAME_MAX];
     ThreadVars *tv = NULL;
     TmModule *tm_module = NULL;
     char *cur_queue = NULL;
 
-    int nqueue = LiveGetDeviceCount();
+    int nqueue = LiveGetDeviceCount(runmode);
 
     for (int i = 0; i < nqueue; i++) {
         /* create the threads */
-        cur_queue = LiveGetDeviceName(i);
+        cur_queue = LiveGetDeviceName(i, runmode);
         if (cur_queue == NULL) {
             SCLogError(SC_ERR_RUNMODE, "invalid queue number");
             exit(EXIT_FAILURE);

--- a/src/util-runmodes.h
+++ b/src/util-runmodes.h
@@ -34,35 +34,37 @@ int RunModeSetLiveCaptureAuto(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureSingle(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetLiveCaptureWorkers(ConfigIfaceParserFunc configparser,
                               ConfigIfaceThreadsCountFunc ModThreadsCount,
                               char *recv_mod_name,
                               char *decode_mod_name, char *thread_name,
-                              const char *live_dev);
+                              const char *live_dev, int runmode);
 
 int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name);
+                        char *decode_mod_name,
+                        int runmode);
 
 int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
                         char *recv_mod_name,
                         char *verdict_mod_name,
-                        char *decode_mod_name);
+                        char *decode_mod_name,
+                        int runmode);
 
 char *RunmodeAutoFpCreatePickupQueuesString(int n);
 


### PR DESCRIPTION
A rebased patchset of https://github.com/inliniac/suricata/pull/1773

There is also a small change in ca9feda:
In the previous code we set a flag only if a packet is not in ips mode:

	if (!PacketModeIsIPS(p)) {
	    if (p->flowflags & FLOW_PKT_TOSERVER) {
		    flag = FLOW_PKT_TOCLIENT;
	    } else {
		    flag = FLOW_PKT_TOSERVER;
	    }
	}

The first test has been removed since doesn't look correct and it also fires up the following warning:

    output-json-alert.c: In function ‘JsonAlertLogger’:
    output-json-alert.c:286:17: warning: ‘flag’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                 StreamSegmentForEach((const Packet *)p, flag,
                 ^
    output-json-alert.c:274:25: note: ‘flag’ was declared here
                 uint8_t flag;

[Old code https://github.com/glongo/suricata/commit/2f447d6dfe53a84f66218a9aa3d60de8ac6084b2#diff-e2a291d82d2cff36c51007fafaa79b86R277]:

Ticket: [#1604] (https://redmine.openinfosecfoundation.org/issues/1604)

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/98
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/97