### PR TITLE
app-layer-ssl: fix memleak

### DIFF
--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -89,6 +89,9 @@ enum {
 /* extensions */
 #define SSL_EXTENSION_SNI                       0x0000
 
+/* SNI types */
+#define SSL_SNI_TYPE_HOST_NAME                  0
+
 /* SSL versions.  We'll use a unified format for all, with the top byte
  * holding the major version and the lower byte the minor version */
 enum {


### PR DESCRIPTION
Avoid that the SNI extension code is executed multiple times on malformed packets, causing memory leaks.

https://redmine.openinfosecfoundation.org/issues/1736