### PR TITLE
Lock hunting 2

### DIFF
--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -162,6 +162,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
             }
 
             f->alproto = *alproto;
+            p->alproto = f->alproto;
             StreamTcpSetStreamFlagAppProtoDetectionCompleted(stream);
 
             /* if we have seen data from the other direction first, send
@@ -509,6 +510,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
             f->flags |= FLOW_ALPROTO_DETECT_DONE;
             SCLogDebug("ALPROTO_UNKNOWN flow %p", f);
         }
+        p->alproto = f->alproto;
     } else {
         SCLogDebug("stream data (len %" PRIu32 " ), alproto "
                    "%"PRIu16" (flow %p)", p->payload_len, f->alproto, f);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -152,12 +152,12 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                                                  APPLAYER_MISMATCH_PROTOCOL_BOTH_DIRECTIONS);
                 /* it indicates some data has already been sent to the parser */
                 if (ssn->data_first_seen_dir == APP_LAYER_DATA_ALREADY_SENT_TO_APP_LAYER) {
-                    f->alproto = *alproto = *alproto_otherdir;
+                    *alproto = *alproto_otherdir;
                 } else {
                     if (flags & STREAM_TOCLIENT)
-                        f->alproto = *alproto_otherdir = *alproto;
+                        *alproto_otherdir = *alproto;
                     else
-                        f->alproto = *alproto = *alproto_otherdir;
+                        *alproto = *alproto_otherdir;
                 }
             }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -396,15 +396,12 @@ typedef struct Packet_
     uint8_t flowflags;
     /* coccinelle: Packet:flowflags:FLOW_PKT_ */
 
-    uint8_t cachedflags;
-    uint16_t alproto;
-
     /* Pkt Flags */
     uint32_t flags;
 
-    struct Flow_ *flow;
-
     struct timeval ts;
+
+    struct Flow_ *flow;
 
     union {
         /* nfq stuff */
@@ -550,6 +547,9 @@ typedef struct Packet_
      * the packet to its owner's stack. If NULL, then allocated with malloc.
      */
     struct PktPool_ *pool;
+
+    uint16_t alproto;
+    uint8_t cachedflags;
 
 #ifdef PROFILING
     PktProfiling *profile;

--- a/src/decode.h
+++ b/src/decode.h
@@ -274,6 +274,8 @@ typedef struct PacketAlert_ {
 /** alert is in a tx, tx_id set */
 #define PACKET_ALERT_FLAG_TX            0x08
 
+#define PACKET_APPLAYER_LOGGED          (1<<0)
+
 #define PACKET_ALERT_MAX 15
 
 typedef struct PacketAlerts_ {
@@ -393,6 +395,9 @@ typedef struct Packet_
     /* flow */
     uint8_t flowflags;
     /* coccinelle: Packet:flowflags:FLOW_PKT_ */
+
+    uint8_t cachedflags;
+    uint16_t alproto;
 
     /* Pkt Flags */
     uint32_t flags;
@@ -708,6 +713,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         PACKET_FREE_EXTDATA((p));               \
         (p)->flags = (p)->flags & PKT_ALLOC;    \
         (p)->flowflags = 0;                     \
+        (p)->cachedflags = 0;                 \
         (p)->pkt_src = 0;                       \
         (p)->vlan_id[0] = 0;                    \
         (p)->vlan_id[1] = 0;                    \

--- a/src/decode.h
+++ b/src/decode.h
@@ -276,6 +276,7 @@ typedef struct PacketAlert_ {
 
 #define PACKET_APPLAYER_LOGGED          (1<<0)
 #define PACKET_FLOW_DROP_LOGGED         (1<<1)
+#define PACKET_APPLAYER_LOGGED_LUA      (1<<2)
 
 #define PACKET_ALERT_MAX 15
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -275,6 +275,7 @@ typedef struct PacketAlert_ {
 #define PACKET_ALERT_FLAG_TX            0x08
 
 #define PACKET_APPLAYER_LOGGED          (1<<0)
+#define PACKET_FLOW_DROP_LOGGED         (1<<1)
 
 #define PACKET_ALERT_MAX 15
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -273,6 +273,10 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
     /* Point the Packet at the Flow */
     FlowReference(&p->flow, f);
 
+    /* Copy applicatoin layer infos from flag */
+    p->cachedflags = f->cachedflags;
+    p->alproto = f->alproto;
+ 
     /* update flags and counters */
     if (FlowGetPacketDirection(f, p) == TOSERVER) {
         f->todstpktcnt++;

--- a/src/flow.h
+++ b/src/flow.h
@@ -174,6 +174,7 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_PKT_TOCLIENT_IPONLY_SET    0x10
 #define FLOW_PKT_TOSERVER_FIRST         0x20
 #define FLOW_PKT_TOCLIENT_FIRST         0x40
+#define FLOW_PKT_LOGGED                 0x80
 
 #define FLOW_END_FLAG_STATE_NEW         0x01
 #define FLOW_END_FLAG_STATE_ESTABLISHED 0x02
@@ -363,6 +364,8 @@ typedef struct Flow_
 
     uint8_t flow_end_flags;
     /* coccinelle: Flow:flow_end_flags:FLOW_END_FLAG_ */
+
+    uint8_t cachedflags;
 
     AppProto alproto; /**< \brief application level protocol */
     AppProto alproto_ts;

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -276,7 +276,16 @@ filectx_error:
  */
 static int LogTlsCondition(ThreadVars *tv, const Packet *p)
 {
+
+    if (p->cachedflags & PACKET_APPLAYER_LOGGED) {
+        return FALSE;
+    }
+
     if (p->flow == NULL) {
+        return FALSE;
+    }
+
+    if (p->alproto != ALPROTO_TLS) {
         return FALSE;
     }
 
@@ -305,8 +314,8 @@ static int LogTlsCondition(ThreadVars *tv, const Packet *p)
             ssl_state->server_connp.cert0_subject == NULL)
         goto dontlog;
 
-    /* todo: logic to log once */
-
+    /* Backup the fact we have logged */
+    p->flow->cachedflags |= PACKET_APPLAYER_LOGGED;
     FLOWLOCK_UNLOCK(p->flow);
     return TRUE;
 dontlog:

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -374,6 +374,9 @@ static int JsonDropLogCondition(ThreadVars *tv, const Packet *p)
         SCLogDebug("drop log doesn't log pseudo packets");
         return FALSE;
     }
+    if (p->cachedflags & PACKET_FLOW_DROP_LOGGED) {
+        return FALSE;
+    }
 
     if (p->flow != NULL) {
         int ret = FALSE;

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -267,6 +267,7 @@ static int LuaPacketLoggerTls(ThreadVars *tv, void *thread_data, const Packet *p
     SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
     if (ssl_state != NULL)
         ssl_state->flags |= SSL_AL_FLAG_STATE_LOGGED_LUA;
+    p->flow->cachedflags |= PACKET_APPLAYER_LOGGED_LUA;
 
     FLOWLOCK_UNLOCK(p->flow);
     SCReturnInt(0);
@@ -274,6 +275,10 @@ static int LuaPacketLoggerTls(ThreadVars *tv, void *thread_data, const Packet *p
 
 static int LuaPacketConditionTls(ThreadVars *tv, const Packet *p)
 {
+    if (p->cachedflags & PACKET_APPLAYER_LOGGED_LUA) {
+        return FALSE;
+    }
+
     if (p->flow == NULL) {
         return FALSE;
     }
@@ -347,6 +352,7 @@ static int LuaPacketLoggerSsh(ThreadVars *tv, void *thread_data, const Packet *p
     SshState *ssh_state = (SshState *)FlowGetAppState(p->flow);
     if (ssh_state != NULL)
         ssh_state->cli_hdr.flags |= SSH_FLAG_STATE_LOGGED_LUA;
+    p->flow->cachedflags |= PACKET_APPLAYER_LOGGED_LUA;
 
     FLOWLOCK_UNLOCK(p->flow);
     SCReturnInt(0);
@@ -354,6 +360,10 @@ static int LuaPacketLoggerSsh(ThreadVars *tv, void *thread_data, const Packet *p
 
 static int LuaPacketConditionSsh(ThreadVars *tv, const Packet *p)
 {
+    if (p->cachedflags & PACKET_APPLAYER_LOGGED_LUA) {
+        return FALSE;
+    }
+
     if (p->flow == NULL) {
         return FALSE;
     }

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -286,11 +286,11 @@ static int LuaPacketConditionTls(ThreadVars *tv, const Packet *p)
         return FALSE;
     }
 
-    FLOWLOCK_RDLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto dontlog;
+    if (p->alproto != ALPROTO_TLS) {
+        return FALSE;
+    }
 
+    FLOWLOCK_RDLOCK(p->flow);
     SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
     if (ssl_state == NULL) {
         SCLogDebug("no tls state, so no request logging");
@@ -366,11 +366,11 @@ static int LuaPacketConditionSsh(ThreadVars *tv, const Packet *p)
         return FALSE;
     }
 
-    FLOWLOCK_RDLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_SSH)
-        goto dontlog;
+    if (p->alproto != ALPROTO_SSH) {
+        return FALSE;
+    }
 
+    FLOWLOCK_RDLOCK(p->flow);
     SshState *ssh_state = (SshState *)FlowGetAppState(p->flow);
     if (ssh_state == NULL) {
         SCLogDebug("no ssh state, so no request logging");


### PR DESCRIPTION
When playing with perf top on a busy box, I've realized the lock and unlock function of pthread library were taking some time. By looking at the call graph, we could see that the logging condition functions were partly responsible of that. This PR is updating the code to cache some flow related information in the packet. This result in locking the flow to be less common in the condition functions.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/158
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/154
