### PR TITLE
[preview] flow worker v38

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -220,6 +220,7 @@ flow-storage.c flow-storage.h \
 flow-timeout.c flow-timeout.h \
 flow-util.c flow-util.h \
 flow-var.c flow-var.h \
+flow-worker.c flow-worker.h \
 host.c host.h \
 host-bit.c host-bit.h \
 host-queue.c host-queue.h \

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -461,7 +461,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
  *  If the protocol is yet unknown, the proto detection code is run first.
  *
  *  \param dp_ctx Thread app layer detect context
- *  \param f unlocked flow
+ *  \param f *locked* flow
  *  \param p UDP packet
  *
  *  \retval 0 ok
@@ -472,8 +472,6 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
     SCEnter();
 
     int r = 0;
-
-    FLOWLOCK_WRLOCK(f);
 
     uint8_t flags = 0;
     if (p->flowflags & FLOW_PKT_TOSERVER) {
@@ -527,7 +525,6 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
         }
     }
 
-    FLOWLOCK_UNLOCK(f);
     PACKET_PROFILING_APP_STORE(tctx, p);
 
     SCReturnInt(r);

--- a/src/decode-icmpv4.c
+++ b/src/decode-icmpv4.c
@@ -194,7 +194,7 @@ int DecodeICMPV4(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt,
                     {
                         /* ICMP ICMP_DEST_UNREACH influence TCP/UDP flows */
                         if (ICMPV4_DEST_UNREACH_IS_VALID(p)) {
-                            FlowHandlePacket(tv, dtv, p);
+                            FlowSetupPacket(p);
                         }
                     }
                 }

--- a/src/decode-icmpv6.c
+++ b/src/decode-icmpv6.c
@@ -362,8 +362,7 @@ int DecodeICMPV6(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
         SCLogDebug("Unknown Type, ICMPV6_UNKNOWN_TYPE");
 #endif
 
-    /* Flow is an integral part of us */
-    FlowHandlePacket(tv, dtv, p);
+    FlowSetupPacket(p);
 
     return TM_ECODE_OK;
 }

--- a/src/decode-ipv4.c
+++ b/src/decode-ipv4.c
@@ -1754,7 +1754,6 @@ int DecodeIPV4DefragTest03(void)
         0x80, 0x00, 0xb1, 0xa3, 0x00, 0x00
     };
 
-    Flow *f = NULL;
     Packet *p = PacketGetFromAlloc();
     if (unlikely(p == NULL))
         return 0;
@@ -1778,12 +1777,11 @@ int DecodeIPV4DefragTest03(void)
         result = 0;
         goto end;
     }
-    if (p->flow == NULL) {
+    if (!(p->flags & PKT_WANTS_FLOW)) {
         printf("packet flow shouldn't be NULL\n");
         result = 0;
         goto end;
     }
-    f = p->flow;
     PACKET_RECYCLE(p);
 
     PacketCopyData(p, pkt1, sizeof(pkt1));
@@ -1821,11 +1819,11 @@ int DecodeIPV4DefragTest03(void)
         result = 0;
         goto end;
     }
-    if (tp->flow == NULL) {
+    if (!(tp->flags & PKT_WANTS_FLOW)) {
         result = 0;
         goto end;
     }
-    if (tp->flow != f) {
+    if (tp->flow_hash != p->flow_hash) {
         result = 0;
         goto end;
     }

--- a/src/decode-sctp.c
+++ b/src/decode-sctp.c
@@ -73,8 +73,7 @@ int DecodeSCTP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, u
         SCTP_GET_SRC_PORT(p), SCTP_GET_DST_PORT(p));
 #endif
 
-    /* Flow is an integral part of us */
-    FlowHandlePacket(tv, dtv, p);
+    FlowSetupPacket(p);
 
     return TM_ECODE_OK;
 }

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -214,8 +214,7 @@ int DecodeTCP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, ui
         TCP_HAS_MSS(p) ? "MSS " : "");
 #endif
 
-    /* Flow is an integral part of us */
-    FlowHandlePacket(tv, dtv, p);
+    FlowSetupPacket(p);
 
     return TM_ECODE_OK;
 }

--- a/src/decode-udp.c
+++ b/src/decode-udp.c
@@ -85,17 +85,11 @@ int DecodeUDP(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p, uint8_t *pkt, ui
     if (unlikely(DecodeTeredo(tv, dtv, p, p->payload, p->payload_len, pq) == TM_ECODE_OK)) {
         /* Here we have a Teredo packet and don't need to handle app
          * layer */
-        FlowHandlePacket(tv, dtv, p);
+        FlowSetupPacket(p);
         return TM_ECODE_OK;
     }
 
-    /* Flow is an integral part of us */
-    FlowHandlePacket(tv, dtv, p);
-
-    /* handle the app layer part of the UDP packet payload */
-    if (unlikely(p->flow != NULL)) {
-        AppLayerHandleUdp(tv, dtv->app_tctx, p, p->flow);
-    }
+    FlowSetupPacket(p);
 
     return TM_ECODE_OK;
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -399,6 +399,10 @@ typedef struct Packet_
 
     struct Flow_ *flow;
 
+    /* raw hash value for looking up the flow, will need to modulated to the
+     * hash size still */
+    uint32_t flow_hash;
+
     struct timeval ts;
 
     union {
@@ -1048,6 +1052,10 @@ int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
 #define PKT_IS_FRAGMENT                 (1<<19)     /**< Packet is a fragment */
 #define PKT_IS_INVALID                  (1<<20)
 #define PKT_PROFILE                     (1<<21)
+
+/** indication by decoder that it feels the packet should be handled by
+ *  flow engine: Packet::flow_hash will be set */
+#define PKT_WANTS_FLOW                  (1<<22)
 
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) ((p)->flags & PKT_PSEUDO_STREAM_END)

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -267,8 +267,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
 
                     if (p->flow != NULL) {
                         /* Update flow flags for iponly */
-                        FLOWLOCK_WRLOCK(p->flow);
-                        FlowSetIPOnlyFlagNoLock(p->flow, p->flowflags & FLOW_PKT_TOSERVER ? 1 : 0);
+                        FlowSetIPOnlyFlag(p->flow, (p->flowflags & FLOW_PKT_TOSERVER) ? 1 : 0);
 
                         if (s->action & ACTION_DROP)
                             p->flow->flags |= FLOW_ACTION_DROP;
@@ -281,7 +280,6 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                         if (s->action & ACTION_PASS) {
                             FlowSetNoPacketInspectionFlag(p->flow);
                         }
-                        FLOWLOCK_UNLOCK(p->flow);
                     }
                 }
             }
@@ -299,7 +297,7 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                     (p->alerts.alerts[i].flags &
                         (PACKET_ALERT_FLAG_STATE_MATCH|PACKET_ALERT_FLAG_STREAM_MATCH)))
                 {
-                    FlowLockSetNoPacketInspectionFlag(p->flow);
+                    FlowSetNoPacketInspectionFlag(p->flow);
                 }
                 break;
 
@@ -310,10 +308,8 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
                          (s->flags & SIG_FLAG_APPLAYER))
                        && p->flow != NULL)
             {
-                FLOWLOCK_WRLOCK(p->flow);
                 /* This will apply only on IPS mode (check StreamTcpPacket) */
-                p->flow->flags |= FLOW_ACTION_DROP;
-                FLOWLOCK_UNLOCK(p->flow);
+                p->flow->flags |= FLOW_ACTION_DROP; // XXX API?
             }
         }
 

--- a/src/detect-engine-content-inspection.c
+++ b/src/detect-engine-content-inspection.c
@@ -539,13 +539,9 @@ int DetectEngineContentInspection(DetectEngineCtx *de_ctx, DetectEngineThreadCtx
     }
     else if (sm->type == DETECT_LUA) {
         SCLogDebug("lua starting");
-        /* for flowvar gets and sets we need to know the flow's lock status */
-        int flow_lock = LUA_FLOW_LOCKED_BY_PARENT;
-        if (inspection_mode <= DETECT_ENGINE_CONTENT_INSPECTION_MODE_STREAM)
-            flow_lock = LUA_FLOW_NOT_LOCKED_BY_PARENT;
 
         if (DetectLuaMatchBuffer(det_ctx, s, sm, buffer, buffer_len,
-                    det_ctx->buffer_offset, f, flow_lock) != 1)
+                    det_ctx->buffer_offset, f) != 1)
         {
             SCLogDebug("lua no_match");
             goto no_match;

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -132,7 +132,6 @@ int TagFlowAdd(Packet *p, DetectTagDataEntry *tde)
     if (p->flow == NULL)
         return 1;
 
-    FLOWLOCK_WRLOCK(p->flow);
     iter = FlowGetStorageById(p->flow, flow_tag_id);
     if (iter != NULL) {
         /* First iterate installed entries searching a duplicated sid/gid */
@@ -169,7 +168,6 @@ int TagFlowAdd(Packet *p, DetectTagDataEntry *tde)
         SCLogDebug("Max tags for sessions reached (%"PRIu16")", tag_cnt);
     }
 
-    FLOWLOCK_UNLOCK(p->flow);
     return updated;
 }
 
@@ -516,9 +514,7 @@ void TagHandlePacket(DetectEngineCtx *de_ctx,
 
     /* First update and get session tags */
     if (p->flow != NULL) {
-        FLOWLOCK_WRLOCK(p->flow);
         TagHandlePacketFlow(p->flow, p);
-        FLOWLOCK_UNLOCK(p->flow);
     }
 
     Host *src = HostLookupHostFromHash(&p->src);

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -28,6 +28,7 @@
 #include "flow.h"
 #include "flow-private.h"
 #include "flow-util.h"
+#include "flow-worker.h"
 #include "conf.h"
 #include "conf-yaml-loader.h"
 
@@ -686,7 +687,7 @@ static int DetectEngineReloadThreads(DetectEngineCtx *new_de_ctx)
                 continue;
             }
 
-            old_det_ctx[i] = SC_ATOMIC_GET(slots->slot_data);
+            old_det_ctx[i] = FlowWorkerGetDetectCtxPtr(SC_ATOMIC_GET(slots->slot_data));
             detect_tvs[i] = tv;
 
             new_det_ctx[i] = DetectEngineThreadCtxInitForReload(tv, new_de_ctx, 1);
@@ -724,7 +725,7 @@ static int DetectEngineReloadThreads(DetectEngineCtx *new_de_ctx)
             }
             SCLogDebug("swapping new det_ctx - %p with older one - %p",
                        new_det_ctx[i], SC_ATOMIC_GET(slots->slot_data));
-            (void)SC_ATOMIC_SET(slots->slot_data, new_det_ctx[i++]);
+            FlowWorkerReplaceDetectCtx(SC_ATOMIC_GET(slots->slot_data), new_det_ctx[i++]);
             break;
         }
         tv = tv->next;

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -203,9 +203,6 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
     else
         flags |= STREAM_TOSERVER;
 
-    if (det_ctx->flow_locked == 0)
-        FLOWLOCK_WRLOCK(p->flow);
-
     FileContainer *ffc = AppLayerParserGetFiles(p->flow->proto, p->flow->alproto,
                                                 p->flow->alstate, flags);
 
@@ -224,9 +221,6 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
                     det_ctx->filestore[u].file_id, det_ctx->filestore[u].tx_id);
         }
     }
-
-    if (det_ctx->flow_locked == 0)
-        FLOWLOCK_UNLOCK(p->flow);
 
     SCReturnInt(0);
 }

--- a/src/detect-flowint.c
+++ b/src/detect-flowint.c
@@ -89,15 +89,11 @@ void DetectFlowintRegister(void)
 int DetectFlowintMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
                         Packet *p, Signature *s, const SigMatchCtx *ctx)
 {
-    const int flow_locked = det_ctx->flow_locked;
     const DetectFlowintData *sfd = (const DetectFlowintData *)ctx;
     FlowVar *fv;
     FlowVar *fvt;
     uint32_t targetval;
     int ret = 0;
-
-    if (flow_locked == 0)
-        FLOWLOCK_WRLOCK(p->flow);
 
     /** ATM If we are going to compare the current var with another
      * that doesn't exist, the default value will be zero;
@@ -210,8 +206,6 @@ int DetectFlowintMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
     }
 
 end:
-    if (flow_locked == 0)
-        FLOWLOCK_UNLOCK(p->flow);
     return ret;
 }
 

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -98,9 +98,6 @@ int DetectFlowvarMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p
     int ret = 0;
     DetectFlowvarData *fd = (DetectFlowvarData *)ctx;
 
-    /* we need a lock */
-    FLOWLOCK_RDLOCK(p->flow);
-
     FlowVar *fv = FlowVarGet(p->flow, fd->idx);
     if (fv != NULL) {
         uint8_t *ptr = SpmSearch(fv->data.fv_str.value,
@@ -109,7 +106,6 @@ int DetectFlowvarMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p
         if (ptr != NULL)
             ret = 1;
     }
-    FLOWLOCK_UNLOCK(p->flow);
 
     return ret;
 }

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -293,7 +293,7 @@ void LuaDumpStack(lua_State *state)
 
 int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx, Signature *s, SigMatch *sm,
         uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
-        Flow *f, int flow_lock)
+        Flow *f)
 {
     SCEnter();
     int ret = 0;
@@ -310,6 +310,10 @@ int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx, Signature *s, SigMatch 
         SCReturnInt(0);
 
     /* setup extension data for use in lua c functions */
+    int flow_lock = (f != NULL) ? /* if we have a flow, it's locked */
+        LUA_FLOW_LOCKED_BY_PARENT :
+        LUA_FLOW_NOT_LOCKED_BY_PARENT;
+
     LuaExtensionsMatchSetup(tluajit->luastate, luajit, det_ctx,
             f, flow_lock, /* no packet in the ctx */NULL, 0);
 
@@ -419,8 +423,13 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
         flags = STREAM_TOCLIENT;
 
     LuaStateSetThreadVars(tluajit->luastate, tv);
+
+    int flow_lock = (p->flow != NULL) ? /* if we have a flow, it's locked */
+        LUA_FLOW_LOCKED_BY_PARENT :
+        LUA_FLOW_NOT_LOCKED_BY_PARENT;
+
     LuaExtensionsMatchSetup(tluajit->luastate, luajit, det_ctx,
-            p->flow, /* flow not locked */LUA_FLOW_NOT_LOCKED_BY_PARENT, p, flags);
+            p->flow, flow_lock, p, flags);
 
     if ((tluajit->flags & DATATYPE_PAYLOAD) && p->payload_len == 0)
         SCReturnInt(0);
@@ -430,10 +439,7 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
         if (p->flow == NULL)
             SCReturnInt(0);
 
-        FLOWLOCK_RDLOCK(p->flow);
-        int alproto = p->flow->alproto;
-        FLOWLOCK_UNLOCK(p->flow);
-
+        AppProto alproto = p->flow->alproto;
         if (tluajit->alproto != alproto)
             SCReturnInt(0);
     }
@@ -452,7 +458,6 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
         lua_settable(tluajit->luastate, -3);
     }
     if (tluajit->alproto == ALPROTO_HTTP) {
-        FLOWLOCK_RDLOCK(p->flow);
         HtpState *htp_state = p->flow->alstate;
         if (htp_state != NULL && htp_state->connp != NULL) {
             htp_tx_t *tx = NULL;
@@ -474,7 +479,6 @@ static int DetectLuaMatch (ThreadVars *tv, DetectEngineThreadCtx *det_ctx,
                 }
             }
         }
-        FLOWLOCK_UNLOCK(p->flow);
     }
 
     int retval = lua_pcall(tluajit->luastate, 1, 1, 0);

--- a/src/detect-lua.h
+++ b/src/detect-lua.h
@@ -44,7 +44,7 @@ typedef struct DetectLuaData {
     int negated;
     char *filename;
     uint32_t flags;
-    int alproto;
+    AppProto alproto;
     char *buffername; /* buffer name in case of a single buffer */
     uint16_t flowint[DETECT_LUAJIT_MAX_FLOWINTS];
     uint16_t flowints;
@@ -61,7 +61,7 @@ typedef struct DetectLuaData {
 void DetectLuaRegister (void);
 int DetectLuaMatchBuffer(DetectEngineThreadCtx *det_ctx, Signature *s, SigMatch *sm,
         uint8_t *buffer, uint32_t buffer_len, uint32_t offset,
-        Flow *f, int flow_lock);
+        Flow *f);
 
 #ifdef HAVE_LUAJIT
 int DetectLuajitSetupStatesPool(int num, int reloads);

--- a/src/detect.c
+++ b/src/detect.c
@@ -2037,9 +2037,7 @@ TmEcode Detect(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQue
 
     if (p->flow) {
         det_ctx->flow_locked = 1;
-        FLOWLOCK_WRLOCK(p->flow);
         DetectFlow(tv, de_ctx, det_ctx, p);
-        FLOWLOCK_UNLOCK(p->flow);
         det_ctx->flow_locked = 0;
     } else {
         DetectNoFlow(tv, de_ctx, det_ctx, p);

--- a/src/flow-bit.c
+++ b/src/flow-bit.c
@@ -125,28 +125,24 @@ void FlowBitToggle(Flow *f, uint16_t idx)
 int FlowBitIsset(Flow *f, uint16_t idx)
 {
     int r = 0;
-    FLOWLOCK_RDLOCK(f);
 
     FlowBit *fb = FlowBitGet(f, idx);
     if (fb != NULL) {
         r = 1;
     }
 
-    FLOWLOCK_UNLOCK(f);
     return r;
 }
 
 int FlowBitIsnotset(Flow *f, uint16_t idx)
 {
     int r = 0;
-    FLOWLOCK_RDLOCK(f);
 
     FlowBit *fb = FlowBitGet(f, idx);
     if (fb == NULL) {
         r = 1;
     }
 
-    FLOWLOCK_UNLOCK(f);
     return r;
 }
 

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -418,7 +418,7 @@ static Flow *FlowGetNew(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
     return f;
 }
 
-Flow *FlowGetFlowFromHashByPacket(const Packet *p)
+Flow *FlowGetFlowFromHashByPacket(const Packet *p, Flow **dest)
 {
     Flow *f = NULL;
 
@@ -448,6 +448,7 @@ Flow *FlowGetFlowFromHashByPacket(const Packet *p)
         f->fb = fb;
         /* update the last seen timestamp of this flow */
         COPY_TIMESTAMP(&p->ts,&f->lastts);
+        FlowReference(dest, f);
 
     }
     FBLOCK_UNLOCK(fb);
@@ -463,7 +464,7 @@ Flow *FlowGetFlowFromHashByPacket(const Packet *p)
  *
  *  \retval f flow or NULL if not found
  */
-Flow *FlowLookupFlowFromHash(const Packet *p)
+Flow *FlowLookupFlowFromHash(const Packet *p, Flow **dest)
 {
     Flow *f = NULL;
 
@@ -516,6 +517,7 @@ Flow *FlowLookupFlowFromHash(const Packet *p)
                 FLOWLOCK_WRLOCK(f);
                 /* update the last seen timestamp of this flow */
                 COPY_TIMESTAMP(&p->ts,&f->lastts);
+                FlowReference(dest, f);
 
                 FBLOCK_UNLOCK(fb);
                 return f;
@@ -527,6 +529,7 @@ Flow *FlowLookupFlowFromHash(const Packet *p)
     FLOWLOCK_WRLOCK(f);
     /* update the last seen timestamp of this flow */
     COPY_TIMESTAMP(&p->ts,&f->lastts);
+    FlowReference(dest, f);
 
     FBLOCK_UNLOCK(fb);
     return f;
@@ -549,7 +552,7 @@ Flow *FlowLookupFlowFromHash(const Packet *p)
  *
  *  \retval f *LOCKED* flow or NULL
  */
-Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p)
+Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p, Flow **dest)
 {
     Flow *f = NULL;
 
@@ -580,6 +583,7 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p
 
         /* update the last seen timestamp of this flow */
         COPY_TIMESTAMP(&p->ts,&f->lastts);
+        FlowReference(dest, f);
 
         FBLOCK_UNLOCK(fb);
         return f;
@@ -615,6 +619,7 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p
 
                 /* update the last seen timestamp of this flow */
                 COPY_TIMESTAMP(&p->ts,&f->lastts);
+                FlowReference(dest, f);
 
                 FBLOCK_UNLOCK(fb);
                 return f;
@@ -642,6 +647,7 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p
                 FLOWLOCK_WRLOCK(f);
                 /* update the last seen timestamp of this flow */
                 COPY_TIMESTAMP(&p->ts,&f->lastts);
+                FlowReference(dest, f);
 
                 FBLOCK_UNLOCK(fb);
                 return f;
@@ -653,6 +659,7 @@ Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *p
     FLOWLOCK_WRLOCK(f);
     /* update the last seen timestamp of this flow */
     COPY_TIMESTAMP(&p->ts,&f->lastts);
+    FlowReference(dest, f);
 
     FBLOCK_UNLOCK(fb);
     return f;

--- a/src/flow-hash.c
+++ b/src/flow-hash.c
@@ -415,7 +415,6 @@ static Flow *TcpReuseReplace(ThreadVars *tv, DecodeThreadVars *dtv,
     old_f->flags |= FLOW_TCP_REUSED;
     /* get some settings that we move over to the new flow */
     FlowThreadId thread_id = old_f->thread_id;
-    int16_t autofp_tmqh_flow_qid = SC_ATOMIC_GET(old_f->autofp_tmqh_flow_qid);
 
     /* since fb lock is still held this flow won't be found until we are done */
     FLOWLOCK_UNLOCK(old_f);
@@ -439,9 +438,6 @@ static Flow *TcpReuseReplace(ThreadVars *tv, DecodeThreadVars *dtv,
     f->fb = fb;
 
     f->thread_id = thread_id;
-    if (autofp_tmqh_flow_qid != -1) {
-        SC_ATOMIC_SET(f->autofp_tmqh_flow_qid, autofp_tmqh_flow_qid);
-    }
     return f;
 }
 

--- a/src/flow-hash.h
+++ b/src/flow-hash.h
@@ -68,7 +68,7 @@ typedef struct FlowBucket_ {
 
 /* prototypes */
 
-Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *);
+Flow *FlowGetFlowFromHash(ThreadVars *tv, DecodeThreadVars *dtv, const Packet *, Flow **);
 
 void FlowDisableTcpReuseHandling(void);
 

--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -70,8 +70,6 @@
         (f)->hprev = NULL; \
         (f)->lnext = NULL; \
         (f)->lprev = NULL; \
-        SC_ATOMIC_INIT((f)->autofp_tmqh_flow_qid);  \
-        (void) SC_ATOMIC_SET((f)->autofp_tmqh_flow_qid, -1);  \
         RESET_COUNTERS((f)); \
     } while (0)
 
@@ -113,9 +111,6 @@
         (f)->sgh_toclient = NULL; \
         GenericVarFree((f)->flowvar); \
         (f)->flowvar = NULL; \
-        if (SC_ATOMIC_GET((f)->autofp_tmqh_flow_qid) != -1) {   \
-            (void) SC_ATOMIC_SET((f)->autofp_tmqh_flow_qid, -1);   \
-        }                                       \
         RESET_COUNTERS((f)); \
     } while(0)
 
@@ -129,7 +124,6 @@
             DetectEngineStateFlowFree((f)->de_state); \
         } \
         GenericVarFree((f)->flowvar); \
-        SC_ATOMIC_DESTROY((f)->autofp_tmqh_flow_qid);   \
     } while(0)
 
 /** \brief check if a memory alloc would fit in the memcap

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -1,0 +1,233 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ *
+ * Flow Workers are single thread modules taking care of (almost)
+ * everything related to packets with flows:
+ *
+ * - Lookup/creation
+ * - Stream tracking, reassembly
+ * - Applayer update
+ * - Detection
+ *
+ * This all while holding the flow lock.
+ *
+ * TODO
+ * - once we have a single entry point into the outputs they
+ *   will have to move into this as well.
+ * - once outputs are here we can also call StreamTcpPrune here
+ *   instead of in the packet pool return code
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+
+#include "decode.h"
+#include "stream-tcp.h"
+#include "app-layer.h"
+#include "detect-engine.h"
+
+#include "util-validate.h"
+
+typedef DetectEngineThreadCtx *DetectEngineThreadCtxPtr;
+
+typedef struct FlowWorkerThreadData_ {
+    union {
+        StreamTcpThread *stream_thread;
+        void *stream_thread_ptr;
+    };
+
+    SC_ATOMIC_DECLARE(DetectEngineThreadCtxPtr, detect_thread);
+
+#if 0
+    void *output_thread; // XXX multiple, not a single state
+#endif
+    PacketQueue pq;
+
+} FlowWorkerThreadData;
+
+/** \brief handle flow for packet
+ *
+ *  Handle flow creation/lookup
+ */
+static void FlowUpdate(ThreadVars *tv, StreamTcpThread *stt, Packet *p)
+{
+    FlowHandlePacketUpdate(p->flow, p);
+
+    /* handle the app layer part of the UDP packet payload */
+    if (p->proto == IPPROTO_UDP) {
+        AppLayerHandleUdp(tv, stt->ra_ctx->app_tctx, p, p->flow);
+    }
+}
+
+static TmEcode FlowWorkerThreadInit(ThreadVars *tv, void *initdata, void **data)
+{
+    FlowWorkerThreadData *fw = SCCalloc(1, sizeof(*fw));
+    BUG_ON(fw == NULL);
+    SC_ATOMIC_INIT(fw->detect_thread);
+    SC_ATOMIC_SET(fw->detect_thread, NULL);
+
+    /* setup TCP */
+    BUG_ON(StreamTcpThreadInit(tv, NULL, &fw->stream_thread_ptr) != TM_ECODE_OK);
+
+    if (DetectEngineEnabled()) {
+        /* setup DETECT */
+        void *detect_thread = NULL;
+        BUG_ON(DetectEngineThreadCtxInit(tv, NULL, &detect_thread) != TM_ECODE_OK);
+        SC_ATOMIC_SET(fw->detect_thread, detect_thread);
+    }
+#if 0
+    // setup OUTPUTS
+#endif
+
+    /* setup pq for stream end pkts */
+    memset(&fw->pq, 0, sizeof(PacketQueue));
+    SCMutexInit(&fw->pq.mutex_q, NULL);
+
+    *data = fw;
+    return TM_ECODE_OK;
+}
+
+static TmEcode FlowWorkerThreadDeinit(ThreadVars *tv, void *data)
+{
+    FlowWorkerThreadData *fw = data;
+
+    /* free TCP */
+    StreamTcpThreadDeinit(tv, (void *)fw->stream_thread);
+
+    /* free DETECT */
+    void *detect_thread = SC_ATOMIC_GET(fw->detect_thread);
+    if (detect_thread != NULL)
+        DetectEngineThreadCtxDeinit(tv, detect_thread);
+        SC_ATOMIC_SET(fw->detect_thread, NULL);
+#if 0
+    // free OUTPUT
+#endif
+
+    /* free pq */
+    BUG_ON(fw->pq.len);
+    SCMutexDestroy(&fw->pq.mutex_q);
+
+    SCFree(fw);
+    return TM_ECODE_OK;
+}
+
+TmEcode Detect(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, PacketQueue *postpq);
+TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
+
+TmEcode FlowWorker(ThreadVars *tv, Packet *p, void *data, PacketQueue *preq, PacketQueue *unused)
+{
+    FlowWorkerThreadData *fw = data;
+    void *detect_thread = SC_ATOMIC_GET(fw->detect_thread);
+
+    SCLogDebug("packet %"PRIu64, p->pcap_cnt);
+
+    /* update time */
+    if (!(PKT_IS_PSEUDOPKT(p)))
+        TimeSetByThread(tv->id, &p->ts);
+
+    /* handle Flow */
+    if (p->flags & PKT_WANTS_FLOW) {
+        FlowHandlePacket(tv, NULL, p); //TODO what to do about decoder thread vars
+        if (likely(p->flow != NULL)) {
+            DEBUG_ASSERT_FLOW_LOCKED(p->flow);
+            FlowUpdate(tv, fw->stream_thread, p);
+        }
+        /* Flow is now LOCKED */
+
+    /* if PKT_WANTS_FLOW is not set, but PKT_HAS_FLOW is, then this is a
+     * pseudo packet created by the flow manager. */
+    } else if (p->flags & PKT_HAS_FLOW) {
+        FLOWLOCK_WRLOCK(p->flow);
+    }
+
+    SCLogDebug("packet %"PRIu64" has flow? %s", p->pcap_cnt, p->flow ? "yes" : "no");
+
+    /* handle TCP and app layer */
+    if (PKT_IS_TCP(p)) {
+        SCLogDebug("packet %"PRIu64" is TCP", p->pcap_cnt);
+        DEBUG_ASSERT_FLOW_LOCKED(p->flow);
+
+        StreamTcp(tv, p, fw->stream_thread, &fw->pq, NULL);
+
+        /* Packets here can safely access p->flow as it's locked */
+        SCLogDebug("packet %"PRIu64": extra packets %u", p->pcap_cnt, fw->pq.len);
+        Packet *x;
+        while ((x = PacketDequeue(&fw->pq))) {
+            SCLogDebug("packet %"PRIu64" extra packet %p", p->pcap_cnt, x);
+
+            // TODO do we need to call StreamTcp on these pseudo packets or not?
+            //StreamTcp(tv, x, fw->stream_thread, &fw->pq, NULL);
+            if (detect_thread != NULL)
+                Detect(tv, x, detect_thread, NULL, NULL);
+#if 0
+            //  Outputs
+#endif
+            /* put these packets in the preq queue so that they are
+             * by the other thread modules before packet 'p'. */
+            PacketEnqueue(preq, x);
+        }
+    }
+
+    /* handle Detect */
+    DEBUG_ASSERT_FLOW_LOCKED(p->flow);
+    SCLogDebug("packet %"PRIu64" calling Detect", p->pcap_cnt);
+
+    if (detect_thread != NULL) {
+        Detect(tv, p, detect_thread, NULL, NULL);
+    }
+#if 0
+    // Outputs
+
+    // StreamTcpPruneSession (from TmqhOutputPacketpool)
+#endif
+
+    if (p->flow) {
+        DEBUG_ASSERT_FLOW_LOCKED(p->flow);
+        FLOWLOCK_UNLOCK(p->flow);
+    }
+
+    return TM_ECODE_OK;
+}
+
+void FlowWorkerReplaceDetectCtx(void *flow_worker, void *detect_ctx)
+{
+    FlowWorkerThreadData *fw = flow_worker;
+
+    SC_ATOMIC_SET(fw->detect_thread, detect_ctx);
+}
+
+void *FlowWorkerGetDetectCtxPtr(void *flow_worker)
+{
+    FlowWorkerThreadData *fw = flow_worker;
+
+    return SC_ATOMIC_GET(fw->detect_thread);
+}
+
+void TmModuleFlowWorkerRegister (void)
+{
+    tmm_modules[TMM_FLOWWORKER].name = "FlowWorker";
+    tmm_modules[TMM_FLOWWORKER].ThreadInit = FlowWorkerThreadInit;
+    tmm_modules[TMM_FLOWWORKER].Func = FlowWorker;
+    tmm_modules[TMM_FLOWWORKER].ThreadDeinit = FlowWorkerThreadDeinit;
+    tmm_modules[TMM_FLOWWORKER].cap_flags = 0;
+    tmm_modules[TMM_FLOWWORKER].flags = TM_FLAG_STREAM_TM|TM_FLAG_DETECT_TM;
+}

--- a/src/flow-worker.h
+++ b/src/flow-worker.h
@@ -1,0 +1,26 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __FLOW_WORKER_H__
+#define __FLOW_WORKER_H__
+
+void FlowWorkerReplaceDetectCtx(void *flow_worker, void *detect_ctx);
+void *FlowWorkerGetDetectCtxPtr(void *flow_worker);
+
+void TmModuleFlowWorkerRegister (void);
+
+#endif /* __FLOW_WORKER_H__ */

--- a/src/flow.c
+++ b/src/flow.c
@@ -147,26 +147,12 @@ int FlowUpdateSpareFlows(void)
     return 1;
 }
 
-/** \brief Set the IPOnly scanned flag for 'direction'. This function
-  *        handles the locking too.
-  * \param f Flow to set the flag in
-  * \param direction direction to set the flag in
-  */
-void FlowSetIPOnlyFlag(Flow *f, char direction)
-{
-    FLOWLOCK_WRLOCK(f);
-    direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) :
-        (f->flags |= FLOW_TOCLIENT_IPONLY_SET);
-    FLOWLOCK_UNLOCK(f);
-    return;
-}
-
 /** \brief Set the IPOnly scanned flag for 'direction'.
   *
   * \param f Flow to set the flag in
   * \param direction direction to set the flag in
   */
-void FlowSetIPOnlyFlagNoLock(Flow *f, char direction)
+void FlowSetIPOnlyFlag(Flow *f, int direction)
 {
     direction ? (f->flags |= FLOW_TOSERVER_IPONLY_SET) :
         (f->flags |= FLOW_TOCLIENT_IPONLY_SET);

--- a/src/flow.c
+++ b/src/flow.c
@@ -270,9 +270,6 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
 {
     SCLogDebug("packet %"PRIu64" -- flow %p", p->pcap_cnt, f);
 
-    /* Point the Packet at the Flow */
-    FlowReference(&p->flow, f);
-
     /* update flags and counters */
     if (FlowGetPacketDirection(f, p) == TOSERVER) {
         f->todstpktcnt++;
@@ -329,7 +326,7 @@ void FlowHandlePacket(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p)
     /* Get this packet's flow from the hash. FlowHandlePacket() will setup
      * a new flow if nescesary. If we get NULL, we're out of flow memory.
      * The returned flow is locked. */
-    Flow *f = FlowGetFlowFromHash(tv, dtv, p);
+    Flow *f = FlowGetFlowFromHash(tv, dtv, p, &p->flow);
     if (f == NULL)
         return;
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -453,32 +453,12 @@ struct FlowQueue_;
 
 int FlowUpdateSpareFlows(void);
 
-static inline void FlowLockSetNoPacketInspectionFlag(Flow *);
 static inline void FlowSetNoPacketInspectionFlag(Flow *);
-static inline void FlowLockSetNoPayloadInspectionFlag(Flow *);
 static inline void FlowSetNoPayloadInspectionFlag(Flow *);
 
 int FlowGetPacketDirection(const Flow *, const Packet *);
 
 void FlowCleanupAppLayer(Flow *);
-
-/** ----- Inline functions ----- */
-
-/** \brief Set the No Packet Inspection Flag after locking the flow.
- *
- * \param f Flow to set the flag in
- */
-static inline void FlowLockSetNoPacketInspectionFlag(Flow *f)
-{
-    SCEnter();
-
-    SCLogDebug("flow %p", f);
-    FLOWLOCK_WRLOCK(f);
-    f->flags |= FLOW_NOPACKET_INSPECTION;
-    FLOWLOCK_UNLOCK(f);
-
-    SCReturn;
-}
 
 /** \brief Set the No Packet Inspection Flag without locking the flow.
  *
@@ -490,22 +470,6 @@ static inline  void FlowSetNoPacketInspectionFlag(Flow *f)
 
     SCLogDebug("flow %p", f);
     f->flags |= FLOW_NOPACKET_INSPECTION;
-
-    SCReturn;
-}
-
-/** \brief Set the No payload inspection Flag after locking the flow.
- *
- * \param f Flow to set the flag in
- */
-static inline void FlowLockSetNoPayloadInspectionFlag(Flow *f)
-{
-    SCEnter();
-
-    SCLogDebug("flow %p", f);
-    FLOWLOCK_WRLOCK(f);
-    f->flags |= FLOW_NOPAYLOAD_INSPECTION;
-    FLOWLOCK_UNLOCK(f);
 
     SCReturn;
 }

--- a/src/flow.h
+++ b/src/flow.h
@@ -334,9 +334,6 @@ typedef struct Flow_
      */
     SC_ATOMIC_DECLARE(FlowRefCount, use_cnt);
 
-    /** flow queue id, used with autofp */
-    SC_ATOMIC_DECLARE(int16_t, autofp_tmqh_flow_qid);
-
     /** flow tenant id, used to setup flow timeout and stream pseudo
      *  packets with the correct tenant id set */
     uint32_t tenant_id;

--- a/src/flow.h
+++ b/src/flow.h
@@ -441,8 +441,7 @@ void FlowHandlePacket (ThreadVars *, DecodeThreadVars *, Packet *);
 void FlowInitConfig (char);
 void FlowPrintQueueInfo (void);
 void FlowShutdown(void);
-void FlowSetIPOnlyFlag(Flow *, char);
-void FlowSetIPOnlyFlagNoLock(Flow *, char);
+void FlowSetIPOnlyFlag(Flow *, int);
 
 void FlowRegisterTests (void);
 int FlowSetProtoTimeout(uint8_t ,uint32_t ,uint32_t ,uint32_t);

--- a/src/flow.h
+++ b/src/flow.h
@@ -432,6 +432,11 @@ typedef struct FlowProto_ {
     void (*Freefunc)(void *);
 } FlowProto;
 
+/** \brief prepare packet for a life with flow
+ *  Set PKT_WANTS_FLOW flag to incidate workers should do a flow lookup
+ *  and calc the hash value to be used in the lookup and autofp flow
+ *  balancing. */
+void FlowSetupPacket(Packet *p);
 void FlowHandlePacket (ThreadVars *, DecodeThreadVars *, Packet *);
 void FlowInitConfig (char);
 void FlowPrintQueueInfo (void);
@@ -577,11 +582,7 @@ AppProto FlowGetAppProtocol(const Flow *f);
 void *FlowGetAppState(const Flow *f);
 uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags);
 
-void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
-
-Flow *FlowGetFlowFromHashByPacket(const Packet *p, Flow **dest);
-Flow *FlowLookupFlowFromHash(const Packet *p, Flow **dest);
 
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -580,8 +580,8 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags);
 void FlowHandlePacketUpdateRemove(Flow *f, Packet *p);
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
-Flow *FlowGetFlowFromHashByPacket(const Packet *p);
-Flow *FlowLookupFlowFromHash(const Packet *p);
+Flow *FlowGetFlowFromHashByPacket(const Packet *p, Flow **dest);
+Flow *FlowLookupFlowFromHash(const Packet *p, Flow **dest);
 
 #endif /* __FLOW_H__ */
 

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -132,7 +132,6 @@ int RunModeErfFileAutoFp(void)
     int thread;
 
     RunModeInitialize();
-    RunmodeSetFlowStreamAsync();
 
     char *file = NULL;
     if (ConfGet("erf-file.file", &file) == 0) {

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -94,21 +94,12 @@ int RunModeErfFileSingle(void)
     }
     TmSlotSetFuncAppend(tv, tm_module, NULL);
 
-    tm_module = TmModuleGetByName("StreamTcp");
+    tm_module = TmModuleGetByName("FlowWorker");
     if (tm_module == NULL) {
-        printf("ERROR: TmModuleGetByName StreamTcp failed\n");
+        SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
         exit(EXIT_FAILURE);
     }
     TmSlotSetFuncAppend(tv, tm_module, NULL);
-
-    if (DetectEngineEnabled()) {
-        tm_module = TmModuleGetByName("Detect");
-        if (tm_module == NULL) {
-            printf("ERROR: TmModuleGetByName Detect failed\n");
-            exit(EXIT_FAILURE);
-        }
-        TmSlotSetFuncAppend(tv, tm_module, NULL);
-    }
 
     SetupOutputs(tv);
 
@@ -217,21 +208,13 @@ int RunModeErfFileAutoFp(void)
             printf("ERROR: TmThreadsCreate failed\n");
             exit(EXIT_FAILURE);
         }
-        tm_module = TmModuleGetByName("StreamTcp");
+
+        tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            printf("ERROR: TmModuleGetByName StreamTcp failed\n");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                printf("ERROR: TmModuleGetByName Detect failed\n");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-        }
 
         if (threading_set_cpu_affinity) {
             TmThreadSetCPUAffinity(tv_detect_ncpu, (int)cpu);

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -165,7 +165,6 @@ int RunModeFilePcapAutoFp(void)
     int thread;
 
     RunModeInitialize();
-    RunmodeSetFlowStreamAsync();
 
     char *file = NULL;
     if (ConfGet("pcap-file.file", &file) == 0) {

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -100,21 +100,12 @@ int RunModeFilePcapSingle(void)
     }
     TmSlotSetFuncAppend(tv, tm_module, NULL);
 
-    tm_module = TmModuleGetByName("StreamTcp");
+    tm_module = TmModuleGetByName("FlowWorker");
     if (tm_module == NULL) {
-        SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+        SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
         exit(EXIT_FAILURE);
     }
     TmSlotSetFuncAppend(tv, tm_module, NULL);
-
-    if (DetectEngineEnabled()) {
-        tm_module = TmModuleGetByName("Detect");
-        if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-            exit(EXIT_FAILURE);
-        }
-        TmSlotSetFuncAppend(tv, tm_module, NULL);
-    }
 
     SetupOutputs(tv);
 
@@ -249,21 +240,13 @@ int RunModeFilePcapAutoFp(void)
             SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
-        tm_module = TmModuleGetByName("StreamTcp");
+
+        tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-        }
 
         TmThreadSetGroupName(tv_detect_ncpu, "Detect");
 

--- a/src/runmode-tile.c
+++ b/src/runmode-tile.c
@@ -245,21 +245,12 @@ int RunModeTileMpipeWorkers(void)
         }
         TmSlotSetFuncAppend(tv_worker, tm_module, NULL);
 
-        tm_module = TmModuleGetByName("StreamTcp");
+        tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            printf("ERROR: TmModuleGetByName StreamTcp failed\n");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv_worker, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                printf("ERROR: TmModuleGetByName Detect failed\n");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv_worker, tm_module, NULL);
-        }
 
         tm_module = TmModuleGetByName("RespondReject");
         if (tm_module == NULL) {

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -420,10 +420,6 @@ TmEcode DecodePcapFile(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, P
         FlowWakeupFlowManagerThread();
     }
 
-    /* update the engine time representation based on the timestamp
-     * of the packet. */
-    TimeSet(&p->ts);
-
     /* call the decoder */
     pcap_g.Decoder(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4920,7 +4920,7 @@ static void TcpSessionReuseHandle(Packet *p) {
      * a different thread. */
 
     /* Get a flow. It will be either a locked flow or NULL */
-    Flow *new_f = FlowGetFlowFromHashByPacket(p);
+    Flow *new_f = FlowGetFlowFromHashByPacket(p, &p->flow);
     if (new_f == NULL) {
         FlowDeReference(&old_f); // < can't disappear while usecnt >0
         return;
@@ -4992,7 +4992,7 @@ static void TcpSessionReuseHandleApplyToPacket(Packet *p)
     FlowDeReference(&p->flow); // < can't disappear while usecnt >0
 
     /* find the new flow that does belong to this packet */
-    Flow *new_f = FlowLookupFlowFromHash(p);
+    Flow *new_f = FlowLookupFlowFromHash(p, &p->flow);
     if (new_f == NULL) {
         // TODO reset packet flag wrt flow: direction, HAS_FLOW etc
         p->flags &= ~PKT_HAS_FLOW;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4880,6 +4880,8 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
 
     SCLogDebug("p->pcap_cnt %"PRIu64, p->pcap_cnt);
 
+    TimeSetByThread(tv->id, &p->ts);
+
     if (p->flow && p->flags & PKT_PSEUDO_STREAM_END) {
         FLOWLOCK_WRLOCK(p->flow);
         AppLayerProfilingReset(stt->ra_ctx->app_tctx);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -76,10 +76,6 @@ typedef struct TcpStreamCnf_ {
 typedef struct StreamTcpThread_ {
     int ssn_pool_id;
 
-    /** if set to true, we activate the TCP tuple reuse code in the
-     *  stream engine. */
-    int runmode_flow_stream_async;
-
     uint64_t pkts;
 
     /** queue for pseudo packet(s) that were created in the stream

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -43,6 +43,7 @@
 #include "packet-queue.h"
 #include "threads.h"
 #include "threadvars.h"
+#include "flow-worker.h"
 
 #include "util-atomic.h"
 #include "util-spm.h"
@@ -856,6 +857,8 @@ void RegisterAllModules()
     TmModuleNapatechStreamRegister();
     TmModuleNapatechDecodeRegister();
 
+    /* flow worker */
+    TmModuleFlowWorkerRegister();
     /* stream engine */
     TmModuleStreamTcpRegister();
     /* detection */

--- a/src/tm-modules.c
+++ b/src/tm-modules.c
@@ -199,6 +199,7 @@ void TmModuleRegisterTests(void)
 const char * TmModuleTmmIdToString(TmmId id)
 {
     switch (id) {
+        CASE_CODE (TMM_FLOWWORKER);
         CASE_CODE (TMM_RECEIVENFLOG);
         CASE_CODE (TMM_DECODENFLOG);
         CASE_CODE (TMM_DECODENFQ);

--- a/src/tm-threads-common.h
+++ b/src/tm-threads-common.h
@@ -31,6 +31,7 @@
  *        in tm-modules.c
  */
 typedef enum {
+    TMM_FLOWWORKER,
     TMM_DECODENFQ,
     TMM_VERDICTNFQ,
     TMM_RECEIVENFQ,

--- a/src/tm-threads.h
+++ b/src/tm-threads.h
@@ -222,4 +222,7 @@ int TmThreadsRegisterThread(ThreadVars *tv, const int type);
 void TmThreadsUnregisterThread(const int id);
 int TmThreadsInjectPacketsById(Packet **, int id);
 
+void TmThreadsSetThreadTimestamp(const int id, const struct timeval *ts);
+void TmreadsGetMinimalTimestamp(struct timeval *ts);
+
 #endif /* __TM_THREADS_H__ */

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -42,8 +42,6 @@
 Packet *TmqhInputFlow(ThreadVars *t);
 void TmqhOutputFlowHash(ThreadVars *t, Packet *p);
 void TmqhOutputFlowIPPair(ThreadVars *t, Packet *p);
-void TmqhOutputFlowActivePackets(ThreadVars *t, Packet *p);
-void TmqhOutputFlowRoundRobin(ThreadVars *t, Packet *p);
 void *TmqhOutputFlowSetupCtx(char *queue_str);
 void TmqhOutputFlowFreeCtx(void *ctx);
 void TmqhFlowRegisterTests(void);
@@ -59,10 +57,10 @@ void TmqhFlowRegister(void)
     char *scheduler = NULL;
     if (ConfGet("autofp-scheduler", &scheduler) == 1) {
         if (strcasecmp(scheduler, "round-robin") == 0) {
-            tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowRoundRobin;
+            SCLogNotice("using flow hash instead of round robin");
+            tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
         } else if (strcasecmp(scheduler, "active-packets") == 0) {
-            //tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowActivePackets;
-            SCLogNotice("FIXME: using flow hash instead of active packets");
+            SCLogNotice("using flow hash instead of active packets");
             tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
         } else if (strcasecmp(scheduler, "hash") == 0) {
             tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
@@ -75,7 +73,6 @@ void TmqhFlowRegister(void)
             exit(EXIT_FAILURE);
         }
     } else {
-        //tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowActivePackets;
         tmqh_table[TMQH_FLOW].OutHandler = TmqhOutputFlowHash;
     }
 
@@ -88,8 +85,6 @@ void TmqhFlowPrintAutofpHandler(void)
     if (tmqh_table[TMQH_FLOW].OutHandler == (f))    \
         SCLogInfo("AutoFP mode using \"%s\" flow load balancer", (msg))
 
-    PRINT_IF_FUNC(TmqhOutputFlowRoundRobin, "Round Robin");
-    PRINT_IF_FUNC(TmqhOutputFlowActivePackets, "Active Packets");
     PRINT_IF_FUNC(TmqhOutputFlowHash, "Hash");
     PRINT_IF_FUNC(TmqhOutputFlowIPPair, "IPPair");
 
@@ -153,8 +148,6 @@ static int StoreQueueId(TmqhFlowCtx *ctx, char *name)
         memset(ctx->queues + (ctx->size - 1), 0, sizeof(TmqhFlowMode));
     }
     ctx->queues[ctx->size - 1].q = &trans_q[id];
-    SC_ATOMIC_INIT(ctx->queues[ctx->size - 1].total_packets);
-    SC_ATOMIC_INIT(ctx->queues[ctx->size - 1].total_flows);
 
     return 0;
 }
@@ -205,8 +198,6 @@ void *TmqhOutputFlowSetupCtx(char *queue_str)
         tstr = comma ? (comma + 1) : comma;
     } while (tstr != NULL);
 
-    SC_ATOMIC_INIT(ctx->round_robin_idx);
-
     SCFree(str);
     return (void *)ctx;
 
@@ -219,157 +210,12 @@ error:
 
 void TmqhOutputFlowFreeCtx(void *ctx)
 {
-    int i;
     TmqhFlowCtx *fctx = (TmqhFlowCtx *)ctx;
 
     SCLogInfo("AutoFP - Total flow handler queues - %" PRIu16,
               fctx->size);
-    for (i = 0; i < fctx->size; i++) {
-        SCLogInfo("AutoFP - Queue %-2"PRIu32 " - pkts: %-12"PRIu64" flows: %-12"PRIu64, i,
-                SC_ATOMIC_GET(fctx->queues[i].total_packets),
-                SC_ATOMIC_GET(fctx->queues[i].total_flows));
-        SC_ATOMIC_DESTROY(fctx->queues[i].total_packets);
-        SC_ATOMIC_DESTROY(fctx->queues[i].total_flows);
-    }
-
     SCFree(fctx->queues);
     SCFree(fctx);
-
-    return;
-}
-
-/**
- * \brief select the queue to output in a round robin fashion.
- *
- * \param tv thread vars
- * \param p packet
- */
-void TmqhOutputFlowRoundRobin(ThreadVars *tv, Packet *p)
-{
-    int16_t qid = 0;
-
-    TmqhFlowCtx *ctx = (TmqhFlowCtx *)tv->outctx;
-
-    /* if no flow we use the first queue,
-     * should be rare */
-    if (p->flow != NULL) {
-        qid = SC_ATOMIC_GET(p->flow->autofp_tmqh_flow_qid);
-        if (qid == -1) {
-            qid = SC_ATOMIC_ADD(ctx->round_robin_idx, 1);
-            if (qid >= ctx->size) {
-                SC_ATOMIC_RESET(ctx->round_robin_idx);
-                qid = 0;
-            }
-            (void) SC_ATOMIC_ADD(ctx->queues[qid].total_flows, 1);
-            (void) SC_ATOMIC_SET(p->flow->autofp_tmqh_flow_qid, qid);
-        }
-    } else {
-        qid = ctx->last++;
-
-        if (ctx->last == ctx->size)
-            ctx->last = 0;
-    }
-    (void) SC_ATOMIC_ADD(ctx->queues[qid].total_packets, 1);
-
-    PacketQueue *q = ctx->queues[qid].q;
-    SCMutexLock(&q->mutex_q);
-    PacketEnqueue(q, p);
-    SCCondSignal(&q->cond_q);
-    SCMutexUnlock(&q->mutex_q);
-
-    return;
-}
-
-/**
- * \brief select the queue to output to based on queue lengths.
- *
- * \param tv thread vars
- * \param p packet
- */
-void TmqhOutputFlowActivePackets(ThreadVars *tv, Packet *p)
-{
-    int16_t qid = 0;
-
-    TmqhFlowCtx *ctx = (TmqhFlowCtx *)tv->outctx;
-
-    /* if no flow we round robin the packets over the queues */
-    if (p->flow != NULL) {
-        qid = SC_ATOMIC_GET(p->flow->autofp_tmqh_flow_qid);
-        if (qid == -1) {
-            int16_t i = 0;
-            int16_t lowest_id = 0;
-            TmqhFlowMode *queues = ctx->queues;
-            uint32_t lowest = queues[i].q->len;
-            for (i = 1; i < ctx->size; i++) {
-                if (queues[i].q->len < lowest) {
-                    lowest = queues[i].q->len;
-                    lowest_id = i;
-                }
-            }
-            qid = lowest_id;
-            (void) SC_ATOMIC_SET(p->flow->autofp_tmqh_flow_qid, lowest_id);
-            (void) SC_ATOMIC_ADD(ctx->queues[qid].total_flows, 1);
-        }
-    } else {
-        qid = ctx->last++;
-
-        if (ctx->last == ctx->size)
-            ctx->last = 0;
-    }
-    (void) SC_ATOMIC_ADD(ctx->queues[qid].total_packets, 1);
-
-    PacketQueue *q = ctx->queues[qid].q;
-    SCMutexLock(&q->mutex_q);
-    PacketEnqueue(q, p);
-    SCCondSignal(&q->cond_q);
-    SCMutexUnlock(&q->mutex_q);
-
-    return;
-}
-
-/**
- * \brief select the queue to output based on address hash.
- *
- * \param tv thread vars.
- * \param p packet.
- */
-void TmqhOutputFlowHash2(ThreadVars *tv, Packet *p)
-{
-    int16_t qid = 0;
-
-    TmqhFlowCtx *ctx = (TmqhFlowCtx *)tv->outctx;
-
-    /* if no flow we use the first queue,
-     * should be rare */
-    if (p->flow != NULL) {
-        qid = SC_ATOMIC_GET(p->flow->autofp_tmqh_flow_qid);
-        if (qid == -1) {
-#if __WORDSIZE == 64
-            uint64_t addr = (uint64_t)p->flow;
-#else
-            uint32_t addr = (uint32_t)p->flow;
-#endif
-            addr >>= 7;
-
-            /* we don't have to worry about possible overflow, since
-             * ctx->size will be less than 2 ** 15 for sure */
-            qid = addr % ctx->size;
-            (void) SC_ATOMIC_SET(p->flow->autofp_tmqh_flow_qid, qid);
-            (void) SC_ATOMIC_ADD(ctx->queues[qid].total_flows, 1);
-        }
-    } else {
-        qid = ctx->last++;
-
-        if (ctx->last == ctx->size)
-            ctx->last = 0;
-    }
-    (void) SC_ATOMIC_ADD(ctx->queues[qid].total_packets, 1);
-
-    PacketQueue *q = ctx->queues[qid].q;
-    SCMutexLock(&q->mutex_q);
-    PacketEnqueue(q, p);
-    SCCondSignal(&q->cond_q);
-    SCMutexUnlock(&q->mutex_q);
 
     return;
 }
@@ -389,7 +235,6 @@ void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
         if (ctx->last == ctx->size)
             ctx->last = 0;
     }
-    (void) SC_ATOMIC_ADD(ctx->queues[qid].total_packets, 1);
 
     PacketQueue *q = ctx->queues[qid].q;
     SCMutexLock(&q->mutex_q);
@@ -399,6 +244,7 @@ void TmqhOutputFlowHash(ThreadVars *tv, Packet *p)
 
     return;
 }
+
 /**
  * \brief select the queue to output based on IP address pair.
  *
@@ -413,32 +259,17 @@ void TmqhOutputFlowIPPair(ThreadVars *tv, Packet *p)
 
     TmqhFlowCtx *ctx = (TmqhFlowCtx *)tv->outctx;
 
-    /* if no flow we use the first queue,
-     * should be rare */
-    if (p->flow != NULL) {
-        qid = SC_ATOMIC_GET(p->flow->autofp_tmqh_flow_qid);
-        if (qid == -1) {
-            if (p->src.family == AF_INET6) {
-                for (i = 0; i < 4; i++) {
-                    addr_hash += p->src.addr_data32[i] + p->dst.addr_data32[i];
-                }
-            } else {
-                addr_hash = p->src.addr_data32[0] + p->dst.addr_data32[0];
-            }
-
-            /* we don't have to worry about possible overflow, since
-             * ctx->size will be lesser than 2 ** 31 for sure */
-            qid = addr_hash % ctx->size;
-            (void) SC_ATOMIC_SET(p->flow->autofp_tmqh_flow_qid, qid);
-            (void) SC_ATOMIC_ADD(ctx->queues[qid].total_flows, 1);
+    if (p->src.family == AF_INET6) {
+        for (i = 0; i < 4; i++) {
+            addr_hash += p->src.addr_data32[i] + p->dst.addr_data32[i];
         }
     } else {
-        qid = ctx->last++;
-
-        if (ctx->last == ctx->size)
-            ctx->last = 0;
+        addr_hash = p->src.addr_data32[0] + p->dst.addr_data32[0];
     }
-    (void) SC_ATOMIC_ADD(ctx->queues[qid].total_packets, 1);
+
+    /* we don't have to worry about possible overflow, since
+     * ctx->size will be lesser than 2 ** 31 for sure */
+    qid = addr_hash % ctx->size;
 
     PacketQueue *q = ctx->queues[qid].q;
     SCMutexLock(&q->mutex_q);

--- a/src/tmqh-flow.h
+++ b/src/tmqh-flow.h
@@ -26,8 +26,6 @@
 
 typedef struct TmqhFlowMode_ {
     PacketQueue *q;
-    SC_ATOMIC_DECLARE(uint64_t, total_packets);
-    SC_ATOMIC_DECLARE(uint64_t, total_flows);
 } TmqhFlowMode;
 
 /** \brief Ctx for the flow queue handler
@@ -38,8 +36,6 @@ typedef struct TmqhFlowCtx_ {
     uint16_t last;
 
     TmqhFlowMode *queues;
-
-    SC_ATOMIC_DECLARE(int16_t, round_robin_idx);
 } TmqhFlowCtx;
 
 void TmqhFlowRegister (void);

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -246,21 +246,12 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
             SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
-        TmModule *tm_module = TmModuleGetByName("StreamTcp");
+        TmModule *tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-        }
 
         TmThreadSetCPU(tv_detect_ncpu, DETECT_CPU_SET);
 
@@ -347,21 +338,12 @@ static int RunModeSetLiveCaptureWorkersForDevice(ConfigIfaceThreadsCountFunc Mod
         }
         TmSlotSetFuncAppend(tv, tm_module, NULL);
 
-        tm_module = TmModuleGetByName("StreamTcp");
+        tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv, tm_module, NULL);
-        }
 
         tm_module = TmModuleGetByName("RespondReject");
         if (tm_module == NULL) {
@@ -541,21 +523,13 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
             SCLogError(SC_ERR_RUNMODE, "TmThreadsCreate failed");
             exit(EXIT_FAILURE);
         }
-        TmModule *tm_module = TmModuleGetByName("StreamTcp");
+
+        TmModule *tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv_detect_ncpu, tm_module, NULL);
-        }
 
         TmThreadSetCPU(tv_detect_ncpu, DETECT_CPU_SET);
 
@@ -656,21 +630,12 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
         }
         TmSlotSetFuncAppend(tv, tm_module, NULL);
 
-        tm_module = TmModuleGetByName("StreamTcp");
+        TmModule *tm_module = TmModuleGetByName("FlowWorker");
         if (tm_module == NULL) {
-            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName StreamTcp failed");
+            SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName for FlowWorker failed");
             exit(EXIT_FAILURE);
         }
         TmSlotSetFuncAppend(tv, tm_module, NULL);
-
-        if (DetectEngineEnabled()) {
-            tm_module = TmModuleGetByName("Detect");
-            if (tm_module == NULL) {
-                SCLogError(SC_ERR_RUNMODE, "TmModuleGetByName Detect failed");
-                exit(EXIT_FAILURE);
-            }
-            TmSlotSetFuncAppend(tv, tm_module, NULL);
-        }
 
         tm_module = TmModuleGetByName(verdict_mod_name);
         if (tm_module == NULL) {

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -51,21 +51,6 @@
 
 #include "flow-hash.h"
 
-/** set to true if flow engine and stream engine run in different
- *  threads. */
-static int runmode_flow_stream_async = 0;
-
-void RunmodeSetFlowStreamAsync(void)
-{
-    runmode_flow_stream_async = 1;
-    FlowDisableTcpReuseHandling();
-}
-
-int RunmodeGetFlowStreamAsync(void)
-{
-    return runmode_flow_stream_async;
-}
-
 /** \brief create a queue string for autofp to pass to
  *         the flow queue handler.
  *
@@ -120,8 +105,6 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
-
-    RunmodeSetFlowStreamAsync();
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -496,8 +479,6 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
-
-    RunmodeSetFlowStreamAsync();
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2013 Open Information Security Foundation
+/* Copyright (C) 2007-2016 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -25,16 +25,43 @@
  * And time string generation for alerts.
  */
 
+/* Real time vs offline time
+ *
+ * When we run on live traffic, time handling is simple. Packets have a
+ * timestamp set by the capture method. Management threads can simply
+ * use 'gettimeofday' to know the current time. There should never be
+ * any serious gap between the two.
+ *
+ * In offline mode, things are dramatically different. Here we try to keep
+ * the time from the pcap, which means that if the packets are in 2011 the
+ * log output should also reflect this. Multiple issues:
+ * 1. merged pcaps might have huge time jumps or time going backward
+ * 2. slowly recorded pcaps may be processed much faster than their 'realtime'
+ * 3. management threads need a concept of what the 'current' time is for
+ *    enforcing timeouts
+ * 4. due to (1) individual threads may have very different views on what
+ *    the current time is. E.g. T1 processed packet 1 with TS X, while T2
+ *    at the very same time processes packet 2 with TS X+100000s.
+ *
+ * In offline mode we keep the timestamp per thread. If a management thread
+ * needs current time, it will get the minimum of the threads' values. This
+ * is to avoid the problem that T2s time value might already trigger a flow
+ * timeout as the flow lastts + 100000s is almost certainly meaning the flow
+ * would be considered timed out.
+ */
+
 #include "suricata-common.h"
 #include "detect.h"
 #include "threads.h"
+#include "tm-threads.h"
 #include "util-debug.h"
 
+#ifdef UNITTESTS
 static struct timeval current_time = { 0, 0 };
+#endif
 //static SCMutex current_time_mutex = SCMUTEX_INITIALIZER;
 static SCSpinlock current_time_spinlock;
 static char live = TRUE;
-
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 
@@ -63,6 +90,15 @@ void TimeModeSetOffline (void)
     SCLogDebug("offline time mode enabled");
 }
 
+void TimeSetByThread(const int thread_id, const struct timeval *tv)
+{
+    if (live == TRUE)
+        return;
+
+    TmThreadsSetThreadTimestamp(thread_id, tv);
+}
+
+#ifdef UNITTESTS
 void TimeSet(struct timeval *tv)
 {
     if (live == TRUE)
@@ -91,6 +127,7 @@ void TimeSetToCurrentTime(void)
 
     TimeSet(&tv);
 }
+#endif
 
 void TimeGet(struct timeval *tv)
 {
@@ -100,16 +137,25 @@ void TimeGet(struct timeval *tv)
     if (live == TRUE) {
         gettimeofday(tv, NULL);
     } else {
-        SCSpinLock(&current_time_spinlock);
-        tv->tv_sec = current_time.tv_sec;
-        tv->tv_usec = current_time.tv_usec;
-        SCSpinUnlock(&current_time_spinlock);
+#ifdef UNITTESTS
+        if (unlikely(RunmodeIsUnittests())) {
+            SCSpinLock(&current_time_spinlock);
+            tv->tv_sec = current_time.tv_sec;
+            tv->tv_usec = current_time.tv_usec;
+            SCSpinUnlock(&current_time_spinlock);
+        } else {
+#endif
+            TmreadsGetMinimalTimestamp(tv);
+#ifdef UNITTESTS
+        }
+#endif
     }
 
     SCLogDebug("time we got is %" PRIuMAX " sec, %" PRIuMAX " usec",
                (uintmax_t)tv->tv_sec, (uintmax_t)tv->tv_usec);
 }
 
+#ifdef UNITTESTS
 /** \brief increment the time in the engine
  *  \param tv_sec seconds to increment the time with */
 void TimeSetIncrementTime(uint32_t tv_sec)
@@ -122,6 +168,7 @@ void TimeSetIncrementTime(uint32_t tv_sec)
 
     TimeSet(&tv);
 }
+#endif
 
 void CreateIsoTimeString (const struct timeval *ts, char *str, size_t size)
 {

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -37,11 +37,14 @@ typedef struct SCTimeval32_ {
 void TimeInit(void);
 void TimeDeinit(void);
 
-void TimeSet(struct timeval *);
+void TimeSetByThread(const int thread_id, const struct timeval *tv);
 void TimeGet(struct timeval *);
 
+#ifdef UNITTESTS
+void TimeSet(struct timeval *);
 void TimeSetToCurrentTime(void);
 void TimeSetIncrementTime(uint32_t);
+#endif
 
 void TimeModeSetLive(void);
 void TimeModeSetOffline (void);

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -85,7 +85,7 @@ Packet *UTHBuildPacketIPV6Real(uint8_t *payload, uint16_t payload_len,
     if (unlikely(p == NULL))
         return NULL;
 
-    TimeSet(&p->ts);
+    TimeGet(&p->ts);
 
     p->src.family = AF_INET6;
     p->dst.family = AF_INET6;

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -854,8 +854,10 @@ uint32_t UTHBuildPacketOfFlows(uint32_t start, uint32_t end, uint8_t dir)
             p->dst.addr_data32[0] = i;
         }
         FlowHandlePacket(NULL, NULL, p);
-        if (p->flow != NULL)
+        if (p->flow != NULL) {
             SC_ATOMIC_RESET(p->flow->use_cnt);
+            FLOWLOCK_UNLOCK(p->flow);
+        }
 
         /* Now the queues shoul be updated */
         UTHFreePacket(p);

--- a/src/util-validate.h
+++ b/src/util-validate.h
@@ -53,14 +53,12 @@
  */
 #define DEBUG_VALIDATE_FLOW(f) do {                 \
     if ((f) != NULL) {                              \
-        SCMutexLock(&(f)->m);                       \
         BUG_ON((f)->flags & FLOW_IPV4 &&            \
                (f)->flags & FLOW_IPV6);             \
         if ((f)->proto == IPPROTO_TCP) {            \
             BUG_ON((f)->alstate != NULL &&          \
                    (f)->alparser == NULL);          \
         }                                           \
-        SCMutexUnlock(&(f)->m);                     \
     }                                               \
 } while(0)
 


### PR DESCRIPTION
This branch simplifies the flow locking in detection a lot. It introduces the concept of a "FlowWorker": a single thread module that runs Flow, Stream, AppLayer and Detect under a single flow lock.

For workers, not much changes (assuming flow based load balancing works correctly). For autofp, a lot changes:
- capture thread(s) no longer handle the flow lookup, creation and updates.
- capture threads no longer handle UDP app layer
- flow based load balancing for autofp can no longer be smart and stateful, as we have no flow to keep state. Load balancing is hash based again.

In my testing I'm seeing better performance, also for autofp.

Some advantages:
- simpler code
- detection profile stats won't get influenced by flow locks anymore (cc: @wmetcalf)
- detection can keep pointers to flow data w/o risk of data going away

Please help test this.

Todo:
- I would like to move the outputs into the FlowWorker as well. This will require a big output API overhaul though. cc @jasonish 

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/426
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/431
