### PR TITLE
cuda: ensue that compile time conditionals pick up the cuda support definition.

### DIFF
--- a/src/ptxdump.py
+++ b/src/ptxdump.py
@@ -29,6 +29,7 @@ out_h = sys.argv[1] + ".h"
 out = open(out_h, 'w')
 
 out.writelines(header)
+out.writelines("#include \"suricata-common.h\"\n")
 out.writelines("#ifdef __SC_CUDA_SUPPORT__\n")
 out.writelines("#ifndef __ptxdump_h__\n")
 out.writelines("#define __ptxdump_h__\n\n")

--- a/src/util-cuda-buffer.h
+++ b/src/util-cuda-buffer.h
@@ -28,10 +28,12 @@
  * \author Anoop Saldanha <anoopsaldanha@gmail.com>
  */
 
-#ifdef __SC_CUDA_SUPPORT__
-
 #ifndef __UTIL_CUDA_BUFFER_H__
 #define __UTIL_CUDA_BUFFER_H__
+
+#include "suricata-common.h"
+
+#ifdef __SC_CUDA_SUPPORT__
 
 #include "util-atomic.h"
 
@@ -106,6 +108,6 @@ CudaBufferData *CudaBufferRegisterNew(uint8_t *d_buffer, uint32_t d_buffer_len,
 void CudaBufferInit(void);
 void CudaBufferRegisterUnittests(void);
 
-#endif /* __UTIL_CUDA_BUFFER_H__ */
-
 #endif /* __SC_CUDA_SUPPORT__ */
+
+#endif /* __UTIL_CUDA_BUFFER_H__ */

--- a/src/util-cuda-vars.h
+++ b/src/util-cuda-vars.h
@@ -21,10 +21,12 @@
  * \author Anoop Saldanha <anoopsaldanha@gmail.com>
  */
 
-#ifdef __SC_CUDA_SUPPORT__
-
 #ifndef __UTIL_CUDA_VARS__H__
 #define __UTIL_CUDA_VARS__H__
+
+#include "suricata-common.h"
+
+#ifdef __SC_CUDA_SUPPORT__
 
 #include "util-cuda-buffer.h"
 #include "util-mpm.h"
@@ -60,6 +62,7 @@ typedef struct CudaPacketVars_ {
 void CudaVarsSetDeCtx(struct DetectEngineCtx_ *de_ctx);
 int CudaThreadVarsInit(CudaThreadVars *ctv);
 
+#endif /* __SC_CUDA_SUPPORT__ */
+
 #endif /* __UTIL_CUDA_VARS__H__ */
 
-#endif /* __SC_CUDA_SUPPORT__ */

--- a/src/util-cuda.h
+++ b/src/util-cuda.h
@@ -24,6 +24,8 @@
 #ifndef __UTIL_CUDA__H__
 #define __UTIL_CUDA__H__
 
+#include "suricata-common.h"
+
 #ifdef __SC_CUDA_SUPPORT__
 
 #include <cuda.h>
@@ -320,4 +322,5 @@ int SCCudaIsCudaDeviceIdValid(int cuda_device_id);
 void SCCudaRegisterTests(void);
 
 #endif /* __SC_CUDA_SUPPORT__ */
+
 #endif /* __UTIL_CUDA_H__ */

--- a/src/util-mpm-ac.h
+++ b/src/util-mpm-ac.h
@@ -25,11 +25,12 @@
 #ifndef __UTIL_MPM_AC__H__
 #define __UTIL_MPM_AC__H__
 
+#include "suricata-common.h"
+
 #define SC_AC_STATE_TYPE_U16 uint16_t
 #define SC_AC_STATE_TYPE_U32 uint32_t
 
 #ifdef __SC_CUDA_SUPPORT__
-#include "suricata-common.h"
 #include "util-cuda.h"
 #include "util-cuda-vars.h"
 #include "decode.h"

--- a/src/util-mpm.h
+++ b/src/util-mpm.h
@@ -23,6 +23,7 @@
 
 #ifndef __UTIL_MPM_H__
 #define __UTIL_MPM_H__
+
 #include "suricata-common.h"
 
 #define MPM_ENDMATCH_SINGLE     0x01    /**< A single match is sufficient. No

--- a/src/util-running-modes.h
+++ b/src/util-running-modes.h
@@ -23,6 +23,7 @@
 #ifndef __UTIL_RUNNING_MODES_H__
 #define __UTIL_RUNNING_MODES_H__
 
+#include "suricata-common.h"
 
 int ListKeywords(const char *keyword_info);
 int ListAppLayerProtocols();


### PR DESCRIPTION
Adding on to commit 9bbc9e3739ad043af60e0865ec0b1d7bae88cf46. There a few additional files that have compile time conditionals dependent on __SC_CUDA_SUPPORT that do not include suricata-common.h (ultimately config.h where __SC_CUDA_SUPPORT is defined).

This pull requests makes sure that the include suricata-common.h is before any ifdef __SC_CUDA_SUPPORT__.