### PR TITLE
rule-parsing: quick fix for rules with wrong double quotes

### DIFF
--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -62,12 +62,14 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, char *depths
     SigMatch *pm = NULL;
     int ret = -1;
 
-    /* strip "'s */
-    if (depthstr[0] == '\"' && depthstr[strlen(depthstr) - 1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (depthstr[0] == '\"') {
         str = SCStrdup(depthstr + 1);
         if (unlikely(str == NULL))
             goto end;
-        str[strlen(depthstr) - 2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -70,12 +70,14 @@ static int DetectDistanceSetup (DetectEngineCtx *de_ctx, Signature *s,
     SigMatch *pm = NULL;
     int ret = -1;
 
-    /* strip "'s */
-    if (distancestr[0] == '\"' && distancestr[strlen(distancestr) - 1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (distancestr[0] == '\"') {
         str = SCStrdup(distancestr + 1);
         if (unlikely(str == NULL))
             goto end;
-        str[strlen(distancestr) - 2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -73,12 +73,14 @@ static int DetectL3ProtoSetup(DetectEngineCtx *de_ctx, Signature *s, char *optst
     char *str = optstr;
     char dubbed = 0;
 
-    /* strip "'s */
-    if (optstr[0] == '\"' && optstr[strlen(optstr) - 1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (optstr[0] == '\"') {
         str = SCStrdup(optstr + 1);
         if (unlikely(str == NULL))
             goto error;
-        str[strlen(optstr) - 2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 

--- a/src/detect-offset.c
+++ b/src/detect-offset.c
@@ -61,12 +61,14 @@ int DetectOffsetSetup (DetectEngineCtx *de_ctx, Signature *s, char *offsetstr)
     SigMatch *pm = NULL;
     int ret = -1;
 
-    /* strip "'s */
-   if (offsetstr[0] == '\"' && offsetstr[strlen(offsetstr)-1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (offsetstr[0] == '\"') {
         str = SCStrdup(offsetstr+1);
         if (unlikely(str == NULL))
             goto end;
-        str[strlen(offsetstr) - 2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 

--- a/src/detect-rev.c
+++ b/src/detect-rev.c
@@ -46,13 +46,14 @@ static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
     char *str = rawstr;
     char dubbed = 0;
 
-    /* strip "'s */
-    if (rawstr[0] == '\"' && rawstr[strlen(rawstr)-1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (rawstr[0] == '\"') {
         str = SCStrdup(rawstr+1);
         if (unlikely(str == NULL))
             return -1;
-
-        str[strlen(rawstr)-2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(rawstr)-1] = '\0';
+        }
         dubbed = 1;
     }
 

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -74,12 +74,14 @@ static int DetectWithinSetup(DetectEngineCtx *de_ctx, Signature *s, char *within
     SigMatch *pm = NULL;
     int ret = -1;
 
-    /* strip "'s */
-    if (withinstr[0] == '\"' && withinstr[strlen(withinstr)-1] == '\"') {
+    /* Strip leading and trailing "s. */
+    if (withinstr[0] == '\"') {
         str = SCStrdup(withinstr+1);
         if (unlikely(str == NULL))
             goto end;
-        str[strlen(withinstr) - 2] = '\0';
+        if (strlen(str) && str[strlen(str) - 1] == '\"') {
+            str[strlen(str) - 1] = '\0';
+        }
         dubbed = 1;
     }
 


### PR DESCRIPTION
The stripping of leading and trailing "s has issues with rules like the
ones described in issue 1638 thus resulted in crashing the rule parser.
So for now this is a quick fix which approaches this issue directly by
stripping those "s correctly and handling error cases. It also adds the
skip for leading spaces at the msg keyword and worksaround a possible
null pointer dereference (that should never occur though).
A more general approach should be done in the future.

This is a quick fix for https://redmine.openinfosecfoundation.org/issues/1638 and included the comments from the former PR #1884 and IRC suggestions.

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/19
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/19