### PR TITLE
nfqueue: fix wrong return value check in error cases

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -709,7 +709,7 @@ TmEcode ReceiveNFQThreadInit(ThreadVars *tv, void *initdata, void **data)
     ntv->tv = tv;
 
     int r = NFQInitThread(ntv, (max_pending_packets * NFQ_BURST_FACTOR));
-    if (r < 0) {
+    if (r != TM_ECODE_OK) {
         SCLogError(SC_ERR_NFQ_THREAD_INIT, "nfq thread failed to initialize");
 
         SCMutexUnlock(&nfq_init_lock);


### PR DESCRIPTION
The check for the return value was wrong, we have 0 for success and 1
(and 2) for the error cases like TM_ECODE_FAILED, so we should quit
unless TM_ECODE_OK (0) is returned for NFQInitThread. This fixes #1870 

This is the updated version from https://github.com/inliniac/suricata/pull/1870

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/16
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/16