### PR TITLE
Bug 1591 2

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -83,6 +83,9 @@ void RunModeIdsAFPRegister(void)
     return;
 }
 
+
+#ifdef HAVE_AF_PACKET
+
 void AFPDerefConfig(void *conf)
 {
     AFPIfaceConfig *pfp = (AFPIfaceConfig *)conf;
@@ -474,6 +477,9 @@ int AFPRunModeIsIPS()
 
     return has_ips;
 }
+
+#endif
+
 
 int RunModeIdsAFPAutoFp(void)
 {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -370,9 +370,17 @@ void *ParseAFPConfig(const char *iface)
         }
     }
 
-    if (GetIfaceOffloading(iface) == 1) {
-        SCLogWarning(SC_ERR_AFP_CREATE,
-                "Using AF_PACKET with GRO or LRO activated can lead to capture problems");
+
+    int ltype = AFPGetLinkType(iface);
+    switch (ltype) {
+        case LINKTYPE_ETHERNET:
+            if (GetIfaceOffloading(iface) == 1) {
+                SCLogWarning(SC_ERR_AFP_CREATE,
+                    "Using AF_PACKET with GRO or LRO activated can lead to capture problems");
+            }
+        case -1:
+        default:
+            break;
     }
 
     char *active_runmode = RunmodeGetActive();

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1307,6 +1307,7 @@ static int AFPGetDevLinktype(int fd, const char *ifname)
         case ARPHRD_LOOPBACK:
             return LINKTYPE_ETHERNET;
         case ARPHRD_PPP:
+        case ARPHRD_NONE:
             return LINKTYPE_RAW;
         default:
             return ifr.ifr_hwaddr.sa_family;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1314,6 +1314,22 @@ static int AFPGetDevLinktype(int fd, const char *ifname)
     }
 }
 
+int AFPGetLinkType(const char *ifname)
+{
+    int ltype;
+
+    int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (fd == -1) {
+        SCLogError(SC_ERR_AFP_CREATE, "Couldn't create a AF_PACKET socket, error %s", strerror(errno));
+        return LINKTYPE_RAW;
+    }
+
+    ltype =  AFPGetDevLinktype(fd, ifname);
+    close(fd);
+
+    return ltype;
+}
+
 static int AFPComputeRingParams(AFPThreadVars *ptv, int order)
 {
     /* Compute structure:

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -132,6 +132,6 @@ void TmModuleDecodeAFPRegister (void);
 TmEcode AFPPeersListInit();
 TmEcode AFPPeersListCheck();
 void AFPPeersListClean();
-
+int AFPGetLinkType(const char *ifname);
 
 #endif /* __SOURCE_AFP_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -984,6 +984,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
             /* not an error condition if we have a 1.0 config */
             LiveBuildDeviceList("pfring");
         }
+#ifdef HAVE_AF_PACKET
     } else if (run_mode == RUNMODE_AFP_DEV) {
         /* iface has been set on command line */
         if (strlen(pcap_dev)) {
@@ -1002,6 +1003,7 @@ static TmEcode ParseInterfacesList(int run_mode, char *pcap_dev)
                 EngineModeSetIPS();
             }
         }
+#endif
 #ifdef HAVE_NETMAP
     } else if (run_mode == RUNMODE_NETMAP) {
         /* iface has been set on command line */


### PR DESCRIPTION
Update of #1916 fixing build when af_packet is disabled. Initial commit is fixing that by disabling most af-packet code when not built in.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/140
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/138