### PR TITLE
Dev dns custom filter v0.2

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -149,7 +149,15 @@ outputs:
             # custom allows additional http fields to be included in eve-log
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
-        - dns
+            custom: [X-Flash-Version, X-Authenticated-User]
+        - dns:
+            # control logging of queries and answers
+            # default yes, no to disable
+            query: yes     # enable logging of DNS queries
+            answer: yes    # enable logging of DNS answers
+            # control which RR tyeps are logged
+            # all enabled if custom not specified
+            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
         - files:


### PR DESCRIPTION
Add the capability to filter DNS eve-log output by query/answer and RR type. Configured in suricata.yaml as follows:

    - dns:
        # control logging of queries and answers
        # default yes, no to disable
        query: yes     # enable logging of DNS queries
        answer: yes    # enable logging of DNS answers
        # control which RR tyeps are logged
        # all enabled if custom not specified
        #custom: [a, aaaa, cname, mx, ns, ptr, txt]

- PR decanio: https://buildbot.openinfosecfoundation.org/builders/decanio/builds
/20
- PR decanio-pcap: https://buildbot.openinfosecfoundation.org/builders/decanio-p
cap/builds/20
