### PR TITLE
Per direction TX logging - v5

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -1125,3 +1125,27 @@ void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size)
             snprintf(str, str_size, "%04x/%u", rcode, rcode);
     }
 }
+
+int DNSGetTxIsLogged(void *tx, uint8_t direction)
+{
+    DNSTransaction *dnstx = tx;
+    if (direction & STREAM_TOSERVER) {
+        return dnstx->request_logged;
+    }
+    else if (direction & STREAM_TOCLIENT) {
+        return dnstx->response_logged;
+    }
+    return 0;
+}
+
+void DNSSetTxIsLogged(void *tx, uint8_t direction)
+{
+    DNSTransaction *dnstx = tx;
+
+    if (direction & STREAM_TOSERVER) {
+        dnstx->request_logged = 1;
+    }
+    if (direction & STREAM_TOCLIENT) {
+        dnstx->response_logged = 1;
+    }
+}

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -158,11 +158,16 @@ typedef struct DNSAnswerEntry_ {
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
     uint16_t tx_id;                                 /**< transaction id */
-    uint8_t replied;                                /**< bool indicating request is
-                                                         replied to. */
-    uint8_t reply_lost;
     uint8_t rcode;                                  /**< response code (e.g. "no error" / "no such name") */
-    uint8_t recursion_desired;                      /**< server said "recursion desired" */
+
+    uint8_t replied:1;          /**< Flag indicating request is replied to. */
+    uint8_t reply_lost:1;       /**< Flag indicating if reply was lost .*/
+    uint8_t recursion_desired:1; /**< Flag indicating server said
+                                  * "recursion desired". */
+    uint8_t request_logged:1; /**< Set after request has been logged. */
+    uint8_t response_logged:1; /**< Set after response has been
+                                * logged. */
+    uint8_t padding:3;
 
     TAILQ_HEAD(, DNSQueryEntry_) query_list;        /**< list for query/queries */
     TAILQ_HEAD(, DNSAnswerEntry_) answer_list;      /**< list for answers */
@@ -172,6 +177,8 @@ typedef struct DNSTransaction_ {
 
     TAILQ_ENTRY(DNSTransaction_) next;
     DetectEngineState *de_state;
+
+
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */
@@ -235,6 +242,9 @@ void *DNSStateAlloc(void);
 void DNSStateFree(void *s);
 AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id);
 int DNSHasEvents(void *state);
+
+int DNSGetTxIsLogged(void *vtx, uint8_t direction);
+void DNSSetTxIsLogged(void *vtx, uint8_t direction);
 
 int DNSValidateRequestHeader(DNSState *, const DNSHeader *dns_header);
 int DNSValidateResponseHeader(DNSState *, const DNSHeader *dns_header);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -667,6 +667,11 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
+
+        /* Register for directional logging state tracking. Allows
+         * transactions to be logged as each direction completes. */
+        AppLayerParserRegisterTxLogStateFuncs(IPPROTO_TCP, ALPROTO_DNS,
+            DNSGetTxIsLogged, DNSSetTxIsLogged);
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -425,6 +425,11 @@ void RegisterDNSUDPParsers(void)
 
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);
 
+        /* Register for directional logging state tracking. Allows
+         * transactions to be logged as each direction completes. */
+        AppLayerParserRegisterTxLogStateFuncs(IPPROTO_UDP, ALPROTO_DNS,
+            DNSGetTxIsLogged, DNSSetTxIsLogged);
+
         DNSUDPConfigure();
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -146,6 +146,9 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+void AppLayerParserRegisterTxLogStateFuncs(uint8_t ipproto, AppProto alproto,
+    int (*GetTxIsLogged)(void *tx, uint8_t direction),
+    void (*SetTxIsLogged)(void *tx, uint8_t direction));
 
 /***** Get and transaction functions *****/
 
@@ -184,6 +187,9 @@ int AppLayerParserSupportsTxDetectState(uint8_t ipproto, AppProto alproto);
 int AppLayerParserHasTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate);
 DetectEngineState *AppLayerParserGetTxDetectState(uint8_t ipproto, AppProto alproto, void *tx);
 int AppLayerParserSetTxDetectState(uint8_t ipproto, AppProto alproto, void *alstate, void *tx, DetectEngineState *s);
+int AppLayerParserSupportsTxLogState(uint8_t ipproto, AppProto alproto);
+int AppLayerParserGetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx, uint8_t direction);
+void AppLayerParserSetTxIsLogged(uint8_t ipproto, AppProto alproto, void *tx, uint8_t direction);
 
 /***** General *****/
 

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -166,7 +166,7 @@ static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *ds
 }
 
 static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p, Flow *f,
-    void *state, void *tx, uint64_t tx_id)
+    uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     LogDnsLogThread *aft = (LogDnsLogThread *)data;
     DNSTransaction *dns_tx = (DNSTransaction *)tx;

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -61,7 +61,7 @@ TmEcode LogHttpLogThreadDeinit(ThreadVars *, void *);
 void LogHttpLogExitPrintStats(ThreadVars *, void *);
 static void LogHttpLogDeInitCtx(OutputCtx *);
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 void TmModuleLogHttpLogRegister (void)
 {
@@ -515,7 +515,7 @@ end:
 
 }
 
-int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+int LogHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -246,7 +246,7 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
 
 }
 
-static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -368,7 +368,7 @@ static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, ui
     json_object_set_new(js, "http", hjs);
 }
 
-static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -82,7 +82,7 @@ static json_t *JsonSmtpDataLogger(const Flow *f, void *state, void *vtx, uint64_
     return sjs;
 }
 
-static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     SCEnter();
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -52,7 +52,7 @@ typedef struct LogTemplateLogThread_ {
 } LogTemplateLogThread;
 
 static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
-    const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+    const Packet *p, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id)
 {
     TemplateTransaction *templatetx = tx;
     LogTemplateLogThread *thread = thread_data;

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -91,7 +91,7 @@ typedef struct LogLuaThreadCtx_ {
  *
  * NOTE: The flow (f) also referenced by p->flow is locked.
  */
-static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int LuaTxLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, uint8_t flags, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -155,7 +155,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
         }
 
         if (!(ts_ready || tc_ready)) {
-            SCLogNotice("progress not for enough, not logging");
+            SCLogDebug("Neither ts or tc ready, not logging");
             break;
         }
 

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -29,7 +29,7 @@
 #include "decode.h"
 
 /** packet logger function pointer type */
-typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, void *state, void *tx, uint64_t tx_id);
+typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f, uint8_t flags, void *state, void *tx, uint64_t tx_id);
 
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged


### PR DESCRIPTION
Previous PR: https://github.com/inliniac/suricata/pull/1967

This PR is just a rebase.

Where per direction logging is required, the app-layer must now maintain some logging state. This state is not required if per-direction logging is not required, and is how existing loggers are handled.

The second commit converts DNS to per-direction logging and sees the following improvements:
- correct request timestamps
- correct ordering

Changes addressed in previous PR comments:
- More compact DNS data structure.
- Doxygen docs on setting up per direction TX logging.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/210
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/215
