### PR TITLE
doxygen: extract information from static

### DIFF
--- a/doxygen.cfg
+++ b/doxygen.cfg
@@ -366,7 +366,7 @@ EXTRACT_PACKAGE        = NO
 # If the EXTRACT_STATIC tag is set to YES all static members of a file
 # will be included in the documentation.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES classes (and structs)
 # defined locally in source files will be included in the documentation.


### PR DESCRIPTION
Some internal (static) functions are documented but this did not show in doxygen generated doc. Fixing this to help understand internal from doxy doc.