### PR TITLE
nfqueue: fix wrong return value check in error cases

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -709,7 +709,7 @@ TmEcode ReceiveNFQThreadInit(ThreadVars *tv, void *initdata, void **data)
     ntv->tv = tv;
 
     int r = NFQInitThread(ntv, (max_pending_packets * NFQ_BURST_FACTOR));
-    if (r < 0) {
+    if (r != 0) {
         SCLogError(SC_ERR_NFQ_THREAD_INIT, "nfq thread failed to initialize");
 
         SCMutexUnlock(&nfq_init_lock);


### PR DESCRIPTION
The check for the return value was wrong, we have 0 for success and 1 (and 2) for the error cases like 
TM_ECODE_FAILED.

This fixes also https://redmine.openinfosecfoundation.org/issues/1411

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/14
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/14