### PR TITLE
build-info: workaround special _FORTIFY_SOURCE defines

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -779,8 +779,12 @@ void SCPrintBuildInfo(void)
 #if __SSP_ALL__ == 2
     printf("compiled with -fstack-protector-all\n");
 #endif
-#ifdef _FORTIFY_SOURCE
-    printf("compiled with _FORTIFY_SOURCE=%d\n", _FORTIFY_SOURCE);
+#if _FORTIFY_SOURCE == 2
+    printf("compiled with _FORTIFY_SOURCE=2\n");
+#elif _FORTIFY_SOURCE == 1
+    printf("compiled with _FORTIFY_SOURCE=1\n");
+#elif _FORTIFY_SOURCE == 0
+    printf("compiled with _FORTIFY_SOURCE=0\n");
 #endif
 #ifdef CLS
     printf("L1 cache line size (CLS)=%d\n", CLS);


### PR DESCRIPTION
This works around the issue with distributions defining _FORTIFY_SOURCE by default, like Gentoo does (#define _FORTIFY_SOURCE=((defined __OPTIMIZE__ && __OPTIMIZE__ > 0) ? 2 : 0)) and resolves the issue https://redmine.openinfosecfoundation.org/issues/1676

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/12
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/12