### PR TITLE
util-decode-der: fix NULL dereference bug

### DIFF
--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -216,6 +216,10 @@ static Asn1Generic * DecodeAsn1DerGeneric(const unsigned char *buffer, uint32_t 
              * sequence parsing will fail
              */
             child->length += (d_ptr - save_d_ptr);
+
+            if (child->length > max_size - (d_ptr - buffer))
+                return NULL;
+
             break;
     };
     if (child == NULL)


### PR DESCRIPTION
Make sure that the length is not longer than the size of the buffer
provided.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/3
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/3