### PR TITLE
http: close file when http body limit is reached

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -1946,6 +1946,12 @@ int HTPCallbackResponseBodyData(htp_tx_data_t *d)
         HtpBodyAppendChunk(tx_ud, &tx_ud->response_body, (uint8_t *)d->data, len);
 
         HtpResponseBodyHandle(hstate, tx_ud, d->tx, (uint8_t *)d->data, (uint32_t)d->len);
+    } else {
+        if (tx_ud->tcflags & HTP_FILENAME_SET) {
+            SCLogDebug("closing file that was being stored");
+            (void)HTPFileClose(hstate, NULL, 0, FILE_TRUNCATED, STREAM_TOCLIENT);
+            tx_ud->tcflags &= ~HTP_FILENAME_SET;
+        }
     }
 
     /* set the new chunk flag */


### PR DESCRIPTION
In some conditions, if stream.reassembly.depth is greater than
request/response-body-limit size, the logging output is wrong
if filestore keyword is used with http.

For example, we get:
{... "app_proto":"http","fileinfo":{"filename":"\/file.pdf","state":"CLOSED","stored":false,"size":1049292,"tx_id":0}}

"state":"CLOSED","stored":false should be "state":"TRUNCATED","stored":true.

This happens because the file state and file flags,
which is the information that determine a correct output,
are not set properly since a file is logged before and then closed (HTPFileClose).

The logic of this patch is to close a file when we are above
the limits, such that the proper state and flags can be set
and the file will be logged correctly.

Ticket: [#1719] (https://redmine.openinfosecfoundation.org/issues/1719)

Prscript:

- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/99
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/98
