### PR TITLE
Dynamic stream reassembly v9

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -111,6 +111,8 @@ typedef struct AppLayerParserProtoCtx_
     DetectEngineState *(*GetTxDetectState)(void *tx);
     int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *);
 
+    void (*SetupTcpSession)(TcpSession *ssn);
+
     /* Indicates the direction the parser is ready to see the data
      * the first time for a flow.  Values accepted -
      * STREAM_TOSERVER, STREAM_TOCLIENT */
@@ -483,6 +485,18 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateHasTxDetectState = StateHasTxDetectState;
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].GetTxDetectState = GetTxDetectState;
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetTxDetectState = SetTxDetectState;
+
+    SCReturn;
+}
+
+void AppLayerParserRegisterSetupTcpSession(uint8_t ipproto,
+                                           AppProto alproto,
+                   void (*SetupTcpSession)(TcpSession *ssn))
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+        SetupTcpSession = SetupTcpSession;
 
     SCReturn;
 }
@@ -1068,6 +1082,17 @@ void AppLayerParserTriggerRawStreamReassembly(Flow *f)
         StreamTcpReassembleTriggerRawReassembly(f->protoctx);
 
     SCReturn;
+}
+
+void AppLayerParserSetupTcpSession(uint8_t ipproto, AppProto alproto,
+                                   TcpSession *ssn)
+{
+    SCEnter();
+
+    if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetupTcpSession != NULL)
+    {
+        alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].SetupTcpSession(ssn);
+    }
 }
 
 /***** Cleanup *****/

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -28,6 +28,7 @@
 #include "app-layer-events.h"
 #include "detect-engine-state.h"
 #include "util-file.h"
+#include "stream-tcp-private.h"
 
 #define APP_LAYER_PARSER_EOF                    0x01
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
@@ -147,6 +148,13 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
 
+/**
+ * \brief Permits to set a specific stream depth 
+ */
+void AppLayerParserRegisterSetupTcpSession(uint8_t ipproto,
+                                           AppProto alproto,
+                  void (*SetupTcpSession)(TcpSession *ssn));
+
 /***** Get and transaction functions *****/
 
 void *AppLayerParserGetProtocolParserLocalStorage(uint8_t ipproto, AppProto alproto);
@@ -197,6 +205,7 @@ int AppLayerParserProtocolIsTxEventAware(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolSupportsTxs(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserTriggerRawStreamReassembly(Flow *f);
+void AppLayerParserSetupTcpSession(uint8_t ipproto, AppProto alproto, TcpSession *ssn);
 
 /***** Cleanup *****/
 

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -163,6 +163,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
             f->alproto = *alproto;
             StreamTcpSetStreamFlagAppProtoDetectionCompleted(stream);
+            AppLayerParserSetupTcpSession(f->proto, *alproto, ssn);
 
             /* if we have seen data from the other direction first, send
              * data for that direction first to the parser.  This shouldn't
@@ -338,6 +339,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                     AppLayerDecoderEventsSetEventRaw(&p->app_layer_events,
                                                      APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION);
                     StreamTcpSetStreamFlagAppProtoDetectionCompleted(stream);
+                    AppLayerParserSetupTcpSession(f->proto, *alproto_otherdir, ssn);
                     f->data_al_so_far[dir] = 0;
                 } else {
                     f->data_al_so_far[dir] = data_len;

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -280,6 +280,10 @@ static int DetectFilestoreMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, 
         SCReturnInt(1);
     }
 
+    /* set filestore depth for stream reassembling */
+    TcpSession *ssn = (TcpSession *)f->protoctx;
+    StreamTcpSetReassemblyDepth(ssn, FileReassemblyDepth());
+
     /* file can be NULL when a rule with filestore scope > file
      * matches. */
     if (file != NULL) {

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -46,6 +46,7 @@
 #include "util-atomic.h"
 #include "util-file.h"
 #include "util-time.h"
+#include "util-misc.h"
 
 #include "output.h"
 
@@ -480,6 +481,21 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
 #endif
     }
     SCLogInfo("storing files in %s", g_logfile_base_dir);
+
+    const char *filestore_size_str = ConfNodeLookupChildValue(conf, "size");
+    if (filestore_size_str != NULL && strcmp(filestore_size_str, "no")) {
+        uint32_t filestore_size = 0;
+        if (ParseSizeStringU32(filestore_size_str,
+                               &filestore_size) < 0) {
+            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing "
+                       "file-store.size "
+                       "from conf file - %s.  Killing engine",
+                       filestore_size_str);
+            exit(EXIT_FAILURE);
+        } else {
+            FileReassemblyDepthEnable(filestore_size);
+        }
+    }
 
     SCReturnPtr(output_ctx, "OutputCtx");
 }

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -81,6 +81,7 @@ typedef struct TcpStream_ {
     /* reassembly */
     uint32_t ra_app_base_seq;       /**< reassembled seq. We've reassembled up to this point. */
     uint32_t ra_raw_base_seq;       /**< reassembled seq. We've reassembled up to this point. */
+    uint32_t reassembly_depth;      /**< reassembly depth for the stream */
 
     TcpSegment *seg_list;           /**< list of TCP segments that are not yet (fully) used in reassembly */
     TcpSegment *seg_list_tail;      /**< Last segment in the reassembled stream seg list*/

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1776,7 +1776,7 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpStream *stream,
 
     /* if the configured depth value is 0, it means there is no limit on
        reassembly depth. Otherwise carry on my boy ;) */
-    if (stream_config.reassembly_depth == 0) {
+    if (stream->reassembly_depth == 0) {
         SCReturnUInt(size);
     }
 
@@ -1789,24 +1789,24 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpStream *stream,
      * checking and just reject the rest of the packets including
      * retransmissions. Saves us the hassle of dealing with sequence
      * wraps as well */
-    if (SEQ_GEQ((StreamTcpReassembleGetRaBaseSeq(stream)+1),(stream->isn + stream_config.reassembly_depth))) {
+    if (SEQ_GEQ((StreamTcpReassembleGetRaBaseSeq(stream)+1),(stream->isn + stream->reassembly_depth))) {
         stream->flags |= STREAMTCP_STREAM_FLAG_DEPTH_REACHED;
         SCReturnUInt(0);
     }
 
     SCLogDebug("full Depth not yet reached: %"PRIu32" <= %"PRIu32,
             (StreamTcpReassembleGetRaBaseSeq(stream)+1),
-            (stream->isn + stream_config.reassembly_depth));
+            (stream->isn + stream->reassembly_depth));
 
-    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + stream_config.reassembly_depth))) {
+    if (SEQ_GEQ(seq, stream->isn) && SEQ_LT(seq, (stream->isn + stream->reassembly_depth))) {
         /* packet (partly?) fits the depth window */
 
-        if (SEQ_LEQ((seq + size),(stream->isn + stream_config.reassembly_depth))) {
+        if (SEQ_LEQ((seq + size),(stream->isn + stream->reassembly_depth))) {
             /* complete fit */
             SCReturnUInt(size);
         } else {
             /* partial fit, return only what fits */
-            uint32_t part = (stream->isn + stream_config.reassembly_depth) - seq;
+            uint32_t part = (stream->isn + stream->reassembly_depth) - seq;
 #if DEBUG
             BUG_ON(part > size);
 #else
@@ -7284,7 +7284,7 @@ static int StreamTcpReassembleTest45 (void)
     ssn.state = TCP_ESTABLISHED;
 
     /* set the default value of reassembly depth, as there is no config file */
-    stream_config.reassembly_depth = httplen1 + 1;
+    ssn.server.reassembly_depth = httplen1 + 1;
 
     TcpStream *s = NULL;
     s = &ssn.server;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -659,6 +659,8 @@ TcpSession *StreamTcpNewSession (Packet *p, int id)
         }
 
         ssn->state = TCP_NONE;
+        ssn->client.reassembly_depth = stream_config.reassembly_depth;
+        ssn->server.reassembly_depth = stream_config.reassembly_depth;
         ssn->flags = stream_config.ssn_init_flags;
         ssn->tcp_packet_flags = p->tcph ? p->tcph->th_flags : 0;
 
@@ -5966,6 +5968,14 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
     }
     FLOWLOCK_UNLOCK(p->flow);
     return cnt;
+}
+
+void StreamTcpSetReassemblyDepth(TcpSession *ssn, uint32_t size)
+{
+    ssn->server.reassembly_depth = size;
+    ssn->client.reassembly_depth = size;
+
+    return;
 }
 
 #ifdef UNITTESTS

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -129,6 +129,7 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag,
                         StreamSegmentCallback CallbackFunc,
                         void *data);
 void StreamTcpReassembleConfigEnableOverlapCheck(void);
+void StreamTcpSetReassemblyDepth(TcpSession *ssn, uint32_t size);
 
 /** ------- Inline functions: ------ */
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -28,6 +28,7 @@
 #include "debug.h"
 #include "flow.h"
 #include "stream.h"
+#include "stream-tcp.h"
 #include "runmodes.h"
 #include "util-hash.h"
 #include "util-debug.h"
@@ -56,6 +57,16 @@ static int g_file_force_md5 = 0;
  */
 static int g_file_force_tracking = 0;
 
+/** \brief switch to use g_file_store_reassembly_depth
+ *         to reassembly files
+ */
+static int g_file_store_enable = 0;
+
+/** \brief stream_config.reassembly_depth equivalent
+ *         for files
+ */
+static uint32_t g_file_store_reassembly_depth = 0;
+
 /* prototypes */
 static void FileFree(File *);
 static void FileDataFree(FileData *);
@@ -78,6 +89,20 @@ void FileForceMd5Enable(void)
 int FileForceFilestore(void)
 {
     return g_file_force_filestore;
+}
+
+void FileReassemblyDepthEnable(uint32_t size)
+{
+    g_file_store_enable = 1;
+    g_file_store_reassembly_depth = size;
+}
+
+uint32_t FileReassemblyDepth(void)
+{
+    if (g_file_store_enable == 1)
+        return g_file_store_reassembly_depth;
+    else
+        return stream_config.reassembly_depth;
 }
 
 int FileForceMagic(void)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -175,6 +175,8 @@ void FilePrune(FileContainer *ffc);
 
 void FileForceFilestoreEnable(void);
 int FileForceFilestore(void);
+void FileReassemblyDepthEnable(uint32_t size);
+uint32_t FileReassemblyDepth(void);
 
 void FileDisableMagic(Flow *f, uint8_t);
 void FileForceMagicEnable(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -341,7 +341,7 @@ outputs:
   # file "file.<id>.meta" is created.
   #
   # File extraction depends on a lot of things to be fully done:
-  # - stream reassembly depth. For optimal results, set this to 0 (unlimited)
+  # - file-store size. For optimal results, set this to 0 (unlimited)
   # - http request / response body sizes. Again set to 0 for optimal results.
   # - rules that contain the "filestore" keyword.
   - file-store:
@@ -350,6 +350,7 @@ outputs:
       force-magic: no   # force logging magic on all stored files
       force-md5: no     # force logging of md5 checksums
       force-filestore: no # force storing of all files
+      size: 1mb         # reassemble 1mb into a stream, set to no to disable
       #waldo: file.waldo # waldo file to store the file_id across runs
 
   # output module to log files tracked in a easily parsable json format

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1353,6 +1353,9 @@ app-layer:
       # If the limit is reached, app-layer-event:modbus.flooded; will match.
       #request-flood: 500
 
+      # Stream reassembly size for modbus, default is 0
+      stream-depth: 0
+
       enabled: no
       detection-ports:
         dp: 502


### PR DESCRIPTION
This patchset implements some changes on stream reassembly,
permitting us to set a reassembly depth per protocol
and also for a filestore keyword.

Some protocol like modbus require an infinite stream depth
because session are kept open and we want to analyze everything.
For this reason, having a stream reassembly depth per stream
permits us to set a stream size per protocol.

Last PR: https://github.com/inliniac/suricata/pull/1808

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/100
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/99