### PR TITLE
Ruleset stats v5

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -338,6 +338,7 @@ util-decode-asn1.c util-decode-asn1.h \
 util-decode-der.c util-decode-der.h \
 util-decode-der-get.c util-decode-der-get.h \
 util-decode-mime.c util-decode-mime.h \
+util-detect.c util-detect.h \
 util-device.c util-device.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -891,6 +891,19 @@ static void DetectEngineCtxFreeThreadKeywordData(DetectEngineCtx *de_ctx)
     de_ctx->keyword_list = NULL;
 }
 
+static void DetectEngineCtxFreeFailedSigs(DetectEngineCtx *de_ctx)
+{
+    SigString *item = de_ctx->sig_stat.failed_sigs;
+    while (item) {
+        SigString *next = item->next;
+        SCFree(item->filename);
+        SCFree(item->sig_str);
+        SCFree(item);
+        item = next;
+    }
+    de_ctx->sig_stat.failed_sigs = NULL;
+}
+
 /**
  * \brief Free a DetectEngineCtx::
  *
@@ -945,6 +958,7 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
 
     DetectEngineCtxFreeThreadKeywordData(de_ctx);
     SRepDestroy(de_ctx);
+    DetectEngineCtxFreeFailedSigs(de_ctx);
 
     /* if we have a config prefix, remove the config from the tree */
     if (strlen(de_ctx->config_prefix) > 0) {

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -770,6 +770,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
         goto error;
 
     memset(de_ctx,0,sizeof(DetectEngineCtx));
+    memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (minimal) {
         de_ctx->minimal = 1;

--- a/src/detect.c
+++ b/src/detect.c
@@ -449,14 +449,12 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     ConfNode *rule_files;
     ConfNode *file = NULL;
-    SigFileLoaderStat sig_stat;
+    SigFileLoaderStat *sig_stat = &de_ctx->sig_stat;
     int ret = 0;
     char *sfile = NULL;
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
-
-    memset(&sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.rule-files",
@@ -481,7 +479,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 TAILQ_FOREACH(file, &rule_files->head, next) {
                     sfile = DetectLoadCompleteSigPath(de_ctx, file->val);
                     good_sigs = bad_sigs = 0;
-                    ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
+                    ret = ProcessSigFiles(de_ctx, sfile, sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
                     if (ret != 0 || good_sigs == 0) {
@@ -496,7 +494,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     /* If a Signature file is specified from commandline, parse it too */
     if (sig_file != NULL) {
-        ret = ProcessSigFiles(de_ctx, sig_file, &sig_stat, &good_sigs, &bad_sigs);
+        ret = ProcessSigFiles(de_ctx, sig_file, sig_stat, &good_sigs, &bad_sigs);
 
         if (ret != 0) {
             if (de_ctx->failure_fatal == 1) {
@@ -514,9 +512,9 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     /* now we should have signatures to work with */
-    if (sig_stat.good_sigs_total <= 0) {
-        if (sig_stat.total_files > 0) {
-           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat.total_files);
+    if (sig_stat->good_sigs_total <= 0) {
+        if (sig_stat->total_files > 0) {
+           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat->total_files);
         } else {
             SCLogInfo("No signatures supplied.");
             goto end;
@@ -524,10 +522,10 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     } else {
         /* we report the total of files and rules successfully loaded and failed */
         SCLogInfo("%" PRId32 " rule files processed. %" PRId32 " rules successfully loaded, %" PRId32 " rules failed",
-            sig_stat.total_files, sig_stat.good_sigs_total, sig_stat.bad_sigs_total);
+            sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
     }
 
-    if ((sig_stat.bad_sigs_total || sig_stat.bad_files) && de_ctx->failure_fatal) {
+    if ((sig_stat->bad_sigs_total || sig_stat->bad_files) && de_ctx->failure_fatal) {
         ret = -1;
         goto end;
     }
@@ -543,6 +541,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
+    gettimeofday(&de_ctx->last_reload, NULL);
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();

--- a/src/detect.c
+++ b/src/detect.c
@@ -201,6 +201,7 @@
 #include "util-optimize.h"
 #include "util-path.h"
 #include "util-mpm-ac.h"
+#include "util-detect.h"
 
 #include "runmodes.h"
 
@@ -375,6 +376,10 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
                 EngineAnalysisRulesFailure(line, sig_file, lineno - multiline);
             }
             bad++;
+            if (!SigStringAppend(&de_ctx->sig_stat.failed_sigs, sig_file, line, (lineno - multiline))) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Error adding sig \"%s\" from "
+                     "file %s at line %"PRId32"", line, sig_file, lineno - multiline);
+            }
         }
         multiline = 0;
     }

--- a/src/detect.h
+++ b/src/detect.h
@@ -554,6 +554,14 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+/** \brief Signature loader statistics */
+typedef struct SigFileLoaderStat_ {
+    int bad_files;
+    int total_files;
+    int good_sigs_total;
+    int bad_sigs_total;
+} SigFileLoaderStat;
+
 typedef struct DetectEngineThreadKeywordCtxItem_ {
     void *(*InitFunc)(void *);
     void (*FreeFunc)(void *);
@@ -725,6 +733,12 @@ typedef struct DetectEngineCtx_ {
 
     /** id of loader thread 'owning' this de_ctx */
     int loader_id;
+
+    /** time of last ruleset reload */
+    struct timeval last_reload;
+
+    /** signatures stats */
+    SigFileLoaderStat sig_stat;
 
 } DetectEngineCtx;
 
@@ -1104,14 +1118,6 @@ typedef struct DetectEngineMasterCtx_ {
     DetectEngineTenantMapping *tenant_mapping_list;
 
 } DetectEngineMasterCtx;
-
-/** \brief Signature loader statistics */
-typedef struct SigFileLoaderStat_ {
-    int bad_files;
-    int total_files;
-    int good_sigs_total;
-    int bad_sigs_total;
-} SigFileLoaderStat;
 
 /** Remember to add the options in SignatureIsIPOnly() at detect.c otherwise it wont be part of a signature group */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -554,8 +554,16 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+typedef struct SigString_ {
+    char *filename;
+    char *sig_str;
+    int line;
+    struct SigString_ *next;
+} SigString;
+
 /** \brief Signature loader statistics */
 typedef struct SigFileLoaderStat_ {
+    SigString *failed_sigs;
     int bad_files;
     int total_files;
     int good_sigs_total;

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -28,6 +28,7 @@
 #include "detect.h"
 #include "pkt-var.h"
 #include "conf.h"
+#include "detect-engine.h"
 
 #include "threads.h"
 #include "threadvars.h"
@@ -51,6 +52,16 @@
 
 #ifdef HAVE_LIBJANSSON
 
+/**
+ * specify which engine info will be printed in stats log.
+ * ALL means both last reload and ruleset stats.
+ */
+typedef enum OutputEngineInfo_ {
+    OUTPUT_ENGINE_LAST_RELOAD = 0,
+    OUTPUT_ENGINE_RULESET,
+    OUTPUT_ENGINE_ALL,
+} OutputEngineInfo;
+
 typedef struct OutputStatsCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
@@ -60,6 +71,100 @@ typedef struct JsonStatsLogThread_ {
     OutputStatsCtx *statslog_ctx;
     MemBuffer *buffer;
 } JsonStatsLogThread;
+
+static json_t *OutputDetectEngineStats2Json(const DetectEngineCtx *de_ctx,
+                                            const OutputEngineInfo output)
+{
+    struct timeval last_reload;
+    char timebuf[64];
+    const SigFileLoaderStat *sig_stat = NULL;
+
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        return NULL;
+    }
+
+    if (output == OUTPUT_ENGINE_LAST_RELOAD || output == OUTPUT_ENGINE_ALL) {
+        last_reload = de_ctx->last_reload;
+        CreateIsoTimeString(&last_reload, timebuf, sizeof(timebuf));
+        json_object_set_new(jdata, "last_reload", json_string(timebuf));
+    }
+
+    sig_stat = &de_ctx->sig_stat;
+    if ((output == OUTPUT_ENGINE_RULESET || output == OUTPUT_ENGINE_ALL) &&
+        sig_stat != NULL)
+    {
+        json_object_set_new(jdata, "rules_loaded",
+                            json_integer(sig_stat->good_sigs_total));
+        json_object_set_new(jdata, "rules_failed",
+                            json_integer(sig_stat->bad_sigs_total));
+    }
+
+    return jdata;
+}
+
+static TmEcode OutputTenancyStats2Json(json_t **jdata, const OutputEngineInfo output)
+{
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    if (de_ctx == NULL) {
+        json_object_set_new(*jdata, "message", json_string("Unable to get info"));
+        goto error;
+    }
+    /* Since we need to deference de_ctx pointer, we don't want to lost it. */
+    DetectEngineCtx *list = de_ctx;
+
+    if (list->minimal) {
+        json_object_set_new(*jdata, "message", json_string("Detect engine is not yet ready"));
+        goto error;
+    }
+
+    json_t *js_tenant_list = json_array();
+
+    if (js_tenant_list == NULL) {
+        json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+        goto error;
+    }
+
+    while(list) {
+        json_t *js_tenant = json_object();
+        if (js_tenant == NULL) {
+            json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+            json_object_clear(js_tenant_list);
+            json_decref(js_tenant_list);
+            goto error;
+        }
+        json_object_set_new(js_tenant, "id", json_integer(list->tenant_id));
+
+        json_t *js_stats = OutputDetectEngineStats2Json(list, output);
+        if (js_stats == NULL) {
+            json_object_set_new(*jdata, "message", json_string("Unable to get into"));
+            json_object_clear(js_tenant);
+            json_object_clear(js_tenant_list);
+            json_decref(js_tenant);
+            json_decref(js_tenant_list);
+            goto error;
+        }
+        json_object_update(js_tenant, js_stats);
+        json_array_append_new(js_tenant_list, js_tenant);
+        list = list->next;
+    }
+
+    DetectEngineDeReference(&de_ctx);
+    *jdata = js_tenant_list;
+    return TM_ECODE_OK;
+
+error:
+    DetectEngineDeReference(&de_ctx);
+    return TM_ECODE_FAILED;
+}
+
+TmEcode OutputTenancyStatsLastReload(json_t **jdata) {
+    return OutputTenancyStats2Json(jdata, OUTPUT_ENGINE_LAST_RELOAD);
+}
+
+TmEcode OutputTenancyStatsRuleset(json_t **jdata) {
+    return OutputTenancyStats2Json(jdata, OUTPUT_ENGINE_RULESET);
+}
 
 static json_t *OutputStats2Json(json_t *js, const char *key)
 {
@@ -79,6 +184,20 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     json_t *value = json_object_iter_value(iter);
     if (value == NULL) {
         value = json_object();
+        /* If multi-tenancy is disabled, it means we have only one engine.
+           In this case, we add engine stats in detect obj.
+           The output will be:
+           "detect":{"engine":{"last_reload":"...","rules_loaded":...,"rules_failed":...}, ...}
+        */
+        if (!DetectEngineMultiTenantEnabled() && !strncmp(s, "detect", 6)) {
+            DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+            json_t *js_engine =
+                OutputDetectEngineStats2Json(de_ctx, OUTPUT_ENGINE_ALL);
+            if (js_engine != NULL) {
+                json_object_set_new(value, "engine", js_engine);
+            }
+            DetectEngineDeReference(&de_ctx);
+        }
         json_object_set_new(js, s, value);
     }
     if (s2 != NULL) {
@@ -104,6 +223,24 @@ json_t *StatsToJSON(const StatsTable *st, uint8_t flags)
     /* Uptime, in seconds. */
     json_object_set_new(js_stats, "uptime",
         json_integer((int)difftime(tval.tv_sec, st->start_time)));
+
+    /* tenancy stats */
+    if (DetectEngineMultiTenantEnabled()) {
+        /* In this case, we add a new "tenancy" object,
+           which contains stats for each tenant.
+           The output will be:
+           "tenancy":[{"id":1,"last_reload":"...","rules_loaded":...,"rules_failed":...},
+                      {"id":2,"last_reload":"...","rules_loaded":...,"rules_failed":...}]
+        */
+        json_t *js_tenancy = json_object();
+        if (unlikely(js_tenancy == NULL)) {
+            json_decref(js_stats);
+            return 0;
+        }
+        TmEcode ret = OutputTenancyStats2Json(&js_tenancy, OUTPUT_ENGINE_ALL);
+        if (ret == TM_ECODE_OK)
+            json_object_set_new(js_stats, "tenancy", js_tenancy);
+    }
 
     uint32_t u = 0;
     if (flags & JSON_STATS_TOTALS) {

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -34,5 +34,9 @@
 json_t *StatsToJSON(const StatsTable *st, uint8_t flags);
 #endif
 void TmModuleJsonStatsLogRegister (void);
+#ifdef HAVE_LIBJANSSON
+TmEcode OutputTenancyStatsLastReload();
+TmEcode OutputTenancyStatsRuleset();
+#endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_COUNTERS_H__ */

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -757,6 +757,52 @@ TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
     json_object_set_new(server_msg, "message", jdata);
     SCReturnInt(retval);
 }
+
+TmEcode UnixManagerShowFailedRules(json_t *cmd,
+                                   json_t *server_msg, void *data)
+{
+    SCEnter();
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    /* Since we need to deference de_ctx, we don't want to lost it. */
+    DetectEngineCtx *list = de_ctx;
+    json_t *js_sigs_array = json_array();
+
+    if (js_sigs_array == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        goto error;
+    }
+    while (list) {
+        SigString *sigs_str = list->sig_stat.failed_sigs;
+        while (sigs_str != NULL) {
+            json_t *jdata = json_object();
+            if (jdata == NULL) {
+                json_object_set_new(server_msg, "message", json_string("Unable to get the sig"));
+                json_object_clear(js_sigs_array);
+                goto error;
+            }
+
+            json_object_set_new(jdata, "id", json_integer(list->tenant_id));
+            json_object_set_new(jdata, "rule", json_string(sigs_str->sig_str));
+            json_object_set_new(jdata, "filename", json_string(sigs_str->filename));
+            json_object_set_new(jdata, "line", json_integer(sigs_str->line));
+            json_array_append_new(js_sigs_array, jdata);
+
+            sigs_str = sigs_str->next;
+        }
+        list = list->next;
+    }
+
+    json_object_set_new(server_msg, "message", js_sigs_array);
+    DetectEngineDeReference(&de_ctx);
+    SCReturnInt(TM_ECODE_OK);
+
+error:
+    DetectEngineDeReference(&de_ctx);
+    json_object_clear(js_sigs_array);
+    json_decref(js_sigs_array);
+    SCReturnInt(TM_ECODE_FAILED);
+}
+
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -978,6 +1024,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("reload-rules-non-blocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
+    UnixManagerRegisterCommand("show-failed-rules", UnixManagerShowFailedRules, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -29,6 +29,8 @@
 #include "runmodes.h"
 #include "conf.h"
 
+#include "output-json-stats.h"
+
 #include "util-privs.h"
 #include "util-debug.h"
 #include "util-signal.h"
@@ -712,6 +714,37 @@ TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
+TmEcode UnixManagerLastReloadCommand(json_t *cmd,
+                                     json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsLastReload(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
+
+TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
+                                       json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsRuleset(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -930,6 +963,8 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("last-reload", UnixManagerLastReloadCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/util-detect.c
+++ b/src/util-detect.c
@@ -1,0 +1,118 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect.h"
+#include "util-detect.h"
+
+/**
+ * \brief Allocate SigString list member
+ *
+ * \retval Pointer to SigString
+ */
+SigString *SigStringAlloc(void)
+{
+    SigString *sigstr = SCCalloc(1, sizeof(SigString));
+    if (unlikely(sigstr == NULL))
+        return NULL;
+
+    sigstr->line = 0;
+    sigstr->next = NULL;
+
+    return sigstr;
+}
+
+/**
+ * \brief Assigns the filename, signature, lineno to SigString list member
+ *
+ * \param sig pointer to SigString
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+int SigStringAddSig(SigString *sig, const char *sig_file,
+                    const char *sig_str, int line)
+{
+    if (sig_file == NULL || sig_str == NULL) {
+        return 0;
+    }
+
+    sig->filename = SCStrdup(sig_file);
+    if (sig->filename == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        return 0;
+    }
+
+    sig->sig_str = SCStrdup(sig_str);
+    if (sig->sig_str == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        SCFree(sig->filename);
+        return 0;
+    }
+
+    sig->line = line;
+
+    return 1;
+}
+
+/**
+ * \brief Append a new list member to SigString list
+ *
+ * \param list pointer to the start of the SigString list
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+int SigStringAppend(SigString **list, const char *sig_file,
+                    const char *sig_str, int line)
+{
+    SigString *item = SigStringAlloc();
+    if (item == NULL) {
+        return 0;
+    }
+
+    if (!SigStringAddSig(item, sig_file, sig_str, line)) {
+        SCFree(item);
+        return 0;
+    }
+
+    if (*list == NULL) {
+        *list = item;
+    } else {
+        SigString *tmpptr = *list;
+        while (tmpptr->next != NULL) {
+            tmpptr = tmpptr->next;
+        }
+        tmpptr->next = item;
+    }
+    item = item->next;
+
+    return 1;
+}

--- a/src/util-detect.h
+++ b/src/util-detect.h
@@ -1,0 +1,28 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
+ */
+
+SigString *SigStringAlloc(void);
+int SigStringAddSig(SigString *sig, const char *sig_file, const char *sig_start, int line);
+int SigStringAppend(SigString **list, const char *sig_file, const char *sig_str, int line);


### PR DESCRIPTION
A patchset updated that aims at improving information regarding ruleset returned to the user by suricata.

Updates:
- Fixed free funcs and lost objects deletion
- Rename of the unix-socket command
- Add a new file "util-detect" with detection engine helper functions

Small note:
The OutputTenancyStats2Json could set an error message in jdata object, which will be displayed through unix-socket, but to indicate it as "error message", the TM_ECODE_FAILED value is needed.

Last PR: #1853 
Ticket: [#1585] (https://redmine.openinfosecfoundation.org/issues/1585)

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/104
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/103