### PR TITLE
Support sending rejects via libnet when running under non-root.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -969,13 +969,15 @@
 
     AC_MSG_CHECKING(for libnet.h version 1.1.x)
     if test "$LIBNET_INC_DIR" != ""; then
-        if eval "grep LIBNET_VERSION $LIBNET_INC_DIR/libnet.h | grep -v '1.[[12]]' >/dev/null"; then
-            AC_MSG_RESULT(no)
-            LIBNET_DETECT_FAIL="yes"
-            LIBNET_FAIL_WARN($libnet_dir)
-        else
-            AC_MSG_RESULT(yes)
-        fi
+        LIBNET_VER=`grep LIBNET_VERSION $LIBNET_INC_DIR/libnet.h | sed 's/[[^"]]*"\([[^"]]*\).*/\1/'`
+
+        AS_VERSION_COMPARE([LIBNET_VER], [1.1.0],
+            [
+                AC_MSG_RESULT(no)
+                LIBNET_DETECT_FAIL="yes"
+                LIBNET_FAIL_WARN($libnet_dir)
+            ],
+            [AC_MSG_RESULT(yes)], [AC_MSG_RESULT(yes)])
 
         #CentOS, Fedora, Ubuntu-LTS, Ubuntu all set defines to the same values. libnet-config seems
         #to have been depreciated but all distro's seem to include it as part of the package.
@@ -1011,6 +1013,15 @@
                 fi
                 LIBS="${TMPLIBS}"
             fi
+
+            # See if we have libnet 1.1.6 or newer - these versions handle capabilities correctly
+            # Some patched 1.1.4 versions are also good, but it's not guaranteed for all distros.
+            #
+            # Details: https://bugzilla.redhat.com/show_bug.cgi?id=589770
+            AS_VERSION_COMPARE([LIBNET_VER], [1.1.6],
+                [],
+                [AC_DEFINE([HAVE_LIBNET_CAPABILITIES],[1], (libnet_have_capabilities_patch))],
+                [AC_DEFINE([HAVE_LIBNET_CAPABILITIES],[1], (libnet_have_capabilities_patch))])
         fi
     else
         LIBNET_DETECT_FAIL="yes"

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -751,7 +751,7 @@ static int SigParsePort(const DetectEngineCtx *de_ctx,
 static int SigParseActionRejectValidate(const char *action)
 {
 #ifdef HAVE_LIBNET11
-#ifdef HAVE_LIBCAP_NG
+#if defined HAVE_LIBCAP_NG && !defined HAVE_LIBNET_CAPABILITIES
     if (sc_set_caps == TRUE) {
         SCLogError(SC_ERR_LIBNET11_INCOMPATIBLE_WITH_LIBCAP_NG, "Libnet 1.1 is "
             "incompatible with POSIX based capabilities with privs dropping. "


### PR DESCRIPTION
Since version 1.1.6 libnet handles capabilities correctly.
So changing libnet's version checking a little bit should do the trick.