### PR TITLE
Changed "enabled" parsing to use ConfValIs(true|false)

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -280,9 +280,9 @@ int AppLayerParserConfParserEnabled(const char *ipproto,
         }
     }
 
-    if (strcasecmp(node->val, "yes") == 0) {
+    if (ConfValIsTrue(node->val)) {
         goto enabled;
-    } else if (strcasecmp(node->val, "no") == 0) {
+    } else if (ConfValIsFalse(node->val)) {
         goto disabled;
     } else if (strcasecmp(node->val, "detection-only") == 0) {
         goto disabled;


### PR DESCRIPTION
Had some issues when trying to send suricata yamls through different parsers. Some "enabled: yes" were turned into "enabled: true", according to the conf.c code "true" should be allowed. But looking through debugging showed that app-layer-parser.c was hard coded to look for "yes" and "no".