### PR TITLE
Update ASN1_MAX_FRAMES to reflect default in suricata.yaml.in

### DIFF
--- a/src/util-decode-asn1.h
+++ b/src/util-decode-asn1.h
@@ -34,7 +34,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#define ASN1_MAX_FRAMES 128
+#define ASN1_MAX_FRAMES 256
 
 /* For future enconding type implementations */
 enum {


### PR DESCRIPTION
suricata.yaml.in defines asn1-max-frames: 256 and says that the default is 256. In util-decode-asn1.h ASN1_MAX_FRAMES was defined as 128. So i changed ASN1_MAX_FRAMES to 256 to reflect the YAML default that users read.