### PR TITLE
sources: allow interface definitions to be reordered - v2

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -163,9 +163,9 @@ void *ParseAFPConfig(const char *iface)
         return aconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", iface);
+    if_root = ConfFindDeviceConfig(af_packet_node, iface);
 
-    if_default = ConfNodeLookupKeyValue(af_packet_node, "interface", "default");
+    if_default = ConfFindDeviceConfig(af_packet_node, "default");
 
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("Unable to find af-packet config for "
@@ -433,7 +433,7 @@ int AFPRunModeIsIPS()
             return 0;
         }
         char *copymodestr = NULL;
-        if_root = ConfNodeLookupKeyValue(af_packet_node, "interface", live_dev);
+        if_root = ConfFindDeviceConfig(af_packet_node, live_dev);
 
         if (if_root == NULL) {
             if (if_default == NULL) {

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -159,9 +159,9 @@ static void *ParseNetmapConfig(const char *iface_name)
         return aconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(netmap_node, "interface", aconf->iface_name);
+    if_root = ConfFindDeviceConfig(netmap_node, "interface", aconf->iface_name);
 
-    if_default = ConfNodeLookupKeyValue(netmap_node, "interface", "default");
+    if_default = ConfFindDeviceConfig(netmap_node, "default");
 
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("Unable to find netmap config for "

--- a/src/runmode-pcap.c
+++ b/src/runmode-pcap.c
@@ -121,9 +121,9 @@ void *ParsePcapConfig(const char *iface)
         return aconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(pcap_node, "interface", iface);
+    if_root = ConfFindDeviceConfig(pcap_node, "iface");
 
-    if_default = ConfNodeLookupKeyValue(pcap_node, "interface", "default");
+    if_default = ConfFindDeviceConfig(pcap_node, "default");
 
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("Unable to find pcap config for "

--- a/src/runmode-pfring.c
+++ b/src/runmode-pfring.c
@@ -230,9 +230,9 @@ void *ParsePfringConfig(const char *iface)
         return pfconf;
     }
 
-    if_root = ConfNodeLookupKeyValue(pf_ring_node, "interface", iface);
+    if_root = ConfFindDeviceConfig(pf_ring_node, iface);
 
-    if_default = ConfNodeLookupKeyValue(pf_ring_node, "interface", "default");
+    if_default = ConfFindDeviceConfig(pf_ring_node, "default");
 
     if (if_root == NULL && if_default == NULL) {
         SCLogInfo("Unable to find pfring config for "

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -25,6 +25,7 @@
 #include "suricata-common.h"
 #include "config.h"
 #include "conf.h"
+#include "util-conf.h"
 
 TmEcode ConfigSetLogDirectory(char *name)
 {
@@ -62,4 +63,31 @@ TmEcode ConfigCheckLogDirectory(char *log_dir)
             SCReturnInt(TM_ECODE_FAILED);
     }
     SCReturnInt(TM_ECODE_OK);
+}
+
+/**
+ * \brief Find the configuration node for a specific device.
+
+ * Basically hunts through the list of maps for the first one with a
+ * key of "interface", and a value of the provided interface.
+ *
+ * \param node The node to start looking for the device
+ *     configuration. Typically this would be something like the af-packet
+ *     or pf-ring node.
+ *
+ * \param iface The name of the interface to find the config for.
+ */
+ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface)
+{
+    ConfNode *if_node, *item;
+    const char key[] = "interface";
+    TAILQ_FOREACH(if_node, &node->head, next) {
+        TAILQ_FOREACH(item, &if_node->head, next) {
+            if (!(strcmp(item->name, key) && strcmp(item->val, iface))) {
+                return if_node;
+            }
+        }
+    }
+
+    return NULL;
 }

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -25,8 +25,12 @@
 #ifndef __UTIL_UTIL_CONF_H__
 #define __UTIL_UTIL_CONF_H__
 
+#include "conf.h"
+
 TmEcode ConfigSetLogDirectory(char *name);
 char *ConfigGetLogDirectory();
 TmEcode ConfigCheckLogDirectory(char *log_dir);
+
+ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface);
 
 #endif /* __UTIL_UTIL_CONF_H__ */


### PR DESCRIPTION
Previous PR: https://github.com/inliniac/suricata/pull/1554
Related ticket: https://redmine.openinfosecfoundation.org/issues/1487

For af-packet, pf-ring, netmap, and pcap use a generic
lookup function to find the configuration node for an
interface.

The new lookup function does not depend on the ordering
of the items inside the device configuration.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/222
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/227
