### PR TITLE
app-layer-ssl: make tx aware - v13

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -236,6 +236,21 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction)
     }
 }
 
+void DNSSetTxLogged(void *alstate, void *tx, uint32_t logger)
+{
+    DNSTransaction *dns_tx = (DNSTransaction *)tx;
+    dns_tx->logged |= logger;
+}
+
+int DNSGetTxLogged(void *alstate, void *tx, uint32_t logger)
+{
+    DNSTransaction *dns_tx = (DNSTransaction *)tx;
+    if (dns_tx->logged & logger)
+        return 1;
+
+    return 0;
+}
+
 /** \brief get value for 'complete' status in DNS
  *
  *  For DNS we use a simple bool. 1 means done.

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -191,6 +191,7 @@ typedef struct DNSAnswerEntry_ {
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
     uint16_t tx_id;                                 /**< transaction id */
+    uint32_t logged;                                /**< flags for loggers done logging */
     uint8_t replied;                                /**< bool indicating request is
                                                          replied to. */
     uint8_t reply_lost;
@@ -253,6 +254,8 @@ void DNSAppLayerRegisterGetEventInfo(uint8_t ipproto, AppProto alproto);
 
 void *DNSGetTx(void *alstate, uint64_t tx_id);
 uint64_t DNSGetTxCnt(void *alstate);
+void DNSSetTxLogged(void *alstate, void *tx, uint32_t logger);
+int DNSGetTxLogged(void *alstate, void *tx, uint32_t logger);
 int DNSGetAlstateProgress(void *tx, uint8_t direction);
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -664,7 +664,7 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_DNS, DNSGetTxCnt);
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_DNS,
                                                    DNSGetAlstateProgress);
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_DNS,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
     } else {

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -662,6 +662,8 @@ void RegisterDNSTCPParsers(void)
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_DNS, DNSGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_DNS, DNSGetTxCnt);
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_DNS, DNSGetTxLogged,
+                                          DNSSetTxLogged);
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_DNS,
                                                    DNSGetAlstateProgress);
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -422,7 +422,7 @@ void RegisterDNSUDPParsers(void)
                                        DNSGetTxCnt);
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_UDP, ALPROTO_DNS,
                                                    DNSGetAlstateProgress);
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_UDP, ALPROTO_DNS,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
 
         DNSAppLayerRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DNS);

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -420,6 +420,8 @@ void RegisterDNSUDPParsers(void)
                                     DNSGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_DNS,
                                        DNSGetTxCnt);
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_UDP, ALPROTO_DNS, DNSGetTxLogged,
+                                          DNSSetTxLogged);
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_UDP, ALPROTO_DNS,
                                                    DNSGetAlstateProgress);
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2634,6 +2634,24 @@ static void *HTPStateGetTx(void *alstate, uint64_t tx_id)
         return NULL;
 }
 
+static void HTPStateSetTxLogged(void *alstate, void *vtx, uint32_t logger)
+{
+    htp_tx_t *tx = (htp_tx_t *)vtx;
+    HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
+    if (tx_ud)
+        tx_ud->logged |= logger;
+}
+
+static int HTPStateGetTxLogged(void *alstate, void *vtx, uint32_t logger)
+{
+    htp_tx_t *tx = (htp_tx_t *)vtx;
+    HtpTxUserData *tx_ud = (HtpTxUserData *) htp_tx_get_user_data(tx);
+    if (tx_ud && (tx_ud->logged & logger))
+        return 1;
+
+    return 0;
+}
+
 static int HTPStateGetAlstateProgressCompletionStatus(uint8_t direction)
 {
     return (direction & STREAM_TOSERVER) ? HTP_REQUEST_COMPLETE : HTP_RESPONSE_COMPLETE;
@@ -2769,6 +2787,8 @@ void RegisterHTPParsers(void)
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetAlstateProgress);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetTxCnt);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetTx);
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetTxLogged,
+                                          HTPStateSetTxLogged);
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_HTTP,
                                                                HTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPHasEvents);

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2769,7 +2769,7 @@ void RegisterHTPParsers(void)
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetAlstateProgress);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetTxCnt);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_HTTP, HTPStateGetTx);
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_HTTP,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_HTTP,
                                                                HTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPHasEvents);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_HTTP, HTPGetEvents);

--- a/src/app-layer-htp.h
+++ b/src/app-layer-htp.h
@@ -205,6 +205,10 @@ typedef struct HtpTxUserData_ {
     /* Body of the request (if any) */
     uint8_t request_body_init;
     uint8_t response_body_init;
+
+    /* indicates which loggers that have logged */
+    uint32_t logged;
+
     HtpBody request_body;
     HtpBody response_body;
 

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1483,7 +1483,7 @@ void RegisterModbusParsers(void)
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateTxFree);
 
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetAlstateProgress);
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_MODBUS,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_MODBUS,
                                                                 ModbusGetAlstateProgressCompletionStatus);
 
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateGetEventInfo);

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -249,6 +249,21 @@ void *ModbusGetTx(void *alstate, uint64_t tx_id) {
     return NULL;
 }
 
+void ModbusSetTxLogged(void *alstate, void *vtx, uint32_t logger)
+{
+    ModbusTransaction *tx = (ModbusTransaction *)vtx;
+    tx->logged |= logger;
+}
+
+int ModbusGetTxLogged(void *alstate, void *vtx, uint32_t logger)
+{
+    ModbusTransaction *tx = (ModbusTransaction *)vtx;
+    if (tx->logged & logger)
+        return 1;
+
+    return 0;
+}
+
 uint64_t ModbusGetTxCnt(void *alstate) {
     return ((uint64_t) ((ModbusState *) alstate)->transaction_max);
 }
@@ -1480,6 +1495,8 @@ void RegisterModbusParsers(void)
 
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetTx);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetTxCnt);
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetTxLogged,
+                                          ModbusSetTxLogged);
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateTxFree);
 
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_MODBUS, ModbusGetAlstateProgress);

--- a/src/app-layer-modbus.h
+++ b/src/app-layer-modbus.h
@@ -83,6 +83,7 @@ typedef struct ModbusTransaction_ {
     struct ModbusState_ *modbus;
 
     uint64_t    tx_num;         /**< internal: id */
+    uint32_t    logged;         /**< flags indicating which loggers have logged */
     uint16_t    transactionId;
     uint16_t    length;
     uint8_t     function;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -449,13 +449,12 @@ void AppLayerParserRegisterGetTx(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
-void AppLayerParserRegisterGetStateProgressCompletionStatus(uint8_t ipproto,
-                                                   AppProto alproto,
+void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
     int (*StateGetProgressCompletionStatus)(uint8_t direction))
 {
     SCEnter();
 
-    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+    alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
         StateGetProgressCompletionStatus = StateGetProgressCompletionStatus;
 
     SCReturn;
@@ -555,7 +554,7 @@ void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
     int direction = (flags & STREAM_TOSERVER) ? 0 : 1;
     uint64_t total_txs = AppLayerParserGetTxCnt(ipproto, alproto, alstate);
     uint64_t idx = AppLayerParserGetTransactionInspectId(pstate, flags);
-    int state_done_progress = AppLayerParserGetStateProgressCompletionStatus(ipproto, alproto, flags);
+    int state_done_progress = AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
     void *tx;
     int state_progress;
 
@@ -663,7 +662,7 @@ uint64_t AppLayerTransactionGetActiveLogOnly(Flow *f, uint8_t flags)
     /* logger is disabled, return highest 'complete' tx id */
     uint64_t total_txs = AppLayerParserGetTxCnt(f->proto, f->alproto, f->alstate);
     uint64_t idx = AppLayerParserGetTransactionInspectId(f->alparser, flags);
-    int state_done_progress = AppLayerParserGetStateProgressCompletionStatus(f->proto, f->alproto, flags);
+    int state_done_progress = AppLayerParserGetStateProgressCompletionStatus(f->alproto, flags);
     void *tx;
     int state_progress;
 
@@ -739,7 +738,7 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
     SCEnter();
     int r = 0;
     if (unlikely(IS_DISRUPTED(flags))) {
-        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+        r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
             StateGetProgressCompletionStatus(flags);
     } else {
         r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
@@ -766,12 +765,12 @@ void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint
     SCReturnPtr(r, "void *");
 }
 
-int AppLayerParserGetStateProgressCompletionStatus(uint8_t ipproto, AppProto alproto,
-                                        uint8_t direction)
+int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto,
+                                                   uint8_t direction)
 {
     SCEnter();
     int r = 0;
-    r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+    r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
                 StateGetProgressCompletionStatus(direction);
     SCReturnInt(r);
 }

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -107,6 +107,9 @@ typedef struct AppLayerParserProtoCtx_
     int (*StateGetEventInfo)(const char *event_name,
                              int *event_id, AppLayerEventType *event_type);
 
+    int (*StateGetTxLogged)(void *alstate, void *tx, uint32_t logger);
+    void (*StateSetTxLogged)(void *alstate, void *tx, uint32_t logger);
+
     int (*StateHasTxDetectState)(void *alstate);
     DetectEngineState *(*GetTxDetectState)(void *tx);
     int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *);
@@ -386,6 +389,21 @@ void AppLayerParserRegisterHasEventsFunc(uint8_t ipproto, AppProto alproto,
     SCReturn;
 }
 
+void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
+                           int (*StateGetTxLogged)(void *, void *, uint32_t),
+                           void (*StateSetTxLogged)(void *, void *, uint32_t))
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateGetTxLogged =
+        StateGetTxLogged;
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].StateSetTxLogged =
+        StateSetTxLogged;
+
+    SCReturn;
+}
+
 void AppLayerParserRegisterLogger(uint8_t ipproto, AppProto alproto)
 {
     SCEnter();
@@ -516,6 +534,35 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
     }
 
     SCReturn;
+}
+
+void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto,
+                               void *alstate, void *tx, uint32_t logger)
+{
+    SCEnter();
+
+    if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+            StateSetTxLogged != NULL) {
+        alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+                StateSetTxLogged(alstate, tx, logger);
+    }
+
+    SCReturn;
+}
+
+int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto,
+                              void *alstate, void *tx, uint32_t logger)
+{
+    SCEnter();
+
+    uint8_t r = 0;
+    if (alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+            StateGetTxLogged != NULL) {
+        r = alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].
+                StateGetTxLogged(alstate, tx, logger);
+    }
+
+    SCReturnInt(r);
 }
 
 uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -136,8 +136,7 @@ void AppLayerParserRegisterGetTxCnt(uint8_t ipproto, AppProto alproto,
                          uint64_t (*StateGetTxCnt)(void *alstate));
 void AppLayerParserRegisterGetTx(uint8_t ipproto, AppProto alproto,
                       void *(StateGetTx)(void *alstate, uint64_t tx_id));
-void AppLayerParserRegisterGetStateProgressCompletionStatus(uint8_t ipproto,
-                                                 AppProto alproto,
+void AppLayerParserRegisterGetStateProgressCompletionStatus(AppProto alproto,
     int (*StateGetStateProgressCompletionStatus)(uint8_t direction));
 void AppLayerParserRegisterGetEventInfo(uint8_t ipproto, AppProto alproto,
     int (*StateGetEventInfo)(const char *event_name, int *event_id,
@@ -171,8 +170,7 @@ int AppLayerParserGetStateProgress(uint8_t ipproto, AppProto alproto,
                         void *alstate, uint8_t direction);
 uint64_t AppLayerParserGetTxCnt(uint8_t ipproto, AppProto alproto, void *alstate);
 void *AppLayerParserGetTx(uint8_t ipproto, AppProto alproto, void *alstate, uint64_t tx_id);
-int AppLayerParserGetStateProgressCompletionStatus(uint8_t ipproto, AppProto alproto,
-                                        uint8_t direction);
+int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto, uint8_t direction);
 int AppLayerParserGetEventInfo(uint8_t ipproto, AppProto alproto, const char *event_name,
                     int *event_id, AppLayerEventType *event_type);
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -125,6 +125,9 @@ void AppLayerParserRegisterGetEventsFunc(uint8_t ipproto, AppProto proto,
     AppLayerDecoderEvents *(*StateGetEvents)(void *, uint64_t));
 void AppLayerParserRegisterHasEventsFunc(uint8_t ipproto, AppProto alproto,
                               int (*StateHasEvents)(void *));
+void AppLayerParserRegisterLoggerFuncs(uint8_t ipproto, AppProto alproto,
+                         int (*StateGetTxLogged)(void *, void *, uint32_t),
+                         void (*StateSetTxLogged)(void *, void *, uint32_t));
 void AppLayerParserRegisterLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserRegisterTruncateFunc(uint8_t ipproto, AppProto alproto,
                              void (*Truncate)(void *, uint8_t));
@@ -155,6 +158,10 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
 
 uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate);
 void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate);
+void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
+                               void *tx, uint32_t logger);
+int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
+                              void *tx, uint32_t logger);
 uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint8_t direction);
 void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
                                 const uint8_t ipproto, const AppProto alproto, void *alstate,

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1642,7 +1642,7 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetAlstateProgress);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetTxCnt);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetTx);
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_SMTP,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_SMTP,
                                                                SMTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterTruncateFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateTruncate);
     } else {

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1545,6 +1545,21 @@ static void *SMTPStateGetTx(void *state, uint64_t id)
 
 }
 
+static void SMTPStateSetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    SMTPTransaction *tx = vtx;
+    tx->logged |= logger;
+}
+
+static int SMTPStateGetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    SMTPTransaction *tx = vtx;
+    if (tx->logged & logger)
+        return 1;
+
+    return 0;
+}
+
 static int SMTPStateGetAlstateProgressCompletionStatus(uint8_t direction) {
     return 1;
 }
@@ -1642,6 +1657,8 @@ void RegisterSMTPParsers(void)
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetAlstateProgress);
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetTxCnt);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetTx);
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateGetTxLogged,
+                                          SMTPStateSetTxLogged);
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_SMTP,
                                                                SMTPStateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterTruncateFunc(IPPROTO_TCP, ALPROTO_SMTP, SMTPStateTruncate);

--- a/src/app-layer-smtp.h
+++ b/src/app-layer-smtp.h
@@ -66,6 +66,8 @@ typedef struct SMTPTransaction_ {
     /** id of this tx, starting at 0 */
     uint64_t tx_id;
     int done;
+    /** indicates loggers done logging */
+    uint32_t logged;
     /** the first message contained in the session */
     MimeDecEntity *msg_head;
     /** the last message contained in the session */

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -190,6 +190,22 @@ uint64_t SSLGetTxCnt(void *state)
     return 1;
 }
 
+void SSLSetTxLogged(void *state, void *tx, uint32_t logger)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    if (ssl_state)
+        ssl_state->logged |= logger;
+}
+
+int SSLGetTxLogged(void *state, void *tx, uint32_t logger)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    if (ssl_state && (ssl_state->logged & logger))
+        return 1;
+
+    return 0;
+}
+
 int SSLGetAlstateProgressCompletionStatus(uint8_t direction)
 {
     return TLS_STATE_FINISHED;
@@ -1740,6 +1756,8 @@ void RegisterSSLParsers(void)
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxCnt);
 
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetAlstateProgress);
+
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxLogged, SSLSetTxLogged);
 
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_TLS,
                                                                SSLGetAlstateProgressCompletionStatus);

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -3899,9 +3899,9 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -3933,9 +3933,10 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -3968,11 +3969,13 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -4005,12 +4008,15 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC | SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;
@@ -4041,12 +4047,15 @@ static int SSLParserTest23(void)
         goto end;
     }
 
-    if (app_state->flags !=
-        (SSL_AL_FLAG_STATE_CLIENT_HELLO | SSL_AL_FLAG_SSL_CLIENT_HS |
-         SSL_AL_FLAG_SSL_NO_SESSION_ID | SSL_AL_FLAG_STATE_SERVER_HELLO |
-         SSL_AL_FLAG_STATE_CLIENT_KEYX | SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC | SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC |
-         SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
+    if ((app_state->flags & SSL_AL_FLAG_STATE_CLIENT_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_CLIENT_HS) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SSL_NO_SESSION_ID) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_SERVER_HELLO) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_STATE_CLIENT_KEYX) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CLIENT_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC) == 0 ||
+        (app_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC) == 0) {
         printf("flags not set\n");
         result = 0;
         goto end;

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -133,6 +133,87 @@ static void SSLParserReset(SSLState *ssl_state)
     ssl_state->curr_connp->bytes_processed = 0;
 }
 
+void SSLSetEvent(SSLState *ssl_state, uint8_t event)
+{
+    if (ssl_state == NULL) {
+        SCLogDebug("Could not set decoder event: %u", event);
+        return;
+    }
+
+    AppLayerDecoderEventsSetEventRaw(&ssl_state->decoder_events, event);
+    ssl_state->events++;
+}
+
+AppLayerDecoderEvents *SSLGetEvents(void *state, uint64_t id)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return ssl_state->decoder_events;
+}
+
+int SSLHasEvents(void *state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return (ssl_state->events > 0);
+}
+
+int SSLStateHasTxDetectState(void *state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    if (ssl_state->de_state)
+        return 1;
+
+    return 0;
+}
+
+int SSLSetTxDetectState(void *state, void *vtx, DetectEngineState *de_state)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    ssl_state->de_state = de_state;
+    return 0;
+}
+
+DetectEngineState *SSLGetTxDetectState(void *vtx)
+{
+    SSLState *ssl_state = (SSLState *)vtx;
+    return ssl_state->de_state;
+}
+
+void *SSLGetTx(void *state, uint64_t tx_id)
+{
+    SSLState *ssl_state = (SSLState *)state;
+    return ssl_state;
+}
+
+uint64_t SSLGetTxCnt(void *state)
+{
+    /* single tx */
+    return 1;
+}
+
+int SSLGetAlstateProgressCompletionStatus(uint8_t direction)
+{
+    return TLS_STATE_FINISHED;
+}
+
+int SSLGetAlstateProgress(void *tx, uint8_t direction)
+{
+    SSLState *ssl_state = (SSLState *)tx;
+
+    /* we don't care about direction, only that app-layer parser is done
+       and have sent an EOF */
+    if (ssl_state->flags & SSL_AL_FLAG_STATE_FINISHED) {
+        return TLS_STATE_FINISHED;
+    }
+
+    /* we want the logger to log when the handshake is done, even if the
+       state is not finished */
+    if (ssl_state->flags & SSL_AL_FLAG_HANDSHAKE_DONE) {
+        return TLS_HANDSHAKE_DONE;
+    }
+
+    return TLS_STATE_IN_PROGRESS;
+}
+
 static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                                    uint32_t input_len)
 {
@@ -209,7 +290,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            type (RFC5246 section 7.4.1.4) */
                         if (ssl_state->curr_connp->sni) {
                             SCLogDebug("Multiple SNI extensions");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_MULTIPLE_SNI_EXTENSIONS);
                             return -1;
                         }
@@ -226,7 +307,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            (RFC6066 section 3) */
                         if (sni_type != SSL_SNI_TYPE_HOST_NAME) {
                             SCLogDebug("Unknown SNI type");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_INVALID_SNI_TYPE);
                             return -1;
                         }
@@ -245,7 +326,7 @@ static int SSLv3ParseHandshakeType(SSLState *ssl_state, uint8_t *input,
                            name length */
                         if (sni_len > 255) {
                             SCLogDebug("SNI length >255");
-                            AppLayerDecoderEventsSetEvent(ssl_state->f,
+                            SSLSetEvent(ssl_state,
                                     TLS_DECODER_EVENT_INVALID_SNI_LENGTH);
                             return -1;
                         }
@@ -322,7 +403,7 @@ end:
                 if ((ssl_state->curr_connp->record_length +
                         SSLV3_RECORD_HDR_LEN) <
                         ssl_state->curr_connp->bytes_processed) {
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -347,7 +428,7 @@ end:
                    while we expect only the number of bytes parsed bytes
                    from the _current_ fragment */
                 if (write_len < (ssl_state->curr_connp->trec_pos - rc)) {
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -380,8 +461,7 @@ end:
             SCLogDebug("new session ticket");
             break;
         default:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
     }
 
@@ -390,8 +470,7 @@ end:
             ssl_state->curr_connp->record_length + (SSLV3_RECORD_HDR_LEN)) {
         if ((ssl_state->curr_connp->record_length + SSLV3_RECORD_HDR_LEN) <
                 ssl_state->curr_connp->bytes_processed) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
         write_len = (ssl_state->curr_connp->record_length +
@@ -404,8 +483,7 @@ end:
             ssl_state->curr_connp->message_length) {
         if (ssl_state->curr_connp->message_length <
                 ssl_state->curr_connp->trec_pos) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
         parsed += ssl_state->curr_connp->message_length -
@@ -520,8 +598,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
 
     if (!(ssl_state->flags & SSL_AL_FLAG_CHANGE_CIPHER_SPEC)) {
         if (!(hb_type == TLS_HB_REQUEST || hb_type == TLS_HB_RESPONSE)) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
             return -1;
         }
     }
@@ -553,8 +630,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
            the record (CVE-2014-0160) */
         if ((uint32_t)(payload_len+3) > ssl_state->curr_connp->record_length) {
             SCLogDebug("We have a short record in HeartBeat Request");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_OVERFLOW_HEARTBEAT);
             return -1;
         }
 
@@ -563,8 +639,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
         padding_len = ssl_state->curr_connp->record_length - payload_len - 3;
         if (padding_len < 16) {
             SCLogDebug("We have a short record in HeartBeat Request");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
             return -1;
         }
 
@@ -578,15 +653,13 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
     } else if (direction == 1 && (ssl_state->flags & SSL_AL_FLAG_HB_INFLIGHT) &&
             (ssl_state->flags & SSL_AL_FLAG_HB_SERVER_INIT)) {
         SCLogDebug("Multiple in-flight server initiated HeartBeats");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
         return -1;
 
     } else if (direction == 0 && (ssl_state->flags & SSL_AL_FLAG_HB_INFLIGHT) &&
             (ssl_state->flags & SSL_AL_FLAG_HB_CLIENT_INIT)) {
         SCLogDebug("Multiple in-flight client initiated HeartBeats");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_HEARTBEAT);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_HEARTBEAT);
         return -1;
 
     } else {
@@ -605,7 +678,7 @@ static int SSLv3ParseHeartbeatProtocol(SSLState *ssl_state, uint8_t *input,
                     ssl_state->curr_connp->record_length) {
                 SCLogDebug("My heart is bleeding.. OpenSSL HeartBleed response (%u)",
                         ssl_state->hb_record_len);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_DATALEAK_HEARTBEAT_MISMATCH);
                 ssl_state->hb_record_len = 0;
                 return -1;
@@ -784,8 +857,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
             (ssl_state->curr_connp->record_lengths_length + 1)) {
         retval = SSLv2ParseRecord(direction, ssl_state, input, input_len);
         if (retval == -1) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
             return -1;
         } else {
             input += retval;
@@ -800,16 +872,14 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
     /* record_length should never be zero */
     if (ssl_state->curr_connp->record_length == 0) {
         SCLogDebug("SSLv2 record length is zero");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
         return -1;
     }
 
     /* record_lenghts_length should never be zero */
     if (ssl_state->curr_connp->record_lengths_length == 0) {
         SCLogDebug("SSLv2 record lengths length is zero");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSLV2_HEADER);
         return -1;
     }
 
@@ -817,8 +887,7 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
         case SSLV2_MT_ERROR:
             SCLogDebug("SSLV2_MT_ERROR msg_type received. Error encountered "
                        "in establishing the sslv2 session, may be version");
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_ERROR_MSG_ENCOUNTERED);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_ERROR_MSG_ENCOUNTERED);
 
             break;
 
@@ -1039,8 +1108,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
     if (ssl_state->curr_connp->bytes_processed < SSLV3_RECORD_HDR_LEN) {
         retval = SSLv3ParseRecord(direction, ssl_state, input, input_len);
         if (retval < 0) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_TLS_HEADER);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_TLS_HEADER);
             return -1;
         } else {
             parsed += retval;
@@ -1056,16 +1124,14 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
     if (ssl_state->curr_connp->version < SSL_VERSION_3 ||
             ssl_state->curr_connp->version > TLS_VERSION_12) {
 
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_RECORD_VERSION);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_RECORD_VERSION);
         return -1;
     }
 
     /* record_length should never be zero */
     if (ssl_state->curr_connp->record_length == 0) {
         SCLogDebug("SSLv3 Record length is 0");
-        AppLayerDecoderEventsSetEvent(ssl_state->f,
-                TLS_DECODER_EVENT_INVALID_TLS_HEADER);
+        SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_TLS_HEADER);
         return -1;
     }
 
@@ -1097,6 +1163,10 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
                         APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD);
             }
 
+            /* if we see (encrypted) aplication data, then this means the
+               handshake must be done */
+            ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+
             break;
 
         case SSLV3_HANDSHAKE_PROTOCOL:
@@ -1105,16 +1175,15 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
 
             if (ssl_state->curr_connp->record_length < 4) {
                 SSLParserReset(ssl_state);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
-                        TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+                SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                 return -1;
             }
 
             retval = SSLv3ParseHandshakeProtocol(ssl_state, input + parsed, input_len);
             if (retval < 0) {
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_INVALID_HANDSHAKE_MESSAGE);
-                AppLayerDecoderEventsSetEvent(ssl_state->f,
+                SSLSetEvent(ssl_state,
                         TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                 return -1;
             } else {
@@ -1122,7 +1191,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
                     SCLogDebug("Error parsing SSLv3.x. Reseting parser "
                                "state. Let's get outta here");
                     SSLParserReset(ssl_state);
-                    AppLayerDecoderEventsSetEvent(ssl_state->f,
+                    SSLSetEvent(ssl_state,
                             TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                     return -1;
                 }
@@ -1153,10 +1222,8 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
 
         default:
             /* \todo fix the event from invalid rule to unknown rule */
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_RECORD_TYPE);
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_RECORD_TYPE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
     }
 
@@ -1165,8 +1232,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
         if ((ssl_state->curr_connp->record_length + SSLV3_RECORD_HDR_LEN) <
                 ssl_state->curr_connp->bytes_processed) {
             /* defensive checks. Something is wrong. */
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
 
@@ -1223,6 +1289,8 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
 
     if (input == NULL &&
             AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
+        /* flag session as finished if APP_LAYER_PARSER_EOF is set */
+        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
         SCReturnInt(1);
     } else if (input == NULL || input_len == 0) {
         SCReturnInt(-1);
@@ -1239,8 +1307,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
             SCLogDebug("Looks like we have looped quite a bit. Reset state "
                        "and get out of here");
             SSLParserReset(ssl_state);
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_SSL_RECORD);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_SSL_RECORD);
             return -1;
         }
 
@@ -1259,7 +1326,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv2.x. Reseting parser "
                                    "state. Let's get outta here");
                         SSLParserReset(ssl_state);
-                        AppLayerDecoderEventsSetEvent(ssl_state->f,
+                        SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                         return -1;
                     } else {
@@ -1277,7 +1344,7 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                         SCLogDebug("Error parsing SSLv3.x. Reseting parser "
                                    "state. Let's get outta here");
                         SSLParserReset(ssl_state);
-                        AppLayerDecoderEventsSetEvent(ssl_state->f,
+                        SSLSetEvent(ssl_state,
                                 TLS_DECODER_EVENT_INVALID_SSL_RECORD);
                         return -1;
                     } else {
@@ -1339,6 +1406,15 @@ static int SSLDecode(Flow *f, uint8_t direction, void *alstate, AppLayerParserSt
                 break;
         } /* switch (ssl_state->curr_connp->bytes_processed) */
     } /* while (input_len) */
+
+    /* mark handshake as done if we have subject and issuer */
+    if (ssl_state->server_connp.cert0_subject &&
+            ssl_state->server_connp.cert0_issuerdn)
+        ssl_state->flags |= SSL_AL_FLAG_HANDSHAKE_DONE;
+
+    /* flag session as finished if APP_LAYER_PARSER_EOF is set */
+    if (AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF))
+        ssl_state->flags |= SSL_AL_FLAG_STATE_FINISHED;
 
     return 1;
 }
@@ -1405,6 +1481,12 @@ void SSLStateFree(void *p)
     if (ssl_state->server_connp.sni)
         SCFree(ssl_state->server_connp.sni);
 
+    AppLayerDecoderEventsFreeEvents(&ssl_state->decoder_events);
+
+    if (ssl_state->de_state != NULL) {
+        DetectEngineStateFree(ssl_state->de_state);
+    }
+
     /* Free certificate chain */
     while ((item = TAILQ_FIRST(&ssl_state->server_connp.certs))) {
         TAILQ_REMOVE(&ssl_state->server_connp.certs, item, next);
@@ -1415,6 +1497,11 @@ void SSLStateFree(void *p)
     SCFree(ssl_state);
 
     return;
+}
+
+void SSLStateTransactionFree(void *state, uint64_t tx_id)
+{
+    /* do nothing */
 }
 
 static uint16_t SSLProbingParser(uint8_t *input, uint32_t ilen, uint32_t *offset)
@@ -1443,7 +1530,7 @@ int SSLStateGetEventInfo(const char *event_name,
         return -1;
     }
 
-    *event_type = APP_LAYER_EVENT_TYPE_GENERAL;
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
 
     return 0;
 }
@@ -1632,10 +1719,30 @@ void RegisterSSLParsers(void)
 
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOCLIENT,
                                      SSLParseServerRecord);
+
         AppLayerParserRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_TLS, SSLStateGetEventInfo);
 
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateAlloc, SSLStateFree);
+
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_TLS, STREAM_TOSERVER);
+
+        AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TLS, SSLStateTransactionFree);
+
+        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetEvents);
+
+        AppLayerParserRegisterHasEventsFunc(IPPROTO_TCP, ALPROTO_TLS, SSLHasEvents);
+
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_TCP, ALPROTO_TLS, SSLStateHasTxDetectState,
+                                               SSLGetTxDetectState, SSLSetTxDetectState);
+
+        AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TLS, SSLGetTx);
+
+        AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TLS, SSLGetTxCnt);
+
+        AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetAlstateProgress);
+
+        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_TLS,
+                                                               SSLGetAlstateProgressCompletionStatus);
 
         /* Get the value of no reassembly option from the config file */
         if (ConfGetNode("app-layer.protocols.tls.no-reassemble") == NULL) {

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1741,7 +1741,7 @@ void RegisterSSLParsers(void)
 
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP, ALPROTO_TLS, SSLGetAlstateProgress);
 
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP, ALPROTO_TLS,
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_TLS,
                                                                SSLGetAlstateProgressCompletionStatus);
 
         /* Get the value of no reassembly option from the config file */

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -183,6 +183,9 @@ typedef struct SSLState_ {
     /* holds some state flags we need */
     uint32_t flags;
 
+    /* specifies which loggers are done logging */
+    uint32_t logged;
+
     /* there might be a better place to store this*/
     uint16_t hb_record_len;
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -93,9 +93,6 @@ enum {
 /* flag to indicate that handshake is done */
 #define SSL_AL_FLAG_HANDSHAKE_DONE              0x80000
 
-/* flags for file storage */
-#define SSL_AL_FLAG_STATE_STORED                0x40000
-
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -26,6 +26,8 @@
 #ifndef __APP_LAYER_SSL_H__
 #define __APP_LAYER_SSL_H__
 
+#include "app-layer-protos.h"
+#include "app-layer-parser.h"
 #include "decode-events.h"
 #include "queue.h"
 
@@ -53,6 +55,12 @@ enum {
     TLS_DECODER_EVENT_INVALID_SSL_RECORD,
 };
 
+enum {
+    TLS_STATE_IN_PROGRESS = 0,
+    TLS_HANDSHAKE_DONE = 1,
+    TLS_STATE_FINISHED = 2
+};
+
 /* Flag to indicate that server will now on send encrypted msgs */
 #define SSL_AL_FLAG_SERVER_CHANGE_CIPHER_SPEC   0x0001
 /* Flag to indicate that client will now on send encrypted msgs */
@@ -76,10 +84,16 @@ enum {
 
 #define SSL_AL_FLAG_STATE_LOGGED                0x4000
 
+/* flag to indicate that session is finished */
+#define SSL_AL_FLAG_STATE_FINISHED              0x4000
+
 /* flags specific to HeartBeat state */
 #define SSL_AL_FLAG_HB_INFLIGHT                 0x8000
 #define SSL_AL_FLAG_HB_CLIENT_INIT              0x10000
 #define SSL_AL_FLAG_HB_SERVER_INIT              0x20000
+
+/* flag to indicate that handshake is done */
+#define SSL_AL_FLAG_HANDSHAKE_DONE              0x80000
 
 /* flags for file storage */
 #define SSL_AL_FLAG_STATE_STORED                0x40000
@@ -169,16 +183,22 @@ typedef struct SSLState_ {
     /* holds some state flags we need */
     uint32_t flags;
 
+    /* there might be a better place to store this*/
+    uint16_t hb_record_len;
+
+    uint16_t events;
+
     SSLStateConnp *curr_connp;
 
     SSLStateConnp client_connp;
     SSLStateConnp server_connp;
 
-    /* there might be a better place to store this*/
-    uint16_t hb_record_len;
+    DetectEngineState *de_state;
+    AppLayerDecoderEvents *decoder_events;
 } SSLState;
 
 void RegisterSSLParsers(void);
 void SSLParserRegisterTests(void);
+void SSLSetEvent(SSLState *ssl_state, uint8_t event);
 
 #endif /* __APP_LAYER_SSL_H__ */

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -82,8 +82,6 @@ enum {
 #define SSL_AL_FLAG_STATE_SERVER_KEYX           0x1000
 #define SSL_AL_FLAG_STATE_UNKNOWN               0x2000
 
-#define SSL_AL_FLAG_STATE_LOGGED                0x4000
-
 /* flag to indicate that session is finished */
 #define SSL_AL_FLAG_STATE_FINISHED              0x4000
 

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -98,8 +98,6 @@ enum {
 /* flags for file storage */
 #define SSL_AL_FLAG_STATE_STORED                0x40000
 
-#define SSL_AL_FLAG_STATE_LOGGED_LUA            0x80000
-
 /* config flags */
 #define SSL_TLS_LOG_PEM                         (1 << 0)
 

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -364,6 +364,21 @@ static void *TemplateGetTx(void *state, uint64_t tx_id)
     return NULL;
 }
 
+static void TemplateSetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    TemplateTransaction *tx = (TemplateTransaction *)vtx;
+    tx->logged |= logger;
+}
+
+static int TemplateGetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    TemplateTransaction *tx = (TemplateTransaction *)vtx;
+    if (tx->logged & logger)
+        return 1;
+
+    return 0;
+}
+
 /**
  * \brief Called by the application layer.
  *
@@ -495,6 +510,9 @@ void RegisterTemplateParsers(void)
          * when a transaction is to be freed. */
         AppLayerParserRegisterTxFreeFunc(IPPROTO_TCP, ALPROTO_TEMPLATE,
             TemplateStateTxFree);
+
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_TCP, ALPROTO_TEMPLATE,
+            TemplateGetTxLogged, TemplateSetTxLogged);
 
         /* Register a function to return the current transaction count. */
         AppLayerParserRegisterGetTxCnt(IPPROTO_TCP, ALPROTO_TEMPLATE,

--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -501,8 +501,8 @@ void RegisterTemplateParsers(void)
             TemplateGetTxCnt);
 
         /* Transaction handling. */
-        AppLayerParserRegisterGetStateProgressCompletionStatus(IPPROTO_TCP,
-            ALPROTO_TEMPLATE, TemplateGetAlstateProgressCompletionStatus);
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_TEMPLATE,
+            TemplateGetAlstateProgressCompletionStatus);
         AppLayerParserRegisterGetStateProgressFunc(IPPROTO_TCP,
             ALPROTO_TEMPLATE, TemplateGetStateProgress);
         AppLayerParserRegisterGetTx(IPPROTO_TCP, ALPROTO_TEMPLATE,

--- a/src/app-layer-template.h
+++ b/src/app-layer-template.h
@@ -37,6 +37,9 @@ typedef struct TemplateTransaction_ {
     uint8_t *request_buffer;
     uint32_t request_buffer_len;
 
+    /* flags indicating which loggers that have logged */
+    uint32_t logged;
+
     uint8_t *response_buffer;
     uint32_t response_buffer_len;
 

--- a/src/app-layer-tls-handshake.c
+++ b/src/app-layer-tls-handshake.c
@@ -58,25 +58,24 @@ static void TLSCertificateErrCodeToWarning(SSLState *ssl_state,
     switch (errcode) {
         case ERR_DER_ELEMENT_SIZE_TOO_BIG:
         case ERR_DER_INVALID_SIZE:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_INVALID_LENGTH);
             break;
         case ERR_DER_UNSUPPORTED_STRING:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_INVALID_STRING);
             break;
         case ERR_DER_UNKNOWN_ELEMENT:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_UNKNOWN_ELEMENT);
             break;
         case ERR_DER_MISSING_ELEMENT:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
+            SSLSetEvent(ssl_state,
                     TLS_DECODER_EVENT_CERTIFICATE_MISSING_ELEMENT);
             break;
         case ERR_DER_GENERIC:
         default:
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             break;
     };
 }
@@ -108,8 +107,7 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
     i = 0;
     while (certificates_length > 0) {
         if ((uint32_t)(input + 3 - start_data) > (uint32_t)input_len) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 
@@ -119,14 +117,12 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
 
         /* current certificate length should be greater than zero */
         if (cur_cert_length == 0) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 
         if (input - start_data + cur_cert_length > input_len) {
-            AppLayerDecoderEventsSetEvent(ssl_state->f,
-                    TLS_DECODER_EVENT_INVALID_CERTIFICATE);
+            SSLSetEvent(ssl_state, TLS_DECODER_EVENT_INVALID_CERTIFICATE);
             return -1;
         }
 

--- a/src/detect-engine-apt-event.c
+++ b/src/detect-engine-apt-event.c
@@ -68,7 +68,7 @@ int DetectEngineAptEventInspect(ThreadVars *tv,
         return DETECT_ENGINE_INSPECT_SIG_MATCH;
     } else {
         if (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) ==
-            AppLayerParserGetStateProgressCompletionStatus(f->proto, alproto, flags))
+            AppLayerParserGetStateProgressCompletionStatus(alproto, flags))
         {
             return DETECT_ENGINE_INSPECT_SIG_CANT_MATCH;
         } else {

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -581,7 +581,7 @@ int DeStateDetectStartDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
             /* if this is the last tx in our list, and it's incomplete: then
              * we store the state so that ContinueDetection knows about it */
             int tx_is_done = (AppLayerParserGetStateProgress(f->proto, alproto, tx, flags) >=
-                    AppLayerParserGetStateProgressCompletionStatus(f->proto, alproto, flags));
+                    AppLayerParserGetStateProgressCompletionStatus(alproto, flags));
             /* see if we need to consider the next tx in our decision to add
              * a sig to the 'no inspect array'. */
             int next_tx_no_progress = 0;
@@ -1048,7 +1048,7 @@ void DeStateDetectContinueDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
             void *inspect_tx = AppLayerParserGetTx(f->proto, alproto, alstate, inspect_tx_id);
             if (inspect_tx != NULL) {
                 int a = AppLayerParserGetStateProgress(f->proto, alproto, inspect_tx, flags);
-                int b = AppLayerParserGetStateProgressCompletionStatus(f->proto, alproto, flags);
+                int b = AppLayerParserGetStateProgressCompletionStatus(alproto, flags);
                 if (a < b) {
                     inspect_tx_inprogress = 1;
                 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -2579,6 +2579,10 @@ static int SignatureCreateMask(Signature *s)
                         s->mask |= SIG_MASK_REQUIRE_DNS_STATE;
                         SCLogDebug("sig %u requires dns app state (dns event)", s->id);
                         break;
+                    case ALPROTO_TLS:
+                        s->mask |= SIG_MASK_REQUIRE_TLS_STATE;
+                        SCLogDebug("sig %u requires tls app state (tls event)", s->id);
+                        break;
                 }
                 break;
             }

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -194,8 +194,6 @@ static TmEcode LogTlsLogThreadDeinit(ThreadVars *t, void *data)
 
 static void LogTlsLogDeInitCtx(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     LogTlsFileCtx *tlslog_ctx = (LogTlsFileCtx *) output_ctx->data;
     LogFileFreeCtx(tlslog_ctx->file_ctx);
     SCFree(tlslog_ctx);
@@ -218,12 +216,6 @@ static void LogTlsLogExitPrintStats(ThreadVars *tv, void *data)
  * */
 static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
 {
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
-
     LogFileCtx* file_ctx = LogFileNewCtx();
 
     if (file_ctx == NULL) {

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -270,87 +270,31 @@ filectx_error:
     return NULL;
 }
 
-/** \internal
- *  \brief Condition function for TLS logger
- *  \retval bool true or false -- log now?
- */
-static int LogTlsCondition(ThreadVars *tv, const Packet *p)
-{
-    if (p->flow == NULL) {
-        return FALSE;
-    }
-
-    if (!(PKT_IS_TCP(p))) {
-        return FALSE;
-    }
-
-    FLOWLOCK_RDLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto dontlog;
-
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
-    if (ssl_state == NULL) {
-        SCLogDebug("no tls state, so no request logging");
-        goto dontlog;
-    }
-
-    /* we only log the state once if we don't have to write
-     * the cert due to tls.store keyword. */
-    if (!(ssl_state->server_connp.cert_log_flag & SSL_TLS_LOG_PEM) &&
-        (ssl_state->flags & SSL_AL_FLAG_STATE_LOGGED))
-        goto dontlog;
-
-    if (ssl_state->server_connp.cert0_issuerdn == NULL ||
-            ssl_state->server_connp.cert0_subject == NULL)
-        goto dontlog;
-
-    /* todo: logic to log once */
-
-    FLOWLOCK_UNLOCK(p->flow);
-    return TRUE;
-dontlog:
-    FLOWLOCK_UNLOCK(p->flow);
-    return FALSE;
-}
-
-static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
+static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
+                        Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     LogTlsLogThread *aft = (LogTlsLogThread *)thread_data;
     LogTlsFileCtx *hlog = aft->tlslog_ctx;
     char timebuf[64];
     int ipproto = (PKT_IS_IPV4(p)) ? AF_INET : AF_INET6;
 
-    if (unlikely(p->flow == NULL)) {
+    SSLState *ssl_state = (SSLState *)state;
+    if (unlikely(ssl_state == NULL)) {
         return 0;
     }
 
-    /* check if we have TLS state or not */
-    FLOWLOCK_WRLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto end;
-
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
-    if (unlikely(ssl_state == NULL)) {
-        goto end;
+    if (ssl_state->server_connp.cert0_issuerdn == NULL ||
+            ssl_state->server_connp.cert0_subject == NULL) {
+        return 0;
     }
-
-    if (ssl_state->server_connp.cert0_issuerdn == NULL || ssl_state->server_connp.cert0_subject == NULL)
-        goto end;
-
-    /* Don't log again the state. If we are here it was because we had
-     * to store the cert. */
-    if (ssl_state->flags & SSL_AL_FLAG_STATE_LOGGED)
-        goto end;
 
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
 #define PRINT_BUF_LEN 46
     char srcip[PRINT_BUF_LEN], dstip[PRINT_BUF_LEN];
     Port sp, dp;
-    if (!TLSGetIPInformations(p, srcip, PRINT_BUF_LEN,
-                              &sp, dstip, PRINT_BUF_LEN, &dp, ipproto)) {
-        goto end;
+    if (!TLSGetIPInformations(p, srcip, PRINT_BUF_LEN, &sp, dstip,
+                              PRINT_BUF_LEN, &dp, ipproto)) {
+        return 0;
     }
 
     MemBufferReset(aft->buffer);
@@ -373,10 +317,6 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p)
         MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
     SCMutexUnlock(&hlog->file_ctx->fp_mutex);
 
-    /* we only log the state once */
-    ssl_state->flags |= SSL_AL_FLAG_STATE_LOGGED;
-end:
-    FLOWLOCK_UNLOCK(p->flow);
     return 0;
 }
 
@@ -384,13 +324,12 @@ void TmModuleLogTlsLogRegister(void)
 {
     tmm_modules[TMM_LOGTLSLOG].name = MODULE_NAME;
     tmm_modules[TMM_LOGTLSLOG].ThreadInit = LogTlsLogThreadInit;
-    tmm_modules[TMM_LOGTLSLOG].Func = NULL;
     tmm_modules[TMM_LOGTLSLOG].ThreadExitPrintStats = LogTlsLogExitPrintStats;
     tmm_modules[TMM_LOGTLSLOG].ThreadDeinit = LogTlsLogThreadDeinit;
     tmm_modules[TMM_LOGTLSLOG].RegisterTests = NULL;
     tmm_modules[TMM_LOGTLSLOG].cap_flags = 0;
     tmm_modules[TMM_LOGTLSLOG].flags = TM_FLAG_LOGAPI_TM;
 
-    OutputRegisterPacketModule(MODULE_NAME, "tls-log", LogTlsLogInitCtx,
-            LogTlsLogger, LogTlsCondition);
+    OutputRegisterTxModuleWithProgress(MODULE_NAME, "tls-log", LogTlsLogInitCtx,
+            ALPROTO_TLS, LogTlsLogger, TLS_HANDSHAKE_DONE, TLS_HANDSHAKE_DONE);
 }

--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -244,7 +244,7 @@ end_fp:
  *  \brief Condition function for TLS logger
  *  \retval bool true or false -- log now?
  */
-static int LogTlsStoreCondition(ThreadVars *tv, const Packet *p)
+static int LogTlsStoreCondition(ThreadVars *tv, const Packet *p, void *state)
 {
     if (p->flow == NULL) {
         return FALSE;
@@ -254,57 +254,39 @@ static int LogTlsStoreCondition(ThreadVars *tv, const Packet *p)
         return FALSE;
     }
 
-    FLOWLOCK_RDLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto dontlog;
-
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
+    SSLState *ssl_state = (SSLState *)state;
     if (ssl_state == NULL) {
         SCLogDebug("no tls state, so no request logging");
         goto dontlog;
     }
 
-    /* we only log the state once if we don't have to write
-     * the cert due to tls.store keyword. */
-    if (!(ssl_state->server_connp.cert_log_flag & SSL_TLS_LOG_PEM) &&
-        (ssl_state->flags & SSL_AL_FLAG_STATE_STORED))
+    if ((ssl_state->server_connp.cert_log_flag & SSL_TLS_LOG_PEM) == 0)
         goto dontlog;
 
     if (ssl_state->server_connp.cert0_issuerdn == NULL ||
             ssl_state->server_connp.cert0_subject == NULL)
         goto dontlog;
 
-    FLOWLOCK_UNLOCK(p->flow);
     return TRUE;
 dontlog:
-    FLOWLOCK_UNLOCK(p->flow);
     return FALSE;
 }
 
-static int LogTlsStoreLogger(ThreadVars *tv, void *thread_data, const Packet *p)
+static int LogTlsStoreLogger(ThreadVars *tv, void *thread_data, const Packet *p,
+                             Flow *f, void *state, void *tx, uint64_t tx_id)
 {
     LogTlsStoreLogThread *aft = (LogTlsStoreLogThread *)thread_data;
     int ipproto = (PKT_IS_IPV4(p)) ? AF_INET : AF_INET6;
-    /* check if we have TLS state or not */
-    FLOWLOCK_WRLOCK(p->flow);
-    uint16_t proto = FlowGetAppProtocol(p->flow);
-    if (proto != ALPROTO_TLS)
-        goto end;
 
-    SSLState *ssl_state = (SSLState *)FlowGetAppState(p->flow);
+    SSLState *ssl_state = (SSLState *)state;
     if (unlikely(ssl_state == NULL)) {
-        goto end;
+        return 0;
     }
 
     if (ssl_state->server_connp.cert_log_flag & SSL_TLS_LOG_PEM) {
         LogTlsLogPem(aft, p, ssl_state, ipproto);
     }
 
-    /* we only store the state once */
-    ssl_state->flags |= SSL_AL_FLAG_STATE_STORED;
-end:
-    FLOWLOCK_UNLOCK(p->flow);
     return 0;
 }
 
@@ -415,6 +397,9 @@ static OutputCtx *LogTlsStoreLogInitCtx(ConfNode *conf)
 
     SCLogInfo("storing certs in %s", tls_logfile_base_dir);
 
+    /* enable the logger for the app layer */
+    AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
+
     SCReturnPtr(output_ctx, "OutputCtx");
 }
 
@@ -430,8 +415,9 @@ void TmModuleLogTlsStoreRegister (void)
     tmm_modules[TMM_TLSSTORE].flags = TM_FLAG_LOGAPI_TM;
     tmm_modules[TMM_TLSSTORE].priority = 10;
 
-    OutputRegisterPacketModule(MODULE_NAME, "tls-store", LogTlsStoreLogInitCtx,
-            LogTlsStoreLogger, LogTlsStoreCondition);
+    OutputRegisterTxModuleWithCondition(MODULE_NAME, "tls-store",
+            LogTlsStoreLogInitCtx, ALPROTO_TLS, LogTlsStoreLogger,
+            LogTlsStoreCondition);
 
     SC_ATOMIC_INIT(cert_id);
 

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -213,8 +213,6 @@ static TmEcode JsonTlsLogThreadDeinit(ThreadVars *t, void *data)
 
 static void OutputTlsLogDeinit(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     OutputTlsCtx *tls_ctx = output_ctx->data;
     LogFileCtx *logfile_ctx = tls_ctx->file_ctx;
     LogFileFreeCtx(logfile_ctx);
@@ -225,12 +223,6 @@ static void OutputTlsLogDeinit(OutputCtx *output_ctx)
 #define DEFAULT_LOG_FILENAME "tls.json"
 OutputCtx *OutputTlsLogInit(ConfNode *conf)
 {
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
-
     LogFileCtx *file_ctx = LogFileNewCtx();
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_TLS_LOG_GENERIC, "couldn't create new file_ctx");
@@ -277,8 +269,6 @@ OutputCtx *OutputTlsLogInit(ConfNode *conf)
 
 static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 {
-    OutputTlsLoggerDisable();
-
     OutputTlsCtx *tls_ctx = output_ctx->data;
     SCFree(tls_ctx);
     SCFree(output_ctx);
@@ -287,12 +277,6 @@ static void OutputTlsLogDeinitSub(OutputCtx *output_ctx)
 OutputCtx *OutputTlsLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 {
     OutputJsonCtx *ojc = parent_ctx->data;
-
-    if (OutputTlsLoggerEnable() != 0) {
-        SCLogError(SC_ERR_CONF_YAML_ERROR, "only one 'tls' logger "
-            "can be enabled");
-        return NULL;
-    }
 
     OutputTlsCtx *tls_ctx = SCMalloc(sizeof(OutputTlsCtx));
     if (unlikely(tls_ctx == NULL))

--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -867,7 +867,9 @@ static OutputCtx *OutputLuaLogInit(ConfNode *conf)
         } else if (opts.alproto == ALPROTO_TLS) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_TLS;
-        } else if (opts.alproto == ALPROTO_DNS) {
+            om->tc_log_progress = TLS_HANDSHAKE_DONE;
+            om->ts_log_progress = TLS_HANDSHAKE_DONE;
+       } else if (opts.alproto == ALPROTO_DNS) {
             om->TxLogFunc = LuaTxLogger;
             om->alproto = ALPROTO_DNS;
             AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_DNS);

--- a/src/output-streaming.c
+++ b/src/output-streaming.c
@@ -147,11 +147,11 @@ int HttpBodyIterator(Flow *f, int close, void *cbdata, uint8_t iflags)
     HtpState *s = f->alstate;
     if (s != NULL && s->conn != NULL) {
         int tx_progress_done_value_ts =
-            AppLayerParserGetStateProgressCompletionStatus(IPPROTO_TCP,
-                                                           ALPROTO_HTTP, STREAM_TOSERVER);
+            AppLayerParserGetStateProgressCompletionStatus(ALPROTO_HTTP,
+                                                           STREAM_TOSERVER);
         int tx_progress_done_value_tc =
-            AppLayerParserGetStateProgressCompletionStatus(IPPROTO_TCP,
-                                                           ALPROTO_HTTP, STREAM_TOCLIENT);
+            AppLayerParserGetStateProgressCompletionStatus(ALPROTO_HTTP,
+                                                           STREAM_TOCLIENT);
 
         // for each tx
         uint64_t tx_id = 0;

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -47,6 +47,7 @@ typedef struct OutputLoggerThreadData_ {
 typedef struct OutputTxLogger_ {
     AppProto alproto;
     TxLogger LogFunc;
+    TxLoggerCondition LogCondition;
     OutputCtx *output_ctx;
     struct OutputTxLogger_ *next;
     const char *name;
@@ -60,7 +61,7 @@ static OutputTxLogger *list = NULL;
 
 int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
                            OutputCtx *output_ctx, int tc_log_progress,
-                           int ts_log_progress)
+                           int ts_log_progress, TxLoggerCondition LogCondition)
 {
     int module_id = TmModuleGetIdByName(name);
     if (module_id < 0)
@@ -73,6 +74,7 @@ int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
 
     op->alproto = alproto;
     op->LogFunc = LogFunc;
+    op->LogCondition = LogCondition;
     op->output_ctx = output_ctx;
     op->name = name;
     op->module_id = (TmmId) module_id;
@@ -182,16 +184,25 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
 
                 if (!(AppLayerParserStateIssetFlag(f->alparser,
                                                    APP_LAYER_PARSER_EOF))) {
-                    if (tx_progress_tc < logger->tc_log_progress) {
-                        SCLogDebug("progress not far enough, not logging");
-                        logger_not_logged = 1;
-                        goto next;
-                    }
+                    if (logger->LogCondition) {
+                        int r = logger->LogCondition(tv, p, alstate);
+                        if (r == FALSE) {
+                            SCLogDebug("conditions not met, not logging");
+                            logger_not_logged = 1;
+                            goto next;
+                        }
+                    } else {
+                        if (tx_progress_tc < logger->tc_log_progress) {
+                            SCLogDebug("progress not far enough, not logging");
+                            logger_not_logged = 1;
+                            goto next;
+                        }
 
-                    if (tx_progress_ts < logger->ts_log_progress) {
-                        SCLogDebug("progress not far enough, not logging");
-                        logger_not_logged = 1;
-                        goto next;
+                        if (tx_progress_ts < logger->ts_log_progress) {
+                            SCLogDebug("progress not far enough, not logging");
+                            logger_not_logged = 1;
+                            goto next;
+                        }
                     }
                 }
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -51,11 +51,16 @@ typedef struct OutputTxLogger_ {
     struct OutputTxLogger_ *next;
     const char *name;
     TmmId module_id;
+    uint32_t id;
+    int tc_log_progress;
+    int ts_log_progress;
 } OutputTxLogger;
 
 static OutputTxLogger *list = NULL;
 
-int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *output_ctx)
+int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
+                           OutputCtx *output_ctx, int tc_log_progress,
+                           int ts_log_progress)
 {
     int module_id = TmModuleGetIdByName(name);
     if (module_id < 0)
@@ -72,12 +77,34 @@ int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
     op->name = name;
     op->module_id = (TmmId) module_id;
 
-    if (list == NULL)
+    if (tc_log_progress) {
+        op->tc_log_progress = tc_log_progress;
+    } else {
+        op->tc_log_progress =
+            AppLayerParserGetStateProgressCompletionStatus(alproto,
+                                                           STREAM_TOCLIENT);
+    }
+
+    if (ts_log_progress) {
+        op->ts_log_progress = ts_log_progress;
+    } else {
+        op->ts_log_progress =
+            AppLayerParserGetStateProgressCompletionStatus(alproto,
+                                                           STREAM_TOSERVER);
+    }
+
+    if (list == NULL) {
+        op->id = 1;
         list = op;
-    else {
+    } else {
         OutputTxLogger *t = list;
         while (t->next)
             t = t->next;
+        if (t->id * 2 > UINT32_MAX) {
+            SCLogError(SC_ERR_FATAL, "Too many loggers registered.");
+            exit(EXIT_FAILURE);
+        }
+        op->id = t->id * 2;
         t->next = op;
     }
 
@@ -119,15 +146,10 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
 
     uint64_t total_txs = AppLayerParserGetTxCnt(p->proto, alproto, alstate);
     uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
-    int tx_progress_done_value_ts =
-        AppLayerParserGetStateProgressCompletionStatus(alproto,
-                                                       STREAM_TOSERVER);
-    int tx_progress_done_value_tc =
-        AppLayerParserGetStateProgressCompletionStatus(alproto,
-                                                       STREAM_TOCLIENT);
+
     for (; tx_id < total_txs; tx_id++)
     {
-        int proto_logged = 0;
+        int logger_not_logged = 0;
 
         void *tx = AppLayerParserGetTx(p->proto, alproto, alstate, tx_id);
         if (tx == NULL) {
@@ -135,22 +157,11 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
             continue;
         }
 
-        if (!(AppLayerParserStateIssetFlag(f->alparser, APP_LAYER_PARSER_EOF)))
-        {
-            int tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                             tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
-            if (tx_progress < tx_progress_done_value_ts) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
-            }
+        int tx_progress_ts = AppLayerParserGetStateProgress(p->proto, alproto,
+                tx, FlowGetDisruptionFlags(f, STREAM_TOSERVER));
 
-            tx_progress = AppLayerParserGetStateProgress(p->proto, alproto,
-                                                         tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
-            if (tx_progress < tx_progress_done_value_tc) {
-                SCLogDebug("progress not far enough, not logging");
-                break;
-            }
-        }
+        int tx_progress_tc = AppLayerParserGetStateProgress(p->proto, alproto,
+                tx, FlowGetDisruptionFlags(f, STREAM_TOCLIENT));
 
         // call each logger here (pseudo code)
         logger = list;
@@ -161,12 +172,38 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
             SCLogDebug("logger %p", logger);
             if (logger->alproto == alproto) {
                 SCLogDebug("alproto match, logging tx_id %ju", tx_id);
+
+                if (AppLayerParserGetTxLogged(p->proto, alproto, alstate, tx,
+                        logger->id)) {
+                    SCLogDebug("logger has already logged this transaction");
+
+                    goto next;
+                }
+
+                if (!(AppLayerParserStateIssetFlag(f->alparser,
+                                                   APP_LAYER_PARSER_EOF))) {
+                    if (tx_progress_tc < logger->tc_log_progress) {
+                        SCLogDebug("progress not far enough, not logging");
+                        logger_not_logged = 1;
+                        goto next;
+                    }
+
+                    if (tx_progress_ts < logger->ts_log_progress) {
+                        SCLogDebug("progress not far enough, not logging");
+                        logger_not_logged = 1;
+                        goto next;
+                    }
+                }
+
                 PACKET_PROFILING_TMM_START(p, logger->module_id);
                 logger->LogFunc(tv, store->thread_data, p, f, alstate, tx, tx_id);
                 PACKET_PROFILING_TMM_END(p, logger->module_id);
-                proto_logged = 1;
+
+                AppLayerParserSetTxLogged(p->proto, alproto, alstate, tx,
+                                          logger->id);
             }
 
+next:
             logger = logger->next;
             store = store->next;
 
@@ -174,7 +211,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
             BUG_ON(logger != NULL && store == NULL);
         }
 
-        if (proto_logged) {
+        if (!logger_not_logged) {
             SCLogDebug("updating log tx_id %ju", tx_id);
             AppLayerParserSetTransactionLogId(f->alparser);
         }

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -120,10 +120,10 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data, PacketQ
     uint64_t total_txs = AppLayerParserGetTxCnt(p->proto, alproto, alstate);
     uint64_t tx_id = AppLayerParserGetTransactionLogId(f->alparser);
     int tx_progress_done_value_ts =
-        AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
+        AppLayerParserGetStateProgressCompletionStatus(alproto,
                                                        STREAM_TOSERVER);
     int tx_progress_done_value_tc =
-        AppLayerParserGetStateProgressCompletionStatus(p->proto, alproto,
+        AppLayerParserGetStateProgressCompletionStatus(alproto,
                                                        STREAM_TOCLIENT);
     for (; tx_id < total_txs; tx_id++)
     {

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -34,10 +34,11 @@ typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f
 /** packet logger condition function pointer type,
  *  must return true for packets that should be logged
  */
-//typedef int (*TxLogCondition)(ThreadVars *, const Packet *);
+typedef int (*TxLoggerCondition)(ThreadVars *, const Packet *, void *state);
 
 int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
-        OutputCtx *, int tc_log_progress, int ts_log_progress);
+        OutputCtx *, int tc_log_progress, int ts_log_progress,
+        TxLoggerCondition LogCondition);
 
 void TmModuleTxLoggerRegister (void);
 

--- a/src/output-tx.h
+++ b/src/output-tx.h
@@ -36,7 +36,8 @@ typedef int (*TxLogger)(ThreadVars *, void *thread_data, const Packet *, Flow *f
  */
 //typedef int (*TxLogCondition)(ThreadVars *, const Packet *);
 
-int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc, OutputCtx *);
+int OutputRegisterTxLogger(const char *name, AppProto alproto, TxLogger LogFunc,
+        OutputCtx *, int tc_log_progress, int ts_log_progress);
 
 void TmModuleTxLoggerRegister (void);
 

--- a/src/output.c
+++ b/src/output.c
@@ -647,22 +647,6 @@ void OutputDropLoggerDisable(void)
         drop_loggers--;
 }
 
-static int tls_loggers = 0;
-
-int OutputTlsLoggerEnable(void)
-{
-    if (tls_loggers)
-        return -1;
-    tls_loggers++;
-    return 0;
-}
-
-void OutputTlsLoggerDisable(void)
-{
-    if (tls_loggers)
-        tls_loggers--;
-}
-
 static int ssh_loggers = 0;
 
 int OutputSshLoggerEnable(void)

--- a/src/output.c
+++ b/src/output.c
@@ -150,17 +150,16 @@ error:
 }
 
 /**
- * \brief Register a tx output module.
+ * \brief Register a tx output module with progress.
  *
  * This function will register an output module so it can be
  * configured with the configuration file.
  *
  * \retval Returns 0 on success, -1 on failure.
  */
-void
-OutputRegisterTxModule(const char *name, const char *conf_name,
-    OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
-    TxLogger TxLogFunc)
+void OutputRegisterTxModuleWithProgress(const char *name, const char *conf_name,
+        OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+        TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress)
 {
     if (unlikely(TxLogFunc == NULL)) {
         goto error;
@@ -176,6 +175,8 @@ OutputRegisterTxModule(const char *name, const char *conf_name,
     module->InitFunc = InitFunc;
     module->TxLogFunc = TxLogFunc;
     module->alproto = alproto;
+    module->tc_log_progress = tc_log_progress;
+    module->ts_log_progress = ts_log_progress;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
     SCLogDebug("Tx logger \"%s\" registered.", name);
@@ -185,10 +186,10 @@ error:
     exit(EXIT_FAILURE);
 }
 
-void
-OutputRegisterTxSubModule(const char *parent_name, const char *name,
-    const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
-    AppProto alproto, TxLogger TxLogFunc)
+void OutputRegisterTxSubModuleWithProgress(const char *parent_name,
+        const char *name, const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *,
+        OutputCtx *parent_ctx), AppProto alproto, TxLogger TxLogFunc,
+        int tc_log_progress, int ts_log_progress)
 {
     if (unlikely(TxLogFunc == NULL)) {
         goto error;
@@ -205,6 +206,8 @@ OutputRegisterTxSubModule(const char *parent_name, const char *name,
     module->InitSubFunc = InitFunc;
     module->TxLogFunc = TxLogFunc;
     module->alproto = alproto;
+    module->tc_log_progress = tc_log_progress;
+    module->ts_log_progress = ts_log_progress;
     TAILQ_INSERT_TAIL(&output_modules, module, entries);
 
     SCLogDebug("Tx logger \"%s\" registered.", name);
@@ -212,6 +215,34 @@ OutputRegisterTxSubModule(const char *parent_name, const char *name,
 error:
     SCLogError(SC_ERR_FATAL, "Fatal error encountered. Exiting...");
     exit(EXIT_FAILURE);
+}
+
+/**
+ * \brief Register a tx output module.
+ *
+ * This function will register an output module so it can be
+ * configured with the configuration file.
+ *
+ * \retval Returns 0 on success, -1 on failure.
+ */
+void
+OutputRegisterTxModule(const char *name, const char *conf_name,
+    OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+    TxLogger TxLogFunc)
+{
+    /* wrapper function */
+    OutputRegisterTxModuleWithProgress(name, conf_name, InitFunc, alproto,
+                                       TxLogFunc, 0, 0);
+}
+
+void
+OutputRegisterTxSubModule(const char *parent_name, const char *name,
+    const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
+    AppProto alproto, TxLogger TxLogFunc)
+{
+    /* wrapper function */
+    OutputRegisterTxSubModuleWithProgress(parent_name, name, conf_name,
+                                          InitFunc, alproto, TxLogFunc, 0, 0);
 }
 
 /**

--- a/src/output.h
+++ b/src/output.h
@@ -55,6 +55,8 @@ typedef struct OutputModule_ {
     StatsLogger StatsLogFunc;
     AppProto alproto;
     enum OutputStreamingType stream_type;
+    int tc_log_progress;
+    int ts_log_progress;
 
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
@@ -74,6 +76,13 @@ void OutputRegisterTxModule(const char *name, const char *conf_name,
 void OutputRegisterTxSubModule(const char *parent_name, const char *name,
     const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
     AppProto alproto, TxLogger TxLogFunc);
+
+void OutputRegisterTxModuleWithProgress(const char *name, const char *conf_name,
+    OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+    TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress);
+void OutputRegisterTxSubModuleWithProgress(const char *parent_name, const char *name,
+    const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
+    AppProto alproto, TxLogger TxLogFunc, int tc_log_progress, int ts_log_progress);
 
 void OutputRegisterFileModule(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), FileLogger FileLogFunc);

--- a/src/output.h
+++ b/src/output.h
@@ -121,9 +121,6 @@ void OutputDeregisterAll(void);
 int OutputDropLoggerEnable(void);
 void OutputDropLoggerDisable(void);
 
-int OutputTlsLoggerEnable(void);
-void OutputTlsLoggerDisable(void);
-
 int OutputSshLoggerEnable(void);
 void OutputSshLoggerDisable(void);
 

--- a/src/output.h
+++ b/src/output.h
@@ -48,6 +48,7 @@ typedef struct OutputModule_ {
     PacketLogger PacketLogFunc;
     PacketLogCondition PacketConditionFunc;
     TxLogger TxLogFunc;
+    TxLoggerCondition TxLogCondition;
     FileLogger FileLogFunc;
     FiledataLogger FiledataLogFunc;
     FlowLogger FlowLogFunc;
@@ -76,6 +77,14 @@ void OutputRegisterTxModule(const char *name, const char *conf_name,
 void OutputRegisterTxSubModule(const char *parent_name, const char *name,
     const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *, OutputCtx *parent_ctx),
     AppProto alproto, TxLogger TxLogFunc);
+
+void OutputRegisterTxModuleWithCondition(const char *name, const char *conf_name,
+        OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,
+        TxLogger TxLogFunc, TxLoggerCondition TxLogCondition);
+void OutputRegisterTxSubModuleWithCondition(const char *parent_name,
+        const char *name, const char *conf_name, OutputCtx *(*InitFunc)(ConfNode *,
+        OutputCtx *parent_ctx), AppProto alproto, TxLogger TxLogFunc,
+        TxLoggerCondition TxLogCondition);
 
 void OutputRegisterTxModuleWithProgress(const char *name, const char *conf_name,
     OutputCtx *(*InitFunc)(ConfNode *), AppProto alproto,

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -618,7 +618,7 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
         SCLogDebug("%s is a tx logger", module->name);
         OutputRegisterTxLogger(module->name, module->alproto,
                 module->TxLogFunc, output_ctx, module->tc_log_progress,
-                module->ts_log_progress);
+                module->ts_log_progress, module->TxLogCondition);
 
         /* need one instance of the tx logger module */
         if (tx_logger_module == NULL) {

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -617,7 +617,8 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
     } else if (module->TxLogFunc) {
         SCLogDebug("%s is a tx logger", module->name);
         OutputRegisterTxLogger(module->name, module->alproto,
-                module->TxLogFunc, output_ctx);
+                module->TxLogFunc, output_ctx, module->tc_log_progress,
+                module->ts_log_progress);
 
         /* need one instance of the tx logger module */
         if (tx_logger_module == NULL) {


### PR DESCRIPTION
Changed app-layer-ssl to use tx API's and modifed all the TLS loggers to use TxLogger.

This enables the use of multiple TLS Lua output scripts (before only one worked), and enables the use of several TLS loggers active at the same time.

Fixed changes suggested in #2056.

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/27
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/27