### PR TITLE
runmode-pcap-file: don't force flow reassembly

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2516,10 +2516,15 @@ int main(int argc, char **argv)
     TmThreadDisableReceiveThreads();
 
     if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
-        /* we need a packet pool for FlowForceReassembly */
-        PacketPoolInit();
+        /* don't force flow timeout when reading pcap file */
+        if (suri.run_mode != RUNMODE_PCAP_FILE) {
 
-        FlowForceReassembly();
+            /* we need a packet pool for FlowForceReassembly */
+            PacketPoolInit();
+
+            FlowForceReassembly();
+        }
+
         /* kill receive threads when they have processed all
          * flow timeout packets */
         TmThreadDisablePacketThreads();


### PR DESCRIPTION
Don't force flow reassembly when stopping Suricata when reading from PCAP file.

Forcing flow reassembly when Suricata stops, some times messes up app-layer parsing, because APP_LAYER_EOF is set too early on some sessions.

- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/12