### PR TITLE
Fix bugs in app-layer-tls-handshake and util-decode-der

### DIFF
--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -742,6 +742,9 @@ Asn1Generic * DecodeDer(const unsigned char *buffer, uint32_t size, uint32_t *er
     Asn1Generic *cert;
     uint8_t c;
 
+    if (size < 2)
+        return NULL;
+
     /* Check that buffer is an ASN.1 structure (basic checks) */
     if (d_ptr[0] != 0x30 && d_ptr[1] != 0x82) /* Sequence */
         return NULL;

--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -216,6 +216,12 @@ static Asn1Generic * DecodeAsn1DerGeneric(const unsigned char *buffer, uint32_t 
              * sequence parsing will fail
              */
             child->length += (d_ptr - save_d_ptr);
+
+            if (child->length > max_size - (d_ptr - buffer)) {
+                SCFree(child);
+                return NULL;
+            }
+
             break;
     };
     if (child == NULL)


### PR DESCRIPTION
Fixes heap-buffer-overflows in app-layer-tls-handshake.c and util-decode-der.c.

Also fixes a NULL dereference bug in util-decode-der.c

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/4
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/4