### PR TITLE
Tpacket v3 9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1192,6 +1192,11 @@
             AC_DEFINE([HAVE_PACKET_FANOUT],[1],[Recent packet fanout support is available]),
             [],
             [[#include <linux/if_packet.h>]])
+        AC_CHECK_DECL([TPACKET_V3],
+            AC_DEFINE([HAVE_TPACKET_V3],[1],[AF_PACKET tpcket_v3 support is available]),
+            [],
+            [[#include <sys/socket.h>
+              #include <linux/if_packet.h>]])
     ])
 
   # Netmap support

--- a/configure.ac
+++ b/configure.ac
@@ -1197,6 +1197,10 @@
             [],
             [[#include <sys/socket.h>
               #include <linux/if_packet.h>]])
+        AC_CHECK_DECL([SOF_TIMESTAMPING_RAW_HARDWARE],
+            AC_DEFINE([HAVE_HW_TIMESTAMPING],[1],[Hardware timestamping support is available]),
+            [],
+            [[#include <linux/net_tstamp.h>]])
     ])
 
   # Netmap support

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -227,35 +227,40 @@ void *ParseAFPConfig(const char *iface)
         aconf->flags |= AFP_RING_MODE;
     }
 
-    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "mmap-locked", (int *)&boolval);
-    if (boolval) {
-        SCLogInfo("Enabling locked memory for mmap on iface %s",
-                aconf->iface);
-        aconf->flags |= AFP_MMAP_LOCKED;
-    }
-    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "tpacket-v3", (int *)&boolval);
-    if (boolval) {
-        if (strcasecmp(RunmodeGetActive(), "workers") == 0) {
-#ifdef HAVE_TPACKET_V3
-            SCLogInfo("Enabling tpacket v3 capture on iface %s",
+    if (aconf->flags & AFP_RING_MODE) {
+        (void)ConfGetChildValueBoolWithDefault(if_root, if_default,
+                                               "mmap-locked", (int *)&boolval);
+        if (boolval) {
+            SCLogInfo("Enabling locked memory for mmap on iface %s",
                     aconf->iface);
-            aconf->flags |= AFP_TPACKET_V3|AFP_RING_MODE;
-#else 
-            SCLogNotice("System too old for tpacket v3 switching to v2");
-            aconf->flags |= AFP_RING_MODE;
-#endif
-        } else {
-            SCLogError(SC_ERR_RUNMODE,
-                       "tpacket v3 is only implemented for 'workers' running mode."
-                       " Switching to tpacket v2.");
-            aconf->flags |= AFP_RING_MODE;
+            aconf->flags |= AFP_MMAP_LOCKED;
         }
-    }
-    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "use-emergency-flush", (int *)&boolval);
-    if (boolval) {
-        SCLogInfo("Enabling ring emergency flush on iface %s",
-                aconf->iface);
-        aconf->flags |= AFP_EMERGENCY_MODE;
+        (void)ConfGetChildValueBoolWithDefault(if_root, if_default,
+                                               "tpacket-v3", (int *)&boolval);
+        if (boolval) {
+            if (strcasecmp(RunmodeGetActive(), "workers") == 0) {
+#ifdef HAVE_TPACKET_V3
+                SCLogInfo("Enabling tpacket v3 capture on iface %s",
+                        aconf->iface);
+                aconf->flags |= AFP_TPACKET_V3|AFP_RING_MODE;
+#else
+                SCLogNotice("System too old for tpacket v3 switching to v2");
+                aconf->flags |= AFP_RING_MODE;
+#endif
+            } else {
+                SCLogError(SC_ERR_RUNMODE,
+                        "tpacket v3 is only implemented for 'workers' running mode."
+                        " Switching to tpacket v2.");
+                aconf->flags |= AFP_RING_MODE;
+            }
+        }
+        (void)ConfGetChildValueBoolWithDefault(if_root, if_default,
+                                               "use-emergency-flush", (int *)&boolval);
+        if (boolval) {
+            SCLogInfo("Enabling ring emergency flush on iface %s",
+                    aconf->iface);
+            aconf->flags |= AFP_EMERGENCY_MODE;
+        }
     }
 
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -222,6 +222,18 @@ void *ParseAFPConfig(const char *iface)
                 aconf->iface);
         aconf->flags |= AFP_RING_MODE;
     }
+    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "tpacket-v3", (int *)&boolval);
+    if (boolval) {
+        if (strcasecmp(RunmodeGetActive(), "workers") == 0) {
+            SCLogInfo("Enabling tpacket v3 capture on iface %s",
+                    aconf->iface);
+            aconf->flags |= AFP_TPACKET_V3|AFP_RING_MODE;
+        } else {
+            SCLogError(SC_ERR_RUNMODE,
+                       "tpacket v3 is only implemented for 'workers' running mode."
+                       " Switching to tpacket v2.");
+        }
+    }
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "use-emergency-flush", (int *)&boolval);
     if (boolval) {
         SCLogInfo("Enabling ring emergency flush on iface %s",

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -375,6 +375,11 @@ void *ParseAFPConfig(const char *iface)
     } else {
         aconf->block_timeout = 10;
     }
+    if ((ConfGetChildValueIntWithDefault(if_root, if_default, "block-timeout", &value)) == 1) {
+        aconf->block_timeout = value;
+    } else {
+        aconf->block_timeout = 10;
+    }
 
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "disable-promisc", (int *)&boolval);
     if (boolval) {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -361,6 +361,21 @@ void *ParseAFPConfig(const char *iface)
         aconf->ring_size = max_pending_packets * 2 / aconf->threads;
     }
 
+    aconf->block_size = getpagesize() << AFP_BLOCK_SIZE_DEFAULT_ORDER;
+    if ((ConfGetChildValueIntWithDefault(if_root, if_default, "block-size", &value)) == 1) {
+        if (value % getpagesize()) {
+            SCLogError(SC_ERR_INVALID_VALUE, "Block-size must be a multiple of pagesize.");
+        } else {
+            aconf->block_size = value;
+        }
+    }
+
+    if ((ConfGetChildValueIntWithDefault(if_root, if_default, "block-timeout", &value)) == 1) {
+        aconf->block_timeout = value;
+    } else {
+        aconf->block_timeout = 10;
+    }
+
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "disable-promisc", (int *)&boolval);
     if (boolval) {
         SCLogInfo("Disabling promiscuous mode on iface %s",

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -216,12 +216,17 @@ void *ParseAFPConfig(const char *iface)
         }
     }
 
-    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "use-mmap", (int *)&boolval);
-    if (boolval) {
-        SCLogInfo("Enabling mmaped capture on iface %s",
-                aconf->iface);
+    if (ConfGetChildValueBoolWithDefault(if_root, if_default, "use-mmap", (int *)&boolval) == 1) {
+        if (boolval) {
+            aconf->flags |= AFP_RING_MODE;
+        } else {
+            SCLogInfo("Disabling mmaped capture on iface %s",
+                    aconf->iface);
+        }
+    } else {
         aconf->flags |= AFP_RING_MODE;
     }
+
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "mmap-locked", (int *)&boolval);
     if (boolval) {
         SCLogInfo("Enabling locked memory for mmap on iface %s",

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -222,6 +222,12 @@ void *ParseAFPConfig(const char *iface)
                 aconf->iface);
         aconf->flags |= AFP_RING_MODE;
     }
+    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "mmap-locked", (int *)&boolval);
+    if (boolval) {
+        SCLogInfo("Enabling locked memory for mmap on iface %s",
+                aconf->iface);
+        aconf->flags |= AFP_MMAP_LOCKED;
+    }
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "tpacket-v3", (int *)&boolval);
     if (boolval) {
         if (strcasecmp(RunmodeGetActive(), "workers") == 0) {

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -231,13 +231,19 @@ void *ParseAFPConfig(const char *iface)
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "tpacket-v3", (int *)&boolval);
     if (boolval) {
         if (strcasecmp(RunmodeGetActive(), "workers") == 0) {
+#ifdef HAVE_TPACKET_V3
             SCLogInfo("Enabling tpacket v3 capture on iface %s",
                     aconf->iface);
             aconf->flags |= AFP_TPACKET_V3|AFP_RING_MODE;
+#else 
+            SCLogNotice("System too old for tpacket v3 switching to v2");
+            aconf->flags |= AFP_RING_MODE;
+#endif
         } else {
             SCLogError(SC_ERR_RUNMODE,
                        "tpacket v3 is only implemented for 'workers' running mode."
                        " Switching to tpacket v2.");
+            aconf->flags |= AFP_RING_MODE;
         }
     }
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "use-emergency-flush", (int *)&boolval);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -727,7 +727,6 @@ int AFPReadFromRing(AFPThreadVars *ptv)
 {
     Packet *p = NULL;
     union thdr h;
-    struct sockaddr_ll *from;
     uint8_t emergency_flush = 0;
     int read_pkts = 0;
     int loop_start = -1;
@@ -789,20 +788,11 @@ int AFPReadFromRing(AFPThreadVars *ptv)
          * function. */
         h.h2->tp_status |= TP_STATUS_USER_BUSY;
 
-        from = (void *)h.raw + TPACKET_ALIGN(ptv->tp_hdrlen);
-
         ptv->pkts++;
         ptv->bytes += h.h2->tp_len;
         p->livedev = ptv->livedev;
-
-        /* add forged header */
-        if (ptv->cooked) {
-            SllHdr * hdrp = (SllHdr *)ptv->data;
-            /* XXX this is minimalist, but this seems enough */
-            hdrp->sll_protocol = from->sll_protocol;
-        }
-
         p->datalink = ptv->datalink;
+
         if (h.h2->tp_len > h.h2->tp_snaplen) {
             SCLogDebug("Packet length (%d) > snaplen (%d), truncating",
                     h.h2->tp_len, h.h2->tp_snaplen);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1575,17 +1575,154 @@ static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
     return 1;
 }
 
+static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
+{
+    int val;
+    unsigned int len = sizeof(val), i;
+    unsigned int ring_buflen;
+    uint8_t * ring_buf;
+    int order;
+    int r;
+
+    if (ptv->flags & AFP_TPACKET_V3) {
+        val = TPACKET_V3;
+    } else {
+        val = TPACKET_V2;
+    }
+    if (getsockopt(ptv->socket, SOL_PACKET, PACKET_HDRLEN, &val, &len) < 0) {
+        if (errno == ENOPROTOOPT) {
+            if (ptv->flags & AFP_TPACKET_V3) {
+                SCLogError(SC_ERR_AFP_CREATE,
+                        "Too old kernel giving up (need 3.2 for TPACKET_V3)");
+            } else {
+                SCLogError(SC_ERR_AFP_CREATE,
+                        "Too old kernel giving up (need 2.6.27 at least)");
+            }
+        }
+        SCLogError(SC_ERR_AFP_CREATE, "Error when retrieving packet header len");
+        return AFP_FATAL_ERROR;
+    }
+
+    if (ptv->flags & AFP_TPACKET_V3) {
+        val = TPACKET_V3;
+    } else {
+        val = TPACKET_V2;
+    }
+    if (setsockopt(ptv->socket, SOL_PACKET, PACKET_VERSION, &val,
+                sizeof(val)) < 0) {
+        SCLogError(SC_ERR_AFP_CREATE,
+                "Can't activate TPACKET_V2/TPACKET_V3 on packet socket: %s",
+                strerror(errno));
+        return AFP_FATAL_ERROR;
+    }
+
+    /* Allocate RX ring */
+    if (ptv->flags & AFP_TPACKET_V3) {
+        if (AFPComputeRingParamsV3(ptv) != 1) {
+            SCLogInfo("Ring parameter are incorrect. Please correct the devel");
+            return -AFP_FATAL_ERROR;
+        }
+        r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
+                (void *) &ptv->req3, sizeof(ptv->req3));
+        if (r < 0) {
+            SCLogError(SC_ERR_MEM_ALLOC,
+                    "Unable to allocate RX Ring for iface %s: (%d) %s",
+                    devname,
+                    errno,
+                    strerror(errno));
+            return AFP_FATAL_ERROR;
+        }
+    } else {
+#define DEFAULT_ORDER 3
+        for (order = DEFAULT_ORDER; order >= 0; order--) {
+            if (AFPComputeRingParams(ptv, order) != 1) {
+                SCLogInfo("Ring parameter are incorrect. Please correct the devel");
+                return AFP_FATAL_ERROR;
+            }
+
+            r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
+                    (void *) &ptv->req, sizeof(ptv->req));
+
+            if (r < 0) {
+                if (errno == ENOMEM) {
+                    SCLogInfo("Memory issue with ring parameters. Retrying.");
+                    continue;
+                }
+                SCLogError(SC_ERR_MEM_ALLOC,
+                        "Unable to allocate RX Ring for iface %s: (%d) %s",
+                        devname,
+                        errno,
+                        strerror(errno));
+                return AFP_FATAL_ERROR;
+            } else {
+                break;
+            }
+        }
+        if (order < 0) {
+            SCLogError(SC_ERR_MEM_ALLOC,
+                    "Unable to allocate RX Ring for iface %s (order 0 failed)",
+                    devname);
+            return AFP_FATAL_ERROR;
+        }
+    }
+
+    /* Allocate the Ring */
+    if (ptv->flags & AFP_TPACKET_V3) {
+        ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
+    } else {
+        ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
+    }
+    ring_buf = mmap(0, ring_buflen, PROT_READ|PROT_WRITE,
+            MAP_SHARED, ptv->socket, 0);
+    if (ring_buf == MAP_FAILED) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
+        goto mmap_err;
+    }
+    if (ptv->flags & AFP_TPACKET_V3) {
+        ptv->ring_v3 = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->ring_v3));
+        if (!ptv->ring_v3) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to malloc ptv ring_v3");
+            goto mmap_err;
+        }
+        for (i = 0; i < ptv->req3.tp_block_nr; ++i) {
+            ptv->ring_v3[i].iov_base = ring_buf + (i * ptv->req3.tp_block_size);
+            ptv->ring_v3[i].iov_len = ptv->req3.tp_block_size;
+        }
+    } else {
+        /* allocate a ring for each frame header pointer*/
+        ptv->ring_v2 = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
+        if (ptv->ring_v2 == NULL) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate frame buf");
+            goto mmap_err;
+        }
+        memset(ptv->ring_v2, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
+        /* fill the header ring with proper frame ptr*/
+        ptv->frame_offset = 0;
+        for (i = 0; i < ptv->req.tp_block_nr; ++i) {
+            void *base = &ring_buf[i * ptv->req.tp_block_size];
+            unsigned int j;
+            for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
+                (((union thdr **)ptv->ring_v2)[ptv->frame_offset]) = base;
+                base += ptv->req.tp_frame_size;
+            }
+        }
+        ptv->frame_offset = 0;
+    }
+
+    return 0;
+
+mmap_err:
+    /* Packet mmap does the cleaning when socket is closed */
+    return AFP_FATAL_ERROR;
+}
+
 static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
 {
     int r;
     int ret = AFP_FATAL_ERROR;
     struct packet_mreq sock_params;
     struct sockaddr_ll bind_address;
-    int order;
-    unsigned int i;
     int if_idx;
-    unsigned int ring_buflen;
-    uint8_t * ring_buf;
 
     /* open socket */
     ptv->socket = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
@@ -1616,7 +1753,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             SCLogError(SC_ERR_AFP_CREATE,
                     "Couldn't switch iface %s to promiscuous, error %s",
                     devname, strerror(errno));
-            goto frame_err;
+            goto socket_err;
         }
     }
 
@@ -1642,7 +1779,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             SCLogError(SC_ERR_AFP_CREATE,
                     "Couldn't set buffer size to %d on iface %s, error %s",
                     ptv->buffer_size, devname, strerror(errno));
-            goto frame_err;
+            goto socket_err;
         }
     }
 
@@ -1660,7 +1797,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             }
         }
         ret = AFP_RECOVERABLE_ERROR;
-        goto frame_err;
+        goto socket_err;
     }
 
 #ifdef HAVE_PACKET_FANOUT
@@ -1675,7 +1812,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             SCLogError(SC_ERR_AFP_CREATE,
                        "Coudn't set fanout mode, error %s",
                        strerror(errno));
-            goto frame_err;
+            goto socket_err;
         }
     }
 #endif
@@ -1688,7 +1825,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
                     ptv->iface);
         }
         ret = AFP_RECOVERABLE_ERROR;
-        goto frame_err;
+        goto socket_err;
     }
     if ((if_flags & IFF_UP) == 0) {
         if (verbose) {
@@ -1697,129 +1834,13 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
                     ptv->iface);
         }
         ret = AFP_RECOVERABLE_ERROR;
-        goto frame_err;
+        goto socket_err;
     }
 
     if (ptv->flags & AFP_RING_MODE) {
-        int val;
-        unsigned int len = sizeof(val);
-
-        if (ptv->flags & AFP_TPACKET_V3) {
-            val = TPACKET_V3;
-        } else {
-            val = TPACKET_V2;
-        }
-        if (getsockopt(ptv->socket, SOL_PACKET, PACKET_HDRLEN, &val, &len) < 0) {
-            if (errno == ENOPROTOOPT) {
-                if (ptv->flags & AFP_TPACKET_V3) {
-                    SCLogError(SC_ERR_AFP_CREATE,
-                            "Too old kernel giving up (need 3.2 for TPACKET_V3)");
-                } else {
-                    SCLogError(SC_ERR_AFP_CREATE,
-                            "Too old kernel giving up (need 2.6.27 at least)");
-                }
-            }
-            SCLogError(SC_ERR_AFP_CREATE, "Error when retrieving packet header len");
+        ret = AFPSetupRing(ptv, devname);
+        if (ret != 0)
             goto socket_err;
-        }
-
-        if (ptv->flags & AFP_TPACKET_V3) {
-            val = TPACKET_V3;
-        } else {
-            val = TPACKET_V2;
-        }
-        if (setsockopt(ptv->socket, SOL_PACKET, PACKET_VERSION, &val,
-                    sizeof(val)) < 0) {
-            SCLogError(SC_ERR_AFP_CREATE,
-                       "Can't activate TPACKET_V2/TPACKET_V3 on packet socket: %s",
-                       strerror(errno));
-            goto socket_err;
-        }
-
-        /* Allocate RX ring */
-        if (ptv->flags & AFP_TPACKET_V3) {
-            if (AFPComputeRingParamsV3(ptv) != 1) {
-                SCLogInfo("Ring parameter are incorrect. Please correct the devel");
-                goto socket_err;
-            }
-            r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
-                    (void *) &ptv->req3, sizeof(ptv->req3));
-        } else {
-#define DEFAULT_ORDER 3
-            for (order = DEFAULT_ORDER; order >= 0; order--) {
-                if (AFPComputeRingParams(ptv, order) != 1) {
-                    SCLogInfo("Ring parameter are incorrect. Please correct the devel");
-                    goto socket_err;
-                }
-
-                r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
-                        (void *) &ptv->req, sizeof(ptv->req));
-
-                if (r < 0) {
-                    if (errno == ENOMEM) {
-                        SCLogInfo("Memory issue with ring parameters. Retrying.");
-                        continue;
-                    }
-                    SCLogError(SC_ERR_MEM_ALLOC,
-                            "Unable to allocate RX Ring for iface %s: (%d) %s",
-                            devname,
-                            errno,
-                            strerror(errno));
-                    goto socket_err;
-                } else {
-                    break;
-                }
-            }
-            if (order < 0) {
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Unable to allocate RX Ring for iface %s (order 0 failed)",
-                        devname);
-                goto socket_err;
-            }
-        }
-
-        /* Allocate the Ring */
-        if (ptv->flags & AFP_TPACKET_V3) {
-            ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
-        } else {
-            ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
-        }
-        ring_buf = mmap(0, ring_buflen, PROT_READ|PROT_WRITE,
-                MAP_SHARED, ptv->socket, 0);
-        if (ring_buf == MAP_FAILED) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
-            goto socket_err;
-        }
-        if (ptv->flags & AFP_TPACKET_V3) {
-            ptv->ring_v3 = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->ring_v3));
-            if (!ptv->ring_v3) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to malloc ptv ring_v3");
-                goto mmap_err;
-            }
-            for (i = 0; i < ptv->req3.tp_block_nr; ++i) {
-                ptv->ring_v3[i].iov_base = ring_buf + (i * ptv->req3.tp_block_size);
-                ptv->ring_v3[i].iov_len = ptv->req3.tp_block_size;
-            }
-        } else {
-            /* allocate a ring for each frame header pointer*/
-            ptv->ring_v2 = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
-            if (ptv->ring_v2 == NULL) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate frame buf");
-                goto mmap_err;
-            }
-            memset(ptv->ring_v2, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
-            /* fill the header ring with proper frame ptr*/
-            ptv->frame_offset = 0;
-            for (i = 0; i < ptv->req.tp_block_nr; ++i) {
-                void *base = &ring_buf[i * ptv->req.tp_block_size];
-                unsigned int j;
-                for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
-                    (((union thdr **)ptv->ring_v2)[ptv->frame_offset]) = base;
-                    base += ptv->req.tp_frame_size;
-                }
-            }
-            ptv->frame_offset = 0;
-        }
     }
 
     SCLogDebug("Using interface '%s' via socket %d", (char *)devname, ptv->socket);
@@ -1851,8 +1872,6 @@ frame_err:
         if (ptv->ring_v2)
             SCFree(ptv->ring_v2);
     }
-mmap_err:
-    /* Packet mmap does the cleaning when socket is closed */
 socket_err:
     close(ptv->socket);
     ptv->socket = -1;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -188,30 +188,32 @@ union thdr {
  */
 typedef struct AFPThreadVars_
 {
+    union {
+        char *ring_v2;
+        struct iovec *ring_v3;
+    };
+
     /* counters */
     uint64_t pkts;
-    uint64_t bytes;
 
     ThreadVars *tv;
     TmSlot *slot;
     LiveDevice *livedev;
     /* data link type for the thread */
-    int datalink;
-    int flags;
+    uint32_t datalink;
 
     unsigned int frame_offset;
 
     ChecksumValidationMode checksum_mode;
 
+    /* references to packet and drop counters */
     uint16_t capture_kernel_packets;
     uint16_t capture_kernel_drops;
 
     /* handle state */
     uint8_t afp_state;
     uint8_t copy_mode;
-
-    struct iovec *rd;
-    char *frame_buf;
+    uint8_t flags;
 
     /* IPS peer */
     AFPPeer *mpeer;
@@ -227,29 +229,31 @@ typedef struct AFPThreadVars_
 
     /* thread specific socket */
     int socket;
+
+    int ring_size;
     /* Filter */
     char *bpf_filter;
 
     /* socket buffer size */
     int buffer_size;
 
-    int ring_size;
-
     int promisc;
 
     int down_count;
-
-    char iface[AFP_IFACE_NAME_LENGTH];
-    /* IPS output iface */
-    char out_iface[AFP_IFACE_NAME_LENGTH];
 
     int cluster_id;
     int cluster_type;
 
     int threads;
 
-    struct tpacket_req req;
-    struct tpacket_req3 req3;
+    union {
+        struct tpacket_req req;
+        struct tpacket_req3 req3;
+    };
+
+    char iface[AFP_IFACE_NAME_LENGTH];
+    /* IPS output iface */
+    char out_iface[AFP_IFACE_NAME_LENGTH];
 
 } AFPThreadVars;
 
@@ -591,7 +595,6 @@ int AFPRead(AFPThreadVars *ptv)
     }
 
     ptv->pkts++;
-    ptv->bytes += caplen + offset;
     p->livedev = ptv->livedev;
 
     /* add forged header */
@@ -757,7 +760,7 @@ int AFPReadFromRing(AFPThreadVars *ptv)
         }
 
         /* Read packet from ring */
-        h.raw = (((union thdr **)ptv->frame_buf)[ptv->frame_offset]);
+        h.raw = (((union thdr **)ptv->ring_v2)[ptv->frame_offset]);
         if (h.raw == NULL) {
             SCReturnInt(AFP_FAILURE);
         }
@@ -807,7 +810,6 @@ int AFPReadFromRing(AFPThreadVars *ptv)
         h.h2->tp_status |= TP_STATUS_USER_BUSY;
 
         ptv->pkts++;
-        ptv->bytes += h.h2->tp_len;
         p->livedev = ptv->livedev;
         p->datalink = ptv->datalink;
 
@@ -914,7 +916,6 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
     ptv->pkts++;
-    ptv->bytes += ppd->tp_len;
     p->livedev = ptv->livedev;
     p->datalink = ptv->datalink;
 
@@ -1007,7 +1008,7 @@ int AFPReadFromRingV3(AFPThreadVars *ptv)
             break;
         }
 
-        pbd = (struct tpacket_block_desc *) ptv->rd[ptv->frame_offset].iov_base;
+        pbd = (struct tpacket_block_desc *) ptv->ring_v3[ptv->frame_offset].iov_base;
 
         /* block is not ready to be read */
         if ((pbd->hdr.bh1.block_status & TP_STATUS_USER) == 0) {
@@ -1074,10 +1075,10 @@ void AFPSwitchState(AFPThreadVars *ptv, int state)
 
     /* Do cleaning if switching to down state */
     if (state == AFP_STATE_DOWN) {
-        if (ptv->frame_buf) {
+        if (ptv->ring_v2) {
             /* only used in reading phase, we can free it */
-            SCFree(ptv->frame_buf);
-            ptv->frame_buf = NULL;
+            SCFree(ptv->ring_v2);
+            ptv->ring_v2 = NULL;
         }
         if (ptv->socket != -1) {
             /* we need to wait for all packets to return data */
@@ -1149,7 +1150,7 @@ static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv)
     }
 
     /* Read packet from ring */
-    h.raw = (((union thdr **)ptv->frame_buf)[ptv->frame_offset]);
+    h.raw = (((union thdr **)ptv->ring_v2)[ptv->frame_offset]);
     if (h.raw == NULL) {
         return -1;
     }
@@ -1777,30 +1778,30 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             goto socket_err;
         }
         if (ptv->flags & AFP_TPACKET_V3) {
-            ptv->rd = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->rd));
-            if (!ptv->rd) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Unable to malloc ptv rd");
+            ptv->ring_v3 = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->ring_v3));
+            if (!ptv->ring_v3) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Unable to malloc ptv ring_v3");
                 goto mmap_err;
             }
             for (i = 0; i < ptv->req3.tp_block_nr; ++i) {
-                ptv->rd[i].iov_base = ring_buf + (i * ptv->req3.tp_block_size);
-                ptv->rd[i].iov_len = ptv->req3.tp_block_size;
+                ptv->ring_v3[i].iov_base = ring_buf + (i * ptv->req3.tp_block_size);
+                ptv->ring_v3[i].iov_len = ptv->req3.tp_block_size;
             }
         } else {
             /* allocate a ring for each frame header pointer*/
-            ptv->frame_buf = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
-            if (ptv->frame_buf == NULL) {
+            ptv->ring_v2 = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
+            if (ptv->ring_v2 == NULL) {
                 SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate frame buf");
                 goto mmap_err;
             }
-            memset(ptv->frame_buf, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
+            memset(ptv->ring_v2, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
             /* fill the header ring with proper frame ptr*/
             ptv->frame_offset = 0;
             for (i = 0; i < ptv->req.tp_block_nr; ++i) {
                 void *base = &ring_buf[i * ptv->req.tp_block_size];
                 unsigned int j;
                 for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
-                    (((union thdr **)ptv->frame_buf)[ptv->frame_offset]) = base;
+                    (((union thdr **)ptv->ring_v2)[ptv->frame_offset]) = base;
                     base += ptv->req.tp_frame_size;
                 }
             }
@@ -1830,10 +1831,13 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
     return 0;
 
 frame_err:
-    if (ptv->frame_buf)
-        SCFree(ptv->frame_buf);
-    if (ptv->rd)
-        SCFree(ptv->rd);
+    if (ptv->flags & AFP_TPACKET_V3) {
+        if (ptv->ring_v3)
+            SCFree(ptv->ring_v3);
+    } else {
+        if (ptv->ring_v2)
+            SCFree(ptv->ring_v2);
+    }
 mmap_err:
     /* Packet mmap does the cleaning when socket is closed */
 socket_err:
@@ -2027,7 +2031,7 @@ void ReceiveAFPThreadExitStats(ThreadVars *tv, void *data)
             StatsGetLocalCounterValue(tv, ptv->capture_kernel_drops));
 #endif
 
-    SCLogInfo("(%s) Packets %" PRIu64 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
+    SCLogInfo("(%s) Packets %" PRIu64, tv->name, ptv->pkts);
 }
 
 /**

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -232,6 +232,7 @@ typedef struct AFPThreadVars_
 
     int ring_size;
     int block_size;
+    int block_timeout;
     /* socket buffer size */
     int buffer_size;
     /* Filter */
@@ -1565,7 +1566,7 @@ static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
     ptv->req3.tp_block_nr = ptv->ring_size / frames_per_block + 1;
     /* exact division */
     ptv->req3.tp_frame_nr = ptv->req3.tp_block_nr * frames_per_block;
-    ptv->req3.tp_retire_blk_tov = 10; /* 10 ms timeout on block */
+    ptv->req3.tp_retire_blk_tov = ptv->block_timeout;
     ptv->req3.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
     SCLogInfo("AF_PACKET V3 RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d (mem: %d)",
               ptv->req3.tp_block_size, ptv->req3.tp_block_nr,

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1583,7 +1583,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
     unsigned int ring_buflen;
     uint8_t * ring_buf;
     int order;
-    int r;
+    int r, mmap_flag;
 
     if (ptv->flags & AFP_TPACKET_V3) {
         val = TPACKET_V3;
@@ -1672,8 +1672,11 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
     } else {
         ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
     }
+    mmap_flag = MAP_SHARED;
+    if (ptv->flags & AFP_MMAP_LOCKED)
+        mmap_flag |= MAP_LOCKED;
     ring_buf = mmap(0, ring_buflen, PROT_READ|PROT_WRITE,
-            MAP_SHARED, ptv->socket, 0);
+            mmap_flag, ptv->socket, 0);
     if (ring_buf == MAP_FAILED) {
         SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
         goto mmap_err;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -94,6 +94,8 @@
 #include <sys/mman.h>
 #endif
 
+#include <linux/net_tstamp.h>
+
 #endif /* HAVE_AF_PACKET */
 
 extern int max_pending_packets;
@@ -1651,6 +1653,16 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
                 strerror(errno));
         return AFP_FATAL_ERROR;
     }
+
+#ifdef HAVE_HW_TIMESTAMPING
+    int req = SOF_TIMESTAMPING_RAW_HARDWARE;
+    if (setsockopt(ptv->socket, SOL_PACKET, PACKET_TIMESTAMP, (void *) &req,
+                sizeof(req)) < 0) {
+        SCLogWarning(SC_ERR_AFP_CREATE,
+                "Can't activate hardware timestamping on packet socket: %s",
+                strerror(errno));
+    }
+#endif
 
     /* Allocate RX ring */
 #ifdef HAVE_TPACKET_V3

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -162,8 +162,6 @@ TmEcode NoAFPSupportExit(ThreadVars *tv, void *initdata, void **data)
 #define TP_STATUS_VLAN_VALID (1 << 4)
 #endif
 
-#define AFP_BLOCK_SIZE_DEFAULT_ORDER 3
-
 /** protect pfring_set_bpf_filter, as it is not thread safe */
 static SCMutex afpacket_bpf_set_filter_lock = SCMUTEX_INITIALIZER;
 
@@ -233,11 +231,11 @@ typedef struct AFPThreadVars_
     int socket;
 
     int ring_size;
-    /* Filter */
-    char *bpf_filter;
-
+    int block_size;
     /* socket buffer size */
     int buffer_size;
+    /* Filter */
+    char *bpf_filter;
 
     int promisc;
 
@@ -1557,7 +1555,7 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
 
 static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
 {
-    ptv->req3.tp_block_size = getpagesize() << AFP_BLOCK_SIZE_DEFAULT_ORDER;
+    ptv->req3.tp_block_size = ptv->block_size;
     ptv->req3.tp_frame_size = 2048;
     int frames_per_block = ptv->req3.tp_block_size / ptv->req3.tp_frame_size;
     if (frames_per_block == 0) {
@@ -1967,6 +1965,7 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     ptv->buffer_size = afpconfig->buffer_size;
     ptv->ring_size = afpconfig->ring_size;
+    ptv->block_size = afpconfig->block_size;
 
     ptv->promisc = afpconfig->promisc;
     ptv->checksum_mode = afpconfig->checksum_mode;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2011-2014 Open Information Security Foundation
+/* Copyright (C) 2011-2016 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -179,6 +179,7 @@ enum {
 
 union thdr {
     struct tpacket2_hdr *h2;
+    struct tpacket3_hdr *h3;
     void *raw;
 };
 
@@ -236,10 +237,13 @@ typedef struct AFPThreadVars_
     int copy_mode;
 
     struct tpacket_req req;
+    struct tpacket_req3 req3;
     unsigned int tp_hdrlen;
     unsigned int ring_buflen;
     char *ring_buf;
     char *frame_buf;
+    struct iovec *rd;
+
     unsigned int frame_offset;
     int ring_size;
 
@@ -708,6 +712,16 @@ cleanup:
     AFPV_CLEANUP(&p->afp_v);
 }
 
+void AFPReleasePacketV3(Packet *p)
+{
+    /* Need to be in copy mode and need to detect early release
+       where Ethernet header could not be set (and pseudo packet) */
+    if ((p->afp_v.copy_mode != AFP_COPY_MODE_NONE) && !PKT_IS_PSEUDOPKT(p)) {
+        AFPWritePacket(p);
+    }
+    PacketFreeOrRelease(p);
+}
+
 void AFPReleasePacket(Packet *p)
 {
     AFPReleaseDataFromRing(p);
@@ -882,6 +896,136 @@ next_frame:
     SCReturnInt(AFP_READ_OK);
 }
 
+static inline void AFPFlushBlock(struct tpacket_block_desc *pbd)
+{
+    pbd->hdr.bh1.block_status = TP_STATUS_KERNEL;
+}
+
+static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc *pbd, struct tpacket3_hdr *ppd)
+{
+    Packet *p = PacketGetFromQueueOrAlloc();
+    if (p == NULL) {
+        SCReturnInt(AFP_FAILURE);
+    }
+    PKT_SET_SRC(p, PKT_SRC_WIRE);
+
+    ptv->pkts++;
+    ptv->bytes += ppd->tp_len;
+    p->livedev = ptv->livedev;
+    p->datalink = ptv->datalink;
+
+    if (ptv->flags & AFP_ZERO_COPY) {
+        if (PacketSetData(p, (unsigned char*)ppd + ppd->tp_mac, ppd->tp_snaplen) == -1) {
+            TmqhOutputPacketpool(ptv->tv, p);
+            SCReturnInt(AFP_FAILURE);
+        }
+        p->afp_v.relptr = pbd;
+        p->ReleasePacket = AFPReleasePacketV3;
+        p->afp_v.mpeer = ptv->mpeer;
+        AFPRefSocket(ptv->mpeer);
+
+        p->afp_v.copy_mode = ptv->copy_mode;
+        if (p->afp_v.copy_mode != AFP_COPY_MODE_NONE) {
+            p->afp_v.peer = ptv->mpeer->peer;
+        } else {
+            p->afp_v.peer = NULL;
+        }
+    } else {
+        if (PacketCopyData(p, (unsigned char*)ppd + ppd->tp_mac, ppd->tp_snaplen) == -1) {
+            TmqhOutputPacketpool(ptv->tv, p);
+            SCReturnInt(AFP_FAILURE);
+        }
+    }
+    /* Timestamp */
+    p->ts.tv_sec = ppd->tp_sec;
+    p->ts.tv_usec = ppd->tp_nsec/1000;
+    SCLogDebug("pktlen: %" PRIu32 " (pkt %p, pkt data %p)",
+            GET_PKT_LEN(p), p, GET_PKT_DATA(p));
+
+    /* We only check for checksum disable */
+    if (ptv->checksum_mode == CHECKSUM_VALIDATION_DISABLE) {
+        p->flags |= PKT_IGNORE_CHECKSUM;
+    } else if (ptv->checksum_mode == CHECKSUM_VALIDATION_AUTO) {
+        if (ptv->livedev->ignore_checksum) {
+            p->flags |= PKT_IGNORE_CHECKSUM;
+        } else if (ChecksumAutoModeCheck(ptv->pkts,
+                    SC_ATOMIC_GET(ptv->livedev->pkts),
+                    SC_ATOMIC_GET(ptv->livedev->invalid_checksums))) {
+            ptv->livedev->ignore_checksum = 1;
+            p->flags |= PKT_IGNORE_CHECKSUM;
+        }
+    } else {
+        if (ppd->tp_status & TP_STATUS_CSUMNOTREADY) {
+            p->flags |= PKT_IGNORE_CHECKSUM;
+        }
+    }
+
+    if (TmThreadsSlotProcessPkt(ptv->tv, ptv->slot, p) != TM_ECODE_OK) {
+        AFPFlushBlock(pbd);
+        TmqhOutputPacketpool(ptv->tv, p);
+        SCReturnInt(AFP_FAILURE);
+    }
+
+    SCReturnInt(AFP_READ_OK);
+}
+
+static inline int AFPWalkBlock(AFPThreadVars *ptv, struct tpacket_block_desc *pbd)
+{
+    int num_pkts = pbd->hdr.bh1.num_pkts, i;
+    uint8_t *ppd;
+
+    ppd = (uint8_t *)pbd + pbd->hdr.bh1.offset_to_first_pkt;
+    for (i = 0; i < num_pkts; ++i) {
+        AFPParsePacketV3(ptv, pbd, (struct tpacket3_hdr *)ppd);
+        ppd = ppd + ((struct tpacket3_hdr *)ppd)->tp_next_offset;
+    }
+
+    SCReturnInt(AFP_READ_OK);
+}
+
+/**
+ * \brief AF packet read function for ring
+ *
+ * This function fills
+ * From here the packets are picked up by the DecodeAFP thread.
+ *
+ * \param user pointer to AFPThreadVars
+ * \retval TM_ECODE_FAILED on failure and TM_ECODE_OK on success
+ */
+int AFPReadFromRingV3(AFPThreadVars *ptv)
+{
+    struct tpacket_block_desc *pbd;
+
+    /* Loop till we have packets available */
+    while (1) {
+        if (unlikely(suricata_ctl_flags != 0)) {
+            SCLogInfo("Exiting AFP V3 read loop");
+            break;
+        }
+
+        pbd = (struct tpacket_block_desc *) ptv->rd[ptv->frame_offset].iov_base;
+
+        /* block is not ready to be read */
+        if ((pbd->hdr.bh1.block_status & TP_STATUS_USER) == 0) {
+            SCReturnInt(AFP_READ_OK);
+        }
+
+        if (unlikely(AFPWalkBlock(ptv, pbd) != AFP_READ_OK)) {
+            AFPFlushBlock(pbd);
+            SCReturnInt(AFP_READ_FAILURE);
+        }
+
+        AFPFlushBlock(pbd);
+        ptv->frame_offset = (ptv->frame_offset + 1) % ptv->req3.tp_block_nr;
+        /* return to maintenance task after one loop on the ring */
+        if (ptv->frame_offset == 0) {
+            SCReturnInt(AFP_READ_OK);
+        }
+    }
+
+    SCReturnInt(AFP_READ_OK);
+}
+
 /**
  * \brief Reference socket
  *
@@ -992,6 +1136,11 @@ static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv)
     union thdr h;
 
     if (unlikely(suricata_ctl_flags != 0)) {
+        return 1;
+    }
+
+    /* Ignore system for tpacket_v3 */
+    if (ptv->flags & AFP_TPACKET_V3) {
         return 1;
     }
 
@@ -1123,7 +1272,11 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     ptv->slot = s->slot_next;
 
     if (ptv->flags & AFP_RING_MODE) {
-        AFPReadFunc = AFPReadFromRing;
+        if (ptv->flags & AFP_TPACKET_V3) {
+            AFPReadFunc = AFPReadFromRingV3;
+        } else {
+            AFPReadFunc = AFPReadFromRing;
+        }
     } else {
         AFPReadFunc = AFPRead;
     }
@@ -1153,7 +1306,9 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     }
     if (ptv->afp_state == AFP_STATE_UP) {
         SCLogDebug("Thread %s using socket %d", tv->name, ptv->socket);
-        AFPSynchronizeStart(ptv);
+        if ((ptv->flags & AFP_TPACKET_V3) != 0) {
+            AFPSynchronizeStart(ptv);
+        }
     }
 
     fds.fd = ptv->socket;
@@ -1367,7 +1522,7 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
     ptv->req.tp_block_size = getpagesize() << order;
     int frames_per_block = ptv->req.tp_block_size / ptv->req.tp_frame_size;
     if (frames_per_block == 0) {
-        SCLogInfo("frame size to big");
+        SCLogError(SC_ERR_INVALID_VALUE, "Frame size bigger than block size");
         return -1;
     }
     ptv->req.tp_frame_nr = ptv->ring_size;
@@ -1377,6 +1532,28 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
     SCLogInfo("AF_PACKET RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d",
               ptv->req.tp_block_size, ptv->req.tp_block_nr,
               ptv->req.tp_frame_size, ptv->req.tp_frame_nr);
+    return 1;
+}
+
+static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
+{
+    ptv->req3.tp_block_size = getpagesize();
+    ptv->req3.tp_frame_size = 2048;
+    int frames_per_block = ptv->req3.tp_block_size / ptv->req3.tp_frame_size;
+    if (frames_per_block == 0) {
+        SCLogInfo("frame size to big");
+        return -1;
+    }
+    ptv->req3.tp_block_nr = ptv->ring_size / frames_per_block + 1;
+    /* exact division */
+    ptv->req3.tp_frame_nr = ptv->req3.tp_block_nr * frames_per_block;
+    ptv->req3.tp_retire_blk_tov = 10; /* 10 ms timeout on block */
+    ptv->req3.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
+    SCLogInfo("AF_PACKET V3 RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d (mem: %d)",
+              ptv->req3.tp_block_size, ptv->req3.tp_block_nr,
+              ptv->req3.tp_frame_size, ptv->req3.tp_frame_nr,
+              ptv->req3.tp_block_size * ptv->req3.tp_block_nr
+              );
     return 1;
 }
 
@@ -1504,84 +1681,126 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
     }
 
     if (ptv->flags & AFP_RING_MODE) {
-        int val = TPACKET_V2;
+        int val;
         unsigned int len = sizeof(val);
+
+        if (ptv->flags & AFP_TPACKET_V3) {
+            val = TPACKET_V3;
+        } else {
+            val = TPACKET_V2;
+        }
         if (getsockopt(ptv->socket, SOL_PACKET, PACKET_HDRLEN, &val, &len) < 0) {
             if (errno == ENOPROTOOPT) {
-                SCLogError(SC_ERR_AFP_CREATE,
-                           "Too old kernel giving up (need 2.6.27 at least)");
+                if (ptv->flags & AFP_TPACKET_V3) {
+                    SCLogError(SC_ERR_AFP_CREATE,
+                            "Too old kernel giving up (need 3.2 for TPACKET_V3)");
+                } else {
+                    SCLogError(SC_ERR_AFP_CREATE,
+                            "Too old kernel giving up (need 2.6.27 at least)");
+                }
             }
             SCLogError(SC_ERR_AFP_CREATE, "Error when retrieving packet header len");
             goto socket_err;
         }
         ptv->tp_hdrlen = val;
 
-        val = TPACKET_V2;
+        if (ptv->flags & AFP_TPACKET_V3) {
+            val = TPACKET_V3;
+        } else {
+            val = TPACKET_V2;
+        }
         if (setsockopt(ptv->socket, SOL_PACKET, PACKET_VERSION, &val,
                     sizeof(val)) < 0) {
             SCLogError(SC_ERR_AFP_CREATE,
-                       "Can't activate TPACKET_V2 on packet socket: %s",
+                       "Can't activate TPACKET_V2/TPACKET_V3 on packet socket: %s",
                        strerror(errno));
             goto socket_err;
         }
 
         /* Allocate RX ring */
-#define DEFAULT_ORDER 3
-        for (order = DEFAULT_ORDER; order >= 0; order--) {
-            if (AFPComputeRingParams(ptv, order) != 1) {
+        if (ptv->flags & AFP_TPACKET_V3) {
+            if (AFPComputeRingParamsV3(ptv) != 1) {
                 SCLogInfo("Ring parameter are incorrect. Please correct the devel");
-            }
-
-            r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING, (void *) &ptv->req, sizeof(ptv->req));
-            if (r < 0) {
-                if (errno == ENOMEM) {
-                    SCLogInfo("Memory issue with ring parameters. Retrying.");
-                    continue;
-                }
-                SCLogError(SC_ERR_MEM_ALLOC,
-                        "Unable to allocate RX Ring for iface %s: (%d) %s",
-                        devname,
-                        errno,
-                        strerror(errno));
                 goto socket_err;
-            } else {
-                break;
             }
-        }
+            r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
+                    (void *) &ptv->req3, sizeof(ptv->req3));
+        } else {
+#define DEFAULT_ORDER 3
+            for (order = DEFAULT_ORDER; order >= 0; order--) {
+                if (AFPComputeRingParams(ptv, order) != 1) {
+                    SCLogInfo("Ring parameter are incorrect. Please correct the devel");
+                    goto socket_err;
+                }
 
-        if (order < 0) {
-            SCLogError(SC_ERR_MEM_ALLOC,
-                    "Unable to allocate RX Ring for iface %s (order 0 failed)",
-                    devname);
-            goto socket_err;
+                r = setsockopt(ptv->socket, SOL_PACKET, PACKET_RX_RING,
+                        (void *) &ptv->req, sizeof(ptv->req));
+
+                if (r < 0) {
+                    if (errno == ENOMEM) {
+                        SCLogInfo("Memory issue with ring parameters. Retrying.");
+                        continue;
+                    }
+                    SCLogError(SC_ERR_MEM_ALLOC,
+                            "Unable to allocate RX Ring for iface %s: (%d) %s",
+                            devname,
+                            errno,
+                            strerror(errno));
+                    goto socket_err;
+                } else {
+                    break;
+                }
+            }
+            if (order < 0) {
+                SCLogError(SC_ERR_MEM_ALLOC,
+                        "Unable to allocate RX Ring for iface %s (order 0 failed)",
+                        devname);
+                goto socket_err;
+            }
         }
 
         /* Allocate the Ring */
-        ptv->ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
+        if (ptv->flags & AFP_TPACKET_V3) {
+            ptv->ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
+        } else {
+            ptv->ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
+        }
         ptv->ring_buf = mmap(0, ptv->ring_buflen, PROT_READ|PROT_WRITE,
                 MAP_SHARED, ptv->socket, 0);
         if (ptv->ring_buf == MAP_FAILED) {
             SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
             goto socket_err;
         }
-        /* allocate a ring for each frame header pointer*/
-        ptv->frame_buf = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
-        if (ptv->frame_buf == NULL) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate frame buf");
-            goto mmap_err;
-        }
-        memset(ptv->frame_buf, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
-        /* fill the header ring with proper frame ptr*/
-        ptv->frame_offset = 0;
-        for (i = 0; i < ptv->req.tp_block_nr; ++i) {
-            void *base = &ptv->ring_buf[i * ptv->req.tp_block_size];
-            unsigned int j;
-            for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
-                (((union thdr **)ptv->frame_buf)[ptv->frame_offset]) = base;
-                base += ptv->req.tp_frame_size;
+        if (ptv->flags & AFP_TPACKET_V3) {
+            ptv->rd = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->rd));
+            if (!ptv->rd) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Unable to malloc ptv rd");
+                goto mmap_err;
             }
+            for (i = 0; i < ptv->req3.tp_block_nr; ++i) {
+                ptv->rd[i].iov_base = ptv->ring_buf + (i * ptv->req3.tp_block_size);
+                ptv->rd[i].iov_len = ptv->req3.tp_block_size;
+            }
+        } else {
+            /* allocate a ring for each frame header pointer*/
+            ptv->frame_buf = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
+            if (ptv->frame_buf == NULL) {
+                SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate frame buf");
+                goto mmap_err;
+            }
+            memset(ptv->frame_buf, 0, ptv->req.tp_frame_nr * sizeof (union thdr *));
+            /* fill the header ring with proper frame ptr*/
+            ptv->frame_offset = 0;
+            for (i = 0; i < ptv->req.tp_block_nr; ++i) {
+                void *base = &ptv->ring_buf[i * ptv->req.tp_block_size];
+                unsigned int j;
+                for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
+                    (((union thdr **)ptv->frame_buf)[ptv->frame_offset]) = base;
+                    base += ptv->req.tp_frame_size;
+                }
+            }
+            ptv->frame_offset = 0;
         }
-        ptv->frame_offset = 0;
     }
 
     SCLogDebug("Using interface '%s' via socket %d", (char *)devname, ptv->socket);
@@ -1608,6 +1827,8 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
 frame_err:
     if (ptv->frame_buf)
         SCFree(ptv->frame_buf);
+    if (ptv->rd)
+        SCFree(ptv->rd);
 mmap_err:
     /* Packet mmap does the cleaning when socket is closed */
 socket_err:

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1113,7 +1113,8 @@ void AFPSwitchState(AFPThreadVars *ptv, int state)
     }
 }
 
-static int AFPReadAndDiscard(AFPThreadVars *ptv, struct timeval *synctv)
+static int AFPReadAndDiscard(AFPThreadVars *ptv, struct timeval *synctv,
+                             uint64_t *discarded_pkts)
 {
     struct sockaddr_ll from;
     struct iovec iov;
@@ -1155,7 +1156,8 @@ static int AFPReadAndDiscard(AFPThreadVars *ptv, struct timeval *synctv)
     return 0;
 }
 
-static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv)
+static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv,
+                                     uint64_t *discarded_pkts)
 {
     union thdr h;
 
@@ -1163,26 +1165,30 @@ static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv)
         return 1;
     }
 
-    /* Ignore system for tpacket_v3 */
     if (ptv->flags & AFP_TPACKET_V3) {
+        struct tpacket_block_desc *pbd;
+        pbd = (struct tpacket_block_desc *) ptv->ring_v3[ptv->frame_offset].iov_base;
+        *discarded_pkts += pbd->hdr.bh1.num_pkts;
+        AFPFlushBlock(pbd);
+        ptv->frame_offset = (ptv->frame_offset + 1) % ptv->req3.tp_block_nr;
         return 1;
-    }
+    } else {
+        /* Read packet from ring */
+        h.raw = (((union thdr **)ptv->ring_v2)[ptv->frame_offset]);
+        if (h.raw == NULL) {
+            return -1;
+        }
+        (*discarded_pkts)++;
+        if (((time_t)h.h2->tp_sec > synctv->tv_sec) ||
+                ((time_t)h.h2->tp_sec == synctv->tv_sec &&
+                 (suseconds_t) (h.h2->tp_nsec / 1000) > synctv->tv_usec)) {
+            return 1;
+        }
 
-    /* Read packet from ring */
-    h.raw = (((union thdr **)ptv->ring_v2)[ptv->frame_offset]);
-    if (h.raw == NULL) {
-        return -1;
-    }
-
-    if (((time_t)h.h2->tp_sec > synctv->tv_sec) ||
-        ((time_t)h.h2->tp_sec == synctv->tv_sec &&
-        (suseconds_t) (h.h2->tp_nsec / 1000) > synctv->tv_usec)) {
-        return 1;
-    }
-
-    h.h2->tp_status = TP_STATUS_KERNEL;
-    if (++ptv->frame_offset >= ptv->req.tp_frame_nr) {
-        ptv->frame_offset = 0;
+        h.h2->tp_status = TP_STATUS_KERNEL;
+        if (++ptv->frame_offset >= ptv->req.tp_frame_nr) {
+            ptv->frame_offset = 0;
+        }
     }
 
 
@@ -1198,7 +1204,7 @@ static int AFPReadAndDiscardFromRing(AFPThreadVars *ptv, struct timeval *synctv)
  *
  *  \retval r 1 = happy, otherwise unhappy
  */
-static int AFPSynchronizeStart(AFPThreadVars *ptv)
+static int AFPSynchronizeStart(AFPThreadVars *ptv, uint64_t *discarded_pkts)
 {
     int r;
     struct timeval synctv;
@@ -1223,9 +1229,9 @@ static int AFPSynchronizeStart(AFPThreadVars *ptv)
                 gettimeofday(&synctv, NULL);
             }
             if (ptv->flags & AFP_RING_MODE) {
-                r = AFPReadAndDiscardFromRing(ptv, &synctv);
+                r = AFPReadAndDiscardFromRing(ptv, &synctv, discarded_pkts);
             } else {
-                r = AFPReadAndDiscard(ptv, &synctv);
+                r = AFPReadAndDiscard(ptv, &synctv, discarded_pkts);
             }
             SCLogDebug("Discarding on %s", ptv->tv->name);
             switch (r) {
@@ -1292,6 +1298,7 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     time_t last_dump = 0;
     struct timeval current_time;
     int (*AFPReadFunc) (AFPThreadVars *);
+    uint64_t discarded_pkts = 0;
 
     ptv->slot = s->slot_next;
 
@@ -1331,8 +1338,25 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
     if (ptv->afp_state == AFP_STATE_UP) {
         SCLogDebug("Thread %s using socket %d", tv->name, ptv->socket);
         if ((ptv->flags & AFP_TPACKET_V3) != 0) {
-            AFPSynchronizeStart(ptv);
+            AFPSynchronizeStart(ptv, &discarded_pkts);
         }
+        /* let's reset counter as we will start the capture at the
+         * next function call */
+#ifdef PACKET_STATISTICS
+         struct tpacket_stats kstats;
+         socklen_t len = sizeof (struct tpacket_stats);
+         if (getsockopt(ptv->socket, SOL_PACKET, PACKET_STATISTICS,
+                     &kstats, &len) > -1) {
+             uint64_t pkts = 0;
+             SCLogDebug("(%s) Kernel socket startup: Packets %" PRIu32
+                     ", dropped %" PRIu32 "",
+                     ptv->tv->name,
+                     kstats.tp_packets, kstats.tp_drops);
+             pkts = kstats.tp_packets - discarded_pkts - kstats.tp_drops;
+             StatsAddUI64(ptv->tv, ptv->capture_kernel_packets, pkts);
+             (void) SC_ATOMIC_ADD(ptv->livedev->pkts, pkts);
+         }
+#endif
     }
 
     fds.fd = ptv->socket;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -162,6 +162,8 @@ TmEcode NoAFPSupportExit(ThreadVars *tv, void *initdata, void **data)
 #define TP_STATUS_VLAN_VALID (1 << 4)
 #endif
 
+#define AFP_BLOCK_SIZE_DEFAULT_ORDER 3
+
 /** protect pfring_set_bpf_filter, as it is not thread safe */
 static SCMutex afpacket_bpf_set_filter_lock = SCMUTEX_INITIALIZER;
 
@@ -1555,7 +1557,7 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
 
 static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
 {
-    ptv->req3.tp_block_size = getpagesize();
+    ptv->req3.tp_block_size = getpagesize() << AFP_BLOCK_SIZE_DEFAULT_ORDER;
     ptv->req3.tp_frame_size = 2048;
     int frames_per_block = ptv->req3.tp_block_size / ptv->req3.tp_frame_size;
     if (frames_per_block == 0) {
@@ -1633,8 +1635,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
             return AFP_FATAL_ERROR;
         }
     } else {
-#define DEFAULT_ORDER 3
-        for (order = DEFAULT_ORDER; order >= 0; order--) {
+        for (order = AFP_BLOCK_SIZE_DEFAULT_ORDER; order >= 0; order--) {
             if (AFPComputeRingParams(ptv, order) != 1) {
                 SCLogInfo("Ring parameter are incorrect. Please correct the devel");
                 return AFP_FATAL_ERROR;

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -188,64 +188,68 @@ union thdr {
  */
 typedef struct AFPThreadVars_
 {
-    /* thread specific socket */
-    int socket;
-    /* handle state */
-    unsigned char afp_state;
-
-    /* data link type for the thread */
-    int datalink;
-    int cooked;
-
     /* counters */
     uint64_t pkts;
     uint64_t bytes;
-    uint64_t errs;
 
     ThreadVars *tv;
     TmSlot *slot;
+    LiveDevice *livedev;
+    /* data link type for the thread */
+    int datalink;
+    int flags;
 
+    unsigned int frame_offset;
+
+    ChecksumValidationMode checksum_mode;
+
+    uint16_t capture_kernel_packets;
+    uint16_t capture_kernel_drops;
+
+    /* handle state */
+    uint8_t afp_state;
+    uint8_t copy_mode;
+
+    struct iovec *rd;
+    char *frame_buf;
+
+    /* IPS peer */
+    AFPPeer *mpeer;
+
+    /* no mmap mode */
     uint8_t *data; /** Per function and thread data */
     int datalen; /** Length of per function and thread data */
+    int cooked;
 
-    int vlan_disabled;
+    /* 
+     *  Init related members
+     */
 
-    char iface[AFP_IFACE_NAME_LENGTH];
-    LiveDevice *livedev;
-    int down_count;
-
+    /* thread specific socket */
+    int socket;
     /* Filter */
     char *bpf_filter;
 
     /* socket buffer size */
     int buffer_size;
+
+    int ring_size;
+
     int promisc;
-    ChecksumValidationMode checksum_mode;
 
-    /* IPS stuff */
+    int down_count;
+
+    char iface[AFP_IFACE_NAME_LENGTH];
+    /* IPS output iface */
     char out_iface[AFP_IFACE_NAME_LENGTH];
-    AFPPeer *mpeer;
-
-    int flags;
-    uint16_t capture_kernel_packets;
-    uint16_t capture_kernel_drops;
 
     int cluster_id;
     int cluster_type;
 
     int threads;
-    int copy_mode;
 
     struct tpacket_req req;
     struct tpacket_req3 req3;
-    unsigned int tp_hdrlen;
-    unsigned int ring_buflen;
-    char *ring_buf;
-    char *frame_buf;
-    struct iovec *rd;
-
-    unsigned int frame_offset;
-    int ring_size;
 
 } AFPThreadVars;
 
@@ -813,7 +817,7 @@ int AFPReadFromRing(AFPThreadVars *ptv)
         }
 
         /* get vlan id from header */
-        if ((!ptv->vlan_disabled) &&
+        if ((!(ptv->flags & AFP_VLAN_DISABLED)) &&
             (h.h2->tp_status & TP_STATUS_VLAN_VALID || h.h2->tp_vlan_tci)) {
             p->vlan_id[0] = h.h2->tp_vlan_tci & 0x0fff;
             p->vlan_idx = 1;
@@ -1566,6 +1570,8 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
     int order;
     unsigned int i;
     int if_idx;
+    unsigned int ring_buflen;
+    uint8_t * ring_buf;
 
     /* open socket */
     ptv->socket = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
@@ -1702,7 +1708,6 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             SCLogError(SC_ERR_AFP_CREATE, "Error when retrieving packet header len");
             goto socket_err;
         }
-        ptv->tp_hdrlen = val;
 
         if (ptv->flags & AFP_TPACKET_V3) {
             val = TPACKET_V3;
@@ -1761,13 +1766,13 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
 
         /* Allocate the Ring */
         if (ptv->flags & AFP_TPACKET_V3) {
-            ptv->ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
+            ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
         } else {
-            ptv->ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
+            ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
         }
-        ptv->ring_buf = mmap(0, ptv->ring_buflen, PROT_READ|PROT_WRITE,
+        ring_buf = mmap(0, ring_buflen, PROT_READ|PROT_WRITE,
                 MAP_SHARED, ptv->socket, 0);
-        if (ptv->ring_buf == MAP_FAILED) {
+        if (ring_buf == MAP_FAILED) {
             SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
             goto socket_err;
         }
@@ -1778,7 +1783,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
                 goto mmap_err;
             }
             for (i = 0; i < ptv->req3.tp_block_nr; ++i) {
-                ptv->rd[i].iov_base = ptv->ring_buf + (i * ptv->req3.tp_block_size);
+                ptv->rd[i].iov_base = ring_buf + (i * ptv->req3.tp_block_size);
                 ptv->rd[i].iov_len = ptv->req3.tp_block_size;
             }
         } else {
@@ -1792,7 +1797,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
             /* fill the header ring with proper frame ptr*/
             ptv->frame_offset = 0;
             for (i = 0; i < ptv->req.tp_block_nr; ++i) {
-                void *base = &ptv->ring_buf[i * ptv->req.tp_block_size];
+                void *base = &ring_buf[i * ptv->req.tp_block_size];
                 unsigned int j;
                 for (j = 0; j < ptv->req.tp_block_size / ptv->req.tp_frame_size; ++j, ++ptv->frame_offset) {
                     (((union thdr **)ptv->frame_buf)[ptv->frame_offset]) = base;
@@ -1991,14 +1996,14 @@ TmEcode ReceiveAFPThreadInit(ThreadVars *tv, void *initdata, void **data)
      * the capture phase */
     int vlanbool = 0;
     if ((ConfGetBool("vlan.use-for-tracking", &vlanbool)) == 1 && vlanbool == 0) {
-        ptv->vlan_disabled = 1;
+        ptv->flags |= AFP_VLAN_DISABLED;
     }
 
     /* If kernel is older than 3.0, VLAN is not stripped so we don't
      * get the info from packet extended header but we will use a standard
      * parsing of packet data (See Linux commit bcc6d47903612c3861201cc3a866fb604f26b8b2) */
     if (! SCKernelVersionIsAtLeast(3, 0)) {
-        ptv->vlan_disabled = 1;
+        ptv->flags |= AFP_VLAN_DISABLED;
     }
 
     SCReturnInt(TM_ECODE_OK);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1220,6 +1220,14 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
         } else if (r > 0) {
             r = AFPReadFunc(ptv);
             switch (r) {
+                case AFP_READ_OK:
+                    /* Trigger one dump of stats every second */
+                    TimeGet(&current_time);
+                    if (current_time.tv_sec != last_dump) {
+                        AFPDumpCounters(ptv);
+                        last_dump = current_time.tv_sec;
+                    }
+                    break;
                 case AFP_READ_FAILURE:
                     /* AFPRead in error: best to reset the socket */
                     SCLogError(SC_ERR_AFP_READ,
@@ -1230,14 +1238,6 @@ TmEcode ReceiveAFPLoop(ThreadVars *tv, void *data, void *slot)
                 case AFP_FAILURE:
                     AFPSwitchState(ptv, AFP_STATE_DOWN);
                     SCReturnInt(TM_ECODE_FAILED);
-                    break;
-                case AFP_READ_OK:
-                    /* Trigger one dump of stats every second */
-                    TimeGet(&current_time);
-                    if (current_time.tv_sec != last_dump) {
-                        AFPDumpCounters(ptv);
-                        last_dump = current_time.tv_sec;
-                    }
                     break;
                 case AFP_KERNEL_DROP:
                     AFPDumpCounters(ptv);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -179,7 +179,9 @@ enum {
 
 union thdr {
     struct tpacket2_hdr *h2;
+#ifdef HAVE_TPACKET_V3
     struct tpacket3_hdr *h3;
+#endif
     void *raw;
 };
 
@@ -249,7 +251,9 @@ typedef struct AFPThreadVars_
 
     union {
         struct tpacket_req req;
+#ifdef HAVE_TPACKET_V3
         struct tpacket_req3 req3;
+#endif
     };
 
     char iface[AFP_IFACE_NAME_LENGTH];
@@ -1002,6 +1006,7 @@ static inline int AFPWalkBlock(AFPThreadVars *ptv, struct tpacket_block_desc *pb
  */
 int AFPReadFromRingV3(AFPThreadVars *ptv)
 {
+#ifdef HAVE_TPACKET_V3
     struct tpacket_block_desc *pbd;
 
     /* Loop till we have packets available */
@@ -1030,7 +1035,7 @@ int AFPReadFromRingV3(AFPThreadVars *ptv)
             SCReturnInt(AFP_READ_OK);
         }
     }
-
+#endif
     SCReturnInt(AFP_READ_OK);
 }
 
@@ -1554,6 +1559,7 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
     return 1;
 }
 
+#ifdef HAVE_TPACKET_V3
 static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
 {
     ptv->req3.tp_block_size = ptv->block_size;
@@ -1575,6 +1581,7 @@ static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
               );
     return 1;
 }
+#endif
 
 static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
 {
@@ -1585,11 +1592,15 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
     int order;
     int r, mmap_flag;
 
+#ifdef HAVE_TPACKET_V3
     if (ptv->flags & AFP_TPACKET_V3) {
         val = TPACKET_V3;
     } else {
+#endif
         val = TPACKET_V2;
+#ifdef HAVE_TPACKET_V3
     }
+#endif
     if (getsockopt(ptv->socket, SOL_PACKET, PACKET_HDRLEN, &val, &len) < 0) {
         if (errno == ENOPROTOOPT) {
             if (ptv->flags & AFP_TPACKET_V3) {
@@ -1618,6 +1629,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
     }
 
     /* Allocate RX ring */
+#ifdef HAVE_TPACKET_V3
     if (ptv->flags & AFP_TPACKET_V3) {
         if (AFPComputeRingParamsV3(ptv) != 1) {
             SCLogInfo("Ring parameter are incorrect. Please correct the devel");
@@ -1634,6 +1646,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
             return AFP_FATAL_ERROR;
         }
     } else {
+#endif
         for (order = AFP_BLOCK_SIZE_DEFAULT_ORDER; order >= 0; order--) {
             if (AFPComputeRingParams(ptv, order) != 1) {
                 SCLogInfo("Ring parameter are incorrect. Please correct the devel");
@@ -1664,14 +1677,20 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
                     devname);
             return AFP_FATAL_ERROR;
         }
+#ifdef HAVE_TPACKET_V3
     }
+#endif
 
     /* Allocate the Ring */
+#ifdef HAVE_TPACKET_V3
     if (ptv->flags & AFP_TPACKET_V3) {
         ring_buflen = ptv->req3.tp_block_nr * ptv->req3.tp_block_size;
     } else {
+#endif
         ring_buflen = ptv->req.tp_block_nr * ptv->req.tp_block_size;
+#ifdef HAVE_TPACKET_V3
     }
+#endif
     mmap_flag = MAP_SHARED;
     if (ptv->flags & AFP_MMAP_LOCKED)
         mmap_flag |= MAP_LOCKED;
@@ -1681,6 +1700,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
         SCLogError(SC_ERR_MEM_ALLOC, "Unable to mmap");
         goto mmap_err;
     }
+#ifdef HAVE_TPACKET_V3
     if (ptv->flags & AFP_TPACKET_V3) {
         ptv->ring_v3 = SCMalloc(ptv->req3.tp_block_nr * sizeof(*ptv->ring_v3));
         if (!ptv->ring_v3) {
@@ -1692,6 +1712,7 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
             ptv->ring_v3[i].iov_len = ptv->req3.tp_block_size;
         }
     } else {
+#endif
         /* allocate a ring for each frame header pointer*/
         ptv->ring_v2 = SCMalloc(ptv->req.tp_frame_nr * sizeof (union thdr *));
         if (ptv->ring_v2 == NULL) {
@@ -1710,7 +1731,9 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
             }
         }
         ptv->frame_offset = 0;
+#ifdef HAVE_TPACKET_V3
     }
+#endif
 
     return 0;
 

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -50,6 +50,7 @@
 #define AFP_EMERGENCY_MODE (1<<3)
 #define AFP_TPACKET_V3 (1<<4)
 #define AFP_VLAN_DISABLED (1<<5)
+#define AFP_MMAP_LOCKED (1<<6)
 
 #define AFP_COPY_MODE_NONE  0
 #define AFP_COPY_MODE_TAP   1

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -88,16 +88,16 @@ typedef struct AFPIfaceConfig_
  */
 
 typedef struct AFPPeer_ {
-    char iface[AFP_IFACE_NAME_LENGTH];
     SC_ATOMIC_DECLARE(int, socket);
     SC_ATOMIC_DECLARE(int, sock_usage);
     SC_ATOMIC_DECLARE(int, if_idx);
-    SC_ATOMIC_DECLARE(uint8_t, state);
-    SCMutex sock_protect;
     int flags;
+    SCMutex sock_protect;
     int turn; /**< Field used to store initialisation order. */
+    SC_ATOMIC_DECLARE(uint8_t, state);
     struct AFPPeer_ *peer;
     TAILQ_ENTRY(AFPPeer_) next;
+    char iface[AFP_IFACE_NAME_LENGTH];
 } AFPPeer;
 
 /**

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -58,6 +58,8 @@
 #define AFP_FILE_MAX_PKTS 256
 #define AFP_IFACE_NAME_LENGTH 48
 
+#define AFP_BLOCK_SIZE_DEFAULT_ORDER 3
+
 typedef struct AFPIfaceConfig_
 {
     char iface[AFP_IFACE_NAME_LENGTH];
@@ -67,6 +69,8 @@ typedef struct AFPIfaceConfig_
     int buffer_size;
     /* ring size in number of packets */
     int ring_size;
+    /* block size for tpacket_v3 */
+    int block_size;
     /* cluster param */
     int cluster_id;
     int cluster_type;

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -48,6 +48,7 @@
 #define AFP_ZERO_COPY (1<<1)
 #define AFP_SOCK_PROTECT (1<<2)
 #define AFP_EMERGENCY_MODE (1<<3)
+#define AFP_TPACKET_V3 (1<<4)
 
 #define AFP_COPY_MODE_NONE  0
 #define AFP_COPY_MODE_TAP   1

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -71,6 +71,8 @@ typedef struct AFPIfaceConfig_
     int ring_size;
     /* block size for tpacket_v3 */
     int block_size;
+    /* block timeout for tpacket_v3 */
+    int block_timeout;
     /* cluster param */
     int cluster_id;
     int cluster_type;

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -49,6 +49,7 @@
 #define AFP_SOCK_PROTECT (1<<2)
 #define AFP_EMERGENCY_MODE (1<<3)
 #define AFP_TPACKET_V3 (1<<4)
+#define AFP_VLAN_DISABLED (1<<5)
 
 #define AFP_COPY_MODE_NONE  0
 #define AFP_COPY_MODE_TAP   1
@@ -108,12 +109,12 @@ typedef struct AFPPeer_ {
 typedef struct AFPPacketVars_
 {
     void *relptr;
-    int copy_mode;
     AFPPeer *peer; /**< Sending peer for IPS/TAP mode */
     /** Pointer to ::AFPPeer used for capture. Field is used to be able
      * to do reference counting.
      */
     AFPPeer *mpeer;
+    uint8_t copy_mode;
 } AFPPacketVars;
 
 #define AFPV_CLEANUP(afpv) do {           \

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -525,7 +525,7 @@ af-packet:
   # Put default values here
   - interface: default
     #threads: auto
-    #use-mmap: yes
+    #use-mmap: no
     #rollover: yes
     tpacket-v3: yes
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -482,6 +482,9 @@ af-packet:
     # a decent number of packets. Size is in bytes so please consider your MTU. It should be
     # a power of 2 and it must be multiple of page size (usually 4096).
     #block-size: 32768
+    # tpacket_v3 block timeout: an open block is passed to userspace if it is not
+    # filled after block-timeout milliseconds.
+    #block-timeout: 10
     # On busy system, this could help to set it to yes to recover from a packet drop
     # phase. This will result in some packets (at max a ring flush) being non treated.
     #use-emergency-flush: yes

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -478,6 +478,10 @@ af-packet:
     # intensive single-flow you could want to set the ring-size independantly of the number
     # of threads:
     #ring-size: 2048
+    # Block size is used by tpacket_v3 only. It should set to a value high enough to contain
+    # a decent number of packets. Size is in bytes so please consider your MTU. It should be
+    # a power of 2 and it must be multiple of page size (usually 4096).
+    #block-size: 32768
     # On busy system, this could help to set it to yes to recover from a packet drop
     # phase. This will result in some packets (at max a ring flush) being non treated.
     #use-emergency-flush: yes

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -470,6 +470,9 @@ af-packet:
     #rollover: yes
     # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
     use-mmap: yes
+    # Lock memory map to avoid it goes to swap. Be careful that over suscribing could lock
+    # your system
+    #mmap-locked: yes
     # Use tpacket_v3, capture mode, only active if user-mmap is true
     #tpacket-v3: yes
     # Ring size will be computed with respect to max_pending_packets and number

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -470,6 +470,8 @@ af-packet:
     #rollover: yes
     # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
     use-mmap: yes
+    # Use tpacket_v3, capture mode, only active if user-mmap is true
+    #tpacket-v3: yes
     # Ring size will be computed with respect to max_pending_packets and number
     # of threads. You can set manually the ring size in number of packets by setting
     # the following value. If you are using flow cluster-type and have really network
@@ -515,6 +517,7 @@ af-packet:
     #threads: auto
     #use-mmap: yes
     #rollover: yes
+    tpacket-v3: yes
 
 # Netmap support
 #

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -466,7 +466,7 @@ af-packet:
     defrag: yes
     # After Linux kernel 3.10 it is possible to activate the rollover option: if a socket is
     # full then kernel will send the packet on the next socket with room available. This option
-    # can minimize packet drop and increase the treated bandwith on single intensive flow.
+    # can minimize packet drop and increase the treated bandwidth on single intensive flow.
     #rollover: yes
     # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
     use-mmap: yes
@@ -478,7 +478,7 @@ af-packet:
     # Ring size will be computed with respect to max_pending_packets and number
     # of threads. You can set manually the ring size in number of packets by setting
     # the following value. If you are using flow cluster-type and have really network
-    # intensive single-flow you could want to set the ring-size independantly of the number
+    # intensive single-flow you could want to set the ring-size independently of the number
     # of threads:
     #ring-size: 2048
     # Block size is used by tpacket_v3 only. It should set to a value high enough to contain
@@ -508,7 +508,7 @@ af-packet:
     #checksum-checks: kernel
     # BPF filter to apply to this interface. The pcap filter syntax apply here.
     #bpf-filter: port 80 or udp
-    # You can use the following variables to activate AF_PACKET tap od IPS mode.
+    # You can use the following variables to activate AF_PACKET tap or IPS mode.
     # If copy-mode is set to ips or tap, the traffic coming to the current
     # interface will be copied to the copy-iface interface. If 'tap' is set, the
     # copy is complete. If 'ips' is set, the packet matching a 'drop' action


### PR DESCRIPTION
A rework of #2018 addressing the comments. Only open point may be the fact that a new yaml is needed to have tpacket_v3 enabled by default.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/165
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/161
