### PR TITLE
json: use top-level sensor-name if provided - v1

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -435,7 +435,17 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
 {
     OutputJsonCtx *json_ctx = SCCalloc(1, sizeof(OutputJsonCtx));;
 
+    /* First lookup a sensor-name value in this outputs configuration
+     * node (deprecated). If that fails, lookup the global one. */
     const char *sensor_name = ConfNodeLookupChildValue(conf, "sensor-name");
+    if (sensor_name != NULL) {
+        SCLogWarning(SC_ERR_DEPRECATED_CONF,
+            "Found deprecated eve-log setting \"sensor-name\". "
+            "Please set sensor-name globally.");
+    }
+    else {
+        ConfGet("sensor-name", (char **)&sensor_name);
+    }
 
     if (unlikely(json_ctx == NULL)) {
         SCLogDebug("AlertJsonInitCtx: Could not create new LogFileCtx");

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -314,6 +314,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_INVALID_RULE_ARGUMENT);
         CASE_CODE (SC_ERR_STATS_LOG_NEGATED);
         CASE_CODE (SC_ERR_JSON_STATS_LOG_NEGATED);
+        CASE_CODE (SC_ERR_DEPRECATED_CONF);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -304,6 +304,7 @@ typedef enum {
     SC_ERR_MT_NO_MAPPING,
     SC_ERR_STATS_LOG_NEGATED, /** When totals and threads are both NO in yaml **/
     SC_ERR_JSON_STATS_LOG_NEGATED, /** When totals and threads are both NO in yaml **/
+    SC_ERR_DEPRECATED_CONF, /**< Deprecated configuration parameter. */
 } SCError;
 
 const char *SCErrorToString(SCError);


### PR DESCRIPTION
Currently the default configuration file contains a "sensor-name"
at the root of the configuration file, however, eve-log will only
use it if its specified under eve-log.

Now we will look for it at the eve-log, if present we'll use it
but log a deprecation warning, if its not present we'll look
for sensor-name at the root of the configuration.

Related Redmine issues:
https://redmine.openinfosecfoundation.org/issues/1679
https://redmine.openinfosecfoundation.org/issues/1680

Still unsure about the output in json being "host". IMO "sensor_name" would be better, but I don't want to break existing integrations.

Changes from last PR (#1850):
- Cast call to ConfGet to get rid of compiler error (though I wonder if ConfGet should take a const as its parameter).

Prscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/187
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/190
