### PR TITLE
app-layer-ssl: fix memleak

### DIFF
--- a/rules/tls-events.rules
+++ b/rules/tls-events.rules
@@ -18,10 +18,12 @@ alert tls any any -> any any (msg:"SURICATA TLS certificate invalid length"; flo
 alert tls any any -> any any (msg:"SURICATA TLS certificate invalid string"; flow:established; app-layer-event:tls.certificate_invalid_string; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230008; rev:1;)
 alert tls any any -> any any (msg:"SURICATA TLS error message encountered"; flow:established; app-layer-event:tls.error_message_encountered; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230009; rev:1;)
 alert tls any any -> any any (msg:"SURICATA TLS invalid record/traffic"; flow:established; app-layer-event:tls.invalid_ssl_record; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230010; rev:1;)
-
 alert tls any any -> any any (msg:"SURICATA TLS heartbeat encountered"; flow:established; app-layer-event:tls.heartbeat_message; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230011; rev:1;)
 alert tls any any -> any any (msg:"SURICATA TLS overflow heartbeat encountered, possible exploit attempt (heartbleed)"; flow:established; app-layer-event:tls.overflow_heartbeat_message; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; reference:cve,2014-0160; sid:2230012; rev:1;)
 alert tls any any -> any any (msg:"SURICATA TLS invalid heartbeat encountered, possible exploit attempt (heartbleed)"; flow:established; app-layer-event:tls.invalid_heartbeat_message; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; reference:cve,2014-0160; sid:2230013; rev:1;)
 alert tls any any -> any any (msg:"SURICATA TLS invalid encrypted heartbeat encountered, possible exploit attempt (heartbleed)"; flow:established; app-layer-event:tls.dataleak_heartbeat_mismatch; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; reference:cve,2014-0160; sid:2230014; rev:1;)
+alert tls any any -> any any (msg:"SURICATA TLS multiple SNI extensions"; flow:established; app-layer-event:tls.multiple_sni_extensions; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230016; rev:1;)
+alert tls any any -> any any (msg:"SURICATA TLS invalid SNI type"; flow:established; app-layer-event:tls.invalid_sni_type; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230017; rev:1;)
+alert tls any any -> any any (msg:"SURICATA TLS invalid SNI length"; flow:established; app-layer-event:tls.invalid_sni_length; flowint:tls.anomaly.count,+,1; classtype:protocol-command-decode; sid:2230018; rev:1;)
 
-#next sid is 2230016
+#next sid is 2230019

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -65,6 +65,9 @@ SCEnumCharMap tls_decoder_event_table[ ] = {
     { "INVALID_HEARTBEAT_MESSAGE",   TLS_DECODER_EVENT_INVALID_HEARTBEAT },
     { "OVERFLOW_HEARTBEAT_MESSAGE",  TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT },
     { "DATALEAK_HEARTBEAT_MISMATCH", TLS_DECODER_EVENT_DATALEAK_HEARTBEAT_MISMATCH },
+    { "MULTIPLE_SNI_EXTENSIONS",     TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS },
+    { "INVALID_SNI_TYPE",            TLS_DECODER_EVENT_INVALID_SNI_TYPE },
+    { "INVALID_SNI_LENGTH",          TLS_DECODER_EVENT_INVALID_SNI_LENGTH },
     /* Certificates decoding messages */
     { "INVALID_CERTIFICATE",         TLS_DECODER_EVENT_INVALID_CERTIFICATE },
     { "CERTIFICATE_MISSING_ELEMENT", TLS_DECODER_EVENT_CERTIFICATE_MISSING_ELEMENT },
@@ -205,8 +208,31 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                 switch (ext_type) {
                     case SSL_EXTENSION_SNI:
                     {
-                        /* skip sni_list_length and sni_type */
-                        input += 3;
+                        /* there must not be more than one extension of the same
+                           type (RFC5246 section 7.4.1.4) */
+                        if (ssl_state->curr_connp->sni) {
+                            SCLogDebug("Multiple SNI extensions");
+                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                                    TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS);
+                            return -1;
+                        }
+
+                        /* skip sni_list_length */
+                        input += 2;
+
+                        if (!(HAS_SPACE(1)))
+                            goto end;
+
+                        uint8_t sni_type = *(input++);
+
+                        /* currently the only type allowed is host_name
+                           (RFC6066 section 3) */
+                        if (sni_type != SSL_SNI_TYPE_HOST_NAME) {
+                            SCLogDebug("Unknown SNI type");
+                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                                    TLS_DECODER_EVENT_INVALID_SNI_TYPE);
+                            return -1;
+                        }
 
                         if (!(HAS_SPACE(2)))
                             goto end;
@@ -216,6 +242,16 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
 
                         if (!(HAS_SPACE(sni_len)))
                             goto end;
+
+                        /* host_name contains the fully qualified domain name,
+                           and should therefore be limited by the maximum domain
+                           name length */
+                        if (sni_len > 255) {
+                            SCLogDebug("SNI length >255");
+                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                                    TLS_DECODER_EVENT_INVALID_SNI_LENGTH);
+                            return -1;
+                        }
 
                         size_t sni_strlen = sni_len + 1;
                         ssl_state->curr_connp->sni = SCMalloc(sni_strlen);

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -40,6 +40,9 @@ enum {
     TLS_DECODER_EVENT_INVALID_HEARTBEAT,
     TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT,
     TLS_DECODER_EVENT_DATALEAK_HEARTBEAT_MISMATCH,
+    TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS,
+    TLS_DECODER_EVENT_INVALID_SNI_TYPE,
+    TLS_DECODER_EVENT_INVALID_SNI_LENGTH,
     /* Certificates decoding messages */
     TLS_DECODER_EVENT_INVALID_CERTIFICATE,
     TLS_DECODER_EVENT_CERTIFICATE_MISSING_ELEMENT,
@@ -88,6 +91,9 @@ enum {
 
 /* extensions */
 #define SSL_EXTENSION_SNI                       0x0000
+
+/* SNI types */
+#define SSL_SNI_TYPE_HOST_NAME                  0
 
 /* SSL versions.  We'll use a unified format for all, with the top byte
  * holding the major version and the lower byte the minor version */


### PR DESCRIPTION
Avoid that the SNI extension code is executed multiple times on malformed packets, causing memory leaks.

https://redmine.openinfosecfoundation.org/issues/1736