### PR TITLE
Parsing and eve log output of tls validity timestamps.

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1489,6 +1489,10 @@ void SSLStateFree(void *p)
         SCFree(ssl_state->server_connp.trec);
     if (ssl_state->server_connp.cert0_subject)
         SCFree(ssl_state->server_connp.cert0_subject);
+    if (ssl_state->server_connp.cert0_not_valid_after)
+        SCFree(ssl_state->server_connp.cert0_not_valid_after);
+    if (ssl_state->server_connp.cert0_not_valid_before)
+        SCFree(ssl_state->server_connp.cert0_not_valid_before);
     if (ssl_state->server_connp.cert0_issuerdn)
         SCFree(ssl_state->server_connp.cert0_issuerdn);
     if (ssl_state->server_connp.cert0_fingerprint)

--- a/src/app-layer-ssl.h
+++ b/src/app-layer-ssl.h
@@ -147,6 +147,8 @@ typedef struct SSLStateConnp_ {
     char *cert0_subject;
     char *cert0_issuerdn;
     char *cert0_fingerprint;
+    char *cert0_not_valid_before;
+    char *cert0_not_valid_after;
 
     /* ssl server name indication extension */
     char *sni;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -97,6 +97,18 @@ void JsonTlsLogJSONExtended(json_t *tjs, SSLState * state)
                             json_string(state->client_connp.sni));
     }
 
+    /* tls validity */
+    if (state->server_connp.cert0_not_valid_before != NULL && state->server_connp.cert0_not_valid_after != NULL) {
+
+        /* tls.not-valid-before*/
+        json_object_set_new(tjs, "not-valid-before",
+                json_string(state->server_connp.cert0_not_valid_before));
+
+        /* tls.not-valid-after */
+        json_object_set_new(tjs, "not-valid-after",
+                json_string(state->server_connp.cert0_not_valid_after));
+    }
+
     /* tls.version */
     switch (state->server_connp.version) {
         case TLS_VERSION_UNKNOWN:

--- a/src/util-decode-der-get.h
+++ b/src/util-decode-der-get.h
@@ -35,9 +35,13 @@
 #ifndef __UTIL_DECODE_DER_GET_H__
 #define __UTIL_DECODE_DER_GET_H__
 
-const Asn1Generic * Asn1DerGet(const Asn1Generic *top, const uint8_t *seq_index, const uint32_t seqsz, uint32_t *errcode);
+const Asn1Generic * Asn1DerGet(const Asn1Generic *top, const uint8_t *seq_index,
+        const uint32_t seqsz, uint32_t *errcode);
 
 int Asn1DerGetIssuerDN(const Asn1Generic *cert, char *buffer, uint32_t length, uint32_t *errcode);
 int Asn1DerGetSubjectDN(const Asn1Generic *cert, char *buffer, uint32_t length, uint32_t *errcode);
+int Asn1DerGetValidityParseTimestamp(char *dst, uint32_t dst_len, char *src, uint32_t src_len);
+int Asn1DerGetValidity(const Asn1Generic *cert, char *nb_buf, uint32_t nb_buf_len,
+        char *na_buf, uint32_t na_buf_len, uint32_t *errcode);
 
 #endif /* __UTIL_DECODE_DER_GET_H__ */


### PR DESCRIPTION
Added extraction of UTCTIME validity fields from TLS certs along with output of this to the TLS EVE log.

Example of Eve log output:
  "tls": {
    "subject": "unknown=Private Organization, unknown=US, unknown=Delaware, serialNumber=5157550, unknown=88 Colin P Kelly, Jr Street, unknown=94107, C=US, ST=California, L=San Francisco, O=GitHub, Inc., CN=github.com",
    "issuerdn": "C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 Extended Validation Server CA",
    "fingerprint": "d7:9f:07:61:10:b3:92:93:e3:49:ac:89:84:5b:03:80:c1:9e:2f:8b",
    "sni": "github.com",
    **"not-valid-before": "2010-03-15T23:00:00.000000+0100",**
    **"not-valid-after": "2017-05-18T12:00:00.000000+0200",**
    "version": "TLS 1.2"
  }