### PR TITLE
bug-1724: alert-debuglog: trigger rotation on non-decoder events as well - v1

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -321,8 +321,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
     }
 
     SCMutexLock(&aft->file_ctx->fp_mutex);
-    (void)MemBufferPrintToFPAsString(aft->buffer, aft->file_ctx->fp);
-    fflush(aft->file_ctx->fp);
+    aft->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
+        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx);
     aft->file_ctx->alerts += p->alerts.cnt;
     SCMutexUnlock(&aft->file_ctx->fp_mutex);
 


### PR DESCRIPTION
The write handling was missed for non-decoder events that
would trigger rotation after a HUP.

Redmine: https://redmine.openinfosecfoundation.org/issues/1724

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/193
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/196
