### PR TITLE
Dev app layer stats v3

### DIFF
--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -50,6 +50,24 @@
 
 #include "app-layer-dns-udp.h"
 
+SC_ATOMIC_DECLARE(uint64_t, dns_udp_tx_cnt);
+
+/* tx counter functions */
+static void DNSUDPIncTxCounter(void)
+{
+    SC_ATOMIC_ADD(dns_udp_tx_cnt, 1);
+}
+
+static uint64_t DNSUDPGetTxCounter(void)
+{
+    return SC_ATOMIC_GET(dns_udp_tx_cnt);
+}
+
+static void DNSUDPRegisterCounters(void)
+{
+    SC_ATOMIC_INIT(dns_udp_tx_cnt);
+}
+
 /** \internal
  *  \brief Parse DNS request packet
  */
@@ -202,6 +220,8 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
         goto bad_data;
 
     SCLogDebug("queries %04x", ntohs(dns_header->questions));
+
+    DNSUDPIncTxCounter();
 
     uint16_t q;
     const uint8_t *data = input + sizeof(DNSHeader);
@@ -424,8 +444,9 @@ void RegisterDNSUDPParsers(void)
                                                                DNSGetAlstateProgressCompletionStatus);
 
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);
-
+        AppLayerParserRegisterGetTxCounter(IPPROTO_UDP, ALPROTO_DNS, DNSUDPGetTxCounter);
         DNSUDPConfigure();
+        DNSUDPRegisterCounters();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -91,6 +91,8 @@ static uint64_t htp_state_memuse = 0;
 static uint64_t htp_state_memcnt = 0;
 #endif
 
+SC_ATOMIC_DECLARE(uint64_t, htp_tx_cnt);
+
 SCEnumCharMap http_decoder_event_table[ ] = {
     { "UNKNOWN_ERROR",
         HTTP_DECODER_EVENT_UNKNOWN_ERROR},
@@ -231,6 +233,22 @@ static int HTPLookupPersonality(const char *str)
     }
 
     return -1;
+}
+
+/* app-layer stats functions */
+static void HTPIncTxCounter(void)
+{
+    SC_ATOMIC_ADD(htp_tx_cnt, 1);
+}
+
+static uint64_t HTPGetTxCounter(void)
+{
+    return SC_ATOMIC_GET(htp_tx_cnt);
+}
+
+static void HTPRegisterCounters(void)
+{
+    SC_ATOMIC_INIT(htp_tx_cnt);
 }
 
 void HTPSetEvent(HtpState *s, HtpTxUserData *htud, uint8_t e)
@@ -1976,6 +1994,8 @@ static int HTPCallbackRequest(htp_tx_t *tx)
 
     HTPErrorCheckTxRequestFlags(hstate, tx);
 
+    HTPIncTxCounter();
+
     HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
     if (htud != NULL) {
         if (htud->tsflags & HTP_FILENAME_SET) {
@@ -2760,7 +2780,9 @@ void RegisterHTPParsers(void)
                                      HTPHandleResponseData);
         SC_ATOMIC_INIT(htp_config_flags);
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_HTTP, STREAM_TOSERVER);
+        AppLayerParserRegisterGetTxCounter(IPPROTO_TCP, ALPROTO_HTTP, HTPGetTxCounter);
         HTPConfigure();
+        HTPRegisterCounters();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -146,6 +146,8 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+void AppLayerParserRegisterGetTxCounter(uint8_t ipproto, AppProto alproto,
+        uint64_t (*GetTxCounter)(void));
 
 /***** Get and transaction functions *****/
 
@@ -197,6 +199,8 @@ int AppLayerParserProtocolIsTxEventAware(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolSupportsTxs(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserTriggerRawStreamReassembly(Flow *f);
+int AppLayerParserHasGetTxCounter(uint8_t ipproto, AppProto);
+uint64_t AppLayerParserGetTxCounter(uint8_t ipproto, AppProto alproto);
 
 /***** Cleanup *****/
 

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -44,6 +44,10 @@ enum AppProtoEnum {
     ALPROTO_MODBUS,
     ALPROTO_TEMPLATE,
 
+    /* used to avoid the allocation of array slots that
+       will never be incremented */
+    ALPROTO_COUNTER_MAX = ALPROTO_TEMPLATE,
+
     /* used by the probing parser when alproto detection fails
      * permanently for that particular stream */
     ALPROTO_FAILED,

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -132,6 +132,8 @@ static inline void AppLayerProfilingStore(AppLayerThreadCtx *app_tctx, Packet *p
 
 void AppLayerRegisterGlobalCounters(void);
 
+uint64_t AppLayerCountersGetCounter(AppProto alproto);
+
 /***** Unittests *****/
 
 #ifdef UNITTESTS


### PR DESCRIPTION
This patchset adds per app-layer stats in EVE json output, couting precisally the number
of transactions and flows handled by the supported protocol.

To manage the tx counter,  a new API GetTxCounter is added to app-layer-parser. For flows, the counters are stored into an array, and a single counter is incremented when the alproto is recognized.

The output in EVE is:
"app-layer":{
  "tx":{"http":8,"smtp":0,"dns_tcp":0,"dns_udp":0},
  "flow":{"http":12,"ftp":0,"smtp":0,"tls":6,"ssh":0,"imap":0,"msn":0,"smb":0,"dcerpc":0,"dns":24}
}

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1657
Last PR: #1809 

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/105
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/104
