### PR TITLE
rule-parsing: remove unnecessary code

### DIFF
--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -75,10 +75,6 @@ static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, char *msgstr)
         goto error;
     }
 
-    /* make sure that we don't proceed with null pointer */
-    if (unlikely(str == NULL))
-        goto error;
-
     len = strlen(str);
     if (len == 0)
         goto error;


### PR DESCRIPTION
Those lines were included former to prevent possible null pointer
dereference but that won't happen anymore with the rest of the rework
done in the code. The code even results in a control flow issue reported
by coverity scan, so just remove it.

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/20
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/20