### PR TITLE
Issue 1231 - SSL Negation - v4.1

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -147,7 +147,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
 
     switch (ssl_state->curr_connp->handshake_type) {
         case SSLV3_HS_CLIENT_HELLO:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_CLIENT_HELLO;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_HELLO;
 
             /* skip version */
             input += SSLV3_CLIENT_HELLO_VERSION_LEN;
@@ -275,15 +275,15 @@ end:
             break;
 
         case SSLV3_HS_SERVER_HELLO:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_SERVER_HELLO;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_SERVER_HELLO;
             break;
 
         case SSLV3_HS_SERVER_KEY_EXCHANGE:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_SERVER_KEYX;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_SERVER_KEYX;
             break;
 
         case SSLV3_HS_CLIENT_KEY_EXCHANGE:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_CLIENT_KEYX;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_KEYX;
             break;
 
         case SSLV3_HS_CERTIFICATE:
@@ -384,6 +384,8 @@ end:
                     TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
     }
+
+    ssl_state->flags |= ssl_state->current_flags;
 
     uint32_t write_len = 0;
     if ((ssl_state->curr_connp->bytes_processed + input_len) >=
@@ -823,8 +825,8 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
             break;
 
         case SSLV2_MT_CLIENT_HELLO:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_CLIENT_HELLO;
-            ssl_state->flags |= SSL_AL_FLAG_SSL_CLIENT_HS;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_HELLO;
+            ssl_state->current_flags |= SSL_AL_FLAG_SSL_CLIENT_HS;
 
             if (ssl_state->curr_connp->record_lengths_length == 3) {
                 switch (ssl_state->curr_connp->bytes_processed) {
@@ -836,7 +838,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                             input_len -= 6;
                             ssl_state->curr_connp->bytes_processed += 6;
                             if (ssl_state->curr_connp->session_id_length == 0) {
-                                ssl_state->flags |= SSL_AL_FLAG_SSL_NO_SESSION_ID;
+                                ssl_state->current_flags |= SSL_AL_FLAG_SSL_NO_SESSION_ID;
                             }
 
                             break;
@@ -895,7 +897,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                             input_len -= 6;
                             ssl_state->curr_connp->bytes_processed += 6;
                             if (ssl_state->curr_connp->session_id_length == 0) {
-                                ssl_state->flags |= SSL_AL_FLAG_SSL_NO_SESSION_ID;
+                                ssl_state->current_flags |= SSL_AL_FLAG_SSL_NO_SESSION_ID;
                             }
 
                             break;
@@ -945,8 +947,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                 SCLogDebug("Client hello is not seen before master key "
                            "message!");
             }
-
-            ssl_state->flags |= SSL_AL_FLAG_SSL_CLIENT_MASTER_KEY;
+            ssl_state->current_flags = SSL_AL_FLAG_SSL_CLIENT_MASTER_KEY;
 
             break;
 
@@ -955,7 +956,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                 SCLogDebug("Incorrect SSL Record type sent in the toclient "
                            "direction!");
             } else {
-                ssl_state->flags |= SSL_AL_FLAG_STATE_CLIENT_KEYX;
+                ssl_state->current_flags = SSL_AL_FLAG_STATE_CLIENT_KEYX;
             }
 
             /* fall through */
@@ -977,14 +978,14 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
 
                 if (direction == 0) {
                     if (ssl_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) {
-                        ssl_state->flags |= SSL_AL_FLAG_SSL_CLIENT_SSN_ENCRYPTED;
+                        ssl_state->current_flags |= SSL_AL_FLAG_SSL_CLIENT_SSN_ENCRYPTED;
                         SCLogDebug("SSLv2 client side has started the encryption");
                     } else if (ssl_state->flags & SSL_AL_FLAG_SSL_CLIENT_MASTER_KEY) {
-                        ssl_state->flags |= SSL_AL_FLAG_SSL_CLIENT_SSN_ENCRYPTED;
+                        ssl_state->current_flags = SSL_AL_FLAG_SSL_CLIENT_SSN_ENCRYPTED;
                         SCLogDebug("SSLv2 client side has started the encryption");
                     }
                 } else {
-                    ssl_state->flags |= SSL_AL_FLAG_SSL_SERVER_SSN_ENCRYPTED;
+                    ssl_state->current_flags = SSL_AL_FLAG_SSL_SERVER_SSN_ENCRYPTED;
                     SCLogDebug("SSLv2 Server side has started the encryption");
                 }
 
@@ -1002,11 +1003,13 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
             break;
 
         case SSLV2_MT_SERVER_HELLO:
-            ssl_state->flags |= SSL_AL_FLAG_STATE_SERVER_HELLO;
-            ssl_state->flags |= SSL_AL_FLAG_SSL_SERVER_HS;
+            ssl_state->current_flags = SSL_AL_FLAG_STATE_SERVER_HELLO;
+            ssl_state->current_flags |= SSL_AL_FLAG_SSL_SERVER_HS;
 
             break;
     }
+
+    ssl_state->flags |= ssl_state->current_flags;
 
     if (input_len + ssl_state->curr_connp->bytes_processed >=
             (ssl_state->curr_connp->record_length +

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -169,6 +169,8 @@ typedef struct SSLState_ {
     /* holds some state flags we need */
     uint32_t flags;
 
+    uint32_t current_flags;
+
     SSLStateConnp *curr_connp;
 
     SSLStateConnp client_connp;

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -51,11 +51,11 @@
 #include "stream-tcp.h"
 #include "app-layer-ssl.h"
 
-#define PARSE_REGEX1 "^\\s*([_a-zA-Z0-9]+)(.*)$"
+#define PARSE_REGEX1 "^\\s*(!?)([_a-zA-Z0-9]+)(.*)$"
 static pcre *parse_regex1;
 static pcre_extra *parse_regex1_study;
 
-#define PARSE_REGEX2 "^(?:\\s*[|]\\s*([_a-zA-Z0-9]+))(.*)$"
+#define PARSE_REGEX2 "^(?:\\s*[|,]\\s*(!?)([_a-zA-Z0-9]+))(.*)$"
 static pcre *parse_regex2;
 static pcre_extra *parse_regex2_study;
 
@@ -100,7 +100,6 @@ int DetectSslStateMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
                         Flow *f, uint8_t flags, void *alstate, Signature *s,
                         SigMatch *m)
 {
-    int result = 1;
     DetectSslStateData *ssd = (DetectSslStateData *)m->ctx;
     SSLState *ssl_state = (SSLState *)alstate;
     if (ssl_state == NULL) {
@@ -108,29 +107,13 @@ int DetectSslStateMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return 0;
     }
 
-    if ((ssd->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) &&
-        !(ssl_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO)) {
-        result = 0;
-        goto end;
-    }
-    if ((ssd->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) &&
-        !(ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO)) {
-        result = 0;
-        goto end;
-    }
-    if ((ssd->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) &&
-        !(ssl_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX)) {
-        result = 0;
-        goto end;
-    }
-    if ((ssd->flags & SSL_AL_FLAG_STATE_SERVER_KEYX) &&
-        !(ssl_state->flags & SSL_AL_FLAG_STATE_SERVER_KEYX)) {
-        result = 0;
-        goto end;
+    uint32_t ssl_flags = ssl_state->current_flags;
+
+    if ((ssd->flags & ssl_flags) ^ ssd->mask) {
+        return 1;
     }
 
- end:
-    return result;
+    return 0;
 }
 
 /**
@@ -150,7 +133,8 @@ DetectSslStateData *DetectSslStateParse(char *arg)
     int ov2[MAX_SUBSTRINGS];
     const char *str1;
     const char *str2;
-    uint32_t flags = 0;
+    int negate = 0;
+    uint32_t flags = 0, mask = 0;
     DetectSslStateData *ssd = NULL;
 
     ret = pcre_exec(parse_regex1, parse_regex1_study, arg, strlen(arg), 0, 0,
@@ -160,7 +144,16 @@ DetectSslStateData *DetectSslStateParse(char *arg)
                    "ssl_state keyword.", arg);
         goto error;
     }
+
     res = pcre_get_substring((char *)arg, ov1, MAX_SUBSTRINGS, 1, &str1);
+    if (res < 0) {
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        goto error;
+    }
+    negate = !strcmp("!", str1);
+    pcre_free_substring(str1);
+
+    res = pcre_get_substring((char *)arg, ov1, MAX_SUBSTRINGS, 2, &str1);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
         goto error;
@@ -168,14 +161,24 @@ DetectSslStateData *DetectSslStateParse(char *arg)
 
     if (strcmp("client_hello", str1) == 0) {
         flags |= DETECT_SSL_STATE_CLIENT_HELLO;
+        if (negate)
+            mask |= DETECT_SSL_STATE_CLIENT_HELLO;
     } else if (strcmp("server_hello", str1) == 0) {
         flags |= DETECT_SSL_STATE_SERVER_HELLO;
+        if (negate)
+            mask |= DETECT_SSL_STATE_SERVER_HELLO;
     } else if (strcmp("client_keyx", str1) == 0) {
         flags |= DETECT_SSL_STATE_CLIENT_KEYX;
+        if (negate)
+            mask |= DETECT_SSL_STATE_CLIENT_KEYX;
     } else if (strcmp("server_keyx", str1) == 0) {
         flags |= DETECT_SSL_STATE_SERVER_KEYX;
+        if (negate)
+            mask |= DETECT_SSL_STATE_SERVER_KEYX;
     } else if (strcmp("unknown", str1) == 0) {
         flags |= DETECT_SSL_STATE_UNKNOWN;
+        if (negate)
+            mask |= DETECT_SSL_STATE_UNKNOWN;
     } else {
         SCLogError(SC_ERR_INVALID_SIGNATURE, "Found invalid option \"%s\" "
                    "in ssl_state keyword.", str1);
@@ -184,7 +187,7 @@ DetectSslStateData *DetectSslStateParse(char *arg)
 
     pcre_free_substring(str1);
 
-    res = pcre_get_substring((char *)arg, ov1, MAX_SUBSTRINGS, 2, &str1);
+    res = pcre_get_substring((char *)arg, ov1, MAX_SUBSTRINGS, 3, &str1);
     if (res < 0) {
         SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
         goto error;
@@ -197,28 +200,47 @@ DetectSslStateData *DetectSslStateParse(char *arg)
                        "ssl_state keyword.", arg);
             goto error;
         }
+
         res = pcre_get_substring((char *)str1, ov2, MAX_SUBSTRINGS, 1, &str2);
+        if (res < 0) {
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            goto error;
+        }
+        negate = !strcmp("!", str2);
+        pcre_free_substring(str2);
+
+        res = pcre_get_substring((char *)str1, ov2, MAX_SUBSTRINGS, 2, &str2);
         if (res <= 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
             goto error;
         }
         if (strcmp("client_hello", str2) == 0) {
             flags |= DETECT_SSL_STATE_CLIENT_HELLO;
+            if (negate)
+                mask |= DETECT_SSL_STATE_CLIENT_HELLO;
         } else if (strcmp("server_hello", str2) == 0) {
             flags |= DETECT_SSL_STATE_SERVER_HELLO;
+            if (negate)
+                mask |= DETECT_SSL_STATE_SERVER_HELLO;
         } else if (strcmp("client_keyx", str2) == 0) {
             flags |= DETECT_SSL_STATE_CLIENT_KEYX;
+            if (negate)
+                mask |= DETECT_SSL_STATE_CLIENT_KEYX;
         } else if (strcmp("server_keyx", str2) == 0) {
             flags |= DETECT_SSL_STATE_SERVER_KEYX;
+            if (negate)
+                mask |= DETECT_SSL_STATE_SERVER_KEYX;
         } else if (strcmp("unknown", str2) == 0) {
             flags |= DETECT_SSL_STATE_UNKNOWN;
+            if (negate)
+                mask |= DETECT_SSL_STATE_UNKNOWN;
         } else {
             SCLogError(SC_ERR_INVALID_SIGNATURE, "Found invalid option \"%s\" "
                        "in ssl_state keyword.", str2);
             goto error;
         }
 
-        res = pcre_get_substring((char *)str1, ov2, MAX_SUBSTRINGS, 2, &str2);
+        res = pcre_get_substring((char *)str1, ov2, MAX_SUBSTRINGS, 3, &str2);
         if (res < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
             goto error;
@@ -233,6 +255,7 @@ DetectSslStateData *DetectSslStateParse(char *arg)
         goto error;
     }
     ssd->flags = flags;
+    ssd->mask = mask;
 
     return ssd;
 
@@ -323,7 +346,7 @@ int DetectSslStateTest01(void)
 
 int DetectSslStateTest02(void)
 {
-    DetectSslStateData *ssd = DetectSslStateParse("server_hello | client_hello");
+    DetectSslStateData *ssd = DetectSslStateParse("server_hello , client_hello");
     if (ssd == NULL) {
         printf("ssd == NULL\n");
         return 0;
@@ -339,7 +362,7 @@ int DetectSslStateTest02(void)
 
 int DetectSslStateTest03(void)
 {
-    DetectSslStateData *ssd = DetectSslStateParse("server_hello | client_keyx | "
+    DetectSslStateData *ssd = DetectSslStateParse("server_hello , client_keyx , "
                                                   "client_hello");
     if (ssd == NULL) {
         printf("ssd == NULL\n");
@@ -357,8 +380,8 @@ int DetectSslStateTest03(void)
 
 int DetectSslStateTest04(void)
 {
-    DetectSslStateData *ssd = DetectSslStateParse("server_hello | client_keyx | "
-                                                  "client_hello | server_keyx | "
+    DetectSslStateData *ssd = DetectSslStateParse("server_hello , client_keyx , "
+                                                  "client_hello , server_keyx , "
                                                   "unknown");
     if (ssd == NULL) {
         printf("ssd == NULL\n");
@@ -378,8 +401,8 @@ int DetectSslStateTest04(void)
 
 int DetectSslStateTest05(void)
 {
-    DetectSslStateData *ssd = DetectSslStateParse("| server_hello | client_keyx | "
-                                                  "client_hello | server_keyx | "
+    DetectSslStateData *ssd = DetectSslStateParse(", server_hello , client_keyx , "
+                                                  "client_hello , server_keyx , "
                                                   "unknown");
 
     if (ssd != NULL) {
@@ -393,9 +416,9 @@ int DetectSslStateTest05(void)
 
 int DetectSslStateTest06(void)
 {
-    DetectSslStateData *ssd = DetectSslStateParse("server_hello | client_keyx | "
-                                                  "client_hello | server_keyx | "
-                                                  "unknown | ");
+    DetectSslStateData *ssd = DetectSslStateParse("server_hello , client_keyx , "
+                                                  "client_hello , server_keyx , "
+                                                  "unknown , ");
     if (ssd != NULL) {
         printf("ssd != NULL - failure\n");
         SCFree(ssd);
@@ -699,22 +722,29 @@ static int DetectSslStateTest07(void)
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
                               "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello; "
+                              "ssl_state:server_hello; "
                               "sid:2;)");
     if (s == NULL)
         goto end;
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
                               "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello | "
-                              "client_keyx; sid:3;)");
+                              "ssl_state:client_keyx; "
+                              "sid:3;)");
     if (s == NULL)
         goto end;
 
     s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
                               "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello | "
-                              "client_keyx | server_keyx; sid:4;)");
+                              "ssl_state:server_keyx; "
+                              "sid:4;)");
+    if (s == NULL)
+        goto end;
+
+    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
+                              "(msg:\"ssl state\"; "
+                              "ssl_state:!client_hello; "
+                              "sid:5;)");
     if (s == NULL)
         goto end;
 
@@ -749,6 +779,8 @@ static int DetectSslStateTest07(void)
         goto end;
     if (PacketAlertCheck(p, 4))
         goto end;
+    if (PacketAlertCheck(p, 5))
+        goto end;
 
     SCMutexLock(&f.m);
     r = AppLayerParserParse(alp_tctx, &f, ALPROTO_TLS, STREAM_TOCLIENT, shello_buf,
@@ -771,6 +803,8 @@ static int DetectSslStateTest07(void)
     if (PacketAlertCheck(p, 3))
         goto end;
     if (PacketAlertCheck(p, 4))
+        goto end;
+    if (!PacketAlertCheck(p, 5))
         goto end;
 
     SCMutexLock(&f.m);
@@ -862,6 +896,40 @@ static int DetectSslStateTest07(void)
     return result;
 }
 
+/**
+ * \brief Test that the "|" character still works as a separate for
+ * compatibility with older Suricata rules.
+ */
+int DetectSslStateTest08(void)
+{
+    DetectSslStateData *ssd = DetectSslStateParse("server_hello|client_hello");
+    FAIL_IF_NULL(ssd);
+    FAIL_IF_NOT(ssd->flags == (DETECT_SSL_STATE_SERVER_HELLO |
+            DETECT_SSL_STATE_CLIENT_HELLO));
+    SCFree(ssd);
+    PASS;
+}
+
+/**
+ * \test Test parsing of negated states.
+ */
+int DetectSslStateTestParseNegate(void)
+{
+    DetectSslStateData *ssd = DetectSslStateParse("!client_hello");
+    FAIL_IF_NULL(ssd);
+    uint32_t expected = DETECT_SSL_STATE_CLIENT_HELLO;
+    FAIL_IF(ssd->flags != expected || ssd->mask != expected);
+    SCFree(ssd);
+
+    ssd = DetectSslStateParse("!client_hello,!server_hello");
+    FAIL_IF_NULL(ssd);
+    expected = DETECT_SSL_STATE_CLIENT_HELLO | DETECT_SSL_STATE_SERVER_HELLO;
+    FAIL_IF(ssd->flags != expected || ssd->mask != expected);
+    SCFree(ssd);
+
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 void DetectSslStateRegisterTests(void)
@@ -874,6 +942,9 @@ void DetectSslStateRegisterTests(void)
     UtRegisterTest("DetectSslStateTest05", DetectSslStateTest05);
     UtRegisterTest("DetectSslStateTest06", DetectSslStateTest06);
     UtRegisterTest("DetectSslStateTest07", DetectSslStateTest07);
+    UtRegisterTest("DetectSslStateTest08", DetectSslStateTest08);
+    UtRegisterTest("DetectSslStateTestParseNegate",
+        DetectSslStateTestParseNegate);
 #endif
 
     return;

--- a/src/detect-ssl-state.h
+++ b/src/detect-ssl-state.h
@@ -35,6 +35,7 @@
 
 typedef struct DetectSslStateData_ {
     uint32_t flags;
+    uint32_t mask;
 } DetectSslStateData;
 
 void DetectSslStateRegister(void);


### PR DESCRIPTION
Previous PR: #1474 
Redmine issue: https://redmine.openinfosecfoundation.org/issues/1231

Support negation of ssl_state arguments.

First this required the current state being passed to the ssl_state match function instead of the cumulative state, otherwise ssl_state:client_hello would also match while in the state server_hello. Note that this patch is a bit naive as I don't know the SSL protocol that well, so its more of a preview or RFC.

This patch accepts "," as a state separator to be compatible with Snort, but keeps "|" as a separator for compatibility with existing Suricata rules.

And finally, handle negation of SSL states.

PRscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/218
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/223
