### PR TITLE
Dev app layer stats v10

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -622,6 +622,11 @@ void AppLayerParserSetTransactionInspectId(ThreadVars *tv, AppLayerParserState *
         else
             break;
     }
+
+    /* account tx as soon as we have a request to server */
+    if (direction == 0) {
+        AppLayerIncTxCounter(ipproto, alproto, tv, idx - pstate->inspect_id[0]);
+    }
     pstate->inspect_id[direction] = idx;
 
     SCReturn;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -599,7 +599,7 @@ uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint
     SCReturnCT(pstate->inspect_id[direction & STREAM_TOSERVER ? 0 : 1], "uint64_t");
 }
 
-void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
+void AppLayerParserSetTransactionInspectId(ThreadVars *tv, AppLayerParserState *pstate,
                                            const uint8_t ipproto, const AppProto alproto,
                                            void *alstate, const uint8_t flags)
 {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -149,6 +149,13 @@ struct AppLayerParserState_ {
  * Post 2.0 let's look at changing this to move it out to app-layer.c. */
 static AppLayerParserCtx alp_ctx;
 
+int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto)
+{
+    int ipproto_map = FlowGetProtoMapping(ipproto);
+
+    return (alp_ctx.ctxs[ipproto_map][alproto].StateAlloc != NULL) ? 1 : 0;
+}
+
 AppLayerParserState *AppLayerParserStateAlloc(void)
 {
     SCEnter();

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -34,6 +34,7 @@
 #define APP_LAYER_PARSER_NO_REASSEMBLY          0x04
 #define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD  0x08
 
+int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
 /***** transaction handling *****/
 

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -164,7 +164,7 @@ void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
 int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
                               void *tx, uint32_t logger);
 uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint8_t direction);
-void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
+void AppLayerParserSetTransactionInspectId(ThreadVars *tv, AppLayerParserState *pstate,
                                 const uint8_t ipproto, const AppProto alproto, void *alstate,
                                 const uint8_t flags);
 AppLayerDecoderEvents *AppLayerParserGetDecoderEvents(AppLayerParserState *pstate);

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -149,4 +149,6 @@ void AppLayerRegisterGlobalCounters(void);
 void AppLayerUnittestsRegister(void);
 #endif
 
+void AppLayerIncTxCounter(uint8_t ipproto, AppProto alproto, ThreadVars *tv, uint64_t step);
+
 #endif

--- a/src/app-layer.h
+++ b/src/app-layer.h
@@ -109,6 +109,17 @@ AppLayerThreadCtx *AppLayerGetCtxThread(ThreadVars *tv);
  */
 void AppLayerDestroyCtxThread(AppLayerThreadCtx *tctx);
 
+/**
+ * \brief Registers per flow counters for all protocols
+ *
+ */
+void AppLayerRegisterCounters(ThreadVars *tv, uint8_t ipproto);
+
+/**
+ * \brief Frees the counter name
+ *
+ */
+void AppLayerDeRegisterCounters(uint8_t ipproto);
 
 /***** Profiling *****/
 

--- a/src/decode.c
+++ b/src/decode.c
@@ -427,7 +427,9 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
         StatsRegisterCounter("defrag.ipv6.timeouts", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
-    
+
+    AppLayerRegisterCounters(tv, IPPROTO_UDP);
+
     int i = 0;
     for (i = 0; i < DECODE_EVENT_PACKET_MAX; i++) {
         dtv->counter_invalid_events[i] = StatsRegisterCounter(

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -1130,10 +1130,10 @@ end:
  *  \param flags direction and disruption flags
  *
  *  \note it is possible that f->alstate, f->alparser are NULL */
-void DeStateUpdateInspectTransactionId(Flow *f, const uint8_t flags)
+void DeStateUpdateInspectTransactionId(ThreadVars *tv, Flow *f, const uint8_t flags)
 {
     if (f->alparser && f->alstate) {
-        AppLayerParserSetTransactionInspectId(f->alparser, f->proto,
+        AppLayerParserSetTransactionInspectId(tv, f->alparser, f->proto,
                                               f->alproto, f->alstate, flags);
     }
     return;

--- a/src/detect-engine-state.h
+++ b/src/detect-engine-state.h
@@ -230,7 +230,7 @@ void DeStateDetectContinueDetection(ThreadVars *tv, DetectEngineCtx *de_ctx,
  *  \param f unlocked flow
  *  \param flags direction and disruption flags
  */
-void DeStateUpdateInspectTransactionId(Flow *f, const uint8_t flags);
+void DeStateUpdateInspectTransactionId(ThreadVars *tv, Flow *f, const uint8_t flags);
 
 /**
  * \brief Reset a DetectEngineState state.

--- a/src/detect.c
+++ b/src/detect.c
@@ -1815,7 +1815,7 @@ end:
     /* see if we need to increment the inspect_id and reset the de_state */
     if (has_state && AppLayerParserProtocolSupportsTxs(p->proto, alproto)) {
         PACKET_PROFILING_DETECT_START(p, PROF_DETECT_STATEFUL);
-        DeStateUpdateInspectTransactionId(pflow, flow_flags);
+        DeStateUpdateInspectTransactionId(th_v, pflow, flow_flags);
         PACKET_PROFILING_DETECT_END(p, PROF_DETECT_STATEFUL);
     }
 
@@ -1971,7 +1971,7 @@ static void DetectFlow(ThreadVars *tv,
             } else {
                 flags |= STREAM_TOCLIENT;
             }
-            DeStateUpdateInspectTransactionId(p->flow, flags);
+            DeStateUpdateInspectTransactionId(tv, p->flow, flags);
         }
         return;
     }

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -47,6 +47,8 @@
 #include "output-json.h"
 #include "output-json-stats.h"
 
+#include "app-layer.h"
+
 #define MODULE_NAME "JsonStatsLog"
 
 #ifdef HAVE_LIBJANSSON
@@ -245,6 +247,10 @@ static TmEcode JsonStatsLogThreadDeinit(ThreadVars *t, void *data)
 
     /* clear memory */
     memset(aft, 0, sizeof(JsonStatsLogThread));
+
+    /* clear app-layer stats */
+    AppLayerDeRegisterCounters(IPPROTO_UDP);
+    AppLayerDeRegisterCounters(IPPROTO_TCP);
 
     SCFree(aft);
     return TM_ECODE_OK;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4922,6 +4922,8 @@ TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
     stt->counter_tcp_synack = StatsRegisterCounter("tcp.synack", tv);
     stt->counter_tcp_rst = StatsRegisterCounter("tcp.rst", tv);
 
+    AppLayerRegisterCounters(tv, IPPROTO_TCP);
+
     /* init reassembly ctx */
     stt->ra_ctx = StreamTcpReassembleInitThreadCtx(tv);
     if (stt->ra_ctx == NULL)


### PR DESCRIPTION
This patchset adds flow and transaction counters for each application layers. The result is the following:
```JSON
    "app-layer": {
      "flow": {
        "http": 9310,
        "ftp": 0,
        "smtp": 0,
        "tls": 71,
        "ssh": 0,
        "imap": 0,
        "msn": 0,
        "smb": 170,
        "dcerpc_udp": 0,
        "dns_udp": 870,
        "dcerpc_tcp": 2,
        "dns_tcp": 0
      },
      "tx": {
        "dns_udp": 21433,
        "http": 12766,
        "smtp": 0,
        "dns_tcp": 0
      }
    },
```

This is a rework of #2110 with a patch on tx counter to fix memory allocation error spotted by coccinelle tests.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/173
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/169
