### PR TITLE
flow: record the flow hash for use as the output flow id - v1

### DIFF
--- a/src/flow.h
+++ b/src/flow.h
@@ -314,6 +314,14 @@ typedef struct Flow_
     uint8_t recursion_level;
     uint16_t vlan_id[2];
 
+    /** flow hash - the flow hash before hash table size mod. */
+    uint32_t flow_hash;
+
+    /* time stamp of last update (last packet). Set/updated under the
+     * flow and flow hash row locks, safe to read under either the
+     * flow lock or flow hash row lock. */
+    struct timeval lastts;
+
     /* end of flow "header" */
 
     SC_ATOMIC_DECLARE(FlowStateType, flow_state);
@@ -337,11 +345,6 @@ typedef struct Flow_
     uint32_t probing_parser_toclient_alproto_masks;
 
     uint32_t flags;
-
-    /* time stamp of last update (last packet). Set/updated under the
-     * flow and flow hash row locks, safe to read under either the
-     * flow lock or flow hash row lock. */
-    struct timeval lastts;
 
 #ifdef FLOWLOCK_RWLOCK
     SCRWLock r;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -167,12 +167,7 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
 {
     if (f == NULL)
         return;
-#if __WORDSIZE == 64
-    uint64_t addr = (uint64_t)f;
-#else
-    uint32_t addr = (uint32_t)f;
-#endif
-    json_object_set_new(js, "flow_id", json_integer(addr));
+    json_object_set_new(js, "flow_id", json_integer(f->flow_hash));
 }
 
 json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,


### PR DESCRIPTION
Provides a consistent hash for a flow, as well as a better
distribution than using a memory address.

Previous PR: https://github.com/inliniac/suricata/pull/1925

Changes:
- Struct re-org for better caching.

Potential solution to https://redmine.openinfosecfoundation.org/issues/1696

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/198
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/201
