### PR TITLE
BUG #1689: fix stack overflow when parsing variables

### DIFF
--- a/src/util-var.c
+++ b/src/util-var.c
@@ -128,3 +128,44 @@ void GenericVarRemove(GenericVar **list, GenericVar *gv)
         listgv = listgv->next;
     }
 }
+
+// Checks if a variable is already in a resolve list and if it's not, adds it.
+int AddVariableToResolveList(ResolvedVariablesList *list, const char *var)
+{
+    ResolvedVariable *p_item;
+
+    if (list == NULL || var == NULL) {
+        return 0;
+    }
+
+    TAILQ_FOREACH(p_item, list, next) {
+        if (!strcmp(p_item->var_name, var)) {
+            return -1;
+        }
+    }
+
+    p_item = SCMalloc(sizeof(ResolvedVariable));
+
+    if (unlikely(p_item == NULL)) {
+        return -1;
+    }
+
+    strlcpy(p_item->var_name, var, sizeof(p_item->var_name) - 1);
+    TAILQ_INSERT_TAIL(list, p_item, next);
+
+    return 0;
+}
+
+void CleanVariableResolveList(ResolvedVariablesList *var_list)
+{
+    if (var_list == NULL) {
+        return;
+    }
+
+    ResolvedVariable *p_item;
+
+    while ((p_item = TAILQ_FIRST(var_list))) {
+        TAILQ_REMOVE(var_list, p_item, next);
+        SCFree(p_item);
+    }
+}

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -57,9 +57,21 @@ typedef struct XBit_ {
     uint32_t expire;
 } XBit;
 
+// A list of variables we try to resolve while parsing configuration file.
+// Helps to detect recursive declarations.
+typedef struct ResolvedVariable_ {
+    char var_name[256];
+    TAILQ_ENTRY(ResolvedVariable_) next;
+} ResolvedVariable;
+
+typedef TAILQ_HEAD(, ResolvedVariable_) ResolvedVariablesList;
+
 void GenericVarFree(GenericVar *);
 void GenericVarAppend(GenericVar **, GenericVar *);
 void GenericVarRemove(GenericVar **, GenericVar *);
+
+int AddVariableToResolveList(ResolvedVariablesList *list, const char *var);
+void CleanVariableResolveList(ResolvedVariablesList *var_list);
 
 #endif /* __UTIL_VAR_H__ */
 


### PR DESCRIPTION
Reworked #1902 

Suricata crashed when variable (either address or port) referred to itself or if one created a looped chain of variables. For instance:

HOME_NET:     "!$EXTERNAL_NET"
EXTERNAL_NET: "!$HOME_NET"

Or:

Var1: "$Var2"
Var2: "$Var3"
Var3: "$Var1"