### PR TITLE
detect reload on pfring in workers v1

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -370,6 +370,19 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
                 PfringDumpCounters(ptv);
                 last_dump = p->ts.tv_sec;
             }
+        } else if (r == 0) {
+            if (suricata_ctl_flags & (SURICATA_STOP | SURICATA_KILL)) {
+                SCReturnInt(TM_ECODE_OK);
+            }
+
+            Packet *p = PacketGetFromAlloc();
+            if (p != NULL) {
+                p->flags |= PKT_PSEUDO_STREAM_END;
+            }
+            if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
+                PacketFree(p);
+            }
+
         } else {
             SCLogError(SC_ERR_PF_RING_RECV,"pfring_recv error  %" PRId32 "", r);
             TmqhOutputPacketpool(ptv->tv, p);


### PR DESCRIPTION
When PF_RING is seeing no traffic, just using BreakLoop doesn't help us with reloads, as so packet is going through the system.

This PR makes the reload code first inject packets, then call BreakLoop, then wait. In the PF_RING code we 'catch' this BreakLoop and inject and empty packet into the engine. This allows for completion of the reload.

Should fix https://redmine.openinfosecfoundation.org/issues/1716 for PF_RING, however other capture methods will probably have the same issue.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/392
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/395
