### PR TITLE
util-decode-der: fix hang detected by AFL

### DIFF
--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -227,6 +227,12 @@ static Asn1Generic * DecodeAsn1DerGeneric(const unsigned char *buffer, uint32_t 
     if (child == NULL)
         return NULL;
 
+    /* child length should never be zero */
+    if (child->length == 0) {
+        SCFree(child);
+        return NULL;
+    }
+
     child->header = el;
     return child;
 }


### PR DESCRIPTION
Fix hang that occurs when child length is zero, resulting in an endless loop.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/10
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/10