### PR TITLE
xff: fix address overwrite in forward case

### DIFF
--- a/src/app-layer-htp-xff.c
+++ b/src/app-layer-htp-xff.c
@@ -160,7 +160,7 @@ int HttpXFFGetIPFromTx(const Packet *p, uint64_t tx_id, HttpXFFCfg *xff_cfg,
             /** Get the first IP address from the chain */
             p_xff = memchr(xff_chain, ',', bstr_len(h_xff->value));
             if (p_xff != NULL) {
-                xff_chain[bstr_len(h_xff->value) - (p_xff - xff_chain)]=0;
+                *p_xff = 0;
             }
             p_xff = xff_chain;
         }


### PR DESCRIPTION
The address was not correctly extracted in the case of the forward case.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/133
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/131
