### PR TITLE
pcap-file: reset PCAP stats for each new PCAP

### DIFF
--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -136,6 +136,7 @@ void TmModuleDecodePcapFileRegister (void)
 
 void PcapFileGlobalInit()
 {
+    memset(&pcap_g, 0x00, sizeof(pcap_g));
     SC_ATOMIC_INIT(pcap_g.invalid_checksums);
 }
 


### PR DESCRIPTION
PCAP stats not reset between files in Unix socket mode. Added a memset to the Global Init function to clear these stats.