### PR TITLE
 reload on pfring in workers v7

### DIFF
--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -354,7 +354,7 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
             PacketSetData(p, pkt_buffer, hdr.caplen);
         }
 
-        if (r == 1) {
+        if (likely(r == 1)) {
             //printf("RecievePfring src %" PRIu32 " sport %" PRIu32 " dst %" PRIu32 " dstport %" PRIu32 "\n",
             //        hdr.parsed_pkt.ipv4_src,hdr.parsed_pkt.l4_src_port, hdr.parsed_pkt.ipv4_dst,hdr.parsed_pkt.l4_dst_port);
 

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -370,6 +370,19 @@ TmEcode ReceivePfringLoop(ThreadVars *tv, void *data, void *slot)
                 PfringDumpCounters(ptv);
                 last_dump = p->ts.tv_sec;
             }
+        } else if (unlikely(r == 0)) {
+            if (suricata_ctl_flags & (SURICATA_STOP | SURICATA_KILL)) {
+                SCReturnInt(TM_ECODE_OK);
+            }
+
+            /* pfring didn't use the packet yet */
+            if (p != NULL) {
+                p->flags |= PKT_PSEUDO_STREAM_END;
+                if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
+                    TmqhOutputPacketpool(ptv->tv, p);
+                }
+            }
+
         } else {
             SCLogError(SC_ERR_PF_RING_RECV,"pfring_recv error  %" PRId32 "", r);
             TmqhOutputPacketpool(ptv->tv, p);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -276,12 +276,10 @@ int RunmodeGetCurrent(void)
 static void SignalHandlerSigint(/*@unused@*/ int sig)
 {
     sigint_count = 1;
-    suricata_ctl_flags |= SURICATA_STOP;
 }
 static void SignalHandlerSigterm(/*@unused@*/ int sig)
 {
     sigterm_count = 1;
-    suricata_ctl_flags |= SURICATA_KILL;
 }
 
 void SignalHandlerSigusr2StartingUp(int sig)
@@ -2442,9 +2440,14 @@ int main(int argc, char **argv)
 
     int engine_retval = EXIT_SUCCESS;
     while(1) {
+        if (sigterm_count) {
+            suricata_ctl_flags |= SURICATA_KILL;
+        } else if (sigint_count) {
+            suricata_ctl_flags |= SURICATA_STOP;
+        }
+
         if (suricata_ctl_flags & (SURICATA_KILL | SURICATA_STOP)) {
             SCLogNotice("Signal Received.  Stopping engine.");
-
             break;
         }
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -182,11 +182,6 @@ void EngineStop(void);
 void EngineKill(void);
 void EngineDone(void);
 
-/* live rule swap required this to be made static */
-void SignalHandlerSigusr2(int);
-void SignalHandlerSigusr2EngineShutdown(int);
-void SignalHandlerSigusr2Idle(int sig);
-
 int RunmodeIsUnittests(void);
 int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);


### PR DESCRIPTION
When PF_RING is seeing no traffic, just using BreakLoop doesn't help us with reloads, as so packet is going through the system.

This PR makes the reload code first inject packets, then call BreakLoop, then wait. In the PF_RING code we 'catch' this BreakLoop and inject and empty packet into the engine. This allows for completion of the reload.

Should fix https://redmine.openinfosecfoundation.org/issues/1716 for PF_RING, however other capture methods will probably have the same issue.

Changes since #1957:
- fix hanging at interrupted reload
- redo signal handling to avoid deadlocks (see commits)
- cleanups

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/393
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/396