### PR TITLE
Major stability fixes

### DIFF
--- a/src/defrag.c
+++ b/src/defrag.c
@@ -783,7 +783,11 @@ insert:
                 StatsIncr(tv, dtv->counter_defrag_ipv4_reassembled);
                 if (pq && DecodeIPV4(tv, dtv, r, (void *)r->ip4h,
                                IPV4_GET_IPLEN(r), pq) != TM_ECODE_OK) {
+
+                    UNSET_TUNNEL_PKT(r);
+                    r->root = NULL;
                     TmqhOutputPacketpool(tv, r);
+                    r = NULL;
                 } else {
                     PacketDefragPktSetupParent(p);
                 }
@@ -796,7 +800,11 @@ insert:
                 if (pq && DecodeIPV6(tv, dtv, r, (uint8_t *)r->ip6h,
                                IPV6_GET_PLEN(r) + IPV6_HEADER_LEN,
                                pq) != TM_ECODE_OK) {
+
+                    UNSET_TUNNEL_PKT(r);
+                    r->root = NULL;
                     TmqhOutputPacketpool(tv, r);
+                    r = NULL;
                 } else {
                     PacketDefragPktSetupParent(p);
                 }

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -69,6 +69,8 @@ typedef struct DetectContentData_ {
     uint16_t replace_len;
     /* for chopped fast pattern, the length */
     uint16_t fp_chop_len;
+    /* for chopped fast pattern, the offset */
+    uint16_t fp_chop_offset;
     /* would want to move PatIntId here and flags down to remove the padding
      * gap, but I think the first four members was used as a template for
      * casting.  \todo check this and fix it if posssible */
@@ -76,8 +78,6 @@ typedef struct DetectContentData_ {
     PatIntId id;
     uint16_t depth;
     uint16_t offset;
-    /* for chopped fast pattern, the offset */
-    uint16_t fp_chop_offset;
     int32_t distance;
     int32_t within;
     /* Boyer Moore context (for spm search) */

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -1064,14 +1064,14 @@ void PatternMatchDestroyGroup(SigGroupHead *sh)
  *         always used, etc. */
 typedef struct ContentHash_ {
     DetectContentData *ptr;
-    uint16_t cnt;
-    uint8_t use; /* use no matter what */
+    uint32_t cnt;
+    int use; /* use no matter what */
 } ContentHash;
 
 typedef struct UricontentHash_ {
     DetectContentData *ptr;
-    uint16_t cnt;
-    uint8_t use; /* use no matter what */
+    uint32_t cnt;
+    int use; /* use no matter what */
 } UricontentHash;
 
 uint32_t ContentHashFunc(HashTable *ht, void *data, uint16_t datalen)
@@ -2714,8 +2714,8 @@ typedef struct MpmPatternIdTableElmt_ {
     uint8_t *pattern;       /**< ptr to the pattern */
     uint16_t pattern_len;   /**< pattern len */
     PatIntId id;            /**< pattern id */
-    uint16_t dup_count;     /**< duplicate count */
-    uint8_t sm_list;        /**< SigMatch list */
+    uint32_t dup_count;     /**< duplicate count */
+    int sm_list;            /**< SigMatch list */
 } MpmPatternIdTableElmt;
 
 /** \brief Hash compare func for MpmPatternId api

--- a/src/detect.h
+++ b/src/detect.h
@@ -640,7 +640,7 @@ typedef struct DetectEngineCtx_ {
     /** hash table for looking up patterns for
      *  id sharing and id tracking. */
     MpmPatternIdStore *mpm_pattern_id_store;
-    uint16_t max_fp_id;
+    uint32_t max_fp_id;
 
     MpmCtxFactoryContainer *mpm_ctx_factory_container;
 

--- a/src/packet-queue.c
+++ b/src/packet-queue.c
@@ -175,12 +175,11 @@ Packet *PacketDequeue (PacketQueue *q)
 
     /* pull the bottom packet from the queue */
     p = q->bot;
+
     /* Weird issue: sometimes it looks that two thread arrive
      * here at the same time so the bot ptr is NULL (only on OS X?)
      */
-    if (p == NULL) {
-        return NULL;
-    }
+    BUG_ON (p == NULL);
 
     /* more packets in queue */
     if (q->bot->prev != NULL) {

--- a/src/packet-queue.c
+++ b/src/packet-queue.c
@@ -192,6 +192,8 @@ Packet *PacketDequeue (PacketQueue *q)
     }
 
     //PacketQueueValidateDebug(q);
+    p->next = NULL;
+    p->prev = NULL;
     return p;
 }
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -241,7 +241,7 @@
 #define SigIntId uint32_t
 
 /** same for pattern id's */
-#define PatIntId uint16_t
+#define PatIntId uint32_t
 
 /** FreeBSD does not define __WORDSIZE, but it uses __LONG_BIT */
 #ifndef __WORDSIZE

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -307,6 +307,7 @@ void PacketPoolReturnPacket(Packet *p)
         PktPool *pending_pool = my_pool->pending_pool;
         if (pending_pool == NULL) {
             /* No pending packet, so store the current packet. */
+            p->next = NULL;
             my_pool->pending_pool = pool;
             my_pool->pending_head = p;
             my_pool->pending_tail = p;

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -1382,7 +1382,7 @@ void SCACBSDestroyCtx(MpmCtx *mpm_ctx)
     }
 
     if (ctx->pid_pat_list != NULL) {
-        int i;
+        uint32_t i;
         for (i = 0; i < (ctx->max_pat_id + 1); i++) {
             if (ctx->pid_pat_list[i].cs != NULL)
                 SCFree(ctx->pid_pat_list[i].cs);

--- a/src/util-mpm-ac-bs.h
+++ b/src/util-mpm-ac-bs.h
@@ -88,7 +88,7 @@ typedef struct SCACBSCtx_ {
 
     /* the size of each state */
     uint16_t single_state_size;
-    uint16_t max_pat_id;
+    uint32_t max_pat_id;
 } SCACBSCtx;
 
 typedef struct SCACBSThreadCtx_ {

--- a/src/util-mpm-ac-gfbs.c
+++ b/src/util-mpm-ac-gfbs.c
@@ -1259,7 +1259,7 @@ void SCACGfbsDestroyCtx(MpmCtx *mpm_ctx)
     }
 
     if (ctx->pid_pat_list != NULL) {
-        int i;
+        uint32_t i;
         for (i = 0; i < (ctx->max_pat_id + 1); i++) {
             if (ctx->pid_pat_list[i].cs != NULL)
                 SCFree(ctx->pid_pat_list[i].cs);

--- a/src/util-mpm-ac-gfbs.h
+++ b/src/util-mpm-ac-gfbs.h
@@ -97,7 +97,7 @@ typedef struct SCACGfbsCtx_ {
 
     /* the size of each state */
     uint16_t single_state_size;
-    uint16_t max_pat_id;
+    uint32_t max_pat_id;
 } SCACGfbsCtx;
 
 typedef struct SCACGfbsThreadCtx_ {

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -1273,7 +1273,7 @@ void SCACDestroyCtx(MpmCtx *mpm_ctx)
     }
 
     if (ctx->pid_pat_list != NULL) {
-        int i;
+        uint32_t i;
         for (i = 0; i < (ctx->max_pat_id + 1); i++) {
             if (ctx->pid_pat_list[i].cs != NULL)
                 SCFree(ctx->pid_pat_list[i].cs);

--- a/src/util-mpm-ac.h
+++ b/src/util-mpm-ac.h
@@ -97,8 +97,8 @@ typedef struct SCACCtx_ {
     SCACPatternList *pid_pat_list;
 
     /* the size of each state */
-    uint16_t single_state_size;
-    uint16_t max_pat_id;
+    uint32_t single_state_size;
+    uint32_t max_pat_id;
 
     uint32_t allocated_state_count;
 


### PR DESCRIPTION
Fixes crashes due to logic errors in the defrag engine.
Also fix crashes with very large rulesets (70k+ rules).

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/374
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/377