### PR TITLE
config-test: fix memory leak detected by ASAN

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2353,10 +2353,13 @@ static int PostConfLoadedSetup(SCInstance *suri)
     if (InitSignalHandler(suri) != TM_ECODE_OK)
         SCReturnInt(TM_ECODE_FAILED);
 
+
 #ifdef HAVE_NSS
-    /* init NSS for md5 */
-    PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
-    NSS_NoDB_Init(NULL);
+    if (suri->run_mode != RUNMODE_CONF_TEST) {
+        /* init NSS for md5 */
+        PR_Init(PR_USER_THREAD, PR_PRIORITY_NORMAL, 0);
+        NSS_NoDB_Init(NULL);
+    }
 #endif
 
     if (suri->disabled_detect) {
@@ -2536,6 +2539,7 @@ int main(int argc, char **argv)
 
     if (suri.run_mode == RUNMODE_CONF_TEST){
         SCLogNotice("Configuration provided was successfully loaded. Exiting.");
+        MagicDeinit();
         exit(EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
NSS library was not deinit at exit resulting in memory leak. As
it is useless for a config test, the patch updates the code so it
is not initialized.

Patch also calls MagicDeinit to free memory used by libmagic.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/171
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/167
