### PR TITLE
lua_close() segfaults on null pointers

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -731,7 +731,8 @@ static int LuaScriptInit(const char *filename, LogLuaScriptOptions *options) {
     lua_close(luastate);
     return 0;
 error:
-    lua_close(luastate);
+    if (luastate)
+        lua_close(luastate);
     return -1;
 }
 
@@ -796,7 +797,8 @@ static lua_State *LuaScriptSetup(const char *filename)
     SCLogDebug("lua_State %p is set up", luastate);
     return luastate;
 error:
-    lua_close(luastate);
+    if (luastate)
+        lua_close(luastate);
     return NULL;
 }
 


### PR DESCRIPTION
I assume i hit the luajit 2GB memory limit when setting detect.sgh-mpm-context: full

Core was generated by `suricata --pfring -c /etc/suricata/suricata.yaml'.
Program terminated with signal 11, Segmentation fault.
#0  0x00007f731db556ca in lua_close () from /usr/lib64/libluajit-5.1.so.2
Missing separate debuginfos, use: debuginfo-install suricata-3.0.1
(gdb) bt
#0  0x00007f731db556ca in lua_close () from /usr/lib64/libluajit-5.1.so.2
#1  0x00000000004f9b48 in LuaScriptInit (options=0x7ffdf01d73e0, filename=0x7ffdf01d7c10 "/etc/suricata/lua/stats.lua") at output-lua.c:734
#2  OutputLuaLogInit (conf=<optimized out>) at output-lua.c:918
#3  0x0000000000516585 in RunModeInitializeOutputs () at runmodes.c:772
#4  0x000000000040ddd0 in main (argc=<optimized out>, argv=<optimized out>) at suricata.c:2394
(gdb) up
#1  0x00000000004f9b48 in LuaScriptInit (options=0x7ffdf01d73e0, filename=0x7ffdf01d7c10 "/etc/suricata/lua/stats.lua") at output-lua.c:734
734	    lua_close(luastate);
(gdb) p luastate
$1 = (lua_State *) 0x0
