### PR TITLE
app-layer-ssl: make tx aware - v8

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -130,9 +130,15 @@ struct AppLayerParserState_ {
 
     /* State version, incremented for each update.  Can wrap around. */
     uint8_t version;
+
+    /* Indicates which loggers that have already logged the transaction,
+       using the logger id (power of two) as a bitwise flag. */
+    uint32_t logged;
+
     /* Indicates the current transaction that is being inspected.
      * We have a var per direction. */
     uint64_t inspect_id[2];
+
     /* Indicates the current transaction being logged.  Unlike inspect_id,
      * we don't need a var per direction since we don't log a transaction
      * unless we have the entire transaction. */
@@ -532,6 +538,27 @@ void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate)
 
     if (pstate != NULL)
         pstate->log_id++;
+
+    SCReturn;
+}
+
+uint8_t AppLayerParserGetTransactionLogged(AppLayerParserState *pstate, int logger_id)
+{
+    SCEnter();
+
+    if (pstate != NULL)
+        if (pstate->logged & logger_id)
+            SCReturnInt(1);
+
+    SCReturnInt(0);
+}
+
+void AppLayerParserSetTransactionLogged(AppLayerParserState *pstate, int logger_id)
+{
+    SCEnter();
+
+    if (pstate != NULL)
+        pstate->logged |= logger_id;
 
     SCReturn;
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -156,6 +156,8 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
 
 uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate);
 void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate);
+uint8_t AppLayerParserGetTransactionLogged(AppLayerParserState *pstate, int logger_id);
+void AppLayerParserSetTransactionLogged(AppLayerParserState *pstate, int logger_id);
 uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint8_t direction);
 void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
                                 const uint8_t ipproto, const AppProto alproto, void *alstate,

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -3876,9 +3876,9 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -3910,9 +3910,10 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -3945,11 +3946,13 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -3982,12 +3985,15 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC | SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -4018,12 +4024,15 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC | SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -133,6 +133,87 @@ static void SSLParserReset(SSLState *ssl_state)
     ssl_state->curr_connp->bytes_processed = 0;
 }
 
+void SSLSetEvent(SSLState *ssl_state, uint8_t event)
+{
+    if (ssl_state == NULL) {
+        SCLogDebug("Could not set decoder event: %u", event);
+        return;
+    }
+
+    AppLayerDecoderEventsSetEventRaw(&ssl_state->decoder_events, event);
+    ssl_state->events++;
+}
+
+AppLayerDecoderEvents *SSLGetEvents(void *state, uint64_t id)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return ssl_state->decoder_events;
+}
+
+int SSLHasEvents(void *state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return (ssl_state->events > 0);
+}
+
+int SSLStateHasTxDetectState(void *state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    if (ssl_state->de_state)
+        return 1;
+
+    return 0;
+}
+
+int SSLSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    ssl_state->de_state = de_state;
+    return 0;
+}
+
+DetectEngineState *SSLGetTxDetectState(void *vtx)
+{
+    SSLState *ssl_state = (SSLState *)vtx;
+    return ssl_state->de_state;
+}
+
+void *SSLGetTx(void *state, uint64_t tx_id)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return ssl_state;
+}
+
+uint64_t SSLGetTxCnt(void *state)
+{
+    /* single tx */
+    return 1;
+}
+
+int SSLGetAlstateProgressCompletionStatus(uint8_t direction)
+{
+    return TLS_STATE_FINISHED;
+}
+
+int SSLGetAlstateProgress(void *tx, uint8_t direction)
+{
+    SSLState *ssl_state = (SSLState *)tx;
+
+    /* we don't care about direction, only that app-layer parser is done
+       and have sent an EOF */
+    if (ssl_state->flags & SSL_AL_FLAG_STATE_FINISHED) {
+        return TLS_STATE_FINISHED;
+    }
+
+    /* we want the logger to log when the handshake is done, even if the
+       state is not finished */
+    if (ssl_state->flags & SSL_AL_FLAG_HANDSHAKE_DONE) {
+        return TLS_HANDSHAKE_DONE;
+    }
+
+    return TLS_STATE_IN_PROGRESS;
+}
+
 static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                                    uint32_t input_len)
 {
@@ -209,7 +290,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            type (RFC5246 section 7.4.1.4) */
                         if (ssl_state->curr_connp->sni) {
                             SCLogDebug("Multiple SNI extensions");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS);
                             return -1;
                         }
@@ -226,7 +307,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            (RFC6066 section 3) */
                         if (sni_type != SSL_SNI_TYPE_HOST_NAME) {
                             SCLogDebug("Unknown SNI type");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_INVALID_SNI_TYPE);
                             return -1;
                         }
@@ -245,7 +326,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            name length */
                         if (sni_len > 255) {
                             SCLogDebug("SNI length >255");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_INVALID_SNI_LENGTH);
                             return -1;
                         }
@@ -322,7 +403,7 @@ end:
                 if ((ssl_state->curr_connp->record_length +
                         SSLV3_RECORD_HDR_LEN) <
                         ssl_state->curr_connp->bytes_processed) {
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -347,7 +428,7 @@ end:
                    while we expect only the number of bytes parsed bytes
                    from the _current_ fragment */
                 if (write_len < (ssl_state->curr_connp->trec_pos - rc)) {
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -380,8 +461,7 @@ end:
             SCLogDebug("new session ticket");
             break;
         default:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
     }
 
@@ -390,8 +470,7 @@ end:
             ssl_state->curr_connp->record_length + (SSLV3_RECORD_HDR_LEN)) {
         if ((ssl_state->curr_connp->record_length + SSLV3_RECORD_HDR_LEN) <
                 ssl_state->curr_connp->bytes_processed) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
         write_len = (ssl_state->curr_connp->record_length +
@@ -404,8 +483,7 @@ end:
             ssl_state->curr_connp->message_length) {
         if (ssl_state->curr_connp->message_length <
                 ssl_state->curr_connp->trec_pos) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
         parsed += ssl_state->curr_connp->message_length -
@@ -520,8 +598,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
 
     if (!(ssl_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
         if (!(hb_type == TLS_HB_REQUEST || hb_type == TLS_HB_RESPONSE)) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
             return -1;
         }
     }
@@ -553,8 +630,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
            the record (CVE-2014-0160) */
         if ((uint32_t)(payload_len+3) > ssl_state->curr_connp->record_length) {
             SCLogDebug("We have a short record in HeartBeat Request");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT);
             return -1;
         }
 
@@ -563,8 +639,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
         padding_len = ssl_state->curr_connp->record_length - payload_len - 3;
         if (padding_len < 16) {
             SCLogDebug("We have a short record in HeartBeat Request");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
             return -1;
         }
 
@@ -578,15 +653,13 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
     } else if (direction == 1 && (ssl_state->flags & SSL_AL_FLAG_HB_INFLIGHT) &&
             (ssl_state->flags & SSL_AL_FLAG_HB_SERVER_INIT)) {
         SCLogDebug("Multiple in-flight server initiated HeartBeats");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
         return -1;
 
     } else if (direction == 0 && (ssl_state->flags & SSL_AL_FLAG_HB_INFLIGHT) &&
             (ssl_state->flags & SSL_AL_FLAG_HB_CLIENT_INIT)) {
         SCLogDebug("Multiple in-flight client initiated HeartBeats");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
         return -1;
 
     } else {
@@ -605,7 +678,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
                     ssl_state->curr_connp->record_length) {
                 SCLogDebug("My heart is bleeding.. OpenSSL HeartBleed response (%u)",
                         ssl_state->hb_record_len);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_DATALEAK_HEARTBEAT_MISMATCH);
                 ssl_state->hb_record_len = 0;
                 return -1;
@@ -784,8 +857,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
             (ssl_state->curr_connp->record_lengths_length + 1)) {
         retval = SSLv2ParseRecord(direction, ssl_state, input, input_len);
         if (retval == -1) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
             return -1;
         } else {
             input += retval;
@@ -800,16 +872,14 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
     /* record_length should never be zero */
     if (ssl_state->curr_connp->record_length == 0) {
         SCLogDebug("SSLv2 record length is zero");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
         return -1;
     }
 
     /* record_lenghts_length should never be zero */
     if (ssl_state->curr_connp->record_lengths_length == 0) {
         SCLogDebug("SSLv2 record lengths length is zero");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
         return -1;
     }
 
@@ -817,8 +887,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
         case SSLV2_MT_ERROR:
             SCLogDebug("SSLV2_MT_ERROR msg_type received. Error encountered "
                        "in establishing the sslv2 session, may be version");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_ERROR_MSG_ENCOUNTERED);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_ERROR_MSG_ENCOUNTERED);
 
             break;
 
@@ -1039,8 +1108,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
     if (ssl_state->curr_connp->bytes_processed < SSLV3_RECORD_HDR_LEN) {
         retval = SSLv3ParseRecord(direction, ssl_state, input, input_len);
         if (retval < 0) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_TLS_HEADER);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_TLS_HEADER);
             return -1;
         } else {
             parsed += retval;
@@ -1056,16 +1124,14 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
     if (ssl_state->curr_connp->version < SSL_VERSION_3 ||
             ssl_state->curr_connp->version > TLS_VERSION_12) {
 
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_RECORD_VERSION);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_RECORD_VERSION);
         return -1;
     }
 
     /* record_length should never be zero */
     if (ssl_state->curr_connp->record_length == 0) {
         SCLogDebug("SSLv3 Record length is 0");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_TLS_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_TLS_HEADER);
         return -1;
     }
 
@@ -1097,6 +1163,10 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
                         APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
             }
 
+            /* if we see (encrypted) aplication data, then this means the
+               handshake must be done */
+            ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+
             break;
 
         case SSLV3_HANDSHAKE_PROTOCOL:
@@ -1105,16 +1175,15 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
 
             if (ssl_state->curr_connp->record_length < 4) {
                 SSLParserReset(ssl_state);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
-                        TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+                SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                 return -1;
             }
 
             retval = SSLv3ParseHandshakeProtocol(ssl_state, input + parsed, input_len);
             if (retval < 0) {
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_INVALID_HANDSHAKE_MESSAGE);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                 return -1;
             } else {
@@ -1122,7 +1191,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
                     SCLogDebug("Error parsing SSLv3.x. Reseting parser "
                                "state. Let's get outta here");
                     SSLParserReset(ssl_state);
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -1153,10 +1222,8 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
 
         default:
             /* \todo fix the event from invalid rule to unknown rule */
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_RECORD_TYPE);
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_RECORD_TYPE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
     }
 
@@ -1165,8 +1232,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
         if ((ssl_state->curr_connp->record_length + SSLV3_RECORD_HDR_LEN) <
                 ssl_state->curr_connp->bytes_processed) {
             /* defensive checks. Something is wrong. */
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
 
@@ -1223,6 +1289,8 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
 
     if (input == NULL &&
             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
+        /* flag session as finished if APP_LAYER_PARSER_EOF is set */
+        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
         SCReturnInt(1);
     } else if (input == NULL || input_len == 0) {
         SCReturnInt(-1);
@@ -1239,8 +1307,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
             SCLogDebug("Looks like we have looped quite a bit. Reset state "
                        "and get out of here");
             SSLParserReset(ssl_state);
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
 
@@ -1259,7 +1326,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv2.x. Reseting parser "
                                    "state. Let's get outta here");
                         SSLParserReset(ssl_state);
-                        AppLayerDecoderEventsSetEvent(ssl_state->f,
+                        SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                         return -1;
                     } else {
@@ -1277,7 +1344,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv3.x. Reseting parser "
                                    "state. Let's get outta here");
                         SSLParserReset(ssl_state);
-                        AppLayerDecoderEventsSetEvent(ssl_state->f,
+                        SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                         return -1;
                     } else {
@@ -1339,6 +1406,10 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                 break;
         } /* switch (ssl_state->curr_connp->bytes_processed) */
     } /* while (input_len) */
+
+    /* flag session as finished if APP_LAYER_PARSER_EOF is set */
+    if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF))
+        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
 
     return 1;
 }
@@ -1405,6 +1476,12 @@ void SSLStateFree(void *p)
     if (ssl_state->server_connp.sni)
         SCFree(ssl_state->server_connp.sni);
 
+    AppLayerDecoderEventsFreeEvents(&ssl_state->decoder_events);
+
+    if (ssl_state->de_state != NULL) {
+        DetectEngineStateFree(ssl_state->de_state);
+    }
+
     /* Free certificate chain */
     while ((item = TAILQ_FIRST(&ssl_state->server_connp.certs))) {
         TAILQ_REMOVE(&ssl_state->server_connp.certs, item, next);
@@ -1415,6 +1492,11 @@ void SSLStateFree(void *p)
     SCFree(ssl_state);
 
     return;
+}
+
+void SSLStateTransactionFree(void *state, uint64_t tx_id)
+{
+    /* do nothing */
 }
 
 static uint16_t SSLProbingParser(uint8_t *input, uint32_t ilen, uint32_t *offset)
@@ -1443,7 +1525,7 @@ int SSLStateGetEventInfo(const char *event_name,
         return -1;
     }
 
-    *event_type = APP_LAYER_EVENT_TYPE_GENERAL;
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
 }
@@ -1632,10 +1714,30 @@ void RegisterSSLParsers(void)
 
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOCLIENT,
                                      SSLParseServerRecord);
+
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfo);
 
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateAlloc, SSLStateFree);
+
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOSERVER);
+
+        AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
+
+        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
+
+        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLHasEvents);
+
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateHasTxDetectState,
+                                               SSLGetTxDetectState, SSLSetTxDetectState);
+
+        AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);
+
+        AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxCnt);
+
+        AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetAlstateProgress);
+
+        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_TLS,
+                                                               SSLGetAlstateProgressCompletionStatus);
 
         /* Get the value of no reassembly option from the config file */
         if (ConfGetNode("app-layer.protocols.tls.no-reassemble") == NULL) {

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -98,8 +98,6 @@ enum ssl_tx_progress_t {
 /* flags for file storage */
 #define SSL_AL_FLAG_STATE_STORED                0x40000
 
-#define SSL_AL_FLAG_STATE_LOGGED_LUA            0x80000
-
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -26,6 +26,8 @@
 #ifndef __APP_LAYER_SSL_H__
 #define __APP_LAYER_SSL_H__
 
+#include "app-layer-protos.h"
+#include "app-layer-parser.h"
 #include "decode-events.h"
 #include "queue.h"
 
@@ -53,6 +55,12 @@ enum {
     TLS_DECODER_EVENT_INVALID_SSL_RECORD,
 };
 
+enum ssl_tx_progress_t {
+    TLS_STATE_IN_PROGRESS = 0,
+    TLS_HANDSHAKE_DONE = 1,
+    TLS_STATE_FINISHED = 2
+};
+
 /* Flag to indicate that server will now on send encrypted msgs */
 #define SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC   0x0001
 /* Flag to indicate that client will now on send encrypted msgs */
@@ -76,10 +84,16 @@ enum {
 
 #define SSL_AL_FLAG_STATE_LOGGED                0x4000
 
+/* flag to indicate that session is finished */
+#define SSL_AL_FLAG_STATE_FINISHED              0x4000
+
 /* flags specific to HeartBeat state */
 #define SSL_AL_FLAG_HB_INFLIGHT                 0x8000
 #define SSL_AL_FLAG_HB_CLIENT_INIT              0x10000
 #define SSL_AL_FLAG_HB_SERVER_INIT              0x20000
+
+/* flag to indicate that handshake is done */
+#define SSL_AL_FLAG_HANDSHAKE_DONE              0x40000
 
 /* flags for file storage */
 #define SSL_AL_FLAG_STATE_STORED                0x40000
@@ -169,16 +183,22 @@ typedef struct SSLState_ {
     /* holds some state flags we need */
     uint32_t flags;
 
+    /* there might be a better place to store this*/
+    uint16_t hb_record_len;
+
+    uint16_t events;
+
     SSLStateConnp *curr_connp;
 
     SSLStateConnp client_connp;
     SSLStateConnp server_connp;
 
-    /* there might be a better place to store this*/
-    uint16_t hb_record_len;
+    DetectEngineState *de_state;
+    AppLayerDecoderEvents *decoder_events;
 } SSLState;
 
 void RegisterSSLParsers(void);
 void SSLParserRegisterTests(void);
+void SSLSetEvent(SSLState *ssl_state, uint8_t event);
 
 #endif /* __APP_LAYER_SSL_H__ */

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -82,8 +82,6 @@ enum ssl_tx_progress_t {
 #define SSL_AL_FLAG_STATE_SERVER_KEYX           0x1000
 #define SSL_AL_FLAG_STATE_UNKNOWN               0x2000
 
-#define SSL_AL_FLAG_STATE_LOGGED                0x4000
-
 /* flag to indicate that session is finished */
 #define SSL_AL_FLAG_STATE_FINISHED              0x4000
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -93,9 +93,6 @@ enum ssl_tx_progress_t {
 /* flag to indicate that handshake is done */
 #define SSL_AL_FLAG_HANDSHAKE_DONE              0x40000
 
-/* flags for file storage */
-#define SSL_AL_FLAG_STATE_STORED                0x40000
-
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 

--- a/src/app-layer-tls-handshake.c
+++ b/src/app-layer-tls-handshake.c
@@ -58,25 +58,24 @@ static void TLSCertificateErrCodeToWarning(SSLState *ssl_state,
     switch (errcode) {
         case ERR_DER_ELEMENT_SIZE_TOO_BIG:
         case ERR_DER_INVALID_SIZE:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_INVALID_LENGTH);
             break;
         case ERR_DER_UNSUPPORTED_STRING:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_INVALID_STRING);
             break;
         case ERR_DER_UNKNOWN_ELEMENT:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_UNKNOWN_ELEMENT);
             break;
         case ERR_DER_MISSING_ELEMENT:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_MISSING_ELEMENT);
             break;
         case ERR_DER_GENERIC:
         default:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             break;
     };
 }
@@ -108,8 +107,7 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
     i = 0;
     while (certificates_length > 0) {
         if ((uint32_t)(input + 3 - start_data) > (uint32_t)input_len) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 
@@ -119,14 +117,12 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
 
         /* current certificate length should be greater than zero */
         if (cur_cert_length == 0) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 
         if (input - start_data + cur_cert_length > input_len) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -2579,6 +2579,10 @@ static int SignatureCreateMask(Signature *s)
                         s->mask |= SIG_MASK_REQUIRE_DNS_STATE;
                         SCLogDebug("sig %u requires dns app state (dns event)", s->id);
                         break;
+                    case ALPROTO_TLS:
+                        s->mask |= SIG_MASK_REQUIRE_TLS_STATE;
+                        SCLogDebug("sig %u requires tls app state (tls event)", s->id);
+                        break;
                 }
                 break;
             }

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -194,8 +194,6 @@ static TmEcode LogTlsLogThreadDeinit(ThreadVars *t, void *data)
 
 static void LogTlsLogDeInitCtx(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     LogTlsFileCtx *tlslog_ctx = (LogTlsFileCtx *) output_ctx->data;
     LogFileFreeCtx(tlslog_ctx->file_ctx);
     SCFree(tlslog_ctx);
@@ -218,12 +216,6 @@ static void LogTlsLogExitPrintStats(ThreadVars *tv, void *data)
  * */
 static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
 {
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
-
     LogFileCtx* file_ctx = LogFileNewCtx();
 
     if (file_ctx == NULL) {

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -270,87 +270,31 @@ filectx_error:
     return NULL;
 }
 
-/** \internal
- *  \brief Condition function for TLS logger
- *  \retval bool true or false -- log now?
- */
-static int LogTlsCondition(ThreadVars *tv, const Packet *p)
-{
-    if (p->flow == NULL) {
-        return FALSE;
-    }
-
-    if (!(PKT_IS_TCP(p))) {
-        return FALSE;
-    }
-
-    FLOWLOCK_RDLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto dontlog;
-
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
-    if (ssl_state == NULL) {
-        SCLogDebug("no tls state, so no request logging");
-        goto dontlog;
-    }
-
-    /* we only log the state once if we don't have to write
-     * the cert due to tls.store keyword. */
-    if (!(ssl_state->server_connp.cert_log_flag & SSL_TLS_LOG_PEM) &&
-        (ssl_state->flags & SSL_AL_FLAG_STATE_LOGGED))
-        goto dontlog;
-
-    if (ssl_state->server_connp.cert0_issuerdn == NULL ||
-            ssl_state->server_connp.cert0_subject == NULL)
-        goto dontlog;
-
-    /* todo: logic to log once */
-
-    FLOWLOCK_UNLOCK(p->flow);
-    return TRUE;
-dontlog:
-    FLOWLOCK_UNLOCK(p->flow);
-    return FALSE;
-}
-
-static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
+static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
+                        Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     LogTlsLogThread *aft = (LogTlsLogThread *)thread_data;
     LogTlsFileCtx *hlog = aft->tlslog_ctx;
     char timebuf[64];
     int ipproto = (PKT_IS_IPV4(p)) ? AF_INET : AF_INET6;
 
-    if (unlikely(p->flow == NULL)) {
+    SSLState *ssl_state = (SSLState *)state;
+    if (unlikely(ssl_state == NULL)) {
         return 0;
     }
 
-    /* check if we have TLS state or not */
-    FLOWLOCK_WRLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto end;
-
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
-    if (unlikely(ssl_state == NULL)) {
-        goto end;
+    if (ssl_state->server_connp.cert0_issuerdn == NULL ||
+            ssl_state->server_connp.cert0_subject == NULL) {
+        return 0;
     }
-
-    if (ssl_state->server_connp.cert0_issuerdn == NULL || ssl_state->server_connp.cert0_subject == NULL)
-        goto end;
-
-    /* Don't log again the state. If we are here it was because we had
-     * to store the cert. */
-    if (ssl_state->flags & SSL_AL_FLAG_STATE_LOGGED)
-        goto end;
 
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
 #define PRINT_BUF_LEN 46
     char srcip[PRINT_BUF_LEN], dstip[PRINT_BUF_LEN];
     Port sp, dp;
-    if (!TLSGetIPInformations(p, srcip, PRINT_BUF_LEN,
-                              &sp, dstip, PRINT_BUF_LEN, &dp, ipproto)) {
-        goto end;
+    if (!TLSGetIPInformations(p, srcip, PRINT_BUF_LEN, &sp, dstip,
+                              PRINT_BUF_LEN, &dp, ipproto)) {
+        return 0;
     }
 
     MemBufferReset(aft->buffer);
@@ -373,10 +317,6 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
         MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
     SCMutexUnlock(&hlog->file_ctx->fp_mutex);
 
-    /* we only log the state once */
-    ssl_state->flags |= SSL_AL_FLAG_STATE_LOGGED;
-end:
-    FLOWLOCK_UNLOCK(p->flow);
     return 0;
 }
 
@@ -384,13 +324,12 @@ void TmModuleLogTlsLogRegister(void)
 {
     tmm_modules[TMM_LOGTLSLOG].name = MODULE_NAME;
     tmm_modules[TMM_LOGTLSLOG].ThreadInit = LogTlsLogThreadInit;
-    tmm_modules[TMM_LOGTLSLOG].Func = NULL;
     tmm_modules[TMM_LOGTLSLOG].ThreadExitPrintStats = LogTlsLogExitPrintStats;
     tmm_modules[TMM_LOGTLSLOG].ThreadDeinit = LogTlsLogThreadDeinit;
     tmm_modules[TMM_LOGTLSLOG].RegisterTests = NULL;
     tmm_modules[TMM_LOGTLSLOG].cap_flags = 0;
     tmm_modules[TMM_LOGTLSLOG].flags = TM_FLAG_LOGAPI_TM;
 
-    OutputRegisterPacketModule(MODULE_NAME, "tls-log", LogTlsLogInitCtx,
-            LogTlsLogger, LogTlsCondition);
+    OutputRegisterTxModuleWithProgress(MODULE_NAME, "tls-log", LogTlsLogInitCtx,
+            ALPROTO_TLS, LogTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE);
 }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -213,8 +213,6 @@ static TmEcode JsonTlsLogThreadDeinit(ThreadVars *t, void *data)
 
 static void OutputTlsLogDeinit(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     OutputTlsCtx *tls_ctx = output_ctx->data;
     LogFileCtx *logfile_ctx = tls_ctx->file_ctx;
     LogFileFreeCtx(logfile_ctx);
@@ -225,12 +223,6 @@ static void OutputTlsLogDeinit(OutputCtx *output_ctx)
 #define DEFAULT_LOG_FILENAME "tls.json"
 OutputCtx *OutputTlsLogInit(ConfNode *conf)
 {
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
-
     LogFileCtx *file_ctx = LogFileNewCtx();
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_TLS_LOG_GENERIC, "couldn't create new file_ctx");
@@ -277,8 +269,6 @@ OutputCtx *OutputTlsLogInit(ConfNode *conf)
 
 static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     OutputTlsCtx *tls_ctx = output_ctx->data;
     SCFree(tls_ctx);
     SCFree(output_ctx);
@@ -287,12 +277,6 @@ static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputJsonCtx *ojc = parent_ctx->data;
-
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
 
     OutputTlsCtx *tls_ctx = SCMalloc(sizeof(OutputTlsCtx));
     if (unlikely(tls_ctx == NULL))

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -38,6 +38,9 @@ typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f
 
 int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *);
 
+int OutputRegisterTxLoggerWithProgress(const char *name, AppProto alproto,
+        TxLogger LogFunc, OutputCtx *, int tc_log_progress, int ts_log_progress);
+
 void TmModuleTxLoggerRegister (void);
 
 void OutputTxShutdown(void);

--- a/src/output.c
+++ b/src/output.c
@@ -684,22 +684,6 @@ void OutputDropLoggerDisable(void)
         drop_loggers--;
 }
 
-static int tls_loggers = 0;
-
-int OutputTlsLoggerEnable(void)
-{
-    if (tls_loggers)
-        return -1;
-    tls_loggers++;
-    return 0;
-}
-
-void OutputTlsLoggerDisable(void)
-{
-    if (tls_loggers)
-        tls_loggers--;
-}
-
 static int ssh_loggers = 0;
 
 int OutputSshLoggerEnable(void)

--- a/src/output.c
+++ b/src/output.c
@@ -215,6 +215,74 @@ error:
 }
 
 /**
+ * \brief Register a tx output module with progress.
+ *
+ * This function will register an output module so it can be
+ * configured with the configuration file.
+ *
+ * \retval Returns 0 on success, -1 on failure.
+ */
+void OutputRegisterTxModuleWithProgress(const char *name, const char *conf_name,
+        OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+        TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress)
+{
+    if (unlikely(TxLogFunc == NULL)) {
+        goto error;
+    }
+
+    OutputModule *module = SCCalloc(1, sizeof(*module));
+    if (unlikely(module == NULL)) {
+        goto error;
+    }
+
+    module->name = name;
+    module->conf_name = conf_name;
+    module->InitFunc = InitFunc;
+    module->TxLogFunc = TxLogFunc;
+    module->alproto = alproto;
+    module->tc_log_progress = tc_log_progress;
+    module->ts_log_progress = ts_log_progress;
+    TAILQ_INSERT_TAIL(&output_modules, module, entries);
+
+    SCLogDebug("Tx logger \"%s\" registered.", name);
+    return;
+error:
+    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
+    exit(EXIT_FAILURE);
+}
+
+void OutputRegisterTxSubModuleWithProgress(const char *parent_name,
+        const char *name, const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *,
+        OutputCtx *parent_ctx), AppProto alproto, TxLogger TxLogFunc,
+        int tc_log_progress, int ts_log_progress)
+{
+    if (unlikely(TxLogFunc == NULL)) {
+        goto error;
+    }
+
+    OutputModule *module = SCCalloc(1, sizeof(*module));
+    if (unlikely(module == NULL)) {
+        goto error;
+    }
+
+    module->name = name;
+    module->conf_name = conf_name;
+    module->parent_name = parent_name;
+    module->InitSubFunc = InitFunc;
+    module->TxLogFunc = TxLogFunc;
+    module->alproto = alproto;
+    module->tc_log_progress = tc_log_progress;
+    module->ts_log_progress = ts_log_progress;
+    TAILQ_INSERT_TAIL(&output_modules, module, entries);
+
+    SCLogDebug("Tx logger \"%s\" registered.", name);
+    return;
+error:
+    SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
+    exit(EXIT_FAILURE);
+}
+
+/**
  * \brief Register a file output module.
  *
  * This function will register an output module so it can be

--- a/src/output.h
+++ b/src/output.h
@@ -55,6 +55,8 @@ typedef struct OutputModule_ {
     StatsLogger StatsLogFunc;
     AppProto alproto;
     enum OutputStreamingType stream_type;
+    int tc_log_progress;
+    int ts_log_progress;
 
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
@@ -74,6 +76,13 @@ void OutputRegisterTxModule(const char *name, const char *conf_name,
 void OutputRegisterTxSubModule(const char *parent_name, const char *name,
     const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
     AppProto alproto, TxLogger TxLogFunc);
+
+void OutputRegisterTxModuleWithProgress(const char *name, const char *conf_name,
+    OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+    TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress);
+void OutputRegisterTxSubModuleWithProgress(const char *parent_name, const char *name,
+    const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
+    AppProto alproto, TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress);
 
 void OutputRegisterFileModule(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), FileLogger FileLogFunc);

--- a/src/output.h
+++ b/src/output.h
@@ -121,9 +121,6 @@ void OutputDeregisterAll(void);
 int OutputDropLoggerEnable(void);
 void OutputDropLoggerDisable(void);
 
-int OutputTlsLoggerEnable(void);
-void OutputTlsLoggerDisable(void);
-
 int OutputSshLoggerEnable(void);
 void OutputSshLoggerDisable(void);
 

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -604,8 +604,14 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
         }
     } else if (module->TxLogFunc) {
         SCLogDebug("%s is a tx logger", module->name);
-        OutputRegisterTxLogger(module->name, module->alproto,
-                module->TxLogFunc, output_ctx);
+        if (module->tc_log_progress || module->ts_log_progress) {
+            OutputRegisterTxLoggerWithProgress(module->name, module->alproto,
+                    module->TxLogFunc, output_ctx, module->tc_log_progress,
+                    module->ts_log_progress);
+        } else {
+            OutputRegisterTxLogger(module->name, module->alproto,
+                    module->TxLogFunc, output_ctx);
+        }
 
         /* need one instance of the tx logger module */
         if (tx_logger_module == NULL) {


### PR DESCRIPTION
Changed app-layer-ssl to use tx API's and modifed all the TLS loggers to use TxLogger.

This enables the use of multiple TLS Lua output scripts (before only one worked), and enables the use of several TLS loggers active at the same time.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/23
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/23