### PR TITLE
afl: add --afl-der=file and AFL PERSISTANT_MODE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,6 +270,7 @@
             AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
             AC_DEFINE([AFLFUZZ_MIME], [1], [Enable --afl-mime commandline option])
             AC_DEFINE([AFLFUZZ_DECODER], [1], [Enable --afl-decoder-$proto commandline option])
+            AC_DEFINE([AFLFUZZ_DER], [1], [Enable --afl-der commandline option])
     ])
 
   # disable TLS on user request

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,30 @@
     AC_CONFIG_MACRO_DIR(m4)
     AM_INIT_AUTOMAKE
 
+    # enable modifications for AFL fuzzing
+    AC_ARG_ENABLE(afl,
+           AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
+
+    AS_IF([test "x$enable_afl" = "xyes"], [
+        AC_DISABLE_SHARED
+        AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
+        AC_DEFINE([AFLFUZZ_DISABLE_MGTTHREADS], [1], [Disable all management threads])
+        AC_DEFINE([AFLFUZZ_PCAP_RUNMODE], [1], [Enable special AFL 'single' runmode])
+        AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
+        AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
+        AC_DEFINE([AFLFUZZ_MIME], [1], [Enable --afl-mime commandline option])
+        AC_DEFINE([AFLFUZZ_DECODER], [1], [Enable --afl-decoder-$proto commandline option])
+        AC_DEFINE([AFLFUZZ_DER], [1], [Enable --afl-der commandline option])
+
+        # test for AFL PERSISTANT_MODE support
+        CFLAGS_ORIG=$CFLAGS
+        CFLAGS="-Werror"
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[while (__AFL_LOOP(1000))]])],
+                [AC_DEFINE([AFLFUZZ_PERSISTANT_MODE], [1], [Enable AFL PERSISTANT_MODE])],
+                [])
+        CFLAGS=$CFLAGS_ORIG
+    ])
+
     AC_LANG_C
     AC_PROG_CC_C99
     AC_PROG_LIBTOOL
@@ -258,20 +282,6 @@
             ;;
     esac
     AC_MSG_RESULT(ok)
-
-  # enable modifications for AFL fuzzing
-    AC_ARG_ENABLE(afl,
-           AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
-    AS_IF([test "x$enable_afl" = "xyes"], [
-            AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
-            AC_DEFINE([AFLFUZZ_DISABLE_MGTTHREADS], [1], [Disable all management threads])
-            AC_DEFINE([AFLFUZZ_PCAP_RUNMODE], [1], [Enable special AFL 'single' runmode])
-            AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
-            AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
-            AC_DEFINE([AFLFUZZ_MIME], [1], [Enable --afl-mime commandline option])
-            AC_DEFINE([AFLFUZZ_DECODER], [1], [Enable --afl-decoder-$proto commandline option])
-            AC_DEFINE([AFLFUZZ_DER], [1], [Enable --afl-der commandline option])
-    ])
 
   # disable TLS on user request
     AC_ARG_ENABLE(threading-tls,

--- a/configure.ac
+++ b/configure.ac
@@ -268,6 +268,7 @@
             AC_DEFINE([AFLFUZZ_PCAP_RUNMODE], [1], [Enable special AFL 'single' runmode])
             AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
             AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
+            AC_DEFINE([AFLFUZZ_MIME], [1], [Enable --afl-mime commandline option])
     ])
 
   # disable TLS on user request

--- a/configure.ac
+++ b/configure.ac
@@ -269,6 +269,7 @@
             AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
             AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
             AC_DEFINE([AFLFUZZ_MIME], [1], [Enable --afl-mime commandline option])
+            AC_DEFINE([AFLFUZZ_DECODER], [1], [Enable --afl-decoder-$proto commandline option])
     ])
 
   # disable TLS on user request

--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,16 @@
     esac
     AC_MSG_RESULT(ok)
 
+  # enable modifications for AFL fuzzing
+    AC_ARG_ENABLE(afl,
+           AS_HELP_STRING([--enable-afl], Enable AFL fuzzing logic[])], [enable_afl="$enableval"],[enable_afl=no])
+    AS_IF([test "x$enable_afl" = "xyes"], [
+            AC_DEFINE([AFLFUZZ_NO_RANDOM], [1], [Disable all use of random functions])
+            AC_DEFINE([AFLFUZZ_DISABLE_MGTTHREADS], [1], [Disable all management threads])
+            AC_DEFINE([AFLFUZZ_PCAP_RUNMODE], [1], [Enable special AFL 'single' runmode])
+            AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
+    ])
+
   # disable TLS on user request
     AC_ARG_ENABLE(threading-tls,
            AS_HELP_STRING([--disable-threading-tls], [Disable TLS (thread local storage)]), [enable_tls="$enableval"],[enable_tls=yes])

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,7 @@
             AC_DEFINE([AFLFUZZ_DISABLE_MGTTHREADS], [1], [Disable all management threads])
             AC_DEFINE([AFLFUZZ_PCAP_RUNMODE], [1], [Enable special AFL 'single' runmode])
             AC_DEFINE([AFLFUZZ_CONF_TEST], [1], [Enable special --afl-parse-rules commandline option])
+            AC_DEFINE([AFLFUZZ_APPLAYER], [1], [Enable --afl-$proto-request commandline option])
     ])
 
   # disable TLS on user request

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2162,7 +2162,11 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
     cfg_prec->request_inspect_window = HTP_CONFIG_DEFAULT_REQUEST_INSPECT_WINDOW;
     cfg_prec->response_inspect_min_size = HTP_CONFIG_DEFAULT_RESPONSE_INSPECT_MIN_SIZE;
     cfg_prec->response_inspect_window = HTP_CONFIG_DEFAULT_RESPONSE_INSPECT_WINDOW;
+#ifndef AFLFUZZ_NO_RANDOM
     cfg_prec->randomize = HTP_CONFIG_DEFAULT_RANDOMIZE;
+#else
+    cfg_prec->randomize = 0;
+#endif
     cfg_prec->randomize_range = HTP_CONFIG_DEFAULT_RANDOMIZE_RANGE;
 
     htp_config_register_request_header_data(cfg_prec->cfg, HTPCallbackRequestHeaderData);
@@ -2441,7 +2445,9 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                     (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_SOFT,
                     (size_t)limit);
         } else if (strcasecmp("randomize-inspection-sizes", p->name) == 0) {
+#ifndef AFLFUZZ_NO_RANDOM
             cfg_prec->randomize = ConfValIsTrue(p->val);
+#endif
         } else if (strcasecmp("randomize-inspection-range", p->name) == 0) {
             uint32_t range = atoi(p->val);
             if (range > 100) {

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1433,7 +1433,9 @@ void RegisterModbusParsers(void)
                                                 proto_name, ALPROTO_MODBUS,
                                                 0, sizeof(ModbusHeader),
                                                 ModbusProbingParser)) {
+#ifndef AFLFUZZ_APPLAYER
                 return;
+#endif
             }
         }
 
@@ -1448,11 +1450,16 @@ void RegisterModbusParsers(void)
         }
         SCLogInfo("Modbus request flood protection level: %u", request_flood);
     } else {
+#ifndef AFLFUZZ_APPLAYER
         SCLogInfo("Protocol detection and parser disabled for %s protocol.", proto_name);
         return;
+#endif
     }
-
+#ifndef AFLFUZZ_APPLAYER
     if (AppLayerParserConfParserEnabled("tcp", proto_name)) {
+#else
+    if (1) {
+#endif
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER, ModbusParseRequest);
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOCLIENT, ModbusParseResponse);
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateAlloc, ModbusStateFree);

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -222,6 +222,11 @@ void AppLayerParserStateFree(AppLayerParserState *pstate);
 void AppLayerParserStatePrintDetails(AppLayerParserState *pstate);
 #endif
 
+#ifdef AFLFUZZ_APPLAYER
+int AppLayerParserRequestFromFile(AppProto alproto, char *filename);
+int AppLayerParserFromFile(AppProto alproto, char *filename);
+#endif
+
 /***** Unittests *****/
 
 #ifdef UNITTESTS

--- a/src/counters.c
+++ b/src/counters.c
@@ -221,6 +221,10 @@ static ConfNode *GetConfig(void) {
 static void StatsInitCtx(void)
 {
     SCEnter();
+#ifdef AFLFUZZ_DISABLE_MGTTHREADS
+    stats_enabled = FALSE;
+    SCReturn;
+#endif
     ConfNode *stats = GetConfig();
     if (stats != NULL) {
         const char *enabled = ConfNodeLookupChildValue(stats, "enabled");

--- a/src/decode.h
+++ b/src/decode.h
@@ -907,6 +907,13 @@ int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t
 
 void AddressDebugPrint(Address *);
 
+#ifdef AFLFUZZ_DECODER
+typedef int (*DecoderFunc)(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+         uint8_t *pkt, uint16_t len, PacketQueue *pq);
+
+int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
+#endif
+
 /** \brief Set the No payload inspection Flag for the packet.
  *
  * \param p Packet to set the flag in

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -132,10 +132,11 @@ void DefragInitConfig(char quiet)
     SC_ATOMIC_INIT(defragtracker_prune_idx);
     DefragTrackerQueueInit(&defragtracker_spare_q);
 
+#ifndef AFLFUZZ_NO_RANDOM
     unsigned int seed = RandomTimePreseed();
     /* set defaults */
     defrag_config.hash_rand   = (int)(DEFRAG_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
-
+#endif
     defrag_config.hash_size   = DEFRAG_DEFAULT_HASHSIZE;
     defrag_config.memcap      = DEFRAG_DEFAULT_MEMCAP;
     defrag_config.prealloc    = DEFRAG_DEFAULT_PREALLOC;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -105,6 +105,9 @@ typedef struct FlowTimeoutCounters_ {
  */
 void FlowDisableFlowManagerThread(void)
 {
+#ifdef AFLFUZZ_DISABLE_MGTTHREADS
+    return;
+#endif
     ThreadVars *tv = NULL;
     int cnt = 0;
 
@@ -708,6 +711,9 @@ static uint64_t FlowGetMemuse(void)
 /** \brief spawn the flow manager thread */
 void FlowManagerThreadSpawn()
 {
+#ifdef AFLFUZZ_DISABLE_MGTTHREADS
+    return;
+#endif
     intmax_t setting = 1;
     (void)ConfGetInt("flow.managers", &setting);
 
@@ -868,6 +874,9 @@ int FlowRecyclerReadyToShutdown(void)
 /** \brief spawn the flow recycler thread */
 void FlowRecyclerThreadSpawn()
 {
+#ifdef AFLFUZZ_DISABLE_MGTTHREADS
+    return;
+#endif
     intmax_t setting = 1;
     (void)ConfGetInt("flow.recyclers", &setting);
 
@@ -917,6 +926,9 @@ void FlowRecyclerThreadSpawn()
  */
 void FlowDisableFlowRecyclerThread(void)
 {
+#ifdef AFLFUZZ_DISABLE_MGTTHREADS
+    return;
+#endif
     ThreadVars *tv = NULL;
     int cnt = 0;
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -355,10 +355,11 @@ void FlowInitConfig(char quiet)
     FlowQueueInit(&flow_spare_q);
     FlowQueueInit(&flow_recycle_q);
 
+#ifndef AFLFUZZ_NO_RANDOM
     unsigned int seed = RandomTimePreseed();
     /* set defaults */
     flow_config.hash_rand   = (int)( FLOW_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
-
+#endif
     flow_config.hash_size   = FLOW_DEFAULT_HASHSIZE;
     flow_config.memcap      = FLOW_DEFAULT_MEMCAP;
     flow_config.prealloc    = FLOW_DEFAULT_PREALLOC;

--- a/src/host.c
+++ b/src/host.c
@@ -141,10 +141,11 @@ void HostInitConfig(char quiet)
     SC_ATOMIC_INIT(host_prune_idx);
     HostQueueInit(&host_spare_q);
 
+#ifndef AFLFUZZ_NO_RANDOM
     unsigned int seed = RandomTimePreseed();
     /* set defaults */
     host_config.hash_rand   = (int)( HOST_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
-
+#endif
     host_config.hash_size   = HOST_DEFAULT_HASHSIZE;
     host_config.memcap      = HOST_DEFAULT_MEMCAP;
     host_config.prealloc    = HOST_DEFAULT_PREALLOC;

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -137,10 +137,11 @@ void IPPairInitConfig(char quiet)
     SC_ATOMIC_INIT(ippair_prune_idx);
     IPPairQueueInit(&ippair_spare_q);
 
+#ifndef AFLFUZZ_NO_RANDOM
     unsigned int seed = RandomTimePreseed();
     /* set defaults */
     ippair_config.hash_rand   = (int)( IPPAIR_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
-
+#endif
     ippair_config.hash_size   = IPPAIR_DEFAULT_HASHSIZE;
     ippair_config.memcap      = IPPAIR_DEFAULT_MEMCAP;
     ippair_config.prealloc    = IPPAIR_DEFAULT_PREALLOC;

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -125,6 +125,12 @@ int RunModeFilePcapSingle(void)
     /* in afl mode we don't spawn a new thread, but run the pipeline
      * in the main thread */
     tv->tm_func(tv);
+    int afl_runmode_exit_immediately = 0;
+    (void)ConfGetBool("afl.exit_after_pcap", &afl_runmode_exit_immediately);
+    if (afl_runmode_exit_immediately) {
+        SCLogNotice("exit because of afl-runmode-exit-after-pcap commandline option");
+        exit(EXIT_SUCCESS);
+    }
 #endif
 
     return 0;

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -116,10 +116,16 @@ int RunModeFilePcapSingle(void)
 
     TmThreadSetCPU(tv, DETECT_CPU_SET);
 
+#ifndef AFLFUZZ_PCAP_RUNMODE
     if (TmThreadSpawn(tv) != TM_ECODE_OK) {
         SCLogError(SC_ERR_RUNMODE, "TmThreadSpawn failed");
         exit(EXIT_FAILURE);
     }
+#else
+    /* in afl mode we don't spawn a new thread, but run the pipeline
+     * in the main thread */
+    tv->tm_func(tv);
+#endif
 
     return 0;
 }

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -231,6 +231,7 @@
 #define AFLFUZZ_NO_RANDOM 1
 #define AFLFUZZ_DISABLE_MGTTHREADS 1
 #define AFLFUZZ_PCAP_RUNMODE 1
+#define AFLFUZZ_CONF_TEST 1
 
 /* we need this to stringify the defines which are supplied at compiletime see:
    http://gcc.gnu.org/onlinedocs/gcc-3.4.1/cpp/Stringification.html#Stringification */

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -228,11 +228,6 @@
 #endif
 #endif
 
-#define AFLFUZZ_NO_RANDOM 1
-#define AFLFUZZ_DISABLE_MGTTHREADS 1
-#define AFLFUZZ_PCAP_RUNMODE 1
-#define AFLFUZZ_CONF_TEST 1
-
 /* we need this to stringify the defines which are supplied at compiletime see:
    http://gcc.gnu.org/onlinedocs/gcc-3.4.1/cpp/Stringification.html#Stringification */
 #define xstr(s) str(s)

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -228,6 +228,8 @@
 #endif
 #endif
 
+#define AFLFUZZ_NO_RANDOM 1
+
 /* we need this to stringify the defines which are supplied at compiletime see:
    http://gcc.gnu.org/onlinedocs/gcc-3.4.1/cpp/Stringification.html#Stringification */
 #define xstr(s) str(s)

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -230,6 +230,7 @@
 
 #define AFLFUZZ_NO_RANDOM 1
 #define AFLFUZZ_DISABLE_MGTTHREADS 1
+#define AFLFUZZ_PCAP_RUNMODE 1
 
 /* we need this to stringify the defines which are supplied at compiletime see:
    http://gcc.gnu.org/onlinedocs/gcc-3.4.1/cpp/Stringification.html#Stringification */

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -229,6 +229,7 @@
 #endif
 
 #define AFLFUZZ_NO_RANDOM 1
+#define AFLFUZZ_DISABLE_MGTTHREADS 1
 
 /* we need this to stringify the defines which are supplied at compiletime see:
    http://gcc.gnu.org/onlinedocs/gcc-3.4.1/cpp/Stringification.html#Stringification */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -153,6 +153,7 @@
 #include "app-layer-smb.h"
 #include "app-layer-modbus.h"
 
+#include "util-decode-der.h"
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
 #include "util-cidr.h"
@@ -1162,6 +1163,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"afl-mime", required_argument, 0 , 0},
 
         {"afl-decoder-ppp", required_argument, 0 , 0},
+        {"afl-der", required_argument, 0, 0},
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},
 #endif
@@ -1450,6 +1452,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 FlowInitConfig(FLOW_QUIET);
                 //printf("arg: //%s\n", optarg);
                 exit(DecoderParseDataFromFile(optarg, DecodePPP));
+#endif
+#ifdef AFLFUZZ_DER
+            } else if(strcmp((long_opts[option_index]).name, "afl-der") == 0) {
+                //printf("arg: //%s\n", optarg);
+                exit(DerParseDataFromFile(optarg));
 #endif
             } else if(strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
                 SCLogInfo("Setting IPS mode");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -145,6 +145,13 @@
 #include "app-layer.h"
 #include "app-layer-parser.h"
 #include "app-layer-htp.h"
+#include "app-layer-ssl.h"
+#include "app-layer-dns-tcp.h"
+#include "app-layer-ssh.h"
+#include "app-layer-ftp.h"
+#include "app-layer-smtp.h"
+#include "app-layer-smb.h"
+#include "app-layer-modbus.h"
 
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
@@ -1136,6 +1143,22 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"netmap", optional_argument, 0, 0},
         {"pcap", optional_argument, 0, 0},
         {"simulate-ips", 0, 0 , 0},
+        {"afl-http-request", required_argument, 0 , 0},
+        {"afl-http", required_argument, 0 , 0},
+        {"afl-tls-request", required_argument, 0 , 0},
+        {"afl-tls", required_argument, 0 , 0},
+        {"afl-dns-request", required_argument, 0 , 0},
+        {"afl-dns", required_argument, 0 , 0},
+        {"afl-ssh-request", required_argument, 0 , 0},
+        {"afl-ssh", required_argument, 0 , 0},
+        {"afl-ftp-request", required_argument, 0 , 0},
+        {"afl-ftp", required_argument, 0 , 0},
+        {"afl-smtp-request", required_argument, 0 , 0},
+        {"afl-smtp", required_argument, 0 , 0},
+        {"afl-smb-request", required_argument, 0 , 0},
+        {"afl-smb", required_argument, 0 , 0},
+        {"afl-modbus-request", required_argument, 0 , 0},
+        {"afl-modbus", required_argument, 0 , 0},
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},
 #endif
@@ -1324,6 +1347,92 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                     usage(argv[0]);
                     return TM_ECODE_FAILED;
                 }
+#ifdef AFLFUZZ_APPLAYER
+            } else if(strcmp((long_opts[option_index]).name, "afl-http-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterHTPParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_HTTP, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-http") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterHTPParsers();
+                exit(AppLayerParserFromFile(ALPROTO_HTTP, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-tls-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                RegisterSSLParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_TLS, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-tls") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterSSLParsers();
+                exit(AppLayerParserFromFile(ALPROTO_TLS, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-dns-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                RegisterDNSTCPParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_DNS, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-dns") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterDNSTCPParsers();
+                exit(AppLayerParserFromFile(ALPROTO_DNS, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-ssh-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                RegisterSSHParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_SSH, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-ssh") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterSSHParsers();
+                exit(AppLayerParserFromFile(ALPROTO_SSH, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-ftp-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                RegisterFTPParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_FTP, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-ftp") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterFTPParsers();
+                exit(AppLayerParserFromFile(ALPROTO_FTP, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-smtp-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                MpmTableSetup();
+                AppLayerParserSetup();
+                RegisterSMTPParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_SMTP, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-smtp") == 0) {
+                //printf("arg: //%s\n", optarg);
+                MpmTableSetup();
+                AppLayerParserSetup();
+                RegisterSMTPParsers();
+                exit(AppLayerParserFromFile(ALPROTO_SMTP, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-smb-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                RegisterSMBParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_SMB, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-smb") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterSMBParsers();
+                exit(AppLayerParserFromFile(ALPROTO_SMB, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-modbus-request") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterModbusParsers();
+                exit(AppLayerParserRequestFromFile(ALPROTO_MODBUS, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-modbus") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterModbusParsers();
+                exit(AppLayerParserFromFile(ALPROTO_MODBUS, optarg));
+#endif
             } else if(strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
                 SCLogInfo("Setting IPS mode");
                 EngineModeSetIPS();

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1159,6 +1159,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"afl-smb", required_argument, 0 , 0},
         {"afl-modbus-request", required_argument, 0 , 0},
         {"afl-modbus", required_argument, 0 , 0},
+        {"afl-mime", required_argument, 0 , 0},
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},
 #endif
@@ -1432,6 +1433,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerParserSetup();
                 RegisterModbusParsers();
                 exit(AppLayerParserFromFile(ALPROTO_MODBUS, optarg));
+#endif
+#ifdef AFLFUZZ_MIME
+            } else if(strcmp((long_opts[option_index]).name, "afl-mime") == 0) {
+                //printf("arg: //%s\n", optarg);
+                exit(MimeParserDataFromFile(optarg));
 #endif
             } else if(strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
                 SCLogInfo("Setting IPS mode");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1160,6 +1160,8 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"afl-modbus-request", required_argument, 0 , 0},
         {"afl-modbus", required_argument, 0 , 0},
         {"afl-mime", required_argument, 0 , 0},
+
+        {"afl-decoder-ppp", required_argument, 0 , 0},
 #ifdef BUILD_UNIX_SOCKET
         {"unix-socket", optional_argument, 0, 0},
 #endif
@@ -1438,6 +1440,16 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
             } else if(strcmp((long_opts[option_index]).name, "afl-mime") == 0) {
                 //printf("arg: //%s\n", optarg);
                 exit(MimeParserDataFromFile(optarg));
+#endif
+#ifdef AFLFUZZ_DECODER
+            } else if(strcmp((long_opts[option_index]).name, "afl-decoder-ppp") == 0) {
+                StatsInit();
+                MpmTableSetup();
+                AppLayerProtoDetectSetup();
+                DefragInit();
+                FlowInitConfig(FLOW_QUIET);
+                //printf("arg: //%s\n", optarg);
+                exit(DecoderParseDataFromFile(optarg, DecodePPP));
 #endif
             } else if(strcmp((long_opts[option_index]).name, "simulate-ips") == 0) {
                 SCLogInfo("Setting IPS mode");

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1113,6 +1113,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
     int list_keywords = 0;
     int build_info = 0;
     int conf_test = 0;
+#ifdef AFLFUZZ_CONF_TEST
+    int conf_test_force_success = 0;
+#endif
     int engine_analysis = 0;
     int set_log_directory = 0;
     int ret = TM_ECODE_OK;
@@ -1167,6 +1170,9 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"set", required_argument, 0, 0},
 #ifdef HAVE_NFLOG
         {"nflog", optional_argument, 0, 0},
+#endif
+#ifdef AFLFUZZ_CONF_TEST
+        {"afl-parse-rules", 0, &conf_test_force_success, 1},
 #endif
         {NULL, 0, NULL, 0}
     };
@@ -1761,6 +1767,11 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         SCLogError(SC_ERR_INITIALIZATION, "can't use -s/-S when detection is disabled");
         return TM_ECODE_FAILED;
     }
+#ifdef AFLFUZZ_CONF_TEST
+    if (conf_test && conf_test_force_success) {
+        (void)ConfSetFinal("engine.init-failure-fatal", "0");
+    }
+#endif
 
     if ((suri->run_mode == RUNMODE_UNIX_SOCKET) && set_log_directory) {
         SCLogError(SC_ERR_INITIALIZATION, "can't use -l and unix socket runmode at the same time");

--- a/src/util-decode-der.c
+++ b/src/util-decode-der.c
@@ -898,6 +898,34 @@ Asn1Generic * DecodeDer(const unsigned char *buffer, uint32_t size,
     return cert;
 }
 
+#ifdef AFLFUZZ_DER
+int DerParseDataFromFile(char *filename)
+{
+    int result = 1;
+    FILE *fp = fopen(filename, "r");
+    BUG_ON(fp == NULL);
+    uint8_t buffer[65536];
+
+    uint32_t errcode = 0;
+
+    while (1) {
+        int done = 0;
+        size_t result = fread(&buffer, 1, sizeof(buffer), fp);
+        if (result < sizeof(buffer))
+            done = 1;
+
+        DecodeDer(buffer, result, &errcode);
+
+        if (done)
+            break;
+    }
+
+    result = 0;
+    fclose(fp);
+    return result;
+}
+#endif
+
 void DerFree(Asn1Generic *a)
 {
     Asn1Generic *it, *n;

--- a/src/util-decode-der.h
+++ b/src/util-decode-der.h
@@ -93,4 +93,8 @@ typedef struct Asn1Generic_ {
 Asn1Generic * DecodeDer(const unsigned char *buffer, uint32_t size, uint32_t *errcode);
 void DerFree(Asn1Generic *a);
 
+#ifdef AFLFUZZ_DER
+int DerParseDataFromFile(char *filename);
+#endif
+
 #endif /* __UTIL_DECODE_DER_H__ */

--- a/src/util-decode-mime.h
+++ b/src/util-decode-mime.h
@@ -239,6 +239,10 @@ MimeDecEntity * MimeDecParseFullMsg(const uint8_t *buf, uint32_t blen, void *dat
         int (*DataChunkProcessorFunc)(const uint8_t *chunk, uint32_t len, MimeDecParseState *state));
 const char *MimeDecParseStateGetStatus(MimeDecParseState *state);
 
+#ifdef AFLFUZZ_MIME
+int MimeParserDataFromFile(char *filename);
+#endif
+
 /* Test functions */
 void MimeDecRegisterTests(void);
 


### PR DESCRIPTION
Add support for fuzzing SSL/TLS certificates (DER) through --afl-der=file.

Add support for AFL PERSISTANT_MODE when Suricata is compiled with a supported compiler (only afl-clang-fast for now). This gives a ~10x performance boost when fuzzing.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/11
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/11