### PR TITLE
unix socket stats v3

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -36,7 +36,10 @@
 #include "util-privs.h"
 #include "util-signal.h"
 #include "unix-manager.h"
+
 #include "output.h"
+#include "output-stats.h"
+#include "output-json-stats.h"
 
 /* Time interval for syncing the local counters with the global ones */
 #define STATS_WUT_TTS 3
@@ -101,6 +104,7 @@ void StatsReleaseCounters(StatsCounter *head);
 /** stats table is filled each interval and passed to the
  *  loggers. Initialized at first use. */
 static StatsTable stats_table = { NULL, NULL, 0, 0, 0, {0 , 0}};
+static SCMutex stats_table_mutex = SCMUTEX_INITIALIZER;
 
 static uint16_t counters_global_id = 0;
 
@@ -280,6 +284,7 @@ static void StatsReleaseCtx()
     SCFree(stats_ctx);
     stats_ctx = NULL;
 
+    SCMutexLock(&stats_table_mutex);
     /* free stats table */
     if (stats_table.tstats != NULL) {
         SCFree(stats_table.tstats);
@@ -291,6 +296,7 @@ static void StatsReleaseCtx()
         stats_table.stats = NULL;
     }
     memset(&stats_table, 0, sizeof(stats_table));
+    SCMutexUnlock(&stats_table_mutex);
 
     return;
 }
@@ -359,7 +365,9 @@ static void *StatsMgmtThread(void *arg)
         SCCtrlCondTimedwait(tv_local->ctrl_cond, tv_local->ctrl_mutex, &cond_time);
         SCCtrlMutexUnlock(tv_local->ctrl_mutex);
 
+        SCMutexLock(&stats_table_mutex);
         StatsOutput(tv_local);
+        SCMutexUnlock(&stats_table_mutex);
 
         if (TmThreadsCheckFlag(tv_local, THV_KILL)) {
             run = 0;
@@ -757,15 +765,25 @@ static int StatsOutput(ThreadVars *tv)
 }
 
 #ifdef BUILD_UNIX_SOCKET
-/**
- *  \todo reimplement this, probably based on stats-json
+/** \brief callback for getting stats into unix socket
  */
 TmEcode StatsOutputCounterSocket(json_t *cmd,
                                json_t *answer, void *data)
 {
-    json_object_set_new(answer, "message",
-            json_string("not implemented"));
-    return TM_ECODE_FAILED;
+    json_t *message = NULL;
+    TmEcode r = TM_ECODE_OK;
+
+    SCMutexLock(&stats_table_mutex);
+    if (stats_table.start_time == 0) {
+        r = TM_ECODE_FAILED;
+        message = json_string("stats not yet synchronized");
+    } else {
+        message = StatsToJSON(&stats_table, JSON_STATS_TOTALS|JSON_STATS_THREADS);
+    }
+    SCMutexUnlock(&stats_table_mutex);
+
+    json_object_set_new(answer, "message", message);
+    return r;
 }
 #endif /* BUILD_UNIX_SOCKET */
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -45,6 +45,7 @@
 #include "util-crypt.h"
 
 #include "output-json.h"
+#include "output-json-stats.h"
 
 #define MODULE_NAME "JsonStatsLog"
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -51,10 +51,6 @@
 #ifdef HAVE_LIBJANSSON
 #include <jansson.h>
 
-#define JSON_STATS_TOTALS  (1<<0)
-#define JSON_STATS_THREADS (1<<1)
-#define JSON_STATS_DELTAS  (1<<2)
-
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -91,28 +91,18 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     return value;
 }
 
-static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *st)
+/** \brief turn StatsTable into a json object
+ *  \param flags JSON_STATS_* flags for controlling output
+ */
+json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
 {
-    SCEnter();
-    JsonStatsLogThread *aft = (JsonStatsLogThread *)thread_data;
     const char delta_suffix[] = "_delta";
-
     struct timeval tval;
     gettimeofday(&tval, NULL);
 
-    json_t *js = json_object();
-    if (unlikely(js == NULL))
-        return 0;
-
-    char timebuf[64];
-    CreateIsoTimeString(&tval, timebuf, sizeof(timebuf));
-    json_object_set_new(js, "timestamp", json_string(timebuf));
-
-    json_object_set_new(js, "event_type", json_string("stats"));
     json_t *js_stats = json_object();
     if (unlikely(js_stats == NULL)) {
-        json_decref(js);
-        return 0;
+        return NULL;
     }
 
     /* Uptime, in seconds. */
@@ -120,7 +110,7 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
         json_integer((int)difftime(tval.tv_sec, st->start_time)));
 
     uint32_t u = 0;
-    if (aft->statslog_ctx->flags & JSON_STATS_TOTALS) {
+    if (flags & JSON_STATS_TOTALS) {
         for (u = 0; u < st->nstats; u++) {
             if (st->stats[u].name == NULL)
                 continue;
@@ -133,7 +123,8 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
             if (js_type != NULL) {
                 json_object_set_new(js_type, shortname,
                     json_integer(st->stats[u].value));
-                if (aft->statslog_ctx->flags & JSON_STATS_DELTAS) {
+
+                if (flags & JSON_STATS_DELTAS) {
                     char deltaname[strlen(shortname) + strlen(delta_suffix) + 1];
                     snprintf(deltaname, sizeof(deltaname), "%s%s", shortname,
                         delta_suffix);
@@ -145,12 +136,12 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
     }
 
     /* per thread stats - stored in a "threads" object. */
-    if (st->tstats != NULL && (aft->statslog_ctx->flags & JSON_STATS_THREADS)) {
+    if (st->tstats != NULL && (flags & JSON_STATS_THREADS)) {
         /* for each thread (store) */
         json_t *threads = json_object();
         if (unlikely(threads == NULL)) {
-            json_decref(js);
-            return 0;
+            json_decref(js_stats);
+            return NULL;
         }
         uint32_t x;
         for (x = 0; x < st->ntstats; x++) {
@@ -169,7 +160,7 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
                 if (js_type != NULL) {
                     json_object_set_new(js_type, shortname, json_integer(st->tstats[u].value));
 
-                    if (aft->statslog_ctx->flags & JSON_STATS_DELTAS) {
+                    if (flags & JSON_STATS_DELTAS) {
                         char deltaname[strlen(shortname) + strlen(delta_suffix) + 1];
                         snprintf(deltaname, sizeof(deltaname), "%s%s",
                             shortname, delta_suffix);
@@ -180,6 +171,30 @@ static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *
             }
         }
         json_object_set_new(js_stats, "threads", threads);
+    }
+    return js_stats;
+}
+
+static int JsonStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *st)
+{
+    SCEnter();
+    JsonStatsLogThread *aft = (JsonStatsLogThread *)thread_data;
+
+    struct timeval tval;
+    gettimeofday(&tval, NULL);
+
+    json_t *js = json_object();
+    if (unlikely(js == NULL))
+        return 0;
+    char timebuf[64];
+    CreateIsoTimeString(&tval, timebuf, sizeof(timebuf));
+    json_object_set_new(js, "timestamp", json_string(timebuf));
+    json_object_set_new(js, "event_type", json_string("stats"));
+
+    json_t *js_stats = StatsToJSON(st, aft->statslog_ctx->flags);
+    if (js_stats == NULL) {
+        json_decref(js);
+        return 0;
     }
 
     json_object_set_new(js, "stats", js_stats);

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -24,6 +24,15 @@
 #ifndef __OUTPUT_JSON_COUNTERS_H__
 #define __OUTPUT_JSON_COUNTERS_H__
 
+#include "output-stats.h"
+
+#define JSON_STATS_TOTALS  (1<<0)
+#define JSON_STATS_THREADS (1<<1)
+#define JSON_STATS_DELTAS  (1<<2)
+
+#ifdef HAVE_LIBJANSSON
+json_t *StatsToJSON(const StatsTable *st, uint8_t flags);
+#endif
 void TmModuleJsonStatsLogRegister (void);
 
 #endif /* __OUTPUT_JSON_COUNTERS_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -335,18 +335,13 @@ json_t *CreateJSONHeaderWithTxId(Packet *p, int direction_sensitive, char *event
     return js;
 }
 
-/* helper struct for the callback */
-typedef struct MemBufferWrapper_ {
-    MemBuffer **buffer;
-} MemBufferWrapper;
-
-static int MemBufferCallback(const char *str, size_t size, void *data)
+int OutputJSONMemBufferCallback(const char *str, size_t size, void *data)
 {
-    MemBufferWrapper *wrapper = data;
+    OutputJSONMemBufferWrapper *wrapper = data;
     MemBuffer **memb = wrapper->buffer;
 
     if (MEMBUFFER_OFFSET(*memb) + size >= MEMBUFFER_SIZE(*memb)) {
-        MemBufferExpand(memb, OUTPUT_BUFFER_SIZE);
+        MemBufferExpand(memb, wrapper->expand_by);
     }
 
     MemBufferWriteRaw((*memb), str, size);
@@ -364,9 +359,12 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
         MemBufferWriteRaw((*buffer), file_ctx->prefix, file_ctx->prefix_len);
     }
 
-    MemBufferWrapper wrapper = { .buffer = buffer };
+    OutputJSONMemBufferWrapper wrapper = {
+        .buffer = buffer,
+        .expand_by = OUTPUT_BUFFER_SIZE
+    };
 
-    int r = json_dump_callback(js, MemBufferCallback, &wrapper,
+    int r = json_dump_callback(js, OutputJSONMemBufferCallback, &wrapper,
             JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
 #ifdef JSON_ESCAPE_SLASH
                             JSON_ESCAPE_SLASH

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -33,6 +33,14 @@ void TmModuleOutputJsonRegister (void);
 #include "util-buffer.h"
 #include "util-logopenfile.h"
 
+/* helper struct for OutputJSONMemBufferCallback */
+typedef struct OutputJSONMemBufferWrapper_ {
+    MemBuffer **buffer; /**< buffer to use & expand as needed */
+    size_t expand_by;   /**< expand by this size */
+} OutputJSONMemBufferWrapper;
+
+int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
+
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 json_t *CreateJSONHeader(Packet *p, int direction_sensative, char *event_type);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -33,12 +33,16 @@
 #include "util-debug.h"
 #include "util-signal.h"
 
+#include "util-buffer.h"
+
 #include <sys/un.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #ifdef BUILD_UNIX_SOCKET
 #include <jansson.h>
+
+#include "output-json.h"
 
 // MSG_NOSIGNAL does not exists on OS X
 #ifdef OS_DARWIN
@@ -65,8 +69,10 @@ typedef struct Task_ {
     TAILQ_ENTRY(Task_) next;
 } Task;
 
+#define CLIENT_BUFFER_SIZE 4096
 typedef struct UnixClient_ {
     int fd;
+    MemBuffer *mbuf; /**< buffer for response construction */
     TAILQ_ENTRY(UnixClient_) next;
 } UnixClient;
 
@@ -219,6 +225,30 @@ void UnixCommandSetMaxFD(UnixCommand *this)
     }
 }
 
+static UnixClient *UnixClientAlloc(void)
+{
+    UnixClient *uclient = SCMalloc(sizeof(UnixClient));
+    if (unlikely(uclient == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate new cient");
+        return NULL;
+    }
+    uclient->mbuf = MemBufferCreateNew(CLIENT_BUFFER_SIZE);
+    if (uclient->mbuf == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate new cient send buffer");
+        SCFree(uclient);
+        return NULL;
+    }
+    return uclient;
+}
+
+static void UnixClientFree(UnixClient *c)
+{
+    if (c != NULL) {
+        MemBufferFree(c->mbuf);
+        SCFree(c);
+    }
+}
+
 /**
  * \brief Close the unix socket
  */
@@ -243,26 +273,47 @@ void UnixCommandClose(UnixCommand  *this, int fd)
 
     close(item->fd);
     UnixCommandSetMaxFD(this);
-    SCFree(item);
-}
-
-/**
- * \brief Callback function used to send message to socket
- */
-int UnixCommandSendCallback(const char *buffer, size_t size, void *data)
-{
-    int fd = *(int *) data;
-
-    if (send(fd, buffer, size, MSG_NOSIGNAL) == -1) {
-        SCLogInfo("Unable to send block: %s", strerror(errno));
-        return -1;
-    }
-
-    return 0;
+    UnixClientFree(item);
 }
 
 #define UNIX_PROTO_VERSION_LENGTH 200
 #define UNIX_PROTO_VERSION "0.1"
+
+int UnixCommandSendJSONToClient(UnixClient *client, json_t *js)
+{
+    MemBufferReset(client->mbuf);
+
+    OutputJSONMemBufferWrapper wrapper = {
+        .buffer = &client->mbuf,
+        .expand_by = CLIENT_BUFFER_SIZE
+    };
+
+    int r = json_dump_callback(js, OutputJSONMemBufferCallback, &wrapper,
+            JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
+#ifdef JSON_ESCAPE_SLASH
+                            JSON_ESCAPE_SLASH
+#else
+                            0
+#endif
+                            );
+    if (r != 0) {
+        SCLogWarning(SC_ERR_SOCKET, "unable to serialize JSON object");
+        return -1;
+    }
+
+    if (send(client->fd, (const char *)MEMBUFFER_BUFFER(client->mbuf),
+                MEMBUFFER_OFFSET(client->mbuf), MSG_NOSIGNAL) == -1)
+    {
+        SCLogWarning(SC_ERR_SOCKET, "unable to send block of size "
+                "%"PRIuMAX": %s", (uintmax_t)MEMBUFFER_OFFSET(client->mbuf),
+                strerror(errno));
+        return -1;
+    }
+
+    SCLogDebug("sent message of size %"PRIuMAX" to client socket %d",
+            (uintmax_t)MEMBUFFER_OFFSET(client->mbuf), client->fd);
+    return 0;
+}
 
 /**
  * \brief Accept a new client on unix socket
@@ -347,23 +398,27 @@ int UnixCommandAccept(UnixCommand *this)
     }
     json_object_set_new(server_msg, "return", json_string("OK"));
 
-    if (json_dump_callback(server_msg, UnixCommandSendCallback, &client, 0) == -1) {
-        SCLogWarning(SC_ERR_SOCKET, "Unable to send command");
-        json_decref(server_msg);
-        close(client);
-        return 0;
-    }
-    json_decref(server_msg);
-
-    /* client connected */
-    SCLogDebug("Unix socket: client connected");
-
-    uclient = SCMalloc(sizeof(UnixClient));
+    uclient = UnixClientAlloc();
     if (unlikely(uclient == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Can't allocate new cient");
         return 0;
     }
     uclient->fd = client;
+
+    if (UnixCommandSendJSONToClient(uclient, server_msg) != 0) {
+        SCLogWarning(SC_ERR_SOCKET, "Unable to send command");
+
+        UnixClientFree(uclient);
+        json_decref(server_msg);
+        close(client);
+        return 0;
+    }
+
+    json_decref(server_msg);
+
+    /* client connected */
+    SCLogDebug("Unix socket: client connected");
+
     TAILQ_INSERT_TAIL(&this->clients, uclient, next);
     UnixCommandSetMaxFD(this);
     return 1;
@@ -453,10 +508,8 @@ int UnixCommandExecute(UnixCommand * this, char *command, UnixClient *client)
             break;
     }
 
-    /* send answer */
-    if (json_dump_callback(server_msg, UnixCommandSendCallback, &client->fd, 0) == -1) {
-        SCLogWarning(SC_ERR_SOCKET, "Unable to send command");
-        goto error_cmd;
+    if (UnixCommandSendJSONToClient(client, server_msg) != 0) {
+        goto error;
     }
 
     json_decref(jsoncmd);


### PR DESCRIPTION
As #1859, changing:
- log both totals and thread stats
- change unix socket write to client logic to send one message instead of many
