### PR TITLE
tls-json-log: register module as tls-json-log, not dns-json-log - v1

### DIFF
--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -318,7 +318,7 @@ void TmModuleJsonTlsLogRegister (void)
     tmm_modules[TMM_JSONTLSLOG].flags = TM_FLAG_LOGAPI_TM;
 
     /* register as separate module */
-    OutputRegisterTxModuleWithProgress("JsonTlsLog", "dns-json-log",
+    OutputRegisterTxModuleWithProgress("JsonTlsLog", "tls-json-log",
             OutputTlsLogInit, ALPROTO_TLS, JsonTlsLogger, TLS_HANDSHAKE_DONE,
             TLS_HANDSHAKE_DONE);
 


### PR DESCRIPTION
Fixes issue:
https://redmine.openinfosecfoundation.org/issues/1792
where dns-json-log would not log any data.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/229
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/234
