### PR TITLE
Fix wrong boolean conf read v1

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -359,9 +359,9 @@ void *ParseAFPConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {
         if (strcmp(tmpctype, "auto") == 0) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (strcmp(tmpctype, "yes") == 0) {
+        } else if (ConfValIsTrue(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(tmpctype, "no") == 0) {
+        } else if (ConfValIsFalse(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         } else if (strcmp(tmpctype, "kernel") == 0) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_KERNEL;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -254,9 +254,9 @@ static void *ParseNetmapConfig(const char *iface_name)
     if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {
         if (strcmp(tmpctype, "auto") == 0) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (strcmp(tmpctype, "yes") == 0) {
+        } else if (ConfValIsTrue(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(tmpctype, "no") == 0) {
+        } else if (ConfValIsFalse(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         } else {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for checksum-checks for %s", aconf->iface_name);

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -191,9 +191,9 @@ void *ParsePcapConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {
         if (strcmp(tmpctype, "auto") == 0) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (strcmp(tmpctype, "yes") == 0) {
+        } else if (ConfValIsTrue(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(tmpctype, "no") == 0) {
+        } else if (ConfValIsFalse(tmpctype)) {
             aconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         } else {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for checksum-checks for %s", aconf->iface);

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -354,9 +354,9 @@ void *ParsePfringConfig(const char *iface)
     if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {
         if (strcmp(tmpctype, "auto") == 0) {
             pfconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (strcmp(tmpctype, "yes") == 0) {
+        } else if (ConfValIsTrue(tmpctype)) {
             pfconf->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(tmpctype, "no") == 0) {
+        } else if (ConfValIsFalse(tmpctype)) {
             pfconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         } else if (strcmp(tmpctype, "rx-only") == 0) {
             pfconf->checksum_mode = CHECKSUM_VALIDATION_RXONLY;

--- a/src/source-mpipe.c
+++ b/src/source-mpipe.c
@@ -352,9 +352,9 @@ TmEcode ReceiveMpipeLoop(ThreadVars *tv, void *data, void *slot)
 
     ptv->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
     if (ConfGet("mpipe.checksum-checks", &ctype) == 1) {
-        if (strcmp(ctype, "yes") == 0) {
+        if (ConfValIsTrue(ctype)) {
             ptv->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(ctype, "no") == 0)  {
+        } else if (ConfValIsFalse(ctype))  {
             ptv->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         } else {
             SCLogError(SC_ERR_INVALID_ARGUMENT, 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -352,9 +352,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, void *initdata, void **data)
     } else {
         if (strcmp(tmpstring, "auto") == 0) {
             pcap_g.conf_checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (strcmp(tmpstring, "yes") == 0) {
+        } else if (ConfValIsTrue(tmpstring)){
             pcap_g.conf_checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (strcmp(tmpstring, "no") == 0) {
+        } else if (ConfValIsFalse(tmpstring)) {
             pcap_g.conf_checksum_mode = CHECKSUM_VALIDATION_DISABLE;
         }
     }

--- a/src/util-logopenfile-tile.c
+++ b/src/util-logopenfile-tile.c
@@ -349,7 +349,7 @@ PcieFile *TileOpenPcieFp(LogFileCtx *log_ctx, const char *path,
                          const char *append_setting)
 {
     PcieFile *ret = NULL;
-    if (strcasecmp(append_setting, "yes") == 0) {
+    if (ConfValIsTrue(append_setting)) {
         ret = TileOpenPcieFpInternal(path, 'a');
     } else {
         ret = TileOpenPcieFpInternal(path, 'w');

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -172,7 +172,7 @@ SCLogOpenFileFp(const char *path, const char *append_setting)
 {
     FILE *ret = NULL;
 
-    if (strcasecmp(append_setting, "yes") == 0) {
+    if (ConfValIsTrue(append_setting)) {
         ret = fopen(path, "a");
     } else {
         ret = fopen(path, "w");


### PR DESCRIPTION
Multiple places there were checks for "yes" or "no" with regards to some functionality being enabled or not. Refactored these to use the ConfValIsTrue / ConfValIsFalse so that it is more accepting of valid YAML input (true being 1,yes,true,on. false being 0,no,false,off).