### PR TITLE
packet shrink v7

### DIFF
--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -331,7 +331,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
             /** \todo What if more data exist after EOL (possible covert channel or data leakage)? */
             SCLogDebug("IPV4OPT %" PRIu16 " len 1 @ %" PRIu16 "/%" PRIu16 "",
                    *pkt, (len - plen), (len - 1));
-            p->ip4vars.eol = TRUE;
+            p->ip4vars.opts_set |= IPV4_OPT_FLAG_EOL;
             break;
         } else if (*pkt == IPV4_OPT_NOP) {
             SCLogDebug("IPV4OPT %" PRIu16 " len 1 @ %" PRIu16 "/%" PRIu16 "",
@@ -339,7 +339,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
             pkt++;
             plen--;
 
-            p->ip4vars.nop = TRUE;
+            p->ip4vars.opts_set |= IPV4_OPT_FLAG_NOP;
 
         /* multibyte options */
         } else {
@@ -379,7 +379,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_ts = opt;
-                    p->ip4vars.ts = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_TS;
                     break;
                 case IPV4_OPT_RR:
                     if (opts->o_rr.type != 0) {
@@ -390,7 +390,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_rr = opt;
-                    p->ip4vars.rr = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_RR;
                     break;
                 case IPV4_OPT_QS:
                     if (opts->o_qs.type != 0) {
@@ -401,7 +401,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_qs = opt;
-                    p->ip4vars.qs = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_QS;
                     break;
                 case IPV4_OPT_SEC:
                     if (opts->o_sec.type != 0) {
@@ -412,7 +412,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_sec = opt;
-                    p->ip4vars.sec = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_SEC;
                     break;
                 case IPV4_OPT_LSRR:
                     if (opts->o_lsrr.type != 0) {
@@ -423,7 +423,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_lsrr = opt;
-                    p->ip4vars.lsrr = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_LSRR;
                     break;
                 case IPV4_OPT_CIPSO:
                     if (opts->o_cipso.type != 0) {
@@ -434,7 +434,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_cipso = opt;
-                    p->ip4vars.cipso = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_CIPSO;
                     break;
                 case IPV4_OPT_SID:
                     if (opts->o_sid.type != 0) {
@@ -445,7 +445,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_sid = opt;
-                    p->ip4vars.sid = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_SID;
                     break;
                 case IPV4_OPT_SSRR:
                     if (opts->o_ssrr.type != 0) {
@@ -456,7 +456,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_ssrr = opt;
-                    p->ip4vars.ssrr = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_SSRR;
                     break;
                 case IPV4_OPT_RTRALT:
                     if (opts->o_rtralt.type != 0) {
@@ -467,7 +467,7 @@ static int DecodeIPV4Options(Packet *p, uint8_t *pkt, uint16_t len, IPV4Options 
                         return -1;
                     }
                     opts->o_rtralt = opt;
-                    p->ip4vars.rtralt = TRUE;
+                    p->ip4vars.opts_set |= IPV4_OPT_FLAG_RTRALT;
                     break;
                 default:
                     SCLogDebug("IPV4OPT <unknown> (%" PRIu8 ") len %" PRIu8,

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -151,18 +151,7 @@ typedef struct IPV4Hdr_
 #define CLEAR_IPV4_PACKET(p) do { \
     (p)->ip4h = NULL; \
     (p)->level3_comp_csum = -1; \
-    (p)->ip4vars.ip_src_u32 = 0; \
-    (p)->ip4vars.ip_dst_u32 = 0; \
-    (p)->ip4vars.ip_opt_cnt = 0; \
-    (p)->ip4vars.o_rr = NULL; \
-    (p)->ip4vars.o_qs = NULL; \
-    (p)->ip4vars.o_ts = NULL; \
-    (p)->ip4vars.o_sec = NULL; \
-    (p)->ip4vars.o_lsrr = NULL; \
-    (p)->ip4vars.o_cipso = NULL; \
-    (p)->ip4vars.o_sid = NULL; \
-    (p)->ip4vars.o_ssrr = NULL; \
-    (p)->ip4vars.o_rtralt = NULL; \
+    memset(&p->ip4vars, 0x00, sizeof(p->ip4vars)); \
 } while (0)
 
 /* helper structure with parsed ipv4 info */
@@ -172,19 +161,19 @@ typedef struct IPV4Vars_
     uint32_t ip_src_u32;   /* source IP */
     uint32_t ip_dst_u32;   /* dest IP */
 
-    IPV4Opt ip_opts[IPV4_OPTMAX];
-    uint8_t ip_opt_cnt;
+    uint16_t opt_cnt;
+    _Bool rr;
+    _Bool lsrr;
+    _Bool eol;
+    _Bool nop;
+    _Bool ts;
+    _Bool sec;
+    _Bool sid;
+    _Bool qs;
+    _Bool cipso;
+    _Bool rtralt;
+    _Bool ssrr;
 
-    /* These are here for direct access and dup tracking */
-    IPV4Opt *o_rr;
-    IPV4Opt *o_qs;
-    IPV4Opt *o_ts;
-    IPV4Opt *o_sec;
-    IPV4Opt *o_lsrr;
-    IPV4Opt *o_cipso;
-    IPV4Opt *o_sid;
-    IPV4Opt *o_ssrr;
-    IPV4Opt *o_rtralt;
 } IPV4Vars;
 
 

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -154,6 +154,20 @@ typedef struct IPV4Hdr_
     memset(&p->ip4vars, 0x00, sizeof(p->ip4vars)); \
 } while (0)
 
+enum IPV4OptionFlags {
+    IPV4_OPT_FLAG_EOL = 0,
+    IPV4_OPT_FLAG_NOP,
+    IPV4_OPT_FLAG_RR,
+    IPV4_OPT_FLAG_TS,
+    IPV4_OPT_FLAG_QS,
+    IPV4_OPT_FLAG_LSRR,
+    IPV4_OPT_FLAG_SSRR,
+    IPV4_OPT_FLAG_SID,
+    IPV4_OPT_FLAG_SEC,
+    IPV4_OPT_FLAG_CIPSO,
+    IPV4_OPT_FLAG_RTRALT,
+};
+
 /* helper structure with parsed ipv4 info */
 typedef struct IPV4Vars_
 {
@@ -162,18 +176,7 @@ typedef struct IPV4Vars_
     uint32_t ip_dst_u32;   /* dest IP */
 
     uint16_t opt_cnt;
-    _Bool rr;
-    _Bool lsrr;
-    _Bool eol;
-    _Bool nop;
-    _Bool ts;
-    _Bool sec;
-    _Bool sid;
-    _Bool qs;
-    _Bool cipso;
-    _Bool rtralt;
-    _Bool ssrr;
-
+    uint16_t opts_set;
 } IPV4Vars;
 
 

--- a/src/decode-ipv4.h
+++ b/src/decode-ipv4.h
@@ -172,8 +172,6 @@ enum IPV4OptionFlags {
 typedef struct IPV4Vars_
 {
     int32_t comp_csum;     /* checksum computed over the ipv4 packet */
-    uint32_t ip_src_u32;   /* source IP */
-    uint32_t ip_dst_u32;   /* dest IP */
 
     uint16_t opt_cnt;
     uint16_t opts_set;

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -106,7 +106,7 @@ static inline
 #endif
 void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
                           uint16_t hdrextlen, uint16_t plen,
-                          uint16_t ip6_exthdrs_cnt, IPV6GenOptHdr *ip6_exthdrs)
+                          uint16_t prev_hdrextlen)
 {
     uint16_t frag_offset = (*(pkt + 2) << 8 | *(pkt + 3)) & 0xFFF8;
     int frag_morefrags   = (*(pkt + 2) << 8 | *(pkt + 3)) & 0x0001;
@@ -135,8 +135,8 @@ void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
     p->ip6eh.fh_data_len = data_len;
 
     /* if we have a prev hdr, store the type and offset of it */
-    if (ip6_exthdrs_cnt > 1) {
-        p->ip6eh.fh_prev_hdr_offset = frag_hdr_offset - ip6_exthdrs[ip6_exthdrs_cnt - 1].len;
+    if (prev_hdrextlen) {
+        p->ip6eh.fh_prev_hdr_offset = frag_hdr_offset - prev_hdrextlen;
     }
 
     SCLogDebug("IPV6 FH: frag_hdr_offset %u, data_offset %u, data_len %u",
@@ -151,14 +151,11 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
 
     uint8_t *orig_pkt = pkt;
     uint8_t nh = 0; /* careful, 0 is actually a real type */
-    uint16_t hdrextlen;
+    uint16_t hdrextlen = 0;
+    uint16_t prev_hdrextlen = 0;
     uint16_t plen;
     char dstopts = 0;
     char exthdr_fh_done = 0;
-
-    uint8_t ip6_exthdrs_cnt = 0;
-    IPV6GenOptHdr ip6_exthdrs[IPV6_MAX_OPT];
-
     int hh = 0;
     int rh = 0;
     int eh = 0;
@@ -203,6 +200,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
 
             case IPPROTO_ROUTING:
                 IPV6_SET_L4PROTO(p,nh);
+                prev_hdrextlen = hdrextlen;
                 hdrextlen = 8 + (*(pkt+1) * 8);  /* 8 bytes + length in 8 octet units */
 
                 SCLogDebug("hdrextlen %"PRIu8, hdrextlen);
@@ -210,15 +208,6 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 if (hdrextlen > plen) {
                     ENGINE_SET_EVENT(p, IPV6_TRUNC_EXTHDR);
                     SCReturn;
-                }
-
-                if (ip6_exthdrs_cnt < IPV6_MAX_OPT)
-                {
-                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
-                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
-                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
-                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
-                    ip6_exthdrs_cnt++;
                 }
 
                 if (rh) {
@@ -254,19 +243,11 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 uint16_t optslen = 0;
 
                 IPV6_SET_L4PROTO(p,nh);
+                prev_hdrextlen = hdrextlen;
                 hdrextlen =  (*(pkt+1) + 1) << 3;
                 if (hdrextlen > plen) {
                     ENGINE_SET_EVENT(p, IPV6_TRUNC_EXTHDR);
                     SCReturn;
-                }
-
-                if (ip6_exthdrs_cnt < IPV6_MAX_OPT)
-                {
-                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
-                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
-                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
-                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
-                    ip6_exthdrs_cnt++;
                 }
 
                 uint8_t *ptr = pkt + 2; /* +2 to go past nxthdr and len */
@@ -440,6 +421,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     exthdr_fh_done = 1;
                 }
 
+                prev_hdrextlen = hdrextlen;
                 hdrextlen = sizeof(IPV6FragHdr);
                 if (hdrextlen > plen) {
                     ENGINE_SET_EVENT(p, IPV6_TRUNC_EXTHDR);
@@ -450,15 +432,6 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 if (*(pkt + 1) != 0) {
                     ENGINE_SET_EVENT(p, IPV6_FH_NON_ZERO_RES_FIELD);
                     /* non fatal, lets try to continue */
-                }
-
-                if(ip6_exthdrs_cnt<IPV6_MAX_OPT)
-                {
-                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
-                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
-                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
-                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
-                    ip6_exthdrs_cnt++;
                 }
 
                 if (IPV6_EXTHDR_ISSET_FH(p)) {
@@ -473,8 +446,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 IPV6_EXTHDR_SET_FH(p);
 
                 /* parse the header and setup the vars */
-                DecodeIPV6FragHeader(p, pkt, hdrextlen, plen,
-                        ip6_exthdrs_cnt, ip6_exthdrs);
+                DecodeIPV6FragHeader(p, pkt, hdrextlen, plen, prev_hdrextlen);
 
                 /* if FH has offset 0 and no more fragments are coming, we
                  * parse this packet further right away, no defrag will be
@@ -496,19 +468,11 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
             case IPPROTO_ESP:
             {
                 IPV6_SET_L4PROTO(p,nh);
+                prev_hdrextlen = hdrextlen;
                 hdrextlen = sizeof(IPV6EspHdr);
                 if (hdrextlen > plen) {
                     ENGINE_SET_EVENT(p, IPV6_TRUNC_EXTHDR);
                     SCReturn;
-                }
-
-                if(ip6_exthdrs_cnt<IPV6_MAX_OPT)
-                {
-                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
-                    ip6_exthdrs[ip6_exthdrs_cnt].next = IPPROTO_NONE;
-                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
-                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
-                    ip6_exthdrs_cnt++;
                 }
 
                 if (eh) {
@@ -526,6 +490,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
             case IPPROTO_AH:
             {
                 IPV6_SET_L4PROTO(p,nh);
+                prev_hdrextlen = hdrextlen;
                 /* we need the header as a minimum */
                 hdrextlen = sizeof(IPV6AuthHdr);
                 /* the payload len field is the number of extra 4 byte fields,
@@ -543,15 +508,6 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 IPV6AuthHdr *ahhdr = (IPV6AuthHdr *)pkt;
                 if (ahhdr->ip6ah_reserved != 0x0000) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_AH_RES_NOT_NULL);
-                }
-
-                if(ip6_exthdrs_cnt < IPV6_MAX_OPT)
-                {
-                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
-                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
-                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
-                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
-                    ip6_exthdrs_cnt++;
                 }
 
                 if (ah) {
@@ -584,6 +540,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
             case IPPROTO_MH:
             case IPPROTO_HIP:
             case IPPROTO_SHIM6:
+                prev_hdrextlen = hdrextlen;
                 hdrextlen = 8 + (*(pkt+1) * 8);  /* 8 bytes + length in 8 octet units */
                 if (hdrextlen > plen) {
                     ENGINE_SET_EVENT(p, IPV6_TRUNC_EXTHDR);

--- a/src/decode-ipv6.c
+++ b/src/decode-ipv6.c
@@ -113,6 +113,14 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
     char dstopts = 0;
     char exthdr_fh_done = 0;
 
+    uint8_t ip6_exthdrs_cnt = 0;
+    IPV6GenOptHdr ip6_exthdrs[IPV6_MAX_OPT];
+
+    int hh = 0;
+    int rh = 0;
+    int eh = 0;
+    int ah = 0;
+
     nh = IPV6_GET_NH(p);
     plen = len;
 
@@ -161,16 +169,16 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     SCReturn;
                 }
 
-                if (p->IPV6_EH_CNT < IPV6_MAX_OPT)
+                if (ip6_exthdrs_cnt < IPV6_MAX_OPT)
                 {
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].type = nh;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].next = *pkt;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].len = hdrextlen;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].data = pkt+2;
-                    p->IPV6_EH_CNT++;
+                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
+                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
+                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
+                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
+                    ip6_exthdrs_cnt++;
                 }
 
-                if (IPV6_EXTHDR_ISSET_RH(p)) {
+                if (rh) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_DUPL_RH);
                     /* skip past this extension so we can continue parsing the rest
                      * of the packet */
@@ -180,26 +188,14 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     break;
                 }
 
-                IPV6_EXTHDR_SET_RH(p, pkt);
+                rh = 1;
+                IPV6_EXTHDR_SET_RH(p);
 
-                /** \todo move into own function and load on demand */
-                if (IPV6_EXTHDR_RH(p)->ip6rh_type == 0) {
-#if 0 // XXX usused and broken, original packet is modified in the memcpy
-                    uint8_t i;
-
-                    uint8_t n = hdrextlen / 2;
-                    /* because we devide the header len by 2 (as rfc 2460 tells us to)
-                     * we devide the result by 8 and not 16 as the header fields are
-                     * sized */
-                    for (i = 0; i < (n/8) && i < sizeof(IPV6_EXTHDR_RH(p)->ip6rh0_addr)/sizeof(struct in6_addr); ++i) {
-                        /* the address header fields are 16 bytes in size */
-                        /** \todo do this without memcpy since it's expensive */
-                        memcpy(&IPV6_EXTHDR_RH(p)->ip6rh0_addr[i], pkt+(i*16)+8, sizeof(IPV6_EXTHDR_RH(p)->ip6rh0_addr[i]));
-                    }
-                    IPV6_EXTHDR_RH(p)->ip6rh0_num_addrs = i;
-#endif
+                uint8_t ip6rh_type = *(pkt + 2);
+                if (ip6rh_type == 0) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_RH_TYPE_0);
                 }
+                p->ip6eh.rh_type = ip6rh_type;
 
                 nh = *pkt;
                 pkt += hdrextlen;
@@ -209,9 +205,9 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
             case IPPROTO_HOPOPTS:
             case IPPROTO_DSTOPTS:
             {
-                IPV6OptHAO *hao = NULL;
-                IPV6OptRA *ra = NULL;
-                IPV6OptJumbo *jumbo = NULL;
+                IPV6OptHAO hao_s, *hao = &hao_s;
+                IPV6OptRA ra_s, *ra = &ra_s;
+                IPV6OptJumbo jumbo_s, *jumbo = &jumbo_s;
                 uint16_t optslen = 0;
 
                 IPV6_SET_L4PROTO(p,nh);
@@ -221,13 +217,13 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     SCReturn;
                 }
 
-                if (p->IPV6_EH_CNT < IPV6_MAX_OPT)
+                if (ip6_exthdrs_cnt < IPV6_MAX_OPT)
                 {
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].type = nh;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].next = *pkt;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].len = hdrextlen;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].data = pkt+2;
-                    p->IPV6_EH_CNT++;
+                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
+                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
+                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
+                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
+                    ip6_exthdrs_cnt++;
                 }
 
                 uint8_t *ptr = pkt + 2; /* +2 to go past nxthdr and len */
@@ -235,7 +231,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                 /* point the pointers to right structures
                  * in Packet. */
                 if (nh == IPPROTO_HOPOPTS) {
-                    if (IPV6_EXTHDR_ISSET_HH(p)) {
+                    if (hh) {
                         ENGINE_SET_EVENT(p, IPV6_EXTHDR_DUPL_HH);
                         /* skip past this extension so we can continue parsing the rest
                          * of the packet */
@@ -245,28 +241,17 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                         break;
                     }
 
-                    IPV6_EXTHDR_SET_HH(p, pkt);
-                    hao = &IPV6_EXTHDR_HH_HAO(p);
-                    ra = &IPV6_EXTHDR_HH_RA(p);
-                    jumbo = &IPV6_EXTHDR_HH_JUMBO(p);
+                    hh = 1;
 
-                    optslen = ((IPV6_EXTHDR_HH(p)->ip6hh_len+1)<<3)-2;
+                    optslen = ((*(pkt + 1) + 1 ) << 3) - 2;
                 }
                 else if (nh == IPPROTO_DSTOPTS)
                 {
                     if (dstopts == 0) {
-                        IPV6_EXTHDR_SET_DH1(p, pkt);
-                        hao = &IPV6_EXTHDR_DH1_HAO(p);
-                        ra = &IPV6_EXTHDR_DH1_RA(p);
-                        jumbo = &IPV6_EXTHDR_DH2_JUMBO(p);
-                        optslen = ((IPV6_EXTHDR_DH1(p)->ip6dh_len+1)<<3)-2;
+                        optslen = ((*(pkt + 1) + 1 ) << 3) - 2;
                         dstopts = 1;
                     } else if (dstopts == 1) {
-                        IPV6_EXTHDR_SET_DH2(p, pkt);
-                        hao = &IPV6_EXTHDR_DH2_HAO(p);
-                        ra = &IPV6_EXTHDR_DH2_RA(p);
-                        jumbo = &IPV6_EXTHDR_DH2_JUMBO(p);
-                        optslen = ((IPV6_EXTHDR_DH2(p)->ip6dh_len+1)<<3)-2;
+                        optslen = ((*(pkt + 1) + 1 ) << 3) - 2;
                         dstopts = 2;
                     } else {
                         ENGINE_SET_EVENT(p, IPV6_EXTHDR_DUPL_DH);
@@ -424,13 +409,13 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     /* non fatal, lets try to continue */
                 }
 
-                if(p->IPV6_EH_CNT<IPV6_MAX_OPT)
+                if(ip6_exthdrs_cnt<IPV6_MAX_OPT)
                 {
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].type = nh;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].next = *pkt;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].len = hdrextlen;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].data = pkt+2;
-                    p->IPV6_EH_CNT++;
+                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
+                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
+                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
+                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
+                    ip6_exthdrs_cnt++;
                 }
 
                 if (IPV6_EXTHDR_ISSET_FH(p)) {
@@ -441,14 +426,49 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     break;
                 }
 
-                /* set the header ptr first */
-                IPV6_EXTHDR_SET_FH(p, pkt);
+                /* set the header flag first */
+                IPV6_EXTHDR_SET_FH(p);
+
+                uint16_t frag_offset = (*(pkt + 2) << 8 | *(pkt + 3)) & 0xFFF8;
+                int frag_morefrags   = (*(pkt + 2) << 8 | *(pkt + 3)) & 0x0001;
+
+                p->ip6eh.fh_offset = frag_offset;
+                p->ip6eh.fh_more_frags_set = frag_morefrags ? TRUE : FALSE;
+                p->ip6eh.fh_nh = *pkt;
+
+                uint32_t fh_id;
+                memcpy(&fh_id, pkt+4, 4);
+                p->ip6eh.fh_id = ntohl(fh_id);
+
+                SCLogDebug("IPV6 FH: offset %u, mf %s, nh %u, id %u/%x",
+                    p->ip6eh.fh_offset,
+                    p->ip6eh.fh_more_frags_set ? "true" : "false",
+                    p->ip6eh.fh_nh,
+                    p->ip6eh.fh_id, p->ip6eh.fh_id);
+
+                // store header offset, data offset
+                uint16_t frag_hdr_offset = (uint16_t)(pkt - GET_PKT_DATA(p));
+                uint16_t data_offset = (uint16_t)(frag_hdr_offset + hdrextlen);
+                uint16_t data_len = plen - hdrextlen;
+
+                p->ip6eh.fh_header_offset = frag_hdr_offset;
+                p->ip6eh.fh_data_offset = data_offset;
+                p->ip6eh.fh_data_len = data_len;
+
+                /* if we have a prev hdr, store the type and offset of it */
+                if (ip6_exthdrs_cnt > 1) {
+                    p->ip6eh.fh_prev_hdr_offset = frag_hdr_offset - ip6_exthdrs[ip6_exthdrs_cnt - 1].len;
+                }
+
+                SCLogDebug("IPV6 FH: frag_hdr_offset %u, data_offset %u, data_len %u",
+                    p->ip6eh.fh_header_offset, p->ip6eh.fh_data_offset,
+                    p->ip6eh.fh_data_len);
 
                 /* if FH has offset 0 and no more fragments are coming, we
                  * parse this packet further right away, no defrag will be
                  * needed. It is a useless FH then though, so we do set an
                  * decoder event. */
-                if (IPV6_EXTHDR_GET_FH_FLAG(p) == 0 && IPV6_EXTHDR_GET_FH_OFFSET(p) == 0) {
+                if (frag_morefrags == 0 && frag_offset == 0) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_USELESS_FH);
 
                     nh = *pkt;
@@ -470,21 +490,21 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     SCReturn;
                 }
 
-                if(p->IPV6_EH_CNT<IPV6_MAX_OPT)
+                if(ip6_exthdrs_cnt<IPV6_MAX_OPT)
                 {
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].type = nh;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].next = IPPROTO_NONE;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].len = hdrextlen;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].data = pkt+2;
-                    p->IPV6_EH_CNT++;
+                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
+                    ip6_exthdrs[ip6_exthdrs_cnt].next = IPPROTO_NONE;
+                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
+                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
+                    ip6_exthdrs_cnt++;
                 }
 
-                if (IPV6_EXTHDR_ISSET_EH(p)) {
+                if (eh) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_DUPL_EH);
                     SCReturn;
                 }
 
-                IPV6_EXTHDR_SET_EH(p, pkt);
+                eh = 1;
 
                 nh = IPPROTO_NONE;
                 pkt += hdrextlen;
@@ -513,16 +533,16 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_AH_RES_NOT_NULL);
                 }
 
-                if(p->IPV6_EH_CNT < IPV6_MAX_OPT)
+                if(ip6_exthdrs_cnt < IPV6_MAX_OPT)
                 {
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].type = nh;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].next = *pkt;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].len = hdrextlen;
-                    p->IPV6_EXTHDRS[p->IPV6_EH_CNT].data = pkt+2;
-                    p->IPV6_EH_CNT++;
+                    ip6_exthdrs[ip6_exthdrs_cnt].type = nh;
+                    ip6_exthdrs[ip6_exthdrs_cnt].next = *pkt;
+                    ip6_exthdrs[ip6_exthdrs_cnt].len = hdrextlen;
+                    ip6_exthdrs[ip6_exthdrs_cnt].data = pkt+2;
+                    ip6_exthdrs_cnt++;
                 }
 
-                if (IPV6_EXTHDR_ISSET_AH(p)) {
+                if (ah) {
                     ENGINE_SET_EVENT(p, IPV6_EXTHDR_DUPL_AH);
                     nh = *pkt;
                     pkt += hdrextlen;
@@ -530,7 +550,7 @@ DecodeIPV6ExtHdrs(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt
                     break;
                 }
 
-                IPV6_EXTHDR_SET_AH(p, pkt);
+                ah = 1;
 
                 nh = *pkt;
                 pkt += hdrextlen;
@@ -677,30 +697,6 @@ int DecodeIPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         }
     }
 
-#ifdef DEBUG
-    if (IPV6_EXTHDR_ISSET_FH(p)) {
-        SCLogDebug("IPV6 FRAG - HDRLEN: %" PRIuMAX " NH: %" PRIu32 " OFFSET: %" PRIu32 " ID: %" PRIu32 "",
-            (uintmax_t)IPV6_EXTHDR_GET_FH_HDRLEN(p), IPV6_EXTHDR_GET_FH_NH(p),
-            IPV6_EXTHDR_GET_FH_OFFSET(p), IPV6_EXTHDR_GET_FH_ID(p));
-    }
-    if (IPV6_EXTHDR_ISSET_RH(p)) {
-        SCLogDebug("IPV6 ROUTE - HDRLEN: %" PRIu32 " NH: %" PRIu32 " TYPE: %" PRIu32 "",
-            IPV6_EXTHDR_GET_RH_HDRLEN(p), IPV6_EXTHDR_GET_RH_NH(p),
-            IPV6_EXTHDR_GET_RH_TYPE(p));
-    }
-    if (IPV6_EXTHDR_ISSET_HH(p)) {
-        SCLogDebug("IPV6 HOPOPT - HDRLEN: %" PRIu32 " NH: %" PRIu32 "",
-            IPV6_EXTHDR_GET_HH_HDRLEN(p), IPV6_EXTHDR_GET_HH_NH(p));
-    }
-    if (IPV6_EXTHDR_ISSET_DH1(p)) {
-        SCLogDebug("IPV6 DSTOPT1 - HDRLEN: %" PRIu32 " NH: %" PRIu32 "",
-            IPV6_EXTHDR_GET_DH1_HDRLEN(p), IPV6_EXTHDR_GET_DH1_NH(p));
-    }
-    if (IPV6_EXTHDR_ISSET_DH2(p)) {
-        SCLogDebug("IPV6 DSTOPT2 - HDRLEN: %" PRIu32 " NH: %" PRIu32 "",
-            IPV6_EXTHDR_GET_DH2_HDRLEN(p), IPV6_EXTHDR_GET_DH2_NH(p));
-    }
-#endif
     return TM_ECODE_OK;
 }
 
@@ -879,7 +875,6 @@ end:
  */
 static int DecodeIPV6RouteTest01 (void)
 {
-
     uint8_t raw_pkt1[] = {
         0x60, 0x00, 0x00, 0x00, 0x00, 0x1c, 0x2b, 0x40,
         0x20, 0x01, 0xaa, 0xaa, 0x00, 0x01, 0x00, 0x00,
@@ -893,11 +888,9 @@ static int DecodeIPV6RouteTest01 (void)
         0xfa, 0x87, 0x00, 0x00,
     };
     Packet *p1 = PacketGetFromAlloc();
-    if (unlikely(p1 == NULL))
-        return 0;
+    FAIL_IF(unlikely(p1 == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int result = 0;
     PacketQueue pq;
 
     FlowInitConfig(FLOW_QUIET);
@@ -910,22 +903,12 @@ static int DecodeIPV6RouteTest01 (void)
 
     DecodeIPV6(&tv, &dtv, p1, GET_PKT_DATA(p1), GET_PKT_LEN(p1), &pq);
 
-    if (!(IPV6_EXTHDR_ISSET_RH(p1))) {
-        printf("ipv6 routing header not detected: ");
-        goto end;
-    }
-
-    if (p1->ip6eh.ip6_exthdrs[0].len != 8) {
-        printf("ipv6 routing length incorrect: ");
-        goto end;
-    }
-
-    result = 1;
-end:
+    FAIL_IF (!(IPV6_EXTHDR_ISSET_RH(p1)));
+    FAIL_IF (p1->ip6eh.rh_type != 0);
     PACKET_RECYCLE(p1);
     SCFree(p1);
     FlowShutdown();
-    return result;
+    PASS;
 }
 
 /**
@@ -936,16 +919,15 @@ static int DecodeIPV6HopTest01 (void)
     uint8_t raw_pkt1[] = {
         0x60,0x00,0x00,0x00,0x00,0x20,0x00,0x01,0xfe,0x80,0x00,0x00,0x00,0x00,0x00,0x00,
         0x02,0x0f,0xfe,0xff,0xfe,0x98,0x3d,0x01,0xff,0x02,0x00,0x00,0x00,0x00,0x00,0x00,
-        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x3a,0x00,0x05,0x02,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01,0x3a,0x00,0xff, /* 0xff is a nonsene opt */
+        0x02,0x00,0x00,0x00,0x00,
         0x82,0x00,0x1c,0x6f,0x27,0x10,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
     };
     Packet *p1 = PacketGetFromAlloc();
-    if (unlikely(p1 == NULL))
-        return 0;
+    FAIL_IF(unlikely(p1 == NULL));
     ThreadVars tv;
     DecodeThreadVars dtv;
-    int result = 0;
     PacketQueue pq;
 
     FlowInitConfig(FLOW_QUIET);
@@ -958,27 +940,12 @@ static int DecodeIPV6HopTest01 (void)
 
     DecodeIPV6(&tv, &dtv, p1, GET_PKT_DATA(p1), GET_PKT_LEN(p1), &pq);
 
-    if (!(IPV6_EXTHDR_ISSET_HH(p1))) {
-        printf("ipv6 routing header not detected: ");
-        goto end;
-    }
+    FAIL_IF (!(ENGINE_ISSET_EVENT(p1, IPV6_HOPOPTS_UNKNOWN_OPT)));
 
-    if (p1->ip6eh.ip6_exthdrs[0].len != 8) {
-        printf("ipv6 routing length incorrect: ");
-        goto end;
-    }
-
-    if (ENGINE_ISSET_EVENT(p1, IPV6_HOPOPTS_UNKNOWN_OPT)) {
-        printf("engine event IPV6_HOPOPTS_UNKNOWN_OPT set: ");
-        goto end;
-    }
-
-    result = 1;
-end:
     PACKET_RECYCLE(p1);
     SCFree(p1);
     FlowShutdown();
-    return result;
+    PASS;
 }
 
 #endif /* UNITTESTS */

--- a/src/decode-ipv6.h
+++ b/src/decode-ipv6.h
@@ -109,14 +109,7 @@ typedef struct IPV6Vars_
     (p)->ip6h = NULL; \
     (p)->ip6vars.ip_opts_len = 0; \
     (p)->ip6vars.l4proto = 0; \
-    (p)->ip6eh.ip6fh = NULL; \
-    (p)->ip6eh.fh_offset = 0; \
-    (p)->ip6eh.ip6rh = NULL; \
-    (p)->ip6eh.ip6eh = NULL; \
-    (p)->ip6eh.ip6dh1 = NULL; \
-    (p)->ip6eh.ip6dh2 = NULL; \
-    (p)->ip6eh.ip6hh = NULL; \
-    (p)->ip6eh.ip6_exthdrs_cnt = 0; \
+    memset(&(p)->ip6eh, 0x00, sizeof((p)->ip6eh)); \
 } while (0)
 
 /* Fragment header */
@@ -128,17 +121,10 @@ typedef struct IPV6FragHdr_
     uint32_t ip6fh_ident;           /* identification */
 } __attribute__((__packed__)) IPV6FragHdr;
 
-#define IPV6_EXTHDR_GET_RAW_FH_NH(p)        ((p)->ip6eh.ip6fh->ip6fh_nxt)
-#define IPV6_EXTHDR_GET_RAW_FH_HDRLEN(p)    sizeof(IPV6FragHdr)
-#define IPV6_EXTHDR_GET_RAW_FH_OFFSET(p)    (ntohs((p)->ip6eh.ip6fh->ip6fh_offlg) & 0xFFF8)
-#define IPV6_EXTHDR_GET_RAW_FH_FLAG(p)      (ntohs((p)->ip6eh.ip6fh->ip6fh_offlg) & 0x0001)
-#define IPV6_EXTHDR_GET_RAW_FH_ID(p)        (ntohl((p)->ip6eh.ip6fh->ip6fh_ident))
-
-#define IPV6_EXTHDR_GET_FH_NH(p)            IPV6_EXTHDR_GET_RAW_FH_NH((p))
-#define IPV6_EXTHDR_GET_FH_HDRLEN(p)        IPV6_EXTHDR_GET_RAW_FH_HDRLEN((p))
-#define IPV6_EXTHDR_GET_FH_OFFSET(p)        IPV6_EXTHDR_GET_RAW_FH_OFFSET((p))
-#define IPV6_EXTHDR_GET_FH_FLAG(p)          IPV6_EXTHDR_GET_RAW_FH_FLAG((p))
-#define IPV6_EXTHDR_GET_FH_ID(p)            IPV6_EXTHDR_GET_RAW_FH_ID((p))
+#define IPV6_EXTHDR_GET_FH_NH(p)            (p)->ip6eh.fh_nh
+#define IPV6_EXTHDR_GET_FH_OFFSET(p)        (p)->ip6eh.fh_offset
+#define IPV6_EXTHDR_GET_FH_FLAG(p)          (p)->ip6eh.fh_more_frags_set
+#define IPV6_EXTHDR_GET_FH_ID(p)            (p)->ip6eh.fh_id
 
 /* rfc 1826 */
 typedef struct IPV6AuthHdr_
@@ -164,23 +150,7 @@ typedef struct IPV6RouteHdr_
                                         including first 8 bytes. */
     uint8_t ip6rh_type;              /* routing type */
     uint8_t ip6rh_segsleft;          /* segments left */
-#if 0
-    struct in6_addr ip6rh0_addr[23];  /* type 0 addresses */
-    uint8_t ip6rh0_num_addrs;        /* number of actual addresses in the
-                                        array/packet. The array is guarranteed
-                                        to be filled up to this number. */
-#endif
 } __attribute__((__packed__)) IPV6RouteHdr;
-
-#define IPV6_EXTHDR_GET_RAW_RH_NH(p)        ((p)->ip6eh.ip6rh->ip6rh_nxt)
-#define IPV6_EXTHDR_GET_RAW_RH_HDRLEN(p)    ((p)->ip6eh.ip6rh->ip6rh_len)
-#define IPV6_EXTHDR_GET_RAW_RH_TYPE(p)      (ntohs((p)->ip6eh.ip6rh->ip6rh_type))
-/* XXX */
-
-#define IPV6_EXTHDR_GET_RH_NH(p)            IPV6_EXTHDR_GET_RAW_RH_NH((p))
-#define IPV6_EXTHDR_GET_RH_HDRLEN(p)        IPV6_EXTHDR_GET_RAW_RH_HDRLEN((p))
-#define IPV6_EXTHDR_GET_RH_TYPE(p)          IPV6_EXTHDR_GET_RAW_RH_TYPE((p))
-/* XXX */
 
 
 /* Hop-by-Hop header and Destination Options header use options that are
@@ -223,36 +193,12 @@ typedef struct IPV6HopOptsHdr_
                                        including first 8 bytes. */
 } __attribute__((__packed__)) IPV6HopOptsHdr;
 
-#define IPV6_EXTHDR_GET_RAW_HH_NH(p)        ((p)->ip6eh.ip6hh->ip6hh_nxt)
-#define IPV6_EXTHDR_GET_RAW_HH_HDRLEN(p)    ((p)->ip6eh.ip6hh->ip6hh_len)
-/* XXX */
-
-#define IPV6_EXTHDR_GET_HH_NH(p)            IPV6_EXTHDR_GET_RAW_HH_NH((p))
-#define IPV6_EXTHDR_GET_HH_HDRLEN(p)        IPV6_EXTHDR_GET_RAW_HH_HDRLEN((p))
-/* XXX */
-
 typedef struct IPV6DstOptsHdr_
 {
     uint8_t ip6dh_nxt;              /* next header */
     uint8_t ip6dh_len;              /* header length in units of 8 bytes, not
                                        including first 8 bytes. */
 } __attribute__((__packed__)) IPV6DstOptsHdr;
-
-#define IPV6_EXTHDR_GET_RAW_DH1_NH(p)        ((p)->ip6eh.ip6dh1->ip6dh_nxt)
-#define IPV6_EXTHDR_GET_RAW_DH1_HDRLEN(p)    ((p)->ip6eh.ip6dh1->ip6dh_len)
-/* XXX */
-
-#define IPV6_EXTHDR_GET_DH1_NH(p)            IPV6_EXTHDR_GET_RAW_DH1_NH((p))
-#define IPV6_EXTHDR_GET_DH1_HDRLEN(p)        IPV6_EXTHDR_GET_RAW_DH1_HDRLEN((p))
-/* XXX */
-
-#define IPV6_EXTHDR_GET_RAW_DH2_NH(p)        ((p)->ip6eh.ip6dh2->ip6dh_nxt)
-#define IPV6_EXTHDR_GET_RAW_DH2_HDRLEN(p)    ((p)->ip6eh.ip6dh2->ip6dh_len)
-/* XXX */
-
-#define IPV6_EXTHDR_GET_DH2_NH(p)            IPV6_EXTHDR_GET_RAW_DH2_NH((p))
-#define IPV6_EXTHDR_GET_DH2_HDRLEN(p)        IPV6_EXTHDR_GET_RAW_DH2_HDRLEN((p))
-/* XXX */
 
 typedef struct IPV6GenOptHdr_
 {
@@ -264,69 +210,32 @@ typedef struct IPV6GenOptHdr_
 
 typedef struct IPV6ExtHdrs_
 {
-    const IPV6FragHdr    *ip6fh;
+    _Bool rh_set;
+    uint8_t rh_type;
+
+    _Bool fh_set;
+    _Bool fh_more_frags_set;
+    uint8_t fh_nh;
+
+    uint8_t fh_prev_nh;
+    uint16_t fh_prev_hdr_offset;
+
+    uint16_t fh_header_offset;
+    uint16_t fh_data_offset;
+    uint16_t fh_data_len;
+
     /* In fh_offset we store the offset of this extension into the packet past
      * the ipv6 header. We use it in defrag for creating a defragmented packet
      * without the frag header */
-    uint16_t      fh_offset;
-
-    const IPV6RouteHdr   *ip6rh;
-    const IPV6AuthHdr    *ip6ah;
-    const IPV6EspHdr     *ip6eh;
-    const IPV6DstOptsHdr *ip6dh1;
-    const IPV6DstOptsHdr *ip6dh2;
-    const IPV6HopOptsHdr *ip6hh;
-
-    /* Hop-By-Hop options */
-    IPV6OptHAO ip6hh_opt_hao;
-    IPV6OptRA ip6hh_opt_ra;
-    IPV6OptJumbo ip6hh_opt_jumbo;
-    /* Dest Options 1 */
-    IPV6OptHAO ip6dh1_opt_hao;
-    IPV6OptRA ip6dh1_opt_ra;
-    IPV6OptJumbo ip6dh1_opt_jumbo;
-    /* Dest Options 2 */
-    IPV6OptHAO ip6dh2_opt_hao;
-    IPV6OptRA ip6dh2_opt_ra;
-    IPV6OptJumbo ip6dh2_opt_jumbo;
-
-    IPV6GenOptHdr ip6_exthdrs[IPV6_MAX_OPT];
-    uint8_t ip6_exthdrs_cnt;
+    uint16_t fh_offset;
+    uint32_t fh_id;
 
 } IPV6ExtHdrs;
 
-#define IPV6_EXTHDR_FH(p)             (p)->ip6eh.ip6fh
-#define IPV6_EXTHDR_RH(p)             (p)->ip6eh.ip6rh
-#define IPV6_EXTHDR_AH(p)             (p)->ip6eh.ip6ah
-#define IPV6_EXTHDR_EH(p)             (p)->ip6eh.ip6eh
-#define IPV6_EXTHDR_DH1(p)            (p)->ip6eh.ip6dh1
-#define IPV6_EXTHDR_DH2(p)            (p)->ip6eh.ip6dh2
-#define IPV6_EXTHDR_HH(p)             (p)->ip6eh.ip6hh
-
-#define IPV6_EXTHDR_HH_HAO(p)         (p)->ip6eh.ip6hh_opt_hao
-#define IPV6_EXTHDR_DH1_HAO(p)        (p)->ip6eh.ip6dh1_opt_hao
-#define IPV6_EXTHDR_DH2_HAO(p)        (p)->ip6eh.ip6dh2_opt_hao
-#define IPV6_EXTHDR_HH_RA(p)          (p)->ip6eh.ip6hh_opt_ra
-#define IPV6_EXTHDR_DH1_RA(p)         (p)->ip6eh.ip6dh1_opt_ra
-#define IPV6_EXTHDR_DH2_RA(p)         (p)->ip6eh.ip6dh2_opt_ra
-#define IPV6_EXTHDR_HH_JUMBO(p)       (p)->ip6eh.ip6hh_opt_jumbo
-#define IPV6_EXTHDR_DH1_JUMBO(p)      (p)->ip6eh.ip6dh1_opt_jumbo
-#define IPV6_EXTHDR_DH2_JUMBO(p)      (p)->ip6eh.ip6dh2_opt_jumbo
-
-#define IPV6_EXTHDR_SET_FH(p,pkt)     IPV6_EXTHDR_FH((p)) = (IPV6FragHdr *)pkt
-#define IPV6_EXTHDR_ISSET_FH(p)       (IPV6_EXTHDR_FH((p)) != NULL)
-#define IPV6_EXTHDR_SET_RH(p,pkt)     IPV6_EXTHDR_RH((p)) = (IPV6RouteHdr *)pkt
-#define IPV6_EXTHDR_ISSET_RH(p)       (IPV6_EXTHDR_RH((p)) != NULL)
-#define IPV6_EXTHDR_SET_AH(p,pkt)     IPV6_EXTHDR_AH((p)) = (IPV6AuthHdr *)pkt
-#define IPV6_EXTHDR_ISSET_AH(p)       (IPV6_EXTHDR_AH((p)) != NULL)
-#define IPV6_EXTHDR_SET_EH(p,pkt)     IPV6_EXTHDR_EH((p)) = (IPV6EspHdr *)pkt
-#define IPV6_EXTHDR_ISSET_EH(p)       (IPV6_EXTHDR_EH((p)) != NULL)
-#define IPV6_EXTHDR_SET_DH1(p,pkt)    IPV6_EXTHDR_DH1((p)) = (IPV6DstOptsHdr *)pkt
-#define IPV6_EXTHDR_ISSET_DH1(p)      (IPV6_EXTHDR_DH1((p)) != NULL)
-#define IPV6_EXTHDR_SET_DH2(p,pkt)    IPV6_EXTHDR_DH2((p)) = (IPV6DstOptsHdr *)pkt
-#define IPV6_EXTHDR_ISSET_DH2(p)      (IPV6_EXTHDR_DH2((p)) != NULL)
-#define IPV6_EXTHDR_SET_HH(p,pkt)     IPV6_EXTHDR_HH((p)) = (IPV6HopOptsHdr *)pkt
-#define IPV6_EXTHDR_ISSET_HH(p)       (IPV6_EXTHDR_HH((p)) != NULL)
+#define IPV6_EXTHDR_SET_FH(p)       (p)->ip6eh.fh_set = TRUE
+#define IPV6_EXTHDR_ISSET_FH(p)     (p)->ip6eh.fh_set
+#define IPV6_EXTHDR_SET_RH(p)       (p)->ip6eh.rh_set = TRUE
+#define IPV6_EXTHDR_ISSET_RH(p)     (p)->ip6eh.rh_set
 
 void DecodeIPV6RegisterTests(void);
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1073,7 +1073,7 @@ error:
 
 void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
                           uint16_t hdrextlen, uint16_t plen,
-                          uint16_t ip6_exthdrs_cnt, IPV6GenOptHdr *ip6_exthdrs);
+                          uint16_t prev_hdrextlen);
 
 static Packet *
 IPV6BuildTestPacket(uint32_t id, uint16_t off, int mf, const char content,
@@ -1115,7 +1115,7 @@ IPV6BuildTestPacket(uint32_t id, uint16_t off, int mf, const char content,
     fh->ip6fh_ident = htonl(id);
     fh->ip6fh_offlg = htons((off << 3) | mf);
 
-    DecodeIPV6FragHeader(p, (uint8_t *)fh, 8, 8 + content_len, 0, NULL);
+    DecodeIPV6FragHeader(p, (uint8_t *)fh, 8, 8 + content_len, 0);
 
     pcontent = SCCalloc(1, content_len);
     if (unlikely(pcontent == NULL))

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -1071,6 +1071,10 @@ error:
     return NULL;
 }
 
+void DecodeIPV6FragHeader(Packet *p, uint8_t *pkt,
+                          uint16_t hdrextlen, uint16_t plen,
+                          uint16_t ip6_exthdrs_cnt, IPV6GenOptHdr *ip6_exthdrs);
+
 static Packet *
 IPV6BuildTestPacket(uint32_t id, uint16_t off, int mf, const char content,
     int content_len)
@@ -1110,6 +1114,8 @@ IPV6BuildTestPacket(uint32_t id, uint16_t off, int mf, const char content,
     fh->ip6fh_nxt = IPPROTO_ICMP;
     fh->ip6fh_ident = htonl(id);
     fh->ip6fh_offlg = htons((off << 3) | mf);
+
+    DecodeIPV6FragHeader(p, (uint8_t *)fh, 8, 8 + content_len, 0, NULL);
 
     pcontent = SCCalloc(1, content_len);
     if (unlikely(pcontent == NULL))

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -87,7 +87,7 @@ int DetectFragOffsetMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet
     if (PKT_IS_IPV4(p)) {
         frag = IPV4_GET_IPOFFSET(p);
     } else if (PKT_IS_IPV6(p)) {
-        if(IPV6_EXTHDR_FH(p)) {
+        if (IPV6_EXTHDR_ISSET_FH(p)) {
             frag = IPV6_EXTHDR_GET_FH_OFFSET(p);
         } else {
             return 0;

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -94,28 +94,28 @@ int DetectIpOptsMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p,
 
     switch (de->ipopt) {
         case IPV4_OPT_RR:
-            return (p->ip4vars.rr);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_RR);
             break;
         case IPV4_OPT_LSRR:
-            return (p->ip4vars.lsrr);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_LSRR);
             break;
         case IPV4_OPT_EOL:
-            return (p->ip4vars.eol);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_EOL);
             break;
         case IPV4_OPT_NOP:
-            return (p->ip4vars.nop);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_NOP);
             break;
         case IPV4_OPT_TS:
-            return (p->ip4vars.ts);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_TS);
             break;
         case IPV4_OPT_SEC:
-            return (p->ip4vars.sec);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SEC);
             break;
         case IPV4_OPT_SSRR:
-            return (p->ip4vars.ssrr);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SSRR);
             break;
         case IPV4_OPT_SID:
-            return (p->ip4vars.sid);
+            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SID);
             break;
     }
 
@@ -281,7 +281,7 @@ int IpOptsTestParse03 (void)
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
-    p->ip4vars.rr = TRUE;
+    p->ip4vars.opts_set = IPV4_OPT_FLAG_RR;
 
     de = DetectIpOptsParse("rr");
 
@@ -331,7 +331,7 @@ int IpOptsTestParse04 (void)
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
-    p->ip4vars.rr = TRUE;
+    p->ip4vars.opts_set = IPV4_OPT_FLAG_RR;
 
     de = DetectIpOptsParse("lsrr");
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -82,31 +82,44 @@ void DetectIpOptsRegister (void)
  */
 int DetectIpOptsMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, const SigMatchCtx *ctx)
 {
-    int ret = 0;
-    int ipopt = 0;
     const DetectIpOptsData *de = (const DetectIpOptsData *)ctx;
 
     if (!de || !PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
-        return ret;
+        return 0;
 
     /* IPV4_OPT_ANY matches on any options */
-
-    if (p->IPV4_OPTS_CNT && (de->ipopt == IPV4_OPT_ANY)) {
+    if (p->ip4vars.opt_cnt && (de->ipopt == IPV4_OPT_ANY)) {
         return 1;
     }
 
-    /* Loop through instead of using o_xxx direct access fields so that
-     * future options do not require any modification here.
-     */
-
-    while(ipopt < p->IPV4_OPTS_CNT) {
-        if (p->IPV4_OPTS[ipopt].type == de->ipopt) {
-            return 1;
-        }
-        ipopt++;
+    switch (de->ipopt) {
+        case IPV4_OPT_RR:
+            return (p->ip4vars.rr);
+            break;
+        case IPV4_OPT_LSRR:
+            return (p->ip4vars.lsrr);
+            break;
+        case IPV4_OPT_EOL:
+            return (p->ip4vars.eol);
+            break;
+        case IPV4_OPT_NOP:
+            return (p->ip4vars.nop);
+            break;
+        case IPV4_OPT_TS:
+            return (p->ip4vars.ts);
+            break;
+        case IPV4_OPT_SEC:
+            return (p->ip4vars.sec);
+            break;
+        case IPV4_OPT_SSRR:
+            return (p->ip4vars.ssrr);
+            break;
+        case IPV4_OPT_SID:
+            return (p->ip4vars.sid);
+            break;
     }
 
-    return ret;
+    return 0;
 }
 
 /**
@@ -268,9 +281,7 @@ int IpOptsTestParse03 (void)
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
-    p->IPV4_OPTS[0].type = IPV4_OPT_RR;
-
-    p->IPV4_OPTS_CNT++;
+    p->ip4vars.rr = TRUE;
 
     de = DetectIpOptsParse("rr");
 
@@ -320,9 +331,7 @@ int IpOptsTestParse04 (void)
     memset(&ip4h, 0, sizeof(IPV4Hdr));
 
     p->ip4h = &ip4h;
-    p->IPV4_OPTS[0].type = IPV4_OPT_RR;
-
-    p->IPV4_OPTS_CNT++;
+    p->ip4vars.rr = TRUE;
 
     de = DetectIpOptsParse("lsrr");
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -35,9 +35,6 @@
 
 #include "util-debug.h"
 
-/* Need to get the DIpOpts[] array */
-#define DETECT_EVENTS
-
 #include "detect-ipopts.h"
 #include "util-unittest.h"
 
@@ -66,6 +63,33 @@ void DetectIpOptsRegister (void)
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
+
+/**
+ * Used to check ipopts:any
+ */
+
+#define IPV4_OPT_ANY    0xff
+
+/**
+ * \struct DetectIpOptss_
+ * DetectIpOptss_ is used to store supported iptops values
+ */
+
+struct DetectIpOptss_ {
+    char *ipopt_name;   /**< Ip option name */
+    uint8_t code;   /**< Ip option value */
+} ipopts[] = {
+    { "rr", IPV4_OPT_RR, },
+    { "lsrr", IPV4_OPT_LSRR, },
+    { "eol", IPV4_OPT_EOL, },
+    { "nop", IPV4_OPT_NOP, },
+    { "ts", IPV4_OPT_TS, },
+    { "sec", IPV4_OPT_SEC, },
+    { "ssrr", IPV4_OPT_SSRR, },
+    { "satid", IPV4_OPT_SID, },
+    { "any", IPV4_OPT_ANY, },
+    { NULL, 0 },
+};
 
 /**
  * \internal
@@ -145,8 +169,8 @@ DetectIpOptsData *DetectIpOptsParse (char *rawstr)
         goto error;
     }
 
-    for(i = 0; DIpOpts[i].ipopt_name != NULL; i++)  {
-        if((strcasecmp(DIpOpts[i].ipopt_name,rawstr)) == 0) {
+    for(i = 0; ipopts[i].ipopt_name != NULL; i++)  {
+        if((strcasecmp(ipopts[i].ipopt_name,rawstr)) == 0) {
             found = 1;
             break;
         }
@@ -159,7 +183,7 @@ DetectIpOptsData *DetectIpOptsParse (char *rawstr)
     if (unlikely(de == NULL))
         goto error;
 
-    de->ipopt = DIpOpts[i].code;
+    de->ipopt = ipopts[i].code;
 
     return de;
 

--- a/src/detect-ipopts.c
+++ b/src/detect-ipopts.c
@@ -65,29 +65,23 @@ void DetectIpOptsRegister (void)
 }
 
 /**
- * Used to check ipopts:any
- */
-
-#define IPV4_OPT_ANY    0xff
-
-/**
  * \struct DetectIpOptss_
  * DetectIpOptss_ is used to store supported iptops values
  */
 
-struct DetectIpOptss_ {
-    char *ipopt_name;   /**< Ip option name */
-    uint8_t code;   /**< Ip option value */
+struct DetectIpOpts_ {
+    const char *ipopt_name;   /**< ip option name */
+    uint16_t code;   /**< ip option flag value */
 } ipopts[] = {
-    { "rr", IPV4_OPT_RR, },
-    { "lsrr", IPV4_OPT_LSRR, },
-    { "eol", IPV4_OPT_EOL, },
-    { "nop", IPV4_OPT_NOP, },
-    { "ts", IPV4_OPT_TS, },
-    { "sec", IPV4_OPT_SEC, },
-    { "ssrr", IPV4_OPT_SSRR, },
-    { "satid", IPV4_OPT_SID, },
-    { "any", IPV4_OPT_ANY, },
+    { "rr", IPV4_OPT_FLAG_RR, },
+    { "lsrr", IPV4_OPT_FLAG_LSRR, },
+    { "eol", IPV4_OPT_FLAG_EOL, },
+    { "nop", IPV4_OPT_FLAG_NOP, },
+    { "ts", IPV4_OPT_FLAG_TS, },
+    { "sec", IPV4_OPT_FLAG_SEC, },
+    { "ssrr", IPV4_OPT_FLAG_SSRR, },
+    { "satid", IPV4_OPT_FLAG_SID, },
+    { "any", 0xffff, },
     { NULL, 0 },
 };
 
@@ -111,36 +105,8 @@ int DetectIpOptsMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p,
     if (!de || !PKT_IS_IPV4(p) || PKT_IS_PSEUDOPKT(p))
         return 0;
 
-    /* IPV4_OPT_ANY matches on any options */
-    if (p->ip4vars.opt_cnt && (de->ipopt == IPV4_OPT_ANY)) {
+    if (p->ip4vars.opts_set & de->ipopt) {
         return 1;
-    }
-
-    switch (de->ipopt) {
-        case IPV4_OPT_RR:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_RR);
-            break;
-        case IPV4_OPT_LSRR:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_LSRR);
-            break;
-        case IPV4_OPT_EOL:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_EOL);
-            break;
-        case IPV4_OPT_NOP:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_NOP);
-            break;
-        case IPV4_OPT_TS:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_TS);
-            break;
-        case IPV4_OPT_SEC:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SEC);
-            break;
-        case IPV4_OPT_SSRR:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SSRR);
-            break;
-        case IPV4_OPT_SID:
-            return (p->ip4vars.opts_set & IPV4_OPT_FLAG_SID);
-            break;
     }
 
     return 0;

--- a/src/detect-ipopts.h
+++ b/src/detect-ipopts.h
@@ -47,34 +47,5 @@ typedef struct DetectIpOptsData_ {
 
 void DetectIpOptsRegister (void);
 
-#ifdef DETECT_EVENTS
-
-/**
- * Used to check ipopts:any
- */
-
-#define IPV4_OPT_ANY    0xff
-
-/**
- * \struct DetectIpOptss_
- * DetectIpOptss_ is used to store supported iptops values
- */
-
-struct DetectIpOptss_ {
-    char *ipopt_name;   /**< Ip option name */
-    uint8_t code;   /**< Ip option value */
-} DIpOpts[] = {
-    { "rr", IPV4_OPT_RR, },
-    { "lsrr", IPV4_OPT_LSRR, },
-    { "eol", IPV4_OPT_EOL, },
-    { "nop", IPV4_OPT_NOP, },
-    { "ts", IPV4_OPT_TS, },
-    { "sec", IPV4_OPT_SEC, },
-    { "ssrr", IPV4_OPT_SSRR, },
-    { "satid", IPV4_OPT_SID, },
-    { "any", IPV4_OPT_ANY, },
-    { NULL, 0 },
-};
-#endif /* DETECT_EVENTS */
 #endif /*__DETECT_IPOPTS_H__ */
 

--- a/src/detect-ipopts.h
+++ b/src/detect-ipopts.h
@@ -38,7 +38,7 @@
  */
 
 typedef struct DetectIpOptsData_ {
-    uint8_t ipopt;  /**< Ip option */
+    uint16_t ipopt; /**< ip option flag */
 } DetectIpOptsData;
 
 /**


### PR DESCRIPTION
Change IPv4 options parsing and IPv6 extension header parsing to keep much less state in the packet. This reduces the size of the Packet structure from about 1700 bytes to ~936 bytes.

Not really happy with https://github.com/inliniac/suricata/commit/b4e3b74e75675347453546fe1d076890dc450b1c, but the defrag code has a ugly packet generation logic that bypasses the decoders. @jasonish any ideas? In general it might be good to formalize packet buffer generation in our code a bit.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/424
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/429
