### PR TITLE
Bug 1708 - dcerpc mem leak - v1

### DIFF
--- a/src/app-layer-dcerpc-common.h
+++ b/src/app-layer-dcerpc-common.h
@@ -145,6 +145,8 @@ typedef struct DCERPCUuidEntry_ {
     TAILQ_ENTRY(DCERPCUuidEntry_) next;
 } DCERPCUuidEntry;
 
+typedef TAILQ_HEAD(DCERPCUuidEntryList_, DCERPCUuidEntry_) DCERPCUuidEntryList;
+
 typedef struct DCERPCBindBindAck_ {
     uint8_t numctxitems;
     uint8_t numctxitemsleft;
@@ -154,9 +156,9 @@ typedef struct DCERPCBindBindAck_ {
     uint16_t version;
     uint16_t versionminor;
     DCERPCUuidEntry *uuid_entry;
-    TAILQ_HEAD(, DCERPCUuidEntry_) uuid_list;
+    DCERPCUuidEntryList uuid_list;
     /* the interface uuids that the server has accepted */
-    TAILQ_HEAD(, DCERPCUuidEntry_) accepted_uuid_list;
+    DCERPCUuidEntryList accepted_uuid_list;
     uint16_t uuid_internal_id;
     uint16_t secondaryaddrlen;
     uint16_t secondaryaddrlenleft;

--- a/src/app-layer-dcerpc.h
+++ b/src/app-layer-dcerpc.h
@@ -36,6 +36,8 @@ typedef struct DCERPCState_ {
     uint8_t data_needed_for_dir;
 } DCERPCState;
 
+void DCERPCInit(DCERPC *dcerpc);
+void DCERPCCleanup(DCERPC *dcerpc);
 void RegisterDCERPCParsers(void);
 void DCERPCParserTests(void);
 void DCERPCParserRegisterTests(void);


### PR DESCRIPTION
When DCERPC was wrapped in SMB it wasn't being initialized or cleaned up properly. To fix, expose DCERPC initialization and cleanup functions for use by the SMB application layer.

The second commit just cleans up some tailq handling.
    
Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1708

Prscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/192
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/195
