### PR TITLE
configure.ac: escape $srcdir when used in a variable - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1273,7 +1273,7 @@
             HTP_LDADD="../libhtp/htp/libhtp.la"
             AC_SUBST(HTP_LDADD)
             # make sure libhtp is added to the includes
-            CPPFLAGS="-I${srcdir}/../libhtp/ ${CPPFLAGS}"
+            CPPFLAGS="-I\${srcdir}/../libhtp/ ${CPPFLAGS}"
 
             AC_CHECK_HEADER(iconv.h,,[AC_ERROR(iconv.h not found ...)])
             AC_CHECK_LIB(iconv, libiconv_close)


### PR DESCRIPTION
$srcdir needs to be escaped for proper expansion when used
as part of a Makefile variable.

Fixes the issue reported on the mailing list when building Suricata within the OpenBSD ports system, however, this is not OpenBSD specific.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/225
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/230
