### PR TITLE
Changed StatsInitCtx to use ConfGetChildValueInt to get interval.

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -234,9 +234,15 @@ static void StatsInitCtx(void)
             SCLogDebug("Stats module has been disabled");
             SCReturn;
         }
-        const char *interval = ConfNodeLookupChildValue(stats, "interval");
-        if (interval != NULL)
-            stats_tts = (uint32_t) atoi(interval);
+        
+        intmax_t interval;
+        if (ConfGetChildValueInt(stats, "interval", &interval) == 0) {
+            stats_enabled = FALSE;
+            SCLogDebug("Stats module has been disabled, invalid interval");
+            SCReturn;
+        }
+        stats_tts = (uint32_t)interval;
+        SCLogDebug("Setting stats interval to %d seconds.", stats_tts);
     }
 
     if (!OutputStatsLoggersRegistered()) {


### PR DESCRIPTION
Encountered an error were the value "yes" was set under stats.interval. This lead to the value being set to 0 (zero). And well, alot of stats were generated =). So changed this to get an int instead.