### PR TITLE
Dev dns custom filter v0.3

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -57,7 +57,7 @@
 #define QUERY 0
 
 #define LOG_QUERIES   (1<<0)
-#define LOG_ANSWERS  (1<<1)
+#define LOG_ANSWERS   (1<<1)
 
 #define LOG_A         (1<<2)
 #define LOG_NS        (1<<3)

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -149,7 +149,15 @@ outputs:
             # custom allows additional http fields to be included in eve-log
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
-        - dns
+            custom: [X-Flash-Version, X-Authenticated-User]
+        - dns:
+            # control logging of queries and answers
+            # default yes, no to disable
+            query: yes     # enable logging of DNS queries
+            answer: yes    # enable logging of DNS answers
+            # control which RR tyeps are logged
+            # all enabled if custom not specified
+            #custom: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
         - files:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -149,7 +149,6 @@ outputs:
             # custom allows additional http fields to be included in eve-log
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
-            custom: [X-Flash-Version, X-Authenticated-User]
         - dns:
             # control logging of queries and answers
             # default yes, no to disable


### PR DESCRIPTION
Add the capability to filter DNS eve-log output by query/answer and RR type. Configured in suricata.yaml as follows:
<pre>
- dns:
    # control logging of queries and answers
    # default yes, no to disable
    query: yes     # enable logging of DNS queries
    answer: yes    # enable logging of DNS answers
    # control which RR tyeps are logged
    # all enabled if custom not specified
    #custom: [a, aaaa, cname, mx, ns, ptr, txt]
</pre>

Prscript:
- PR decanio: https://buildbot.openinfosecfoundation.org/builders/decanio/builds/22
- PR decanio-pcap: https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/22

