### PR TITLE
app-layer-ssl: fix memleak

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -214,6 +214,11 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                         uint16_t sni_len = ntohs(*(uint16_t *)input);
                         input += 2;
 
+                        /* the length of the server name should never be
+                           longer than the length of the extension */
+                        if (sni_len >= ext_len)
+                            goto end;
+
                         if (!(HAS_SPACE(sni_len)))
                             goto end;
 


### PR DESCRIPTION
An invalid TLS client hello packet where the SNI extensions length field is set to a smaller value than the SNI server name length field, causes memory to be allocated multiple times.