### PR TITLE
Hyperscan SPM integration v3

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -350,6 +350,7 @@ util-hashlist.c util-hashlist.h \
 util-hash-lookup3.c util-hash-lookup3.h \
 util-host-os-info.c util-host-os-info.h \
 util-host-info.c util-host-info.h \
+util-hyperscan.c util-hyperscan.h \
 util-ioctl.h util-ioctl.c \
 util-ip.h util-ip.c \
 util-logopenfile.h util-logopenfile.c \
@@ -397,6 +398,7 @@ util-signal.c util-signal.h \
 util-spm-bm.c util-spm-bm.h \
 util-spm-bs2bm.c util-spm-bs2bm.h \
 util-spm-bs.c util-spm-bs.h \
+util-spm-hs.c util-spm-hs.h \
 util-spm.c util-spm.h util-clock.h \
 util-storage.c util-storage.h \
 util-strlcatu.c \

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -142,6 +142,9 @@ typedef struct AppLayerProtoDetectCtx_ {
      *       implemented if needed.  Waste of space otherwise. */
     AppLayerProtoDetectCtxIpproto ctx_ipp[FLOW_PROTO_DEFAULT];
 
+    /* Global SPM thread context prototype. */
+    SpmGlobalThreadCtx *spm_global_thread_ctx;
+
     AppLayerProtoDetectProbingParser *ctx_pp;
 
     /* Indicates the protocols that have registered themselves
@@ -157,6 +160,7 @@ struct AppLayerProtoDetectThreadCtx_ {
     PatternMatcherQueue pmq;
     /* The value 2 is for direction(0 - toserver, 1 - toclient). */
     MpmThreadCtx mpm_tctx[FLOW_PROTO_DEFAULT][2];
+    SpmThreadCtx *spm_thread_ctx;
 };
 
 /* The global app layer proto detection context. */
@@ -167,6 +171,7 @@ static AppLayerProtoDetectCtx alpd_ctx;
 /** \internal
  *  \brief Handle SPM search for Signature */
 static AppProto AppLayerProtoDetectPMMatchSignature(const AppLayerProtoDetectPMSignature *s,
+                                                    AppLayerProtoDetectThreadCtx *tctx,
                                                     uint8_t *buf, uint16_t buflen,
                                                     uint8_t ipproto)
 {
@@ -191,10 +196,7 @@ static AppProto AppLayerProtoDetectPMMatchSignature(const AppLayerProtoDetectPMS
     SCLogDebug("s->co->offset (%"PRIu16") s->cd->depth (%"PRIu16")",
                s->cd->offset, s->cd->depth);
 
-    if (s->cd->flags & DETECT_CONTENT_NOCASE)
-        found = BoyerMooreNocase(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx);
-    else
-        found = BoyerMoore(s->cd->content, s->cd->content_len, sbuf, sbuflen, s->cd->bm_ctx);
+    found = SpmScan(s->cd->spm_ctx, tctx->spm_thread_ctx, sbuf, sbuflen);
     if (found != NULL)
         proto = s->alproto;
 
@@ -260,7 +262,7 @@ static AppProto AppLayerProtoDetectPMGetProto(AppLayerProtoDetectThreadCtx *tctx
         const AppLayerProtoDetectPMSignature *s = pm_ctx->map[tctx->pmq.rule_id_array[cnt]];
         while (s != NULL) {
             AppProto proto = AppLayerProtoDetectPMMatchSignature(s,
-                    buf, searchlen, ipproto);
+                    tctx, buf, searchlen, ipproto);
 
             /* store each unique proto once */
             if (proto != ALPROTO_UNKNOWN &&
@@ -1240,13 +1242,20 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
     DetectContentData *cd;
     int ret = 0;
 
-    cd = DetectContentParseEncloseQuotes(pattern);
+    cd = DetectContentParseEncloseQuotes(alpd_ctx.spm_global_thread_ctx,
+                                         pattern);
     if (cd == NULL)
         goto error;
     cd->depth = depth;
     cd->offset = offset;
     if (!is_cs) {
-        BoyerMooreCtxToNocase(cd->bm_ctx, cd->content, cd->content_len);
+        /* Rebuild as nocase */
+        SpmDestroyCtx(cd->spm_ctx);
+        cd->spm_ctx = SpmInitCtx(cd->content, cd->content_len, 1,
+                                 alpd_ctx.spm_global_thread_ctx);
+        if (cd->spm_ctx == NULL) {
+            goto error;
+        }
         cd->flags |= DETECT_CONTENT_NOCASE;
     }
     if (depth < cd->content_len)
@@ -1518,6 +1527,13 @@ int AppLayerProtoDetectSetup(void)
 
     memset(&alpd_ctx, 0, sizeof(alpd_ctx));
 
+    uint16_t spm_matcher = SinglePatternMatchDefaultMatcher();
+    alpd_ctx.spm_global_thread_ctx = SpmInitGlobalThreadCtx(spm_matcher);
+    if (alpd_ctx.spm_global_thread_ctx == NULL) {
+        SCLogError(SC_ERR_FATAL, "Unable to alloc SpmGlobalThreadCtx.");
+        exit(EXIT_FAILURE);
+    }
+
     for (i = 0; i < FLOW_PROTO_DEFAULT; i++) {
         for (j = 0; j < 2; j++) {
             MpmInitCtx(&alpd_ctx.ctx_ipp[i].ctx_pm[j].mpm_ctx, MPM_AC);
@@ -1549,6 +1565,8 @@ int AppLayerProtoDetectDeSetup(void)
             }
         }
     }
+
+    SpmDestroyGlobalThreadCtx(alpd_ctx.spm_global_thread_ctx);
 
     AppLayerProtoDetectFreeProbingParsers(alpd_ctx.ctx_pp);
 
@@ -1674,6 +1692,11 @@ AppLayerProtoDetectThreadCtx *AppLayerProtoDetectGetCtxThread(void)
         }
     }
 
+    alpd_tctx->spm_thread_ctx = SpmMakeThreadCtx(alpd_ctx.spm_global_thread_ctx);
+    if (alpd_tctx->spm_thread_ctx == NULL) {
+        goto error;
+    }
+
     goto end;
  error:
     if (alpd_tctx != NULL)
@@ -1699,6 +1722,9 @@ void AppLayerProtoDetectDestroyCtxThread(AppLayerProtoDetectThreadCtx *alpd_tctx
         }
     }
     PmqFree(&alpd_tctx->pmq);
+    if (alpd_tctx->spm_thread_ctx != NULL) {
+        SpmDestroyThreadCtx(alpd_tctx->spm_thread_ctx);
+    }
     SCFree(alpd_tctx);
 
     SCReturn;

--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -73,7 +73,7 @@
                                        ((c)->flags & DETECT_CONTENT_FAST_PATTERN_CHOP))
 
 
-#include "util-spm-bm.h"
+#include "util-spm.h"
 
 typedef struct DetectContentData_ {
     uint8_t *content;
@@ -92,8 +92,8 @@ typedef struct DetectContentData_ {
     uint16_t offset;
     int32_t distance;
     int32_t within;
-    /* Boyer Moore context (for spm search) */
-    BmCtx *bm_ctx;
+    /* SPM search context. */
+    SpmCtx *spm_ctx;
     /* pointer to replacement data */
     uint8_t *replace;
 } DetectContentData;
@@ -101,10 +101,12 @@ typedef struct DetectContentData_ {
 /* prototypes */
 void DetectContentRegister (void);
 uint32_t DetectContentMaxId(DetectEngineCtx *);
-DetectContentData *DetectContentParse (char *contentstr);
+DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,
+                                      char *contentstr);
 int DetectContentDataParse(const char *keyword, const char *contentstr,
     uint8_t **pstr, uint16_t *plen, uint32_t *flags);
-DetectContentData *DetectContentParseEncloseQuotes(char *);
+DetectContentData *DetectContentParseEncloseQuotes(SpmGlobalThreadCtx *spm_global_thread_ctx,
+                                      char *contentstr);
 
 int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, char *contentstr);
 void DetectContentPrint(DetectContentData *);

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -48,7 +48,6 @@
 #include "app-layer-dcerpc.h"
 
 #include "util-spm.h"
-#include "util-spm-bm.h"
 #include "util-debug.h"
 #include "util-print.h"
 
@@ -279,10 +278,8 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
              * greater than sbuffer_len found is anyways NULL */
 
             /* do the actual search */
-            if (cd->flags & DETECT_CONTENT_NOCASE)
-                found = BoyerMooreNocase(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
-            else
-                found = BoyerMoore(cd->content, cd->content_len, sbuffer, sbuffer_len, cd->bm_ctx);
+            found = SpmScan(cd->spm_ctx, det_ctx->spm_thread_ctx, sbuffer,
+                            sbuffer_len);
 
             /* next we evaluate the result in combination with the
              * negation flag. */

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -84,6 +84,7 @@
 #include "util-action.h"
 #include "util-magic.h"
 #include "util-signal.h"
+#include "util-spm.h"
 
 #include "util-var-name.h"
 
@@ -829,6 +830,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
     }
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
+    de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();
     DetectEngineCtxLoadConf(de_ctx);
 
     SigGroupHeadHashInit(de_ctx);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -831,6 +831,13 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
     de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();
+
+    de_ctx->spm_global_thread_ctx = SpmInitGlobalThreadCtx(de_ctx->spm_matcher);
+    if (de_ctx->spm_global_thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmGlobalThreadCtx.");
+        goto error;
+    }
+
     DetectEngineCtxLoadConf(de_ctx);
 
     SigGroupHeadHashInit(de_ctx);
@@ -940,6 +947,8 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
     SCRConfDeInitContext(de_ctx);
 
     SigGroupCleanup(de_ctx);
+
+    SpmDestroyGlobalThreadCtx(de_ctx->spm_global_thread_ctx);
 
     MpmFactoryDeRegisterAllMpmCtxProfiles(de_ctx);
 
@@ -1419,6 +1428,11 @@ static TmEcode ThreadCtxDoInit (DetectEngineCtx *de_ctx, DetectEngineThreadCtx *
 
     PmqSetup(&det_ctx->pmq);
 
+    det_ctx->spm_thread_ctx = SpmMakeThreadCtx(de_ctx->spm_global_thread_ctx);
+    if (det_ctx->spm_thread_ctx == NULL) {
+        return TM_ECODE_FAILED;
+    }
+
     /* sized to the max of our sgh settings. A max setting of 0 implies that all
      * sgh's have: sgh->non_mpm_store_cnt == 0 */
     if (de_ctx->non_mpm_store_cnt_max > 0) {
@@ -1633,6 +1647,10 @@ void DetectEngineThreadCtxFree(DetectEngineThreadCtx *det_ctx)
     }
 
     PmqFree(&det_ctx->pmq);
+
+    if (det_ctx->spm_thread_ctx != NULL) {
+        SpmDestroyThreadCtx(det_ctx->spm_thread_ctx);
+    }
 
     if (det_ctx->non_mpm_id_array != NULL)
         SCFree(det_ctx->non_mpm_id_array);

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -123,7 +123,7 @@ void DetectHttpClientBodyFree(void *ptr)
     if (hcbd->content != NULL)
         SCFree(hcbd->content);
 
-    BoyerMooreCtxDeInit(hcbd->bm_ctx);
+    SpmDestroyCtx(hcbd->spm_ctx);
     SCFree(hcbd);
 
     SCReturn;

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -118,7 +118,7 @@ void DetectHttpHHFree(void *ptr)
     if (hhhd->content != NULL)
         SCFree(hhhd->content);
 
-    BoyerMooreCtxDeInit(hhhd->bm_ctx);
+    SpmDestroyCtx(hhhd->spm_ctx);
     SCFree(hhhd);
 
     return;

--- a/src/detect-http-hrh.c
+++ b/src/detect-http-hrh.c
@@ -118,7 +118,7 @@ void DetectHttpHRHFree(void *ptr)
     if (hrhhd->content != NULL)
         SCFree(hrhhd->content);
 
-    BoyerMooreCtxDeInit(hrhhd->bm_ctx);
+    SpmDestroyCtx(hrhhd->spm_ctx);
     SCFree(hrhhd);
 
     return;

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -127,7 +127,7 @@ void DetectHttpServerBodyFree(void *ptr)
     if (hsbd->content != NULL)
         SCFree(hsbd->content);
 
-    BoyerMooreCtxDeInit(hsbd->bm_ctx);
+    SpmDestroyCtx(hsbd->spm_ctx);
     SCFree(hsbd);
 
     SCReturn;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -119,7 +119,7 @@ void DetectHttpUAFree(void *ptr)
     if (huad->content != NULL)
         SCFree(huad->content);
 
-    BoyerMooreCtxDeInit(huad->bm_ctx);
+    SpmDestroyCtx(huad->spm_ctx);
     SCFree(huad);
 
     return;

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -54,7 +54,6 @@
 #include "util-unittest-helper.h"
 #include "util-binsearch.h"
 #include "util-spm.h"
-#include "util-spm-bm.h"
 #include "conf.h"
 
 /* prototypes */
@@ -95,7 +94,7 @@ void DetectUricontentFree(void *ptr)
     if (cd == NULL)
         SCReturn;
 
-    BoyerMooreCtxDeInit(cd->bm_ctx);
+    SpmDestroyCtx(cd->spm_ctx);
     SCFree(cd);
 
     SCReturn;

--- a/src/detect-uricontent.h
+++ b/src/detect-uricontent.h
@@ -27,7 +27,6 @@
 
 #include "detect-content.h"
 
-#include "util-spm-bm.h"
 #include "app-layer-htp.h"
 
 /* prototypes */

--- a/src/detect.h
+++ b/src/detect.h
@@ -587,6 +587,7 @@ typedef struct DetectEngineCtx_ {
     ThresholdCtx ths_ctx;
 
     uint16_t mpm_matcher; /**< mpm matcher this ctx uses */
+    uint16_t spm_matcher; /**< spm matcher this ctx uses */
 
     /* Config options */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -33,6 +33,7 @@
 
 #include "packet-queue.h"
 #include "util-mpm.h"
+#include "util-spm.h"
 #include "util-hash.h"
 #include "util-hashlist.h"
 #include "util-debug.h"
@@ -589,6 +590,10 @@ typedef struct DetectEngineCtx_ {
     uint16_t mpm_matcher; /**< mpm matcher this ctx uses */
     uint16_t spm_matcher; /**< spm matcher this ctx uses */
 
+    /* spm thread context prototype, built as spm matchers are constructed and
+     * later used to construct thread context for each thread. */
+    SpmGlobalThreadCtx *spm_global_thread_ctx;
+
     /* Config options */
 
     uint16_t max_uniq_toclient_groups;
@@ -817,6 +822,10 @@ typedef struct DetectEngineThreadCtx_ {
     MpmThreadCtx mtcu;  /**< thread ctx for uricontent mpm */
     MpmThreadCtx mtcs;  /**< thread ctx for stream mpm */
     PatternMatcherQueue pmq;
+
+    /** SPM thread context used for scanning. This has been cloned from the
+     * prototype held by DetectEngineCtx. */
+    SpmThreadCtx *spm_thread_ctx;
 
     /** ip only rules ctx */
     DetectEngineIPOnlyThreadCtx io_ctx;

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -151,6 +151,7 @@ void RunUnittests(int list_unittests, char *regex_arg)
 #ifdef __SC_CUDA_SUPPORT__
     MpmCudaEnvironmentSetup();
 #endif
+    SpmTableSetup();
 
     AppLayerSetup();
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2225,6 +2225,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
 #ifdef __SC_CUDA_SUPPORT__
     MpmCudaEnvironmentSetup();
 #endif
+    SpmTableSetup();
 
     switch (suri->checksum_validation) {
         case 0:

--- a/src/util-hyperscan.c
+++ b/src/util-hyperscan.c
@@ -1,0 +1,59 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Support functions for Hyperscan library integration.
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#ifdef BUILD_HYPERSCAN
+
+/**
+ * \internal
+ * \brief Convert a pattern into a regex string accepted by the Hyperscan
+ * compiler.
+ *
+ * For simplicity, we just take each byte of the original pattern and render it
+ * with a hex escape (i.e. ' ' -> "\x20")/
+ */
+char *HSRenderPattern(const uint8_t *pat, uint16_t pat_len)
+{
+    if (pat == NULL) {
+        return NULL;
+    }
+    const size_t hex_len = (pat_len * 4) + 1;
+    char *str = SCMalloc(hex_len);
+    if (str == NULL) {
+        return NULL;
+    }
+    memset(str, 0, hex_len);
+    char *sp = str;
+    for (uint16_t i = 0; i < pat_len; i++) {
+        snprintf(sp, 5, "\\x%02x", pat[i]);
+        sp += 4;
+    }
+    *sp = '\0';
+    return str;
+}
+
+#endif /* BUILD_HYPERSCAN */

--- a/src/util-hyperscan.h
+++ b/src/util-hyperscan.h
@@ -1,0 +1,31 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Support functions for Hyperscan library integration.
+ */
+
+#ifndef __UTIL_HYPERSCAN__H__
+#define __UTIL_HYPERSCAN__H__
+
+char *HSRenderPattern(const uint8_t *pat, uint16_t pat_len);
+
+#endif /* __UTIL_HYPERSCAN__H__ */

--- a/src/util-spm-bm.c
+++ b/src/util-spm-bm.c
@@ -34,6 +34,7 @@
 #include "suricata.h"
 
 #include "util-spm-bm.h"
+#include "util-spm.h"
 #include "util-debug.h"
 #include "util-error.h"
 #include "util-memcpy.h"
@@ -380,3 +381,133 @@ uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, int32_
    return NULL;
 }
 
+typedef struct SpmBmCtx_ {
+    BmCtx *bm_ctx;
+    uint8_t *needle;
+    uint16_t needle_len;
+    int nocase;
+} SpmBmCtx;
+
+static SpmCtx *BMInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                         SpmGlobalThreadCtx *global_thread_ctx)
+{
+    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    if (ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmCtx.");
+        return NULL;
+    }
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->matcher = SPM_BM;
+
+    SpmBmCtx *sctx = SCMalloc(sizeof(SpmBmCtx));
+    if (sctx == NULL) {
+        SCLogDebug("Unable to alloc SpmBmCtx.");
+        SCFree(ctx);
+        return NULL;
+    }
+    memset(sctx, 0, sizeof(*sctx));
+
+    sctx->needle = SCMalloc(needle_len);
+    if (sctx->needle == NULL) {
+        SCLogDebug("Unable to alloc string.");
+        SCFree(sctx);
+        SCFree(ctx);
+        return NULL;
+    }
+    memcpy(sctx->needle, needle, needle_len);
+    sctx->needle_len = needle_len;
+
+    if (nocase) {
+        sctx->bm_ctx = BoyerMooreNocaseCtxInit(sctx->needle, sctx->needle_len);
+        sctx->nocase = 1;
+    } else {
+        sctx->bm_ctx = BoyerMooreCtxInit(sctx->needle, sctx->needle_len);
+        sctx->nocase = 0;
+    }
+
+    ctx->ctx = sctx;
+    return ctx;
+}
+
+static void BMDestroyCtx(SpmCtx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+
+    SpmBmCtx *sctx = ctx->ctx;
+    if (sctx != NULL) {
+        BoyerMooreCtxDeInit(sctx->bm_ctx);
+        if (sctx->needle != NULL) {
+            SCFree(sctx->needle);
+        }
+        SCFree(sctx);
+    }
+
+    SCFree(ctx);
+}
+
+static uint8_t *BMScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                       const uint8_t *haystack, uint16_t haystack_len)
+{
+    const SpmBmCtx *sctx = ctx->ctx;
+
+    if (sctx->nocase) {
+        return BoyerMooreNocase(sctx->needle, sctx->needle_len, haystack,
+                                haystack_len, sctx->bm_ctx);
+    } else {
+        return BoyerMoore(sctx->needle, sctx->needle_len, haystack,
+                          haystack_len, sctx->bm_ctx);
+    }
+}
+
+static SpmGlobalThreadCtx *BMInitGlobalThreadCtx(void)
+{
+    SpmGlobalThreadCtx *global_thread_ctx = SCMalloc(sizeof(SpmGlobalThreadCtx));
+    if (global_thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmThreadCtx.");
+        return NULL;
+    }
+    memset(global_thread_ctx, 0, sizeof(*global_thread_ctx));
+    global_thread_ctx->matcher = SPM_BM;
+    return global_thread_ctx;
+}
+
+static void BMDestroyGlobalThreadCtx(SpmGlobalThreadCtx *global_thread_ctx)
+{
+    if (global_thread_ctx == NULL) {
+        return;
+    }
+    SCFree(global_thread_ctx);
+}
+
+static void BMDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    if (thread_ctx == NULL) {
+        return;
+    }
+    SCFree(thread_ctx);
+}
+
+static SpmThreadCtx *BMMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx) {
+    SpmThreadCtx *thread_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    if (thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmThreadCtx.");
+        return NULL;
+    }
+    memset(thread_ctx, 0, sizeof(*thread_ctx));
+    thread_ctx->matcher = SPM_BM;
+    return thread_ctx;
+}
+
+void SpmBMRegister(void)
+{
+    spm_table[SPM_BM].name = "bm";
+    spm_table[SPM_BM].InitGlobalThreadCtx = BMInitGlobalThreadCtx;
+    spm_table[SPM_BM].DestroyGlobalThreadCtx = BMDestroyGlobalThreadCtx;
+    spm_table[SPM_BM].MakeThreadCtx = BMMakeThreadCtx;
+    spm_table[SPM_BM].DestroyThreadCtx = BMDestroyThreadCtx;
+    spm_table[SPM_BM].InitCtx = BMInitCtx;
+    spm_table[SPM_BM].DestroyCtx = BMDestroyCtx;
+    spm_table[SPM_BM].Scan = BMScan;
+}

--- a/src/util-spm-bm.h
+++ b/src/util-spm-bm.h
@@ -45,5 +45,7 @@ uint8_t *BoyerMoore(const uint8_t *x, uint16_t m, const uint8_t *y, int32_t n, B
 uint8_t *BoyerMooreNocase(const uint8_t *x, uint16_t m, const uint8_t *y, int32_t n, BmCtx *bm_ctx);
 void BoyerMooreCtxDeInit(BmCtx *);
 
+void SpmBMRegister(void);
+
 #endif /* __UTIL_SPM_BM__ */
 

--- a/src/util-spm-hs.c
+++ b/src/util-spm-hs.c
@@ -1,0 +1,237 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Single pattern matcher that uses the Hyperscan regex matcher.
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "util-hyperscan.h"
+#include "util-spm-hs.h"
+
+#ifdef BUILD_HYPERSCAN
+
+#include <hs.h>
+
+/**
+ * \internal
+ * \brief Hyperscan match callback, called by hs_scan.
+ */
+static int MatchEvent(unsigned int id, unsigned long long from,
+                      unsigned long long to, unsigned int flags, void *context)
+{
+    uint64_t *match_offset = context;
+    BUG_ON(*match_offset != UINT64_MAX);
+    *match_offset = to;
+    return 1; /* Terminate matching. */
+}
+
+typedef struct SpmHsCtx_ {
+    hs_database_t *db;
+    uint16_t needle_len;
+} SpmHsCtx;
+
+static void HSDestroyCtx(SpmCtx *ctx)
+{
+    if (ctx == NULL) {
+        return;
+    }
+    SpmHsCtx *sctx = ctx->ctx;
+    if (sctx) {
+        hs_free_database(sctx->db);
+        SCFree(sctx);
+    }
+    SCFree(ctx);
+}
+
+static int HSBuildDatabase(const uint8_t *needle, uint16_t needle_len,
+                            int nocase, SpmHsCtx *sctx,
+                            SpmGlobalThreadCtx *global_thread_ctx)
+{
+    char *expr = HSRenderPattern(needle, needle_len);
+    if (expr == NULL) {
+        SCLogDebug("HSRenderPattern returned NULL");
+        return -1;
+    }
+
+    unsigned flags = nocase ? HS_FLAG_CASELESS : 0;
+
+    hs_database_t *db = NULL;
+    hs_compile_error_t *compile_err = NULL;
+    hs_error_t err = hs_compile(expr, flags, HS_MODE_BLOCK, NULL, &db,
+                                &compile_err);
+    if (err != HS_SUCCESS) {
+        SCLogError(SC_ERR_FATAL, "Unable to compile '%s' with Hyperscan, "
+                                 "returned %d.", expr, err);
+        exit(EXIT_FAILURE);
+    }
+
+    SCFree(expr);
+
+    /* Update scratch for this database. */
+    hs_scratch_t *scratch = global_thread_ctx->ctx;
+    err = hs_alloc_scratch(db, &scratch);
+    if (err != HS_SUCCESS) {
+        /* If scratch allocation failed, this is not recoverable:  other SPM
+         * contexts may need this scratch space. */
+        SCLogError(SC_ERR_FATAL,
+                   "Unable to alloc scratch for Hyperscan, returned %d.", err);
+        exit(EXIT_FAILURE);
+    }
+    global_thread_ctx->ctx = scratch;
+    sctx->db = db;
+    sctx->needle_len = needle_len;
+
+    return 0;
+}
+
+static SpmCtx *HSInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                         SpmGlobalThreadCtx *global_thread_ctx)
+{
+    SpmCtx *ctx = SCMalloc(sizeof(SpmCtx));
+    if (ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmCtx.");
+        return NULL;
+    }
+    memset(ctx, 0, sizeof(SpmCtx));
+    ctx->matcher = SPM_HS;
+
+    SpmHsCtx *sctx = SCMalloc(sizeof(SpmHsCtx));
+    if (sctx == NULL) {
+        SCLogDebug("Unable to alloc SpmHsCtx.");
+        SCFree(ctx);
+        return NULL;
+    }
+    ctx->ctx = sctx;
+
+    memset(sctx, 0, sizeof(SpmHsCtx));
+    if (HSBuildDatabase(needle, needle_len, nocase, sctx,
+                        global_thread_ctx) != 0) {
+        SCLogDebug("HSBuildDatabase failed.");
+        HSDestroyCtx(ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+static uint8_t *HSScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                       const uint8_t *haystack, uint16_t haystack_len)
+{
+    const SpmHsCtx *sctx = ctx->ctx;
+    hs_scratch_t *scratch = thread_ctx->ctx;
+
+    uint64_t match_offset = UINT64_MAX;
+    hs_error_t err = hs_scan(sctx->db, (const char *)haystack, haystack_len, 0,
+                             scratch, MatchEvent, &match_offset);
+    if (err != HS_SUCCESS && err != HS_SCAN_TERMINATED) {
+        /* An error value (other than HS_SCAN_TERMINATED) from hs_scan()
+         * indicates that it was passed an invalid database or scratch region,
+         * which is not something we can recover from at scan time. */
+        SCLogError(SC_ERR_FATAL, "Hyperscan returned fatal error %d.", err);
+        exit(EXIT_FAILURE);
+    }
+
+    if (match_offset == UINT64_MAX) {
+        return NULL;
+    }
+
+    BUG_ON(match_offset < sctx->needle_len);
+    BUG_ON(match_offset > UINT16_MAX); /* haystack_len is a uint16_t */
+
+    /* Note: existing API returns non-const ptr */
+    return (uint8_t *)haystack + (match_offset - sctx->needle_len);
+}
+
+static SpmGlobalThreadCtx *HSInitGlobalThreadCtx(void)
+{
+    SpmGlobalThreadCtx *global_thread_ctx = SCMalloc(sizeof(SpmGlobalThreadCtx));
+    if (global_thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmGlobalThreadCtx.");
+        return NULL;
+    }
+    memset(global_thread_ctx, 0, sizeof(*global_thread_ctx));
+    global_thread_ctx->matcher = SPM_HS;
+
+    /* We store scratch in the HS-specific ctx. This will be initialized as
+     * patterns are compiled by SpmInitCtx. */
+    global_thread_ctx->ctx = NULL;
+
+    return global_thread_ctx;
+}
+
+static void HSDestroyGlobalThreadCtx(SpmGlobalThreadCtx *global_thread_ctx)
+{
+    if (global_thread_ctx == NULL) {
+        return;
+    }
+    hs_free_scratch(global_thread_ctx->ctx);
+    SCFree(global_thread_ctx);
+}
+
+static void HSDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    if (thread_ctx == NULL) {
+        return;
+    }
+    hs_free_scratch(thread_ctx->ctx);
+    SCFree(thread_ctx);
+}
+
+static SpmThreadCtx *HSMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx)
+{
+    SpmThreadCtx *thread_ctx = SCMalloc(sizeof(SpmThreadCtx));
+    if (thread_ctx == NULL) {
+        SCLogDebug("Unable to alloc SpmThreadCtx.");
+        return NULL;
+    }
+    memset(thread_ctx, 0, sizeof(*thread_ctx));
+    thread_ctx->matcher = SPM_HS;
+
+    if (global_thread_ctx->ctx != NULL) {
+        hs_scratch_t *scratch = NULL;
+        hs_error_t err = hs_clone_scratch(global_thread_ctx->ctx, &scratch);
+        if (err != HS_SUCCESS) {
+            SCLogError(SC_ERR_FATAL, "Unable to clone scratch (error %d).",
+                       err);
+            exit(EXIT_FAILURE);
+        }
+        thread_ctx->ctx = scratch;
+    }
+
+    return thread_ctx;
+}
+
+void SpmHSRegister(void)
+{
+    spm_table[SPM_HS].name = "hs";
+    spm_table[SPM_HS].InitGlobalThreadCtx = HSInitGlobalThreadCtx;
+    spm_table[SPM_HS].DestroyGlobalThreadCtx = HSDestroyGlobalThreadCtx;
+    spm_table[SPM_HS].MakeThreadCtx = HSMakeThreadCtx;
+    spm_table[SPM_HS].DestroyThreadCtx = HSDestroyThreadCtx;
+    spm_table[SPM_HS].InitCtx = HSInitCtx;
+    spm_table[SPM_HS].DestroyCtx = HSDestroyCtx;
+    spm_table[SPM_HS].Scan = HSScan;
+}
+
+#endif /* BUILD_HYPERSCAN */

--- a/src/util-spm-hs.h
+++ b/src/util-spm-hs.h
@@ -1,0 +1,32 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Justin Viiret <justin.viiret@intel.com>
+ *
+ * Single pattern matcher that uses the Hyperscan regex matcher.
+ */
+
+#ifndef __UTIL_SPM_HS_H__
+#define __UTIL_SPM_HS_H__
+
+void SpmHSRegister(void);
+
+#endif /* __UTIL_SPM_HS_H__ */
+

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -65,6 +65,9 @@ uint16_t SinglePatternMatchDefaultMatcher(void)
     char *spm_algo;
     if ((ConfGet("spm-algo", &spm_algo)) == 1) {
         if (spm_algo != NULL) {
+            if (strcmp("auto", spm_algo) == 0) {
+                goto default_matcher;
+            }
             for (uint16_t i = 0; i < SPM_TABLE_SIZE; i++) {
                 if (spm_table[i].name == NULL) {
                     continue;
@@ -82,7 +85,15 @@ uint16_t SinglePatternMatchDefaultMatcher(void)
         exit(EXIT_FAILURE);
     }
 
-    return SPM_BM; /* default to Boyer-Moore */
+default_matcher:
+    /* When Suricata is built with Hyperscan support, default to using it for
+     * SPM. */
+#ifdef BUILD_HYPERSCAN
+    return SPM_HS;
+#else
+    /* Otherwise, default to Boyer-Moore */
+    return SPM_BM;
+#endif
 }
 
 void SpmTableSetup(void)

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -53,6 +53,7 @@
 #include "util-spm-bs.h"
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
+#include "util-spm-hs.h"
 #include "util-clock.h"
 
 /**
@@ -89,6 +90,9 @@ void SpmTableSetup(void)
     memset(spm_table, 0, sizeof(spm_table));
 
     SpmBMRegister();
+#ifdef BUILD_HYPERSCAN
+    SpmHSRegister();
+#endif
 }
 
 SpmGlobalThreadCtx *SpmInitGlobalThreadCtx(uint16_t matcher)

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -47,12 +47,34 @@
 #include "suricata.h"
 #include "util-unittest.h"
 
+#include "conf.h"
+
 #include "util-spm.h"
 #include "util-spm-bs.h"
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
 #include "util-clock.h"
 
+/**
+ * \brief Returns the single pattern matcher algorithm to be used, based on the
+ * spm-algo setting in yaml.
+ */
+uint16_t SinglePatternMatchDefaultMatcher(void) {
+    char *spm_algo;
+    if ((ConfGet("spm-algo", &spm_algo)) == 1) {
+        if (strcmp("bm", spm_algo) == 0) {
+            return SPM_BM;
+        }
+
+        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
+                   "Invalid spm algo supplied "
+                   "in the yaml conf file: \"%s\"",
+                   spm_algo);
+        exit(EXIT_FAILURE);
+    }
+
+    return SPM_BM; /* default to Boyer-Moore */
+}
 
 /**
  * Wrappers for building context and searching (Bs2Bm and boyermoore)

--- a/src/util-spm.c
+++ b/src/util-spm.c
@@ -59,11 +59,19 @@
  * \brief Returns the single pattern matcher algorithm to be used, based on the
  * spm-algo setting in yaml.
  */
-uint16_t SinglePatternMatchDefaultMatcher(void) {
+uint16_t SinglePatternMatchDefaultMatcher(void)
+{
     char *spm_algo;
     if ((ConfGet("spm-algo", &spm_algo)) == 1) {
-        if (strcmp("bm", spm_algo) == 0) {
-            return SPM_BM;
+        if (spm_algo != NULL) {
+            for (uint16_t i = 0; i < SPM_TABLE_SIZE; i++) {
+                if (spm_table[i].name == NULL) {
+                    continue;
+                }
+                if (strcmp(spm_table[i].name, spm_algo) == 0) {
+                    return i;
+                }
+            }
         }
 
         SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
@@ -74,6 +82,56 @@ uint16_t SinglePatternMatchDefaultMatcher(void) {
     }
 
     return SPM_BM; /* default to Boyer-Moore */
+}
+
+void SpmTableSetup(void)
+{
+    memset(spm_table, 0, sizeof(spm_table));
+
+    SpmBMRegister();
+}
+
+SpmGlobalThreadCtx *SpmInitGlobalThreadCtx(uint16_t matcher)
+{
+    return spm_table[matcher].InitGlobalThreadCtx();
+}
+
+void SpmDestroyGlobalThreadCtx(SpmGlobalThreadCtx *global_thread_ctx)
+{
+    uint16_t matcher = global_thread_ctx->matcher;
+    spm_table[matcher].DestroyGlobalThreadCtx(global_thread_ctx);
+}
+
+SpmThreadCtx *SpmMakeThreadCtx(const SpmGlobalThreadCtx *global_thread_ctx)
+{
+    uint16_t matcher = global_thread_ctx->matcher;
+    return spm_table[matcher].MakeThreadCtx(global_thread_ctx);
+}
+
+void SpmDestroyThreadCtx(SpmThreadCtx *thread_ctx)
+{
+    uint16_t matcher = thread_ctx->matcher;
+    spm_table[matcher].DestroyThreadCtx(thread_ctx);
+}
+
+SpmCtx *SpmInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                   SpmGlobalThreadCtx *global_thread_ctx)
+{
+    uint16_t matcher = global_thread_ctx->matcher;
+    return spm_table[matcher].InitCtx(needle, needle_len, nocase,
+                                      global_thread_ctx);
+}
+
+void SpmDestroyCtx(SpmCtx *ctx)
+{
+    spm_table[ctx->matcher].DestroyCtx(ctx);
+}
+
+uint8_t *SpmScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                 const uint8_t *haystack, uint16_t haystack_len)
+{
+    uint16_t matcher = ctx->matcher;
+    return spm_table[matcher].Scan(ctx, thread_ctx, haystack, haystack_len);
 }
 
 /**
@@ -2338,6 +2396,213 @@ int UtilSpmNocaseSearchStatsTest07()
     return 1;
 }
 
+/* Unit tests for new SPM API. */
+
+#define SPM_NO_MATCH UINT32_MAX
+
+/* Helper structure describing a particular search. */
+typedef struct SpmTestData_ {
+    const char *needle;
+    uint16_t needle_len;
+    const char *haystack;
+    uint16_t haystack_len;
+    int nocase;
+    uint32_t match_offset; /* offset in haystack, or SPM_NO_MATCH. */
+} SpmTestData;
+
+/* Helper function to conduct a search with a particular SPM matcher. */
+static int SpmTestSearch(const SpmTestData *d, uint16_t matcher)
+{
+    int ret = 1;
+    SpmGlobalThreadCtx *global_thread_ctx = NULL;
+    SpmThreadCtx *thread_ctx = NULL;
+    SpmCtx *ctx = NULL;
+    uint8_t *found = NULL;
+
+    global_thread_ctx = SpmInitGlobalThreadCtx(matcher);
+    if (global_thread_ctx == NULL) {
+        ret = 0;
+        goto exit;
+    }
+
+    ctx = SpmInitCtx((const uint8_t *)d->needle, d->needle_len, d->nocase,
+                     global_thread_ctx);
+    if (ctx == NULL) {
+        ret = 0;
+        goto exit;
+    }
+
+    thread_ctx = SpmMakeThreadCtx(global_thread_ctx);
+    if (thread_ctx == NULL) {
+        ret = 0;
+        goto exit;
+    }
+
+    found = SpmScan(ctx, thread_ctx, (const uint8_t *)d->haystack,
+                    d->haystack_len);
+    if (found == NULL) {
+        if (d->match_offset != SPM_NO_MATCH) {
+            printf("  should have matched at %" PRIu32 " but didn't\n",
+                   d->match_offset);
+            ret = 0;
+        }
+    } else {
+        uint32_t offset = (uint32_t)(found - (const uint8_t *)d->haystack);
+        if (offset != d->match_offset) {
+            printf("  should have matched at %" PRIu32
+                   " but matched at %" PRIu32 "\n",
+                   d->match_offset, offset);
+            ret = 0;
+        }
+    }
+
+exit:
+    SpmDestroyCtx(ctx);
+    SpmDestroyThreadCtx(thread_ctx);
+    SpmDestroyGlobalThreadCtx(global_thread_ctx);
+    return ret;
+}
+
+int SpmSearchTest01() {
+    SpmTableSetup();
+    printf("\n");
+
+    /* Each of the following tests will be run against every registered SPM
+     * algorithm. */
+
+    static const SpmTestData data[] = {
+        /* Some trivial single-character case/nocase tests */
+        {"a", 1, "a", 1, 0, 0},
+        {"a", 1, "A", 1, 1, 0},
+        {"A", 1, "A", 1, 0, 0},
+        {"A", 1, "a", 1, 1, 0},
+        {"a", 1, "A", 1, 0, SPM_NO_MATCH},
+        {"A", 1, "a", 1, 0, SPM_NO_MATCH},
+        /* Nulls and odd characters */
+        {"\x00", 1, "test\x00test", 9, 0, 4},
+        {"\x00", 1, "testtest", 8, 0, SPM_NO_MATCH},
+        {"\n", 1, "new line\n", 9, 0, 8},
+        {"\n", 1, "new line\x00\n", 10, 0, 9},
+        {"\xff", 1, "abcdef\xff", 7, 0, 6},
+        {"\xff", 1, "abcdef\xff", 7, 1, 6},
+        {"$", 1, "dollar$", 7, 0, 6},
+        {"^", 1, "caret^", 6, 0, 5},
+        /* Longer literals */
+        {"Suricata", 8, "This is a Suricata test", 23, 0, 10},
+        {"Suricata", 8, "This is a suricata test", 23, 1, 10},
+        {"Suricata", 8, "This is a suriCATA test", 23, 1, 10},
+        {"suricata", 8, "This is a Suricata test", 23, 0, SPM_NO_MATCH},
+        {"Suricata", 8, "This is a Suricat_ test", 23, 0, SPM_NO_MATCH},
+        {"Suricata", 8, "This is a _uricata test", 23, 0, SPM_NO_MATCH},
+        /* First occurrence with the correct case should match */
+        {"foo", 3, "foofoofoo", 9, 0, 0},
+        {"foo", 3, "_foofoofoo", 9, 0, 1},
+        {"FOO", 3, "foofoofoo", 9, 1, 0},
+        {"FOO", 3, "_foofoofoo", 9, 1, 1},
+        {"FOO", 3, "foo Foo FOo fOo foO FOO", 23, 0, 20},
+        {"foo", 3, "Foo FOo fOo foO FOO foo", 23, 0, 20},
+    };
+
+    int ret = 1;
+
+    uint16_t matcher;
+    for (matcher = 0; matcher < SPM_TABLE_SIZE; matcher++) {
+        const SpmTableElmt *m = &spm_table[matcher];
+        if (m->name == NULL) {
+            continue;
+        }
+        printf("matcher: %s\n", m->name);
+
+        uint32_t i;
+        for (i = 0; i < sizeof(data)/sizeof(data[0]); i++) {
+            const SpmTestData *d = &data[i];
+            if (SpmTestSearch(d, matcher) == 0) {
+                printf("  test %" PRIu32 ": fail\n", i);
+                ret = 0;
+            }
+        }
+        printf("  %" PRIu32 " tests passed\n", i);
+    }
+
+    return ret;
+}
+
+int SpmSearchTest02() {
+    SpmTableSetup();
+    printf("\n");
+
+    /* Test that we can find needles of various lengths at various alignments
+     * in the haystack. Note that these are passed to strlen. */
+
+    static const char* needles[] = {
+        /* Single bytes */
+        "a", "b", "c", ":", "/", "\x7f", "\xff",
+        /* Repeats */
+        "aa", "aaa", "aaaaaaaaaaaaaaaaaaaaaaa",
+        /* Longer literals */
+        "suricata", "meerkat", "aardvark", "raptor", "marmot", "lemming",
+        /* Mixed case */
+        "Suricata", "CAPS LOCK", "mIxEd cAsE",
+    };
+
+    int ret = 1;
+
+    uint16_t matcher;
+    for (matcher = 0; matcher < SPM_TABLE_SIZE; matcher++) {
+        const SpmTableElmt *m = &spm_table[matcher];
+        if (m->name == NULL) {
+            continue;
+        }
+        printf("matcher: %s\n", m->name);
+
+        SpmTestData d;
+
+        uint32_t i;
+        for (i = 0; i < sizeof(needles) / sizeof(needles[0]); i++) {
+            const char *needle = needles[i];
+            uint16_t prefix;
+            for (prefix = 0; prefix < 32; prefix++) {
+                d.needle = needle;
+                d.needle_len = strlen(needle);
+                uint16_t haystack_len = prefix + d.needle_len;
+                char *haystack = SCMalloc(haystack_len);
+                if (haystack == NULL) {
+                    printf("alloc failure\n");
+                    return 0;
+                }
+                memset(haystack, ' ', haystack_len);
+                memcpy(haystack + prefix, d.needle, d.needle_len);
+                d.haystack = haystack;
+                d.haystack_len = haystack_len;
+                d.nocase = 0;
+                d.match_offset = prefix;
+
+                /* Case-sensitive scan */
+                if (SpmTestSearch(&d, matcher) == 0) {
+                    printf("  test %" PRIu32 ": fail (case-sensitive)\n", i);
+                    ret = 0;
+                }
+
+                /* Case-insensitive scan */
+                d.nocase = 1;
+                uint16_t j;
+                for (j = 0; j < haystack_len; j++) {
+                    haystack[j] = toupper(haystack[j]);
+                }
+                if (SpmTestSearch(&d, matcher) == 0) {
+                    printf("  test %" PRIu32 ": fail (case-insensitive)\n", i);
+                    ret = 0;
+                }
+
+                SCFree(haystack);
+            }
+        }
+        printf("  %" PRIu32 " tests passed\n", i);
+    }
+
+    return ret;
+}
+
 #endif
 
 /* Register unittests */
@@ -2377,6 +2642,10 @@ void UtilSpmSearchRegistertests(void)
     UtRegisterTest("UtilSpmSearchOffsetsTest01", UtilSpmSearchOffsetsTest01);
     UtRegisterTest("UtilSpmSearchOffsetsNocaseTest01",
                    UtilSpmSearchOffsetsNocaseTest01);
+
+    /* new SPM API */
+    UtRegisterTest("SpmSearchTest01", SpmSearchTest01);
+    UtRegisterTest("SpmSearchTest02", SpmSearchTest02);
 
 #ifdef ENABLE_SEARCH_STATS
     /* Give some stats searching given a prepared context (look at the wrappers) */

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -31,9 +31,64 @@
 enum {
     SPM_BM, /* Boyer-Moore */
     /* Other SPM matchers will go here. */
+    SPM_TABLE_SIZE
 };
 
 uint16_t SinglePatternMatchDefaultMatcher(void);
+
+/** Structure holding an immutable "built" SPM matcher (such as the Boyer-Moore
+ * tables, Hyperscan database etc) that is passed to the Scan call. */
+typedef struct SpmCtx_ {
+    uint16_t matcher;
+    void *ctx;
+} SpmCtx;
+
+/** Structure holding a global prototype for per-thread scratch space, passed
+ * to each InitCtx call. */
+typedef struct SpmGlobalThreadCtx_ {
+    uint16_t matcher;
+    void *ctx;
+} SpmGlobalThreadCtx;
+
+/** Structure holding some mutable per-thread space for use by a matcher at
+ * scan time. Constructed from SpmGlobalThreadCtx by the MakeThreadCtx call. */
+typedef struct SpmThreadCtx_ {
+    uint16_t matcher;
+    void *ctx;
+} SpmThreadCtx;
+
+typedef struct SpmTableElmt_ {
+    const char *name;
+    SpmGlobalThreadCtx *(*InitGlobalThreadCtx)(void);
+    void (*DestroyGlobalThreadCtx)(SpmGlobalThreadCtx *g_thread_ctx);
+    SpmThreadCtx *(*MakeThreadCtx)(const SpmGlobalThreadCtx *g_thread_ctx);
+    void (*DestroyThreadCtx)(SpmThreadCtx *thread_ctx);
+    SpmCtx *(*InitCtx)(const uint8_t *needle, uint16_t needle_len, int nocase,
+                       SpmGlobalThreadCtx *g_thread_ctx);
+    void (*DestroyCtx)(SpmCtx *);
+    uint8_t *(*Scan)(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                     const uint8_t *haystack, uint16_t haystack_len);
+} SpmTableElmt;
+
+SpmTableElmt spm_table[SPM_TABLE_SIZE];
+
+void SpmTableSetup(void);
+
+SpmGlobalThreadCtx *SpmInitGlobalThreadCtx(uint16_t matcher);
+
+void SpmDestroyGlobalThreadCtx(SpmGlobalThreadCtx *g_thread_ctx);
+
+SpmThreadCtx *SpmMakeThreadCtx(const SpmGlobalThreadCtx *g_thread_ctx);
+
+void SpmDestroyThreadCtx(SpmThreadCtx *thread_ctx);
+
+SpmCtx *SpmInitCtx(const uint8_t *needle, uint16_t needle_len, int nocase,
+                   SpmGlobalThreadCtx *g_thread_ctx);
+
+void SpmDestroyCtx(SpmCtx *ctx);
+
+uint8_t *SpmScan(const SpmCtx *ctx, SpmThreadCtx *thread_ctx,
+                 const uint8_t *haystack, uint16_t haystack_len);
 
 /** Default algorithm to use: Boyer Moore */
 uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -30,6 +30,7 @@
 
 enum {
     SPM_BM, /* Boyer-Moore */
+    SPM_HS, /* Hyperscan */
     /* Other SPM matchers will go here. */
     SPM_TABLE_SIZE
 };

--- a/src/util-spm.h
+++ b/src/util-spm.h
@@ -28,6 +28,13 @@
 #include "util-spm-bs2bm.h"
 #include "util-spm-bm.h"
 
+enum {
+    SPM_BM, /* Boyer-Moore */
+    /* Other SPM matchers will go here. */
+};
+
+uint16_t SinglePatternMatchDefaultMatcher(void);
+
 /** Default algorithm to use: Boyer Moore */
 uint8_t *Bs2bmSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);
 uint8_t *Bs2bmNocaseSearch(const uint8_t *text, uint32_t textlen, const uint8_t *needle, uint16_t needlelen);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -729,8 +729,10 @@ mpm-algo: ac
 #
 # Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
 # available if Suricata has been built with Hyperscan support).
+#
+# The default of "auto" will use "hs" if available, otherwise "bm".
 
-spm-algo: bm
+spm-algo: auto
 
 # Defrag settings:
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -725,6 +725,13 @@ cuda:
 
 mpm-algo: ac
 
+# Select the matching algorithm you want to use for single-pattern searches.
+#
+# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
+# available if Suricata has been built with Hyperscan support).
+
+spm-algo: bm
+
 # Defrag settings:
 
 defrag:


### PR DESCRIPTION
> Version 3. Removed some dead code that was erroneously left in v2. The previous PR was #2078.

This pull request adds an SPM API (roughly similar to the MPM API) and provides two single pattern matcher implementations:

- Boyer-Moore ("bm") using the existing code in Suricata;
- Hyperscan ("hs") using Hyperscan as a single-string matcher, provided that Hyperscan is configured in.

As well as the API changes, support for some per-thread context (`SpmThreadCtx`) for SPM algorithms is provided -- in Hyperscan this is used for `hs_scratch_t` scratch regions.

The algorithm is selectable with the "spm-algo" yaml option, and defaults to "hs" when compiled with Hyperscan support, and "bm" otherwise.