### PR TITLE
Hyperscan SPM integration v1

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -350,6 +350,7 @@ util-hashlist.c util-hashlist.h \
 util-hash-lookup3.c util-hash-lookup3.h \
 util-host-os-info.c util-host-os-info.h \
 util-host-info.c util-host-info.h \
+util-hyperscan.c util-hyperscan.h \
 util-ioctl.h util-ioctl.c \
 util-ip.h util-ip.c \
 util-logopenfile.h util-logopenfile.c \
@@ -397,6 +398,7 @@ util-signal.c util-signal.h \
 util-spm-bm.c util-spm-bm.h \
 util-spm-bs2bm.c util-spm-bs2bm.h \
 util-spm-bs.c util-spm-bs.h \
+util-spm-hs.c util-spm-hs.h \
 util-spm.c util-spm.h util-clock.h \
 util-storage.c util-storage.h \
 util-strlcatu.c \

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1249,7 +1249,6 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
     cd->offset = offset;
     if (!is_cs) {
         /* Rebuild as nocase */
-        BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
         uint16_t matcher = cd->spm_ctx->matcher;
         SpmDestroyCtx(cd->spm_ctx);
         cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -41,7 +41,7 @@
 #include "util-unittest.h"
 #include "util-print.h"
 #include "util-debug.h"
-#include "util-spm-bm.h"
+#include "util-spm.h"
 #include "threads.h"
 #include "util-unittest-helper.h"
 #include "pkt-var.h"

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -247,6 +247,7 @@ DetectContentData *DetectContentParse (char *contentstr)
 
     /* Prepare Boyer Moore context for searching faster */
     cd->bm_ctx = BoyerMooreCtxInit(cd->content, cd->content_len);
+    cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 0, NULL, SPM_BM);
     cd->depth = 0;
     cd->offset = 0;
     cd->within = 0;
@@ -416,6 +417,7 @@ void DetectContentFree(void *ptr)
         SCReturn;
 
     BoyerMooreCtxDeInit(cd->bm_ctx);
+    SpmDestroyCtx(cd->spm_ctx);
 
     SCFree(cd);
     SCReturn;

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -246,8 +246,7 @@ DetectContentData *DetectContentParse(SpmThreadCtx *spm_thread_ctx,
     memcpy(cd->content, content, len);
     cd->content_len = len;
 
-    /* Prepare Boyer Moore context for searching faster */
-    cd->bm_ctx = BoyerMooreCtxInit(cd->content, cd->content_len);
+    /* Prepare SPM search context. */
     cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 0, spm_thread_ctx,
                              spm_thread_ctx->matcher);
     cd->depth = 0;
@@ -419,7 +418,6 @@ void DetectContentFree(void *ptr)
     if (cd == NULL)
         SCReturn;
 
-    BoyerMooreCtxDeInit(cd->bm_ctx);
     SpmDestroyCtx(cd->spm_ctx);
 
     SCFree(cd);

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -104,10 +104,12 @@ typedef struct DetectContentData_ {
 /* prototypes */
 void DetectContentRegister (void);
 uint32_t DetectContentMaxId(DetectEngineCtx *);
-DetectContentData *DetectContentParse (char *contentstr);
+DetectContentData *DetectContentParse(SpmThreadCtx *spm_thread_ctx,
+                                      char *contentstr);
 int DetectContentDataParse(const char *keyword, const char *contentstr,
     uint8_t **pstr, uint16_t *plen, uint32_t *flags);
-DetectContentData *DetectContentParseEncloseQuotes(char *);
+DetectContentData *DetectContentParseEncloseQuotes(SpmThreadCtx *spm_thread_ctx,
+                                      char *contentstr);
 
 int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, char *contentstr);
 void DetectContentPrint(DetectContentData *);

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -74,7 +74,6 @@
 
 
 #include "util-spm.h"
-#include "util-spm-bm.h"
 
 typedef struct DetectContentData_ {
     uint8_t *content;

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -93,8 +93,6 @@ typedef struct DetectContentData_ {
     uint16_t offset;
     int32_t distance;
     int32_t within;
-    /* Boyer Moore context (for spm search) */
-    BmCtx *bm_ctx;
     /* SPM search context. */
     SpmCtx *spm_ctx;
     /* pointer to replacement data */

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -73,6 +73,7 @@
                                        ((c)->flags & DETECT_CONTENT_FAST_PATTERN_CHOP))
 
 
+#include "util-spm.h"
 #include "util-spm-bm.h"
 
 typedef struct DetectContentData_ {
@@ -94,6 +95,8 @@ typedef struct DetectContentData_ {
     int32_t within;
     /* Boyer Moore context (for spm search) */
     BmCtx *bm_ctx;
+    /* SPM search context. */
+    SpmCtx *spm_ctx;
     /* pointer to replacement data */
     uint8_t *replace;
 } DetectContentData;

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -279,7 +279,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
              * greater than sbuffer_len found is anyways NULL */
 
             /* do the actual search */
-            found = SpmScan(cd->spm_ctx, NULL, sbuffer, sbuffer_len);
+            found = SpmScan(cd->spm_ctx, det_ctx->spm_thread_ctx, sbuffer,
+                            sbuffer_len);
 
             /* next we evaluate the result in combination with the
              * negation flag. */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -279,10 +279,7 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
              * greater than sbuffer_len found is anyways NULL */
 
             /* do the actual search */
-            if (cd->flags & DETECT_CONTENT_NOCASE)
-                found = BoyerMooreNocase(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
-            else
-                found = BoyerMoore(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
+            found = SpmScan(cd->spm_ctx, NULL, sbuffer, sbuffer_len);
 
             /* next we evaluate the result in combination with the
              * negation flag. */

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -48,7 +48,6 @@
 #include "app-layer-dcerpc.h"
 
 #include "util-spm.h"
-#include "util-spm-bm.h"
 #include "util-debug.h"
 #include "util-print.h"
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -84,6 +84,7 @@
 #include "util-action.h"
 #include "util-magic.h"
 #include "util-signal.h"
+#include "util-spm.h"
 
 #include "util-var-name.h"
 
@@ -829,6 +830,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
     }
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
+    de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();
     DetectEngineCtxLoadConf(de_ctx);
 
     SigGroupHeadHashInit(de_ctx);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -831,6 +831,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
     de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();
+    de_ctx->spm_thread_ctx = SpmInitThreadCtx(de_ctx->spm_matcher);
     DetectEngineCtxLoadConf(de_ctx);
 
     SigGroupHeadHashInit(de_ctx);
@@ -940,6 +941,8 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     SCRConfDeInitContext(de_ctx);
 
     SigGroupCleanup(de_ctx);
+
+    SpmDestroyThreadCtx(de_ctx->spm_thread_ctx);
 
     MpmFactoryDeRegisterAllMpmCtxProfiles(de_ctx);
 

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -1422,6 +1422,11 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
 
     PmqSetup(&det_ctx->pmq);
 
+    det_ctx->spm_thread_ctx = SpmCloneThreadCtx(de_ctx->spm_thread_ctx);
+    if (det_ctx->spm_thread_ctx == NULL) {
+        return TM_ECODE_FAILED;
+    }
+
     /* sized to the max of our sgh settings. A max setting of 0 implies that all
      * sgh's have: sgh->non_mpm_store_cnt == 0 */
     if (de_ctx->non_mpm_store_cnt_max > 0) {
@@ -1636,6 +1641,10 @@ void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
     }
 
     PmqFree(&det_ctx->pmq);
+
+    if (det_ctx->spm_thread_ctx != NULL) {
+        SpmDestroyThreadCtx(det_ctx->spm_thread_ctx);
+    }
 
     if (det_ctx->non_mpm_id_array != NULL)
         SCFree(det_ctx->non_mpm_id_array);

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -123,7 +123,7 @@ void DetectHttpClientBodyFree(void *ptr)
     if (hcbd->content != NULL)
         SCFree(hcbd->content);
 
-    BoyerMooreCtxDeInit(hcbd->bm_ctx);
+    SpmDestroyCtx(hcbd->spm_ctx);
     SCFree(hcbd);
 
     SCReturn;

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -118,7 +118,7 @@ void DetectHttpHHFree(void *ptr)
     if (hhhd->content != NULL)
         SCFree(hhhd->content);
 
-    BoyerMooreCtxDeInit(hhhd->bm_ctx);
+    SpmDestroyCtx(hhhd->spm_ctx);
     SCFree(hhhd);
 
     return;

--- a/src/detect-http-hrh.c
+++ b/src/detect-http-hrh.c
@@ -118,7 +118,7 @@ void DetectHttpHRHFree(void *ptr)
     if (hrhhd->content != NULL)
         SCFree(hrhhd->content);
 
-    BoyerMooreCtxDeInit(hrhhd->bm_ctx);
+    SpmDestroyCtx(hrhhd->spm_ctx);
     SCFree(hrhhd);
 
     return;

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -127,7 +127,7 @@ void DetectHttpServerBodyFree(void *ptr)
     if (hsbd->content != NULL)
         SCFree(hsbd->content);
 
-    BoyerMooreCtxDeInit(hsbd->bm_ctx);
+    SpmDestroyCtx(hsbd->spm_ctx);
     SCFree(hsbd);
 
     SCReturn;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -119,7 +119,7 @@ void DetectHttpUAFree(void *ptr)
     if (huad->content != NULL)
         SCFree(huad->content);
 
-    BoyerMooreCtxDeInit(huad->bm_ctx);
+    SpmDestroyCtx(huad->spm_ctx);
     SCFree(huad);
 
     return;

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -121,6 +121,9 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, char *nulls
     /* Recreate the context with nocase chars */
     BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
 
+    SpmDestroyCtx(cd->spm_ctx);
+    cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1, NULL, SPM_BM);
+
     ret = 0;
  end:
     SCReturnInt(ret);

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -117,10 +117,15 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, char *nulls
         SCLogError(SC_ERR_INVALID_SIGNATURE, "can't use multiple nocase modifiers with the same content");
         goto end;
     }
+
+    /* for consistency in later use (e.g. by MPM construction and hashing),
+     * coerce the content string to lower-case. */
+    for (uint8_t *c = cd->content; c < cd->content + cd->content_len; c++) {
+        *c = u8_tolower(*c);
+    }
+
     cd->flags |= DETECT_CONTENT_NOCASE;
     /* Recreate the context with nocase chars */
-    BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
-
     uint16_t matcher = cd->spm_ctx->matcher;
     SpmDestroyCtx(cd->spm_ctx);
     cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,

--- a/src/detect-nocase.c
+++ b/src/detect-nocase.c
@@ -121,8 +121,10 @@ static int DetectNocaseSetup (DetectEngineCtx *de_ctx, Signature *s, char *nulls
     /* Recreate the context with nocase chars */
     BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
 
+    uint16_t matcher = cd->spm_ctx->matcher;
     SpmDestroyCtx(cd->spm_ctx);
-    cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1, NULL, SPM_BM);
+    cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,
+                             de_ctx->spm_thread_ctx, matcher);
 
     ret = 0;
  end:

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -54,7 +54,6 @@
 #include "util-unittest-helper.h"
 #include "util-binsearch.h"
 #include "util-spm.h"
-#include "util-spm-bm.h"
 #include "conf.h"
 
 /* prototypes */

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -95,7 +95,7 @@ void DetectUricontentFree(void *ptr)
     if (cd == NULL)
         SCReturn;
 
-    BoyerMooreCtxDeInit(cd->bm_ctx);
+    SpmDestroyCtx(cd->spm_ctx);
     SCFree(cd);
 
     SCReturn;

--- a/src/detect-uricontent.h
+++ b/src/detect-uricontent.h
@@ -27,7 +27,6 @@
 
 #include "detect-content.h"
 
-#include "util-spm-bm.h"
 #include "app-layer-htp.h"
 
 /* prototypes */

--- a/src/detect.h
+++ b/src/detect.h
@@ -823,6 +823,10 @@ typedef struct DetectEngineThreadCtx_ {
     MpmThreadCtx mtcs;  /**< thread ctx for stream mpm */
     PatternMatcherQueue pmq;
 
+    /** SPM thread context used for scanning. This has been cloned from the
+     * prototype held by DetectEngineCtx. */
+    SpmThreadCtx *spm_thread_ctx;
+
     /** ip only rules ctx */
     DetectEngineIPOnlyThreadCtx io_ctx;
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -33,6 +33,7 @@
 
 #include "packet-queue.h"
 #include "util-mpm.h"
+#include "util-spm.h"
 #include "util-hash.h"
 #include "util-hashlist.h"
 #include "util-debug.h"
@@ -588,6 +589,10 @@ typedef struct DetectEngineCtx_ {
 
     uint16_t mpm_matcher; /**< mpm matcher this ctx uses */
     uint16_t spm_matcher; /**< spm matcher this ctx uses */
+
+    /* spm thread context prototype, built as spm matchers are constructed and
+     * later cloned for each thread. */
+    SpmThreadCtx *spm_thread_ctx;
 
     /* Config options */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -587,6 +587,7 @@ typedef struct DetectEngineCtx_ {
     ThresholdCtx ths_ctx;
 
     uint16_t mpm_matcher; /**< mpm matcher this ctx uses */
+    uint16_t spm_matcher; /**< spm matcher this ctx uses */
 
     /* Config options */
 

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -151,6 +151,7 @@ void RunUnittests(int list_unittests, char *regex_arg)
 #ifdef __SC_CUDA_SUPPORT__
     MpmCudaEnvironmentSetup();
 #endif
+    SpmTableSetup();
 
     AppLayerSetup();
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2225,6 +2225,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
 #ifdef __SC_CUDA_SUPPORT__
     MpmCudaEnvironmentSetup();
 #endif
+    SpmTableSetup();
 
     switch (suri->checksum_validation) {
         case 0:

--- a/src/util-hyperscan.c
+++ b/src/util-hyperscan.c
@@ -1,0 +1,59 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Support functions for Hyperscan library integration.
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#ifdef BUILD_HYPERSCAN
+
+/**
+ * \internal
+ * \brief Convert a pattern into a regex string accepted by the Hyperscan
+ * compiler.
+ *
+ * For simplicity, we just take each byte of the original pattern and render it
+ * with a hex escape (i.e. ' ' -> "\x20")/
+ */
+char *HSRenderPattern(const uint8_t *pat, uint16_t pat_len)
+{
+    if (pat == NULL) {
+        return NULL;
+    }
+    const size_t hex_len = (pat_len * 4) + 1;
+    char *str = SCMalloc(hex_len);
+    if (str == NULL) {
+        return NULL;
+    }
+    memset(str, 0, hex_len);
+    char *sp = str;
+    for (uint16_t i = 0; i < pat_len; i++) {
+        snprintf(sp, 5, "\\x%02x", pat[i]);
+        sp += 4;
+    }
+    *sp = '\0';
+    return str;
+}
+
+#endif /* BUILD_HYPERSCAN */

--- a/src/util-hyperscan.h
+++ b/src/util-hyperscan.h
@@ -1,0 +1,31 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Support functions for Hyperscan library integration.
+ */
+
+#ifndef __UTIL_HYPERSCAN__H__
+#define __UTIL_HYPERSCAN__H__
+
+char *HSRenderPattern(const uint8_t *pat, uint16_t pat_len);
+
+#endif /* __UTIL_HYPERSCAN__H__ */

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -34,6 +34,7 @@
 #include "suricata.h"
 
 #include "util-spm-bm.h"
+#include "util-spm.h"
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-memcpy.h"
@@ -380,3 +381,87 @@ uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, int32_
    return NULL;
 }
 
+typedef struct SpmBmCtx_ {
+    BmCtx *bm_ctx;
+    uint8_t *needle;
+    uint16_t needle_len;
+    int nocase;
+} SpmBmCtx;
+
+SpmCtx *BMInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                  void **thread_ctx)
+{
+    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    if (ctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->matcher = SPM_BM;
+
+    SpmBmCtx *sctx = SCMalloc(sizeof(SpmBmCtx));
+    if (sctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmBmCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(sctx, 0, sizeof(*sctx));
+
+    sctx->needle = SCMalloc(needle_len);
+    if (sctx->needle == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc string. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memcpy(sctx->needle, needle, needle_len);
+    sctx->needle_len = needle_len;
+
+    if (nocase) {
+        sctx->bm_ctx = BoyerMooreNocaseCtxInit(sctx->needle, sctx->needle_len);
+        sctx->nocase = 1;
+    } else {
+        sctx->bm_ctx = BoyerMooreCtxInit(sctx->needle, sctx->needle_len);
+        sctx->nocase = 0;
+    }
+
+    ctx->ctx = sctx;
+    return ctx;
+}
+
+void BMDestroyCtx(SpmCtx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    SpmBmCtx *sctx = ctx->ctx;
+    if (sctx != NULL) {
+        BoyerMooreCtxDeInit(sctx->bm_ctx);
+        if (sctx->needle != NULL) {
+            SCFree(sctx->needle);
+        }
+        SCFree(sctx);
+    }
+
+    SCFree(ctx);
+}
+
+uint8_t *BMScan(const SpmCtx *ctx, void *thread_ctx, const uint8_t *haystack,
+                uint16_t haystack_len)
+{
+    const SpmBmCtx *sctx = ctx->ctx;
+
+    if (sctx->nocase) {
+        return BoyerMooreNocase(sctx->needle, sctx->needle_len, haystack,
+                                haystack_len, sctx->bm_ctx);
+    } else {
+        return BoyerMoore(sctx->needle, sctx->needle_len, haystack,
+                          haystack_len, sctx->bm_ctx);
+    }
+}
+
+void SpmBMRegister(void)
+{
+    spm_table[SPM_BM].name = "bm";
+    spm_table[SPM_BM].InitCtx = BMInitCtx;
+    spm_table[SPM_BM].DestroyCtx = BMDestroyCtx;
+    spm_table[SPM_BM].Scan = BMScan;
+}

--- a/src/util-spm-bm.h
+++ b/src/util-spm-bm.h
@@ -45,5 +45,7 @@ uint8_t *BoyerMoore(const uint8_t *x, uint16_t m, const uint8_t *y, int32_t n, B
 uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, int32_t n, BmCtx *bm_ctx);
 void BoyerMooreCtxDeInit(BmCtx *);
 
+void SpmBMRegister(void);
+
 #endif /* __UTIL_SPM_BM__ */
 

--- a/src/util-spm-hs.c
+++ b/src/util-spm-hs.c
@@ -1,0 +1,201 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Single pattern matcher that uses the Hyperscan regex matcher.
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "util-hyperscan.h"
+#include "util-spm-hs.h"
+
+#ifdef BUILD_HYPERSCAN
+
+#include <hs.h>
+
+/**
+ * \internal
+ * \brief Hyperscan match callback, called by hs_scan.
+ */
+static int MatchEvent(unsigned int id, unsigned long long from,
+                      unsigned long long to, unsigned int flags, void *context)
+{
+    uint64_t *match_offset = context;
+    BUG_ON(*match_offset != UINT64_MAX);
+    *match_offset = to;
+    return 1; /* Terminate matching. */
+}
+
+typedef struct SpmHsCtx_ {
+    hs_database_t *db;
+    uint16_t needle_len;
+} SpmHsCtx;
+
+static SpmCtx *HSInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                         SpmThreadCtx *thread_ctx)
+{
+    char *expr = HSRenderPattern(needle, needle_len);
+    if (expr == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc string. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+
+    unsigned flags = nocase ? HS_FLAG_CASELESS : 0;
+
+    hs_database_t *db = NULL;
+    hs_compile_error_t *compile_err = NULL;
+    hs_error_t err = hs_compile(expr, flags, HS_MODE_BLOCK, NULL, &db,
+                                &compile_err);
+    if (err != HS_SUCCESS) {
+        SCLogError(SC_ERR_FATAL, "Unable to compile '%s' with Hyperscan, "
+                                 "returned %d.", expr, err);
+        exit(EXIT_FAILURE);
+    }
+
+    SCFree(expr);
+
+    /* Update scratch for this database. */
+    hs_scratch_t *scratch = thread_ctx->ctx;
+    hs_alloc_scratch(db, &scratch);
+    thread_ctx->ctx = scratch;
+
+    SpmHsCtx *sctx = SCMalloc(sizeof(SpmHsCtx));
+    if (sctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmHsCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(sctx, 0, sizeof(SpmHsCtx));
+    sctx->db = db;
+    sctx->needle_len = needle_len;
+
+    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    if (ctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(ctx, 0, sizeof(SpmCtx));
+    ctx->matcher = SPM_HS;
+    ctx->ctx = sctx;
+    return ctx;
+}
+
+static void HSDestroyCtx(SpmCtx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+    SpmHsCtx *sctx = ctx->ctx;
+    if (sctx) {
+        hs_free_database(sctx->db);
+        SCFree(sctx);
+    }
+    SCFree(ctx);
+}
+
+static uint8_t *HSScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                       const uint8_t *haystack, uint16_t haystack_len)
+{
+    const SpmHsCtx *sctx = ctx->ctx;
+    hs_scratch_t *scratch = thread_ctx->ctx;
+
+    uint64_t match_offset = UINT64_MAX;
+    hs_error_t err = hs_scan(sctx->db, (const char *)haystack, haystack_len, 0,
+                             scratch, MatchEvent, &match_offset);
+    if (err != HS_SUCCESS && err != HS_SCAN_TERMINATED) {
+        SCLogError(SC_ERR_FATAL, "Scan with Hyperscan returned error %d.", err);
+        return NULL;
+    }
+
+    if (match_offset == UINT64_MAX) {
+        return NULL;
+    }
+
+    BUG_ON(match_offset < sctx->needle_len);
+    BUG_ON(match_offset > UINT16_MAX); /* haystack_len is a uint16_t */
+
+    /* Note: existing API returns non-const ptr */
+    return (uint8_t *)haystack + (match_offset - sctx->needle_len);
+}
+
+static SpmThreadCtx *HSInitThreadCtx(void)
+{
+    SpmThreadCtx *thread_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    if (thread_ctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmThreadCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(thread_ctx, 0, sizeof(*thread_ctx));
+    thread_ctx->matcher = SPM_HS;
+
+    /* We store scratch in the HS-specific ctx. This will be initialized as
+     * patterns are compiled by SpmInitCtx. */
+    thread_ctx->ctx = NULL;
+
+    return thread_ctx;
+}
+
+static void HSDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    if (thread_ctx == NULL) {
+        return;
+    }
+    hs_free_scratch(thread_ctx->ctx);
+    SCFree(thread_ctx);
+}
+
+static SpmThreadCtx *HSCloneThreadCtx(const SpmThreadCtx *thread_ctx)
+{
+    SpmThreadCtx *cloned_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    if (cloned_ctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmThreadCtx. Exiting.");
+        exit(EXIT_FAILURE);
+    }
+    memset(cloned_ctx, 0, sizeof(*cloned_ctx));
+    cloned_ctx->matcher = SPM_HS;
+
+    if (thread_ctx->ctx != NULL) {
+        hs_scratch_t *scratch = NULL;
+        hs_error_t err = hs_clone_scratch(thread_ctx->ctx, &scratch);
+        if (err != HS_SUCCESS) {
+            SCLogError(SC_ERR_FATAL, "Unable to clone scratch (error %d).",
+                       err);
+            exit(EXIT_FAILURE);
+        }
+        cloned_ctx->ctx = scratch;
+    }
+
+    return cloned_ctx;
+}
+
+void SpmHSRegister(void)
+{
+    spm_table[SPM_HS].name = "hs";
+    spm_table[SPM_HS].InitThreadCtx = HSInitThreadCtx;
+    spm_table[SPM_HS].DestroyThreadCtx = HSDestroyThreadCtx;
+    spm_table[SPM_HS].CloneThreadCtx = HSCloneThreadCtx;
+    spm_table[SPM_HS].InitCtx = HSInitCtx;
+    spm_table[SPM_HS].DestroyCtx = HSDestroyCtx;
+    spm_table[SPM_HS].Scan = HSScan;
+}
+
+#endif /* BUILD_HYPERSCAN */

--- a/src/util-spm-hs.h
+++ b/src/util-spm-hs.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Single pattern matcher that uses the Hyperscan regex matcher.
+ */
+
+#ifndef __UTIL_SPM_HS_H__
+#define __UTIL_SPM_HS_H__
+
+void SpmHSRegister(void);
+
+#endif /* __UTIL_SPM_HS_H__ */
+

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -47,12 +47,34 @@
 #include "suricata.h"
 #include "util-unittest.h"
 
+#include "conf.h"
+
 #include "util-spm.h"
 #include "util-spm-bs.h"
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
 #include "util-clock.h"
 
+/**
+ * \brief Returns the single pattern matcher algorithm to be used, based on the
+ * spm-algo setting in yaml.
+ */
+uint16_t SinglePatternMatchDefaultMatcher(void) {
+    char *spm_algo;
+    if ((ConfGet("spm-algo", &spm_algo)) == 1) {
+        if (strcmp("bm", spm_algo) == 0) {
+            return SPM_BM;
+        }
+
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                   "Invalid spm algo supplied "
+                   "in the yaml conf file: \"%s\"",
+                   spm_algo);
+        exit(EXIT_FAILURE);
+    }
+
+    return SPM_BM; /* default to Boyer-Moore */
+}
 
 /**
  * Wrappers for building context and searching (Bs2Bm and boyermoore)

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -91,8 +91,23 @@ void SpmTableSetup(void)
     SpmBMRegister();
 }
 
+SpmThreadCtx *SpmInitThreadCtx(uint16_t matcher)
+{
+    return spm_table[matcher].InitThreadCtx();
+}
+
+void SpmDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    spm_table[thread_ctx->matcher].DestroyThreadCtx(thread_ctx);
+}
+
+SpmThreadCtx *SpmCloneThreadCtx(const SpmThreadCtx *thread_ctx)
+{
+    return spm_table[thread_ctx->matcher].CloneThreadCtx(thread_ctx);
+}
+
 SpmCtx *SpmInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
-                   void **thread_ctx, uint16_t matcher)
+                   SpmThreadCtx *thread_ctx, uint16_t matcher)
 {
     return spm_table[matcher].InitCtx(needle, needle_len, nocase, thread_ctx);
 }
@@ -102,8 +117,8 @@ void SpmDestroyCtx(SpmCtx *ctx)
     spm_table[ctx->matcher].DestroyCtx(ctx);
 }
 
-uint8_t *SpmScan(const SpmCtx *ctx, void *thread_ctx, const uint8_t *haystack,
-                 uint16_t haystack_len)
+uint8_t *SpmScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                 const uint8_t *haystack, uint16_t haystack_len)
 {
     return spm_table[ctx->matcher].Scan(ctx, thread_ctx, haystack,
                                         haystack_len);

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -53,6 +53,7 @@
 #include "util-spm-bs.h"
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
+#include "util-spm-hs.h"
 #include "util-clock.h"
 
 /**
@@ -89,6 +90,9 @@ void SpmTableSetup(void)
     memset(spm_table, 0, sizeof(spm_table));
 
     SpmBMRegister();
+#ifdef BUILD_HYPERSCAN
+    SpmHSRegister();
+#endif
 }
 
 SpmThreadCtx *SpmInitThreadCtx(uint16_t matcher)

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -31,9 +31,36 @@
 enum {
     SPM_BM, /* Boyer-Moore */
     /* Other SPM matchers will go here. */
+    SPM_TABLE_SIZE
 };
 
 uint16_t SinglePatternMatchDefaultMatcher(void);
+
+typedef struct SpmCtx_ {
+    uint16_t matcher;
+    void *ctx;
+} SpmCtx;
+
+typedef struct SpmTableElmt_ {
+    const char *name;
+    SpmCtx *(*InitCtx)(const uint8_t *needle, uint16_t needle_len, int nocase,
+                       void **thread_ctx);
+    void (*DestroyCtx)(SpmCtx *);
+    uint8_t *(*Scan)(const SpmCtx *ctx, void *thread_ctx,
+                     const uint8_t *haystack, uint16_t haystack_len);
+} SpmTableElmt;
+
+SpmTableElmt spm_table[SPM_TABLE_SIZE];
+
+void SpmTableSetup(void);
+
+SpmCtx *SpmInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                   void **thread_ctx, uint16_t matcher);
+
+void SpmDestroyCtx(SpmCtx *ctx);
+
+uint8_t *SpmScan(const SpmCtx *ctx, void *thread_ctx, const uint8_t *haystack,
+                 uint16_t haystack_len);
 
 /** Default algorithm to use: Boyer Moore */
 uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -41,12 +41,20 @@ typedef struct SpmCtx_ {
     void *ctx;
 } SpmCtx;
 
+typedef struct SpmThreadCtx_ {
+    uint16_t matcher;
+    void *ctx;
+} SpmThreadCtx;
+
 typedef struct SpmTableElmt_ {
     const char *name;
+    SpmThreadCtx *(*InitThreadCtx)(void);
+    void (*DestroyThreadCtx)(SpmThreadCtx *thread_ctx);
+    SpmThreadCtx *(*CloneThreadCtx)(const SpmThreadCtx *thread_ctx);
     SpmCtx *(*InitCtx)(const uint8_t *needle, uint16_t needle_len, int nocase,
-                       void **thread_ctx);
+                       SpmThreadCtx *thread_ctx);
     void (*DestroyCtx)(SpmCtx *);
-    uint8_t *(*Scan)(const SpmCtx *ctx, void *thread_ctx,
+    uint8_t *(*Scan)(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
                      const uint8_t *haystack, uint16_t haystack_len);
 } SpmTableElmt;
 
@@ -54,13 +62,19 @@ SpmTableElmt spm_table[SPM_TABLE_SIZE];
 
 void SpmTableSetup(void);
 
+SpmThreadCtx *SpmInitThreadCtx(uint16_t matcher);
+
+void SpmDestroyThreadCtx(SpmThreadCtx *thread_ctx);
+
+SpmThreadCtx *SpmCloneThreadCtx(const SpmThreadCtx *thread_ctx);
+
 SpmCtx *SpmInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
-                   void **thread_ctx, uint16_t matcher);
+                   SpmThreadCtx *thread_ctx, uint16_t matcher);
 
 void SpmDestroyCtx(SpmCtx *ctx);
 
-uint8_t *SpmScan(const SpmCtx *ctx, void *thread_ctx, const uint8_t *haystack,
-                 uint16_t haystack_len);
+uint8_t *SpmScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                 const uint8_t *haystack, uint16_t haystack_len);
 
 /** Default algorithm to use: Boyer Moore */
 uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -30,6 +30,7 @@
 
 enum {
     SPM_BM, /* Boyer-Moore */
+    SPM_HS, /* Hyperscan */
     /* Other SPM matchers will go here. */
     SPM_TABLE_SIZE
 };

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -28,6 +28,13 @@
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
 
+enum {
+    SPM_BM, /* Boyer-Moore */
+    /* Other SPM matchers will go here. */
+};
+
+uint16_t SinglePatternMatchDefaultMatcher(void);
+
 /** Default algorithm to use: Boyer Moore */
 uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *Bs2bmNocaseSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -725,6 +725,13 @@ cuda:
 
 mpm-algo: ac
 
+# Select the matching algorithm you want to use for single-pattern searches.
+#
+# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
+# available if Suricata has been built with Hyperscan support).
+
+spm-algo: bm
+
 # Defrag settings:
 
 defrag:


### PR DESCRIPTION
This pull request adds an SPM API (roughly similar to the MPM API) and provides two single pattern matcher implementations:

- Boyer-Moore ("bm") using the existing code in Suricata;
- Hyperscan ("hs") using Hyperscan as a single-string matcher, provided that Hyperscan is configured in.

As well as the API changes, support for some per-thread context (`SpmThreadCtx`) for SPM algorithms is provided -- in Hyperscan this is used for `hs_scratch_t` scratch regions.

The algorithm is selectable with the "spm-algo" yaml option, and defaults to "bm".