### PR TITLE
build-info: workaround special _FORTIFY_SOURCE defines

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -780,8 +780,19 @@ void SCPrintBuildInfo(void)
 #if __SSP_ALL__ == 2
     printf("compiled with -fstack-protector-all\n");
 #endif
-#ifdef _FORTIFY_SOURCE
-    printf("compiled with _FORTIFY_SOURCE=%d\n", _FORTIFY_SOURCE);
+/*
+ * Workaround for special defines of _FORTIFY_SOURCE like
+ * FORTIFY_SOURCE=((defined __OPTIMIZE && OPTIMIZE > 0) ? 2 : 0)
+ * which is used by Gentoo for example and would result in the error
+ * 'defined' undeclared when _FORTIFY_SOURCE used via %d in printf func
+ *
+ */
+#if _FORTIFY_SOURCE == 2
+    printf("compiled with _FORTIFY_SOURCE=2\n");
+#elif _FORTIFY_SOURCE == 1
+    printf("compiled with _FORTIFY_SOURCE=1\n");
+#elif _FORTIFY_SOURCE == 0
+    printf("compiled with _FORTIFY_SOURCE=0\n");
 #endif
 #ifdef CLS
     printf("L1 cache line size (CLS)=%d\n", CLS);


### PR DESCRIPTION
On systems like Gentoo where _FORTIFY_SOURCE is already defined like
FORTIFY_SOURCE=((defined __OPTIMIZE && OPTIMIZE > 0) ? 2 : 0) the use
within the printf function (%d) won't result in the correct value and
we end up with 'defined' undeclared compile error. This workaround makes
sure that just the resolved value is checked and then printed.

This resolves the issue https://redmine.openinfosecfoundation.org/issues/1676 and also added more description/comment as proposed in the former PR: https://github.com/inliniac/suricata/pull/1863

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/15
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/15