### PR TITLE
Fix heap-buffer-overflows

### DIFF
--- a/src/app-layer-tls-handshake.c
+++ b/src/app-layer-tls-handshake.c
@@ -110,9 +110,22 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input, uin
 
     i = 0;
     while (certificates_length > 0) {
+        if (input - start_data + 3 > input_len) {
+            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            return -1;
+        }
+
         cur_cert_length = input[0]<<16 | input[1]<<8 | input[2];
         input += 3;
         parsed += 3;
+
+        /* current certificate length should be greater than zero */
+        if (cur_cert_length == 0) {
+            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            return -1;
+        }
 
         if (input - start_data + cur_cert_length > input_len) {
             AppLayerDecoderEventsSetEvent(ssl_state->f, TLS_DECODER_EVENT_INVALID_CERTIFICATE);

--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -742,6 +742,9 @@ Asn1Generic * DecodeDer(const unsigned char *buffer, uint32_t size, uint32_t *er
     Asn1Generic *cert;
     uint8_t c;
 
+    if (size < 2)
+        return NULL;
+
     /* Check that buffer is an ASN.1 structure (basic checks) */
     if (d_ptr[0] != 0x30 && d_ptr[1] != 0x82) /* Sequence */
         return NULL;


### PR DESCRIPTION
Fix heap-buffer-overflows in app-layer-tls-handshake.c and util-decode-der.c.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/2
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/2