### PR TITLE
flow: record the flow hash for use as the output flow id - v0

### DIFF
--- a/src/flow.h
+++ b/src/flow.h
@@ -329,6 +329,9 @@ typedef struct Flow_
     /** flow queue id, used with autofp */
     SC_ATOMIC_DECLARE(int16_t, autofp_tmqh_flow_qid);
 
+    /** flow hash - the flow hash before hash table size mod. */
+    uint32_t flow_hash;
+
     /** flow tenant id, used to setup flow timeout and stream pseudo
      *  packets with the correct tenant id set */
     uint32_t tenant_id;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -167,12 +167,7 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
 {
     if (f == NULL)
         return;
-#if __WORDSIZE == 64
-    uint64_t addr = (uint64_t)f;
-#else
-    uint32_t addr = (uint32_t)f;
-#endif
-    json_object_set_new(js, "flow_id", json_integer(addr));
+    json_object_set_new(js, "flow_id", json_integer(f->flow_hash));
 }
 
 json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,


### PR DESCRIPTION
Provides a consistent hash for a flow, as well as a better
distribution than using a memory address.

Potential solution to https://redmine.openinfosecfoundation.org/issues/1696

Prscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/196
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/199
