### PR TITLE
yaml reshuffle v3.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -773,6 +773,7 @@
     fi
 
     AS_IF([test "x$enable_unixsocket" = "xyes"], [AC_DEFINE([BUILD_UNIX_SOCKET], [1], [Unix socket support enabled])])
+    e_enable_evelog=$enable_jansson
 
     AC_ARG_ENABLE(nflog,
             AS_HELP_STRING([--enable-nflog],[Enable libnetfilter_log support]),
@@ -1944,6 +1945,7 @@ AC_SUBST(e_localstatedir)
 AC_DEFINE_UNQUOTED([CONFIG_DIR],["$e_sysconfdir"],[Our CONFIG_DIR])
 AC_SUBST(e_magic_file)
 AC_SUBST(e_magic_file_comment)
+AC_SUBST(e_enable_evelog)
 
 EXPAND_VARIABLE(prefix, CONFIGURE_PREFIX)
 EXPAND_VARIABLE(sysconfdir, CONFIGURE_SYSCONDIR)

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2772,6 +2772,7 @@ int main(int argc, char **argv)
 #endif
     ConfDeInit();
 
+    SCLogDeInitLogModule();
     DetectParseFreeRegexes();
     exit(engine_retval);
 }

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -713,6 +713,7 @@ error:
         fclose(iface_ctx->file_d);
         iface_ctx->file_d = NULL;
     }
+    SCFree(iface_ctx);
     return NULL;
 }
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -835,9 +835,12 @@ app-layer:
 coredump:
   max-dump: unlimited
 
-
-
-
+# If suricata box is a router for the sniffed networks, set it to 'router'. If
+# it is a pure sniffing setup, set it to 'sniffer-only'.
+# If set to auto, the variable is internally switch to 'router' in IPS mode
+# and 'sniffer-only' in IDS mode.
+# This feature is currently only used by the reject* keywords.
+host-mode: auto
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
@@ -865,13 +868,6 @@ coredump:
 #
 #autofp-scheduler: active-packets
 
-# If suricata box is a router for the sniffed networks, set it to 'router'. If
-# it is a pure sniffing setup, set it to 'sniffer-only'.
-# If set to auto, the variable is internally switch to 'router' in IPS mode
-# and 'sniffer-only' in IDS mode.
-# This feature is currently only used by the reject* keywords.
-host-mode: auto
-
 # Preallocated size for packet. Default is 1514 which is the classical
 # size for pcap on ethernet. You should adjust this value to the highest
 # packet size (MTU + hardware header) on your system.
@@ -889,43 +885,6 @@ unix-command:
 # Magic file. The extension .mgc is added to the value here.
 #magic-file: /usr/share/file/magic
 @e_magic_file_comment@magic-file: @e_magic_file@
-
-# When running in NFQ inline mode, it is possible to use a simulated
-# non-terminal NFQUEUE verdict.
-# This permit to do send all needed packet to suricata via this a rule:
-#        iptables -I FORWARD -m mark ! --mark $MARK/$MASK -j NFQUEUE
-# And below, you can have your standard filtering ruleset. To activate
-# this mode, you need to set mode to 'repeat'
-# If you want packet to be sent to another queue after an ACCEPT decision
-# set mode to 'route' and set next-queue value.
-# On linux >= 3.1, you can set batchcount to a value > 1 to improve performance
-# by processing several packets before sending a verdict (worker runmode only).
-# On linux >= 3.6, you can set the fail-open option to yes to have the kernel
-# accept the packet if suricata is not able to keep pace.
-nfq:
-#  mode: accept
-#  repeat-mark: 1
-#  repeat-mask: 1
-#  route-queue: 2
-#  batchcount: 20
-#  fail-open: yes
-
-#nflog support
-nflog:
-    # netlink multicast group
-    # (the same as the iptables --nflog-group param)
-    # Group 0 is used by the kernel, so you can't use it
-  - group: 2
-    # netlink buffer size
-    buffer-size: 18432
-    # put default value here
-  - group: default
-    # set number of packet to queue inside kernel
-    qthreshold: 1
-    # set the delay before flushing packet in the queue inside kernel
-    qtimeout: 100
-    # netlink max buffer size
-    max-size: 20000
 
 legacy:
   uricontent: enabled
@@ -1431,6 +1390,47 @@ profiling:
     enabled: no
     filename: pcaplog_stats.log
     append: yes
+
+##
+## Netfilter integration
+##
+
+# When running in NFQ inline mode, it is possible to use a simulated
+# non-terminal NFQUEUE verdict.
+# This permit to do send all needed packet to suricata via this a rule:
+#        iptables -I FORWARD -m mark ! --mark $MARK/$MASK -j NFQUEUE
+# And below, you can have your standard filtering ruleset. To activate
+# this mode, you need to set mode to 'repeat'
+# If you want packet to be sent to another queue after an ACCEPT decision
+# set mode to 'route' and set next-queue value.
+# On linux >= 3.1, you can set batchcount to a value > 1 to improve performance
+# by processing several packets before sending a verdict (worker runmode only).
+# On linux >= 3.6, you can set the fail-open option to yes to have the kernel
+# accept the packet if suricata is not able to keep pace.
+nfq:
+#  mode: accept
+#  repeat-mark: 1
+#  repeat-mask: 1
+#  route-queue: 2
+#  batchcount: 20
+#  fail-open: yes
+
+#nflog support
+nflog:
+    # netlink multicast group
+    # (the same as the iptables --nflog-group param)
+    # Group 0 is used by the kernel, so you can't use it
+  - group: 2
+    # netlink buffer size
+    buffer-size: 18432
+    # put default value here
+  - group: default
+    # set number of packet to queue inside kernel
+    qthreshold: 1
+    # set the delay before flushing packet in the queue inside kernel
+    qtimeout: 100
+    # netlink max buffer size
+    max-size: 20000
 
 ##
 ## Advanced Capture Options

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -463,6 +463,7 @@ logging:
       # type: json
   - file:
       enabled: yes
+      level: info
       filename: @e_logdir@suricata.log
       # type: json
   - syslog:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -472,6 +472,48 @@ app-layer:
            #    double-decode-query: no
 
 
+##############################################################################
+##
+## Advanced settings below
+##
+##############################################################################
+
+##
+## Run Options
+##
+
+# Run suricata as user and group.
+#run-as:
+#  user: suri
+#  group: suri
+
+# Some logging module will use that name in event as identifier. The default
+# value is the hostname
+#sensor-name: suricata
+
+# Default pid file.
+# Will use this file if no --pidfile in command options.
+#pid-file: @e_rundir@suricata.pid
+
+# Daemon working directory
+# Suricata will change directory to this one if provided
+# Default: "/"
+#daemon-directory: "/"
+
+# Suricata core dump configuration. Limits the size of the core dump file to
+# approximately max-dump. The actual core dump size will be a multiple of the
+# page size. Core dumps that would be larger than max-dump are truncated. On
+# Linux, the actual core dump size may be a few pages larger than max-dump.
+# Setting max-dump to 0 disables core dumping.
+# Setting max-dump to 'unlimited' will give the full core dump file.
+# On 32-bit Linux, a max-dump value >= ULONG_MAX may cause the core dump size
+# to be 'unlimited'.
+
+coredump:
+  max-dump: unlimited
+
+
+
 
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
@@ -506,24 +548,6 @@ app-layer:
 # and 'sniffer-only' in IDS mode.
 # This feature is currently only used by the reject* keywords.
 host-mode: auto
-
-# Run suricata as user and group.
-#run-as:
-#  user: suri
-#  group: suri
-
-# Some logging module will use that name in event as identifier. The default
-# value is the hostname
-#sensor-name: suricata
-
-# Default pid file.
-# Will use this file if no --pidfile in command options.
-#pid-file: @e_rundir@suricata.pid
-
-# Daemon working directory
-# Suricata will change directory to this one if provided
-# Default: "/"
-#daemon-directory: "/"
 
 # Preallocated size for packet. Default is 1514 which is the classical
 # size for pcap on ethernet. You should adjust this value to the highest
@@ -903,56 +927,6 @@ nflog:
     qtimeout: 100
     # netlink max buffer size
     max-size: 20000
-
-# Netmap support
-#
-# Netmap operates with NIC directly in driver, so you need FreeBSD wich have
-# built-in netmap support or compile and install netmap module and appropriate
-# NIC driver on your Linux system.
-# To reach maximum throughput disable all receive-, segmentation-,
-# checksum- offloadings on NIC.
-# Disabling Tx checksum offloading is *required* for connecting OS endpoint
-# with NIC endpoint.
-# You can find more information at https://github.com/luigirizzo/netmap
-#
-netmap:
-   # To specify OS endpoint add plus sign at the end (e.g. "eth0+")
- - interface: eth2
-   # Number of receive threads. "auto" uses number of RSS queues on interface.
-   threads: auto
-   # You can use the following variables to activate netmap tap or IPS mode.
-   # If copy-mode is set to ips or tap, the traffic coming to the current
-   # interface will be copied to the copy-iface interface. If 'tap' is set, the
-   # copy is complete. If 'ips' is set, the packet matching a 'drop' action
-   # will not be copied.
-   # To specify the OS as the copy-iface (so the OS can route packets, or forward
-   # to a service running on the same machine) add a plus sign at the end
-   # (e.g. "copy-iface: eth0+"). Don't forget to set up a symmetrical eth0+ -> eth0
-   # for return packets. Hardware checksumming must be *off* on the interface if
-   # using an OS endpoint (e.g. 'ifconfig eth0 -rxcsum -txcsum -rxcsum6 -txcsum6' for FreeBSD
-   # or 'ethtool -K eth0 tx off rx off' for Linux).
-   #copy-mode: tap
-   #copy-iface: eth3
-   # Set to yes to disable promiscuous mode
-   # disable-promisc: no
-   # Choose checksum verification mode for the interface. At the moment
-   # of the capture, some packets may be with an invalid checksum due to
-   # offloading to the network card of the checksum computation.
-   # Possible values are:
-   #  - yes: checksum validation is forced
-   #  - no: checksum validation is disabled
-   #  - auto: suricata uses a statistical approach to detect when
-   #  checksum off-loading is used.
-   # Warning: 'checksum-validation' must be set to yes to have any validation
-   #checksum-checks: auto
-   # BPF filter to apply to this interface. The pcap filter syntax apply here.
-   #bpf-filter: port 80 or udp
- #- interface: eth3
-   #threads: auto
-   #copy-mode: tap
-   #copy-iface: eth2
-   # Put default values here
- - interface: default
 
 legacy:
   uricontent: enabled
@@ -1338,97 +1312,6 @@ host:
 #  prealloc: 1000
 #  memcap: 16777216
 
-# Tilera mpipe configuration. for use on Tilera TILE-Gx.
-mpipe:
-
-  # Load balancing modes: "static", "dynamic", "sticky", or "round-robin".
-  load-balance: dynamic
-
-  # Number of Packets in each ingress packet queue. Must be 128, 512, 2028 or 65536
-  iqueue-packets: 2048
-
-  # List of interfaces we will listen on.
-  inputs:
-  - interface: xgbe2
-  - interface: xgbe3
-  - interface: xgbe4
-
-
-  # Relative weight of memory for packets of each mPipe buffer size.
-  stack:
-    size128: 0
-    size256: 9
-    size512: 0
-    size1024: 0
-    size1664: 7
-    size4096: 0
-    size10386: 0
-    size16384: 0
-
-# PF_RING configuration. for use with native PF_RING support
-# for more info see http://www.ntop.org/products/pf_ring/
-pfring:
-  - interface: eth0
-    # Number of receive threads (>1 will enable experimental flow pinned
-    # runmode)
-    threads: 1
-
-    # Default clusterid.  PF_RING will load balance packets based on flow.
-    # All threads/processes that will participate need to have the same
-    # clusterid.
-    cluster-id: 99
-
-    # Default PF_RING cluster type. PF_RING can load balance per flow.
-    # Possible values are cluster_flow or cluster_round_robin.
-    cluster-type: cluster_flow
-    # bpf filter for this interface
-    #bpf-filter: tcp
-    # Choose checksum verification mode for the interface. At the moment
-    # of the capture, some packets may be with an invalid checksum due to
-    # offloading to the network card of the checksum computation.
-    # Possible values are:
-    #  - rxonly: only compute checksum for packets received by network card.
-    #  - yes: checksum validation is forced
-    #  - no: checksum validation is disabled
-    #  - auto: suricata uses a statistical approach to detect when
-    #  checksum off-loading is used. (default)
-    # Warning: 'checksum-validation' must be set to yes to have any validation
-    #checksum-checks: auto
-  # Second interface
-  #- interface: eth1
-  #  threads: 3
-  #  cluster-id: 93
-  #  cluster-type: cluster_flow
-  # Put default values here
-  - interface: default
-    #threads: 2
-
-# For FreeBSD ipfw(8) divert(4) support.
-# Please make sure you have ipfw_load="YES" and ipdivert_load="YES"
-# in /etc/loader.conf or kldload'ing the appropriate kernel modules.
-# Additionally, you need to have an ipfw rule for the engine to see
-# the packets from ipfw.  For Example:
-#
-#   ipfw add 100 divert 8000 ip from any to any
-#
-# The 8000 above should be the same number you passed on the command
-# line, i.e. -d 8000
-#
-ipfw:
-
-  # Reinject packets at the specified ipfw rule number.  This config
-  # option is the ipfw rule number AT WHICH rule processing continues
-  # in the ipfw processing system after the engine has finished
-  # inspecting the packet for acceptance.  If no rule number is specified,
-  # accepted packets are reinjected at the divert rule which they entered
-  # and IPFW rule processing continues.  No check is done to verify
-  # this will rule makes sense so care must be taken to avoid loops in ipfw.
-  #
-  ## The following example tells the engine to reinject packets
-  # back into the ipfw firewall AT rule number 5500:
-  #
-  # ipfw-reinjection-rule-number: 5500
-
 # Set the order of alerts bassed on actions
 # The default order is pass, drop, reject, alert
 # action-order:
@@ -1550,17 +1433,124 @@ profiling:
     filename: pcaplog_stats.log
     append: yes
 
-# Suricata core dump configuration. Limits the size of the core dump file to
-# approximately max-dump. The actual core dump size will be a multiple of the
-# page size. Core dumps that would be larger than max-dump are truncated. On
-# Linux, the actual core dump size may be a few pages larger than max-dump.
-# Setting max-dump to 0 disables core dumping.
-# Setting max-dump to 'unlimited' will give the full core dump file.
-# On 32-bit Linux, a max-dump value >= ULONG_MAX may cause the core dump size
-# to be 'unlimited'.
+##
+## Advanced Capture Options
+##
 
-coredump:
-  max-dump: unlimited
+# Netmap support
+#
+# Netmap operates with NIC directly in driver, so you need FreeBSD wich have
+# built-in netmap support or compile and install netmap module and appropriate
+# NIC driver on your Linux system.
+# To reach maximum throughput disable all receive-, segmentation-,
+# checksum- offloadings on NIC.
+# Disabling Tx checksum offloading is *required* for connecting OS endpoint
+# with NIC endpoint.
+# You can find more information at https://github.com/luigirizzo/netmap
+#
+netmap:
+   # To specify OS endpoint add plus sign at the end (e.g. "eth0+")
+ - interface: eth2
+   # Number of receive threads. "auto" uses number of RSS queues on interface.
+   threads: auto
+   # You can use the following variables to activate netmap tap or IPS mode.
+   # If copy-mode is set to ips or tap, the traffic coming to the current
+   # interface will be copied to the copy-iface interface. If 'tap' is set, the
+   # copy is complete. If 'ips' is set, the packet matching a 'drop' action
+   # will not be copied.
+   # To specify the OS as the copy-iface (so the OS can route packets, or forward
+   # to a service running on the same machine) add a plus sign at the end
+   # (e.g. "copy-iface: eth0+"). Don't forget to set up a symmetrical eth0+ -> eth0
+   # for return packets. Hardware checksumming must be *off* on the interface if
+   # using an OS endpoint (e.g. 'ifconfig eth0 -rxcsum -txcsum -rxcsum6 -txcsum6' for FreeBSD
+   # or 'ethtool -K eth0 tx off rx off' for Linux).
+   #copy-mode: tap
+   #copy-iface: eth3
+   # Set to yes to disable promiscuous mode
+   # disable-promisc: no
+   # Choose checksum verification mode for the interface. At the moment
+   # of the capture, some packets may be with an invalid checksum due to
+   # offloading to the network card of the checksum computation.
+   # Possible values are:
+   #  - yes: checksum validation is forced
+   #  - no: checksum validation is disabled
+   #  - auto: suricata uses a statistical approach to detect when
+   #  checksum off-loading is used.
+   # Warning: 'checksum-validation' must be set to yes to have any validation
+   #checksum-checks: auto
+   # BPF filter to apply to this interface. The pcap filter syntax apply here.
+   #bpf-filter: port 80 or udp
+ #- interface: eth3
+   #threads: auto
+   #copy-mode: tap
+   #copy-iface: eth2
+   # Put default values here
+ - interface: default
+
+# PF_RING configuration. for use with native PF_RING support
+# for more info see http://www.ntop.org/products/pf_ring/
+pfring:
+  - interface: eth0
+    # Number of receive threads (>1 will enable experimental flow pinned
+    # runmode)
+    threads: 1
+
+    # Default clusterid.  PF_RING will load balance packets based on flow.
+    # All threads/processes that will participate need to have the same
+    # clusterid.
+    cluster-id: 99
+
+    # Default PF_RING cluster type. PF_RING can load balance per flow.
+    # Possible values are cluster_flow or cluster_round_robin.
+    cluster-type: cluster_flow
+    # bpf filter for this interface
+    #bpf-filter: tcp
+    # Choose checksum verification mode for the interface. At the moment
+    # of the capture, some packets may be with an invalid checksum due to
+    # offloading to the network card of the checksum computation.
+    # Possible values are:
+    #  - rxonly: only compute checksum for packets received by network card.
+    #  - yes: checksum validation is forced
+    #  - no: checksum validation is disabled
+    #  - auto: suricata uses a statistical approach to detect when
+    #  checksum off-loading is used. (default)
+    # Warning: 'checksum-validation' must be set to yes to have any validation
+    #checksum-checks: auto
+  # Second interface
+  #- interface: eth1
+  #  threads: 3
+  #  cluster-id: 93
+  #  cluster-type: cluster_flow
+  # Put default values here
+  - interface: default
+    #threads: 2
+
+# For FreeBSD ipfw(8) divert(4) support.
+# Please make sure you have ipfw_load="YES" and ipdivert_load="YES"
+# in /etc/loader.conf or kldload'ing the appropriate kernel modules.
+# Additionally, you need to have an ipfw rule for the engine to see
+# the packets from ipfw.  For Example:
+#
+#   ipfw add 100 divert 8000 ip from any to any
+#
+# The 8000 above should be the same number you passed on the command
+# line, i.e. -d 8000
+#
+ipfw:
+
+  # Reinject packets at the specified ipfw rule number.  This config
+  # option is the ipfw rule number AT WHICH rule processing continues
+  # in the ipfw processing system after the engine has finished
+  # inspecting the packet for acceptance.  If no rule number is specified,
+  # accepted packets are reinjected at the divert rule which they entered
+  # and IPFW rule processing continues.  No check is done to verify
+  # this will rule makes sense so care must be taken to avoid loops in ipfw.
+  #
+  ## The following example tells the engine to reinject packets
+  # back into the ipfw firewall AT rule number 5500:
+  #
+  # ipfw-reinjection-rule-number: 5500
+
 
 napatech:
     # The Host Buffer Allowance for all streams
@@ -1574,6 +1564,34 @@ napatech:
 
     # The streams to listen on
     streams: [1, 2, 3]
+
+# Tilera mpipe configuration. for use on Tilera TILE-Gx.
+mpipe:
+
+  # Load balancing modes: "static", "dynamic", "sticky", or "round-robin".
+  load-balance: dynamic
+
+  # Number of Packets in each ingress packet queue. Must be 128, 512, 2028 or 65536
+  iqueue-packets: 2048
+
+  # List of interfaces we will listen on.
+  inputs:
+  - interface: xgbe2
+  - interface: xgbe3
+  - interface: xgbe4
+
+
+  # Relative weight of memory for packets of each mPipe buffer size.
+  stack:
+    size128: 0
+    size256: 9
+    size512: 0
+    size1024: 0
+    size1664: 7
+    size4096: 0
+    size10386: 0
+    size16384: 0
+
 
 # Includes.  Files included here will be handled as if they were
 # inlined in this configuration file.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -889,6 +889,10 @@ unix-command:
 legacy:
   uricontent: enabled
 
+##
+## Detection settings
+##
+
 # The detection engine builds internal groups of signatures. The engine
 # allow us to specify the profile to use for them, to manage memory on an
 # efficient way keeping a good performance. For the profile keyword you
@@ -937,6 +941,59 @@ detect:
       dump-to-disk: false
       include-rules: false      # very verbose
       include-mpm-stats: false
+
+# Select the multi pattern algorithm you want to run for scan/search the
+# in the engine.
+#
+# The supported algorithms are:
+# "ac"      - Aho-Corasick, default implementation
+# "ac-bs"   - Aho-Corasick, reduced memory implementation
+# "ac-cuda" - Aho-Corasick, CUDA implementation
+# "ac-tile" - Aho-Corasick, optimized for Tilera architecture
+# "hs"      - Hyperscan, available when built with Hyperscan support
+#
+# The default mpm-algo value of "auto" will use "hs" if Hyperscan is available,
+# "ac-tile" on Tilera platforms, and "ac" otherwise.
+#
+# The mpm you choose also decides the distribution of mpm contexts for
+# signature groups, specified by the conf - "detect.sgh-mpm-context".
+# Selecting "ac" as the mpm would require "detect.sgh-mpm-context"
+# to be set to "single", because of ac's memory requirements, unless the
+# ruleset is small enough to fit in one's memory, in which case one can
+# use "full" with "ac".  Rest of the mpms can be run in "full" mode.
+#
+# There is also a CUDA pattern matcher (only available if Suricata was
+# compiled with --enable-cuda: b2g_cuda. Make sure to update your
+# max-pending-packets setting above as well if you use b2g_cuda.
+
+mpm-algo: auto
+
+# Select the matching algorithm you want to use for single-pattern searches.
+#
+# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
+# available if Suricata has been built with Hyperscan support).
+#
+# The default of "auto" will use "hs" if available, otherwise "bm".
+
+spm-algo: auto
+
+# Set the order of alerts bassed on actions
+# The default order is pass, drop, reject, alert
+# action-order:
+#   - pass
+#   - drop
+#   - reject
+#   - alert
+
+# IP Reputation
+#reputation-categories-file: @e_sysconfdir@iprep/categories.txt
+#default-reputation-path: @e_sysconfdir@iprep
+#reputation-files:
+# - reputation.list
+
+##
+## Threading
+##
 
 # Suricata is multi-threaded. Here the threading can be influenced.
 threading:
@@ -993,40 +1050,10 @@ threading:
   #
   detect-thread-ratio: 1.5
 
-# Select the multi pattern algorithm you want to run for scan/search the
-# in the engine.
-#
-# The supported algorithms are:
-# "ac"      - Aho-Corasick, default implementation
-# "ac-bs"   - Aho-Corasick, reduced memory implementation
-# "ac-cuda" - Aho-Corasick, CUDA implementation
-# "ac-tile" - Aho-Corasick, optimized for Tilera architecture
-# "hs"      - Hyperscan, available when built with Hyperscan support
-#
-# The default mpm-algo value of "auto" will use "hs" if Hyperscan is available,
-# "ac-tile" on Tilera platforms, and "ac" otherwise.
-#
-# The mpm you choose also decides the distribution of mpm contexts for
-# signature groups, specified by the conf - "detect.sgh-mpm-context".
-# Selecting "ac" as the mpm would require "detect.sgh-mpm-context"
-# to be set to "single", because of ac's memory requirements, unless the
-# ruleset is small enough to fit in one's memory, in which case one can
-# use "full" with "ac".  Rest of the mpms can be run in "full" mode.
-#
-# There is also a CUDA pattern matcher (only available if Suricata was
-# compiled with --enable-cuda: b2g_cuda. Make sure to update your
-# max-pending-packets setting above as well if you use b2g_cuda.
 
-mpm-algo: auto
-
-# Select the matching algorithm you want to use for single-pattern searches.
-#
-# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
-# available if Suricata has been built with Hyperscan support).
-#
-# The default of "auto" will use "hs" if available, otherwise "bm".
-
-spm-algo: auto
+##
+## Advanced Traffic Tracking and Reconstruction Settings
+##
 
 # Defrag settings:
 
@@ -1239,19 +1266,6 @@ host:
 #  prealloc: 1000
 #  memcap: 16777216
 
-# Set the order of alerts bassed on actions
-# The default order is pass, drop, reject, alert
-# action-order:
-#   - pass
-#   - drop
-#   - reject
-#   - alert
-
-# IP Reputation
-#reputation-categories-file: @e_sysconfdir@iprep/categories.txt
-#default-reputation-path: @e_sysconfdir@iprep
-#reputation-files:
-# - reputation.list
 
 # Host specific policies for defragmentation and TCP stream
 # reassembly.  The host OS lookup is done using a radix tree, just

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -103,6 +103,50 @@ rule-files:
 # - modbus-events.rules  # available in suricata sources under rules dir
 # - app-layer-events.rules  # available in suricata sources under rules dir
 
+##
+## Step 3: select outputs to enable
+##
+
+# Logging configuration.  This is not about logging IDS alerts, but
+# output about what Suricata is doing, like startup messages, errors, etc.
+logging:
+  # The default log level, can be overridden in an output section.
+  # Note that debug level logging will only be emitted if Suricata was
+  # compiled with the --enable-debug configure option.
+  #
+  # This value is overriden by the SC_LOG_LEVEL env var.
+  default-log-level: notice
+
+  # The default output format.  Optional parameter, should default to
+  # something reasonable if not provided.  Can be overriden in an
+  # output section.  You can leave this out to get the default.
+  #
+  # This value is overriden by the SC_LOG_FORMAT env var.
+  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
+
+  # A regex to filter output.  Can be overridden in an output section.
+  # Defaults to empty (no filter).
+  #
+  # This value is overriden by the SC_LOG_OP_FILTER env var.
+  default-output-filter:
+
+  # Define your logging outputs.  If none are defined, or they are all
+  # disabled you will get the default - console output.
+  outputs:
+  - console:
+      enabled: yes
+      # type: json
+  - file:
+      enabled: yes
+      filename: @e_logdir@suricata.log
+      # type: json
+  - syslog:
+      enabled: no
+      facility: local5
+      format: "[%i] <%d> -- "
+      # type: json
+
+
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
@@ -1060,46 +1104,6 @@ host:
 #  hash-size: 4096
 #  prealloc: 1000
 #  memcap: 16777216
-
-# Logging configuration.  This is not about logging IDS alerts, but
-# IDS output about what its doing, errors, etc.
-logging:
-
-  # The default log level, can be overridden in an output section.
-  # Note that debug level logging will only be emitted if Suricata was
-  # compiled with the --enable-debug configure option.
-  #
-  # This value is overriden by the SC_LOG_LEVEL env var.
-  default-log-level: notice
-
-  # The default output format.  Optional parameter, should default to
-  # something reasonable if not provided.  Can be overriden in an
-  # output section.  You can leave this out to get the default.
-  #
-  # This value is overriden by the SC_LOG_FORMAT env var.
-  #default-log-format: "[%i] %t - (%f:%l) <%d> (%n) -- "
-
-  # A regex to filter output.  Can be overridden in an output section.
-  # Defaults to empty (no filter).
-  #
-  # This value is overriden by the SC_LOG_OP_FILTER env var.
-  default-output-filter:
-
-  # Define your logging outputs.  If none are defined, or they are all
-  # disabled you will get the default - console output.
-  outputs:
-  - console:
-      enabled: yes
-      # type: json
-  - file:
-      enabled: no
-      filename: @e_logdir@suricata.log
-      # type: json
-  - syslog:
-      enabled: no
-      facility: local5
-      format: "[%i] <%d> -- "
-      # type: json
 
 # Tilera mpipe configuration. for use on Tilera TILE-Gx.
 mpipe:

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -132,7 +132,7 @@ outputs:
 
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
-      enabled: yes
+      enabled: @e_enable_evelog@
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       #prefix: "@cee: " # prefix to prepend to each log entry

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -47,10 +47,6 @@ vars:
 ## Step 2: select the rules to enable or disable
 ##
 
-classification-file: @e_sysconfdir@classification.config
-reference-config-file: @e_sysconfdir@reference.config
-# threshold-file: @e_sysconfdir@threshold.config
-
 default-rule-path: @e_sysconfdir@rules
 rule-files:
  - botcc.rules
@@ -103,6 +99,10 @@ rule-files:
  - tls-events.rules     # available in suricata sources under rules dir
 # - modbus-events.rules  # available in suricata sources under rules dir
 # - app-layer-events.rules  # available in suricata sources under rules dir
+
+classification-file: @e_sysconfdir@classification.config
+reference-config-file: @e_sysconfdir@reference.config
+# threshold-file: @e_sysconfdir@threshold.config
 
 
 ##

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -213,7 +213,7 @@ outputs:
             threads: no       # per thread stats
             deltas: no        # include delta values
         # bi-directional flows
-        #- flow
+        - flow
         # uni-directional flows
         #- netflow
 
@@ -256,7 +256,7 @@ outputs:
 
   # a line based log of HTTP requests (no alerts)
   - http-log:
-      enabled: yes
+      enabled: no
       filename: http.log
       append: yes
       #extended: yes     # enable this for extended logging information

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -794,6 +794,9 @@ app-layer:
            #    double-decode-path: no
            #    double-decode-query: no
 
+# Limit for the maximum number of asn1 frames to decode (default 256)
+asn1-max-frames: 256
+
 
 ##############################################################################
 ##
@@ -991,6 +994,22 @@ spm-algo: auto
 #reputation-files:
 # - reputation.list
 
+# When run with the option --engine-analysis, the engine will read each of
+# the parameters below, and print reports for each of the enabled sections
+# and exit.  The reports are printed to a file in the default log dir
+# given by the parameter "default-log-dir", with engine reporting
+# subsection below printing reports in its own report file.
+engine-analysis:
+  # enables printing reports for fast-pattern for every rule.
+  rules-fast-pattern: yes
+  # enables printing reports for each rule
+  rules: yes
+
+#recursion and match limits for PCRE where supported
+pcre:
+  match-limit: 3500
+  match-limit-recursion: 1500
+
 ##
 ## Threading
 ##
@@ -1054,6 +1073,25 @@ threading:
 ##
 ## Advanced Traffic Tracking and Reconstruction Settings
 ##
+
+# Host specific policies for defragmentation and TCP stream
+# reassembly.  The host OS lookup is done using a radix tree, just
+# like a routing table so the most specific entry matches.
+host-os-policy:
+  # Make the default policy windows.
+  windows: [0.0.0.0/0]
+  bsd: []
+  bsd-right: []
+  old-linux: []
+  linux: [10.0.0.0/8, 192.168.1.100, "8762:2352:6241:7245:E000:0000:0000:0000"]
+  old-solaris: []
+  solaris: ["::1"]
+  hpux10: []
+  hpux11: []
+  irix: []
+  macos: []
+  vista: []
+  windows2k3: []
 
 # Defrag settings:
 
@@ -1267,44 +1305,6 @@ host:
 #  memcap: 16777216
 
 
-# Host specific policies for defragmentation and TCP stream
-# reassembly.  The host OS lookup is done using a radix tree, just
-# like a routing table so the most specific entry matches.
-host-os-policy:
-  # Make the default policy windows.
-  windows: [0.0.0.0/0]
-  bsd: []
-  bsd-right: []
-  old-linux: []
-  linux: [10.0.0.0/8, 192.168.1.100, "8762:2352:6241:7245:E000:0000:0000:0000"]
-  old-solaris: []
-  solaris: ["::1"]
-  hpux10: []
-  hpux11: []
-  irix: []
-  macos: []
-  vista: []
-  windows2k3: []
-
-
-# Limit for the maximum number of asn1 frames to decode (default 256)
-asn1-max-frames: 256
-
-# When run with the option --engine-analysis, the engine will read each of
-# the parameters below, and print reports for each of the enabled sections
-# and exit.  The reports are printed to a file in the default log dir
-# given by the parameter "default-log-dir", with engine reporting
-# subsection below printing reports in its own report file.
-engine-analysis:
-  # enables printing reports for fast-pattern for every rule.
-  rules-fast-pattern: yes
-  # enables printing reports for each rule
-  rules: yes
-
-#recursion and match limits for PCRE where supported
-pcre:
-  match-limit: 3500
-  match-limit-recursion: 1500
 
 # Profiling settings. Only effective if Suricata has been built with the
 # the --enable-profiling configure flag.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -993,37 +993,6 @@ threading:
   #
   detect-thread-ratio: 1.5
 
-# Cuda configuration.
-cuda:
-  # The "mpm" profile.  On not specifying any of these parameters, the engine's
-  # internal default values are used, which are same as the ones specified in
-  # in the default conf file.
-  mpm:
-    # The minimum length required to buffer data to the gpu.
-    # Anything below this is MPM'ed on the CPU.
-    # Can be specified in kb, mb, gb.  Just a number indicates it's in bytes.
-    # A value of 0 indicates there's no limit.
-    data-buffer-size-min-limit: 0
-    # The maximum length for data that we would buffer to the gpu.
-    # Anything over this is MPM'ed on the CPU.
-    # Can be specified in kb, mb, gb.  Just a number indicates it's in bytes.
-    data-buffer-size-max-limit: 1500
-    # The ring buffer size used by the CudaBuffer API to buffer data.
-    cudabuffer-buffer-size: 500mb
-    # The max chunk size that can be sent to the gpu in a single go.
-    gpu-transfer-size: 50mb
-    # The timeout limit for batching of packets in microseconds.
-    batching-timeout: 2000
-    # The device to use for the mpm.  Currently we don't support load balancing
-    # on multiple gpus.  In case you have multiple devices on your system, you
-    # can specify the device to use, using this conf.  By default we hold 0, to
-    # specify the first device cuda sees.  To find out device-id associated with
-    # the card(s) on the system run "suricata --list-cuda-cards".
-    device-id: 0
-    # No of Cuda streams used for asynchronous processing. All values > 0 are valid.
-    # For this option you need a device with Compute Capability > 1.0.
-    cuda-streams: 2
-
 # Select the multi pattern algorithm you want to run for scan/search the
 # in the engine.
 #
@@ -1590,6 +1559,41 @@ mpipe:
     size4096: 0
     size10386: 0
     size16384: 0
+
+##
+## Hardware accelaration
+##
+
+# Cuda configuration.
+cuda:
+  # The "mpm" profile.  On not specifying any of these parameters, the engine's
+  # internal default values are used, which are same as the ones specified in
+  # in the default conf file.
+  mpm:
+    # The minimum length required to buffer data to the gpu.
+    # Anything below this is MPM'ed on the CPU.
+    # Can be specified in kb, mb, gb.  Just a number indicates it's in bytes.
+    # A value of 0 indicates there's no limit.
+    data-buffer-size-min-limit: 0
+    # The maximum length for data that we would buffer to the gpu.
+    # Anything over this is MPM'ed on the CPU.
+    # Can be specified in kb, mb, gb.  Just a number indicates it's in bytes.
+    data-buffer-size-max-limit: 1500
+    # The ring buffer size used by the CudaBuffer API to buffer data.
+    cudabuffer-buffer-size: 500mb
+    # The max chunk size that can be sent to the gpu in a single go.
+    gpu-transfer-size: 50mb
+    # The timeout limit for batching of packets in microseconds.
+    batching-timeout: 2000
+    # The device to use for the mpm.  Currently we don't support load balancing
+    # on multiple gpus.  In case you have multiple devices on your system, you
+    # can specify the device to use, using this conf.  By default we hold 0, to
+    # specify the first device cuda sees.  To find out device-id associated with
+    # the card(s) on the system run "suricata --list-cuda-cards".
+    device-id: 0
+    # No of Cuda streams used for asynchronous processing. All values > 0 are valid.
+    # For this option you need a device with Compute Capability > 1.0.
+    cuda-streams: 2
 
 
 # Includes.  Files included here will be handled as if they were

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -474,10 +474,13 @@ logging:
 
 
 ##
-## Step 4: configure capture settings
+## Step 4: configure common capture settings
+##
+## See "Advanced Capture Options" below for more options, including NETMAP
+## and PF_RING.
 ##
 
-# af-packet support
+# Linux high speed capture support
 af-packet:
   - interface: eth0
     # Number of receive threads. "auto" uses the number of cores
@@ -562,6 +565,7 @@ af-packet:
     #rollover: yes
     tpacket-v3: yes
 
+# Cross platform libpcap capture support
 pcap:
   - interface: eth0
     # On Linux, pcap will try to use mmaped capture and will use buffer-size
@@ -593,6 +597,7 @@ pcap:
   - interface: default
     #checksum-checks: auto
 
+# Settings for reading pcap files
 pcap-file:
   # Possible values are:
   #  - yes: checksum validation is forced

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -275,6 +275,204 @@ pcap-file:
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
   checksum-checks: auto
 
+##
+## Step 5: App Layer Protocol Configuration
+##
+
+# Configure the app-layer parsers. The protocols section details each
+# protocol.
+#
+# The option "enabled" takes 3 values - "yes", "no", "detection-only".
+# "yes" enables both detection and the parser, "no" disables both, and
+# "detection-only" enables protocol detection only (parser disabled).
+app-layer:
+  protocols:
+    tls:
+      enabled: yes
+      detection-ports:
+        dp: 443
+
+      #no-reassemble: yes
+    dcerpc:
+      enabled: yes
+    ftp:
+      enabled: yes
+    ssh:
+      enabled: yes
+    smtp:
+      enabled: yes
+      # Configure SMTP-MIME Decoder
+      mime:
+        # Decode MIME messages from SMTP transactions
+        # (may be resource intensive)
+        # This field supercedes all others because it turns the entire
+        # process on or off
+        decode-mime: yes
+
+        # Decode MIME entity bodies (ie. base64, quoted-printable, etc.)
+        decode-base64: yes
+        decode-quoted-printable: yes
+
+        # Maximum bytes per header data value stored in the data structure
+        # (default is 2000)
+        header-value-depth: 2000
+
+        # Extract URLs and save in state data structure
+        extract-urls: yes
+        # Set to yes to compute the md5 of the mail body. You will then
+        # be able to journalize it.
+        body-md5: no
+      # Configure inspected-tracker for file_data keyword
+      inspected-tracker:
+        content-limit: 100000
+        content-inspect-min-size: 32768
+        content-inspect-window: 4096
+    imap:
+      enabled: detection-only
+    msn:
+      enabled: detection-only
+    smb:
+      enabled: yes
+      detection-ports:
+        dp: 139
+    # Note: Modbus probe parser is minimalist due to the poor significant field
+    # Only Modbus message length (greater than Modbus header length)
+    # And Protocol ID (equal to 0) are checked in probing parser
+    # It is important to enable detection port and define Modbus port
+    # to avoid false positive
+    modbus:
+      # How many unreplied Modbus requests are considered a flood.
+      # If the limit is reached, app-layer-event:modbus.flooded; will match.
+      #request-flood: 500
+
+      enabled: no
+      detection-ports:
+        dp: 502
+      # According to MODBUS Messaging on TCP/IP Implementation Guide V1.0b, it
+      # is recommended to keep the TCP connection opened with a remote device
+      # and not to open and close it for each MODBUS/TCP transaction. In that
+      # case, it is important to set the depth of the stream reassembling as
+      # unlimited (stream.reassembly.depth: 0)
+    # smb2 detection is disabled internally inside the engine.
+    #smb2:
+    #  enabled: yes
+    dns:
+      # memcaps. Globally and per flow/state.
+      #global-memcap: 16mb
+      #state-memcap: 512kb
+
+      # How many unreplied DNS requests are considered a flood.
+      # If the limit is reached, app-layer-event:dns.flooded; will match.
+      #request-flood: 500
+
+      tcp:
+        enabled: yes
+        detection-ports:
+          dp: 53
+      udp:
+        enabled: yes
+        detection-ports:
+          dp: 53
+    http:
+      enabled: yes
+      # memcap: 64mb
+
+      # default-config:           Used when no server-config matches
+      #   personality:            List of personalities used by default
+      #   request-body-limit:     Limit reassembly of request body for inspection
+      #                           by http_client_body & pcre /P option.
+      #   response-body-limit:    Limit reassembly of response body for inspection
+      #                           by file_data, http_server_body & pcre /Q option.
+      #   double-decode-path:     Double decode path section of the URI
+      #   double-decode-query:    Double decode query section of the URI
+      #
+      # server-config:            List of server configurations to use if address matches
+      #   address:                List of ip addresses or networks for this block
+      #   personalitiy:           List of personalities used by this block
+      #   request-body-limit:     Limit reassembly of request body for inspection
+      #                           by http_client_body & pcre /P option.
+      #   response-body-limit:    Limit reassembly of response body for inspection
+      #                           by file_data, http_server_body & pcre /Q option.
+      #   double-decode-path:     Double decode path section of the URI
+      #   double-decode-query:    Double decode query section of the URI
+      #
+      #   uri-include-all:        Include all parts of the URI. By default the
+      #                           'scheme', username/password, hostname and port
+      #                           are excluded. Setting this option to true adds
+      #                           all of them to the normalized uri as inspected
+      #                           by http_uri, urilen, pcre with /U and the other
+      #                           keywords that inspect the normalized uri.
+      #                           Note that this does not affect http_raw_uri.
+      #                           Also, note that including all was the default in
+      #                           1.4 and 2.0beta1.
+      #
+      #   meta-field-limit:       Hard size limit for request and response size
+      #                           limits. Applies to request line and headers,
+      #                           response line and headers. Does not apply to
+      #                           request or response bodies. Default is 18k.
+      #                           If this limit is reached an event is raised.
+      #
+      # Currently Available Personalities:
+      #   Minimal, Generic, IDS (default), IIS_4_0, IIS_5_0, IIS_5_1, IIS_6_0,
+      #   IIS_7_0, IIS_7_5, Apache_2
+      libhtp:
+         default-config:
+           personality: IDS
+
+           # Can be specified in kb, mb, gb.  Just a number indicates
+           # it's in bytes.
+           request-body-limit: 100kb
+           response-body-limit: 100kb
+
+           # inspection limits
+           request-body-minimal-inspect-size: 32kb
+           request-body-inspect-window: 4kb
+           response-body-minimal-inspect-size: 40kb
+           response-body-inspect-window: 16kb
+
+           # auto will use http-body-inline mode in IPS mode, yes or no set it statically
+           http-body-inline: auto
+
+           # Take a random value for inspection sizes around the specified value.
+           # This lower the risk of some evasion technics but could lead
+           # detection change between runs. It is set to 'yes' by default.
+           #randomize-inspection-sizes: yes
+           # If randomize-inspection-sizes is active, the value of various
+           # inspection size will be choosen in the [1 - range%, 1 + range%]
+           # range
+           # Default value of randomize-inspection-range is 10.
+           #randomize-inspection-range: 10
+
+           # decoding
+           double-decode-path: no
+           double-decode-query: no
+
+         server-config:
+
+           #- apache:
+           #    address: [192.168.1.0/24, 127.0.0.0/8, "::1"]
+           #    personality: Apache_2
+           #    # Can be specified in kb, mb, gb.  Just a number indicates
+           #    # it's in bytes.
+           #    request-body-limit: 4096
+           #    response-body-limit: 4096
+           #    double-decode-path: no
+           #    double-decode-query: no
+
+           #- iis7:
+           #    address:
+           #      - 192.168.0.0/24
+           #      - 192.168.10.0/24
+           #    personality: IIS_7_0
+           #    # Can be specified in kb, mb, gb.  Just a number indicates
+           #    # it's in bytes.
+           #    request-body-limit: 4096
+           #    response-body-limit: 4096
+           #    double-decode-path: no
+           #    double-decode-query: no
+
+
+
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
@@ -1283,215 +1481,6 @@ engine-analysis:
 pcre:
   match-limit: 3500
   match-limit-recursion: 1500
-
-# Holds details on the app-layer. The protocols section details each protocol.
-# Under each protocol, the default value for detection-enabled and "
-# parsed-enabled is yes, unless specified otherwise.
-# Each protocol covers enabling/disabling parsers for all ipprotos
-# the app-layer protocol runs on.  For example "dcerpc" refers to the tcp
-# version of the protocol as well as the udp version of the protocol.
-# The option "enabled" takes 3 values - "yes", "no", "detection-only".
-# "yes" enables both detection and the parser, "no" disables both, and
-# "detection-only" enables detection only(parser disabled).
-app-layer:
-  protocols:
-    tls:
-      enabled: yes
-      detection-ports:
-        dp: 443
-
-      #no-reassemble: yes
-    dcerpc:
-      enabled: yes
-    ftp:
-      enabled: yes
-    ssh:
-      enabled: yes
-    smtp:
-      enabled: yes
-      # Configure SMTP-MIME Decoder
-      mime:
-        # Decode MIME messages from SMTP transactions
-        # (may be resource intensive)
-        # This field supercedes all others because it turns the entire
-        # process on or off
-        decode-mime: yes
-
-        # Decode MIME entity bodies (ie. base64, quoted-printable, etc.)
-        decode-base64: yes
-        decode-quoted-printable: yes
-
-        # Maximum bytes per header data value stored in the data structure
-        # (default is 2000)
-        header-value-depth: 2000
-
-        # Extract URLs and save in state data structure
-        extract-urls: yes
-        # Set to yes to compute the md5 of the mail body. You will then
-        # be able to journalize it.
-        body-md5: no
-      # Configure inspected-tracker for file_data keyword
-      inspected-tracker:
-        content-limit: 100000
-        content-inspect-min-size: 32768
-        content-inspect-window: 4096
-    imap:
-      enabled: detection-only
-    msn:
-      enabled: detection-only
-    smb:
-      enabled: yes
-      detection-ports:
-        dp: 139
-    # Note: Modbus probe parser is minimalist due to the poor significant field
-    # Only Modbus message length (greater than Modbus header length)
-    # And Protocol ID (equal to 0) are checked in probing parser
-    # It is important to enable detection port and define Modbus port
-    # to avoid false positive
-    modbus:
-      # How many unreplied Modbus requests are considered a flood.
-      # If the limit is reached, app-layer-event:modbus.flooded; will match.
-      #request-flood: 500
-
-      enabled: no
-      detection-ports:
-        dp: 502
-      # According to MODBUS Messaging on TCP/IP Implementation Guide V1.0b, it 
-      # is recommended to keep the TCP connection opened with a remote device 
-      # and not to open and close it for each MODBUS/TCP transaction. In that 
-      # case, it is important to set the depth of the stream reassembling as
-      # unlimited (stream.reassembly.depth: 0)
-    # smb2 detection is disabled internally inside the engine.
-    #smb2:
-    #  enabled: yes
-    dns:
-      # memcaps. Globally and per flow/state.
-      #global-memcap: 16mb
-      #state-memcap: 512kb
-
-      # How many unreplied DNS requests are considered a flood.
-      # If the limit is reached, app-layer-event:dns.flooded; will match.
-      #request-flood: 500
-
-      tcp:
-        enabled: yes
-        detection-ports:
-          dp: 53
-      udp:
-        enabled: yes
-        detection-ports:
-          dp: 53
-    http:
-      enabled: yes
-      # memcap: 64mb
-
-      ###########################################################################
-      # Configure libhtp.
-      #
-      #
-      # default-config:           Used when no server-config matches
-      #   personality:            List of personalities used by default
-      #   request-body-limit:     Limit reassembly of request body for inspection
-      #                           by http_client_body & pcre /P option.
-      #   response-body-limit:    Limit reassembly of response body for inspection
-      #                           by file_data, http_server_body & pcre /Q option.
-      #   double-decode-path:     Double decode path section of the URI
-      #   double-decode-query:    Double decode query section of the URI
-      #
-      # server-config:            List of server configurations to use if address matches
-      #   address:                List of ip addresses or networks for this block
-      #   personalitiy:           List of personalities used by this block
-      #   request-body-limit:     Limit reassembly of request body for inspection
-      #                           by http_client_body & pcre /P option.
-      #   response-body-limit:    Limit reassembly of response body for inspection
-      #                           by file_data, http_server_body & pcre /Q option.
-      #   double-decode-path:     Double decode path section of the URI
-      #   double-decode-query:    Double decode query section of the URI
-      #
-      #   uri-include-all:        Include all parts of the URI. By default the
-      #                           'scheme', username/password, hostname and port
-      #                           are excluded. Setting this option to true adds
-      #                           all of them to the normalized uri as inspected
-      #                           by http_uri, urilen, pcre with /U and the other
-      #                           keywords that inspect the normalized uri.
-      #                           Note that this does not affect http_raw_uri.
-      #                           Also, note that including all was the default in
-      #                           1.4 and 2.0beta1.
-      #
-      #   meta-field-limit:       Hard size limit for request and response size
-      #                           limits. Applies to request line and headers,
-      #                           response line and headers. Does not apply to
-      #                           request or response bodies. Default is 18k.
-      #                           If this limit is reached an event is raised.
-      #
-      # Currently Available Personalities:
-      #   Minimal
-      #   Generic
-      #   IDS (default)
-      #   IIS_4_0
-      #   IIS_5_0
-      #   IIS_5_1
-      #   IIS_6_0
-      #   IIS_7_0
-      #   IIS_7_5
-      #   Apache_2
-      ###########################################################################
-      libhtp:
-
-         default-config:
-           personality: IDS
-
-           # Can be specified in kb, mb, gb.  Just a number indicates
-           # it's in bytes.
-           request-body-limit: 100kb
-           response-body-limit: 100kb
-
-           # inspection limits
-           request-body-minimal-inspect-size: 32kb
-           request-body-inspect-window: 4kb
-           response-body-minimal-inspect-size: 40kb
-           response-body-inspect-window: 16kb
-
-           # auto will use http-body-inline mode in IPS mode, yes or no set it statically
-           http-body-inline: auto
-
-           # Take a random value for inspection sizes around the specified value.
-           # This lower the risk of some evasion technics but could lead
-           # detection change between runs. It is set to 'yes' by default.
-           #randomize-inspection-sizes: yes
-           # If randomize-inspection-sizes is active, the value of various
-           # inspection size will be choosen in the [1 - range%, 1 + range%]
-           # range
-           # Default value of randomize-inspection-range is 10.
-           #randomize-inspection-range: 10
-
-           # decoding
-           double-decode-path: no
-           double-decode-query: no
-
-         server-config:
-
-           #- apache:
-           #    address: [192.168.1.0/24, 127.0.0.0/8, "::1"]
-           #    personality: Apache_2
-           #    # Can be specified in kb, mb, gb.  Just a number indicates
-           #    # it's in bytes.
-           #    request-body-limit: 4096
-           #    response-body-limit: 4096
-           #    double-decode-path: no
-           #    double-decode-query: no
-
-           #- iis7:
-           #    address:
-           #      - 192.168.0.0/24
-           #      - 192.168.10.0/24
-           #    personality: IIS_7_0
-           #    # Can be specified in kb, mb, gb.  Just a number indicates
-           #    # it's in bytes.
-           #    request-body-limit: 4096
-           #    response-body-limit: 4096
-           #    double-decode-path: no
-           #    double-decode-query: no
 
 # Profiling settings. Only effective if Suricata has been built with the
 # the --enable-profiling configure flag.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -42,6 +42,68 @@ vars:
     DNP3_PORTS: 20000
     MODBUS_PORTS: 502
 
+##
+## Step 2: select the rules to enable or disable
+##
+
+classification-file: @e_sysconfdir@classification.config
+reference-config-file: @e_sysconfdir@reference.config
+# threshold-file: @e_sysconfdir@threshold.config
+
+default-rule-path: @e_sysconfdir@rules
+rule-files:
+ - botcc.rules
+ - ciarmy.rules
+ - compromised.rules
+ - drop.rules
+ - dshield.rules
+# - emerging-activex.rules
+ - emerging-attack_response.rules
+ - emerging-chat.rules
+ - emerging-current_events.rules
+ - emerging-dns.rules
+ - emerging-dos.rules
+ - emerging-exploit.rules
+ - emerging-ftp.rules
+# - emerging-games.rules
+# - emerging-icmp_info.rules
+# - emerging-icmp.rules
+ - emerging-imap.rules
+# - emerging-inappropriate.rules
+ - emerging-malware.rules
+ - emerging-misc.rules
+ - emerging-mobile_malware.rules
+ - emerging-netbios.rules
+ - emerging-p2p.rules
+ - emerging-policy.rules
+ - emerging-pop3.rules
+ - emerging-rpc.rules
+ - emerging-scada.rules
+ - emerging-scan.rules
+# - emerging-shellcode.rules
+ - emerging-smtp.rules
+ - emerging-snmp.rules
+ - emerging-sql.rules
+ - emerging-telnet.rules
+ - emerging-tftp.rules
+ - emerging-trojan.rules
+ - emerging-user_agents.rules
+ - emerging-voip.rules
+ - emerging-web_client.rules
+ - emerging-web_server.rules
+# - emerging-web_specific_apps.rules
+ - emerging-worm.rules
+ - tor.rules
+# - decoder-events.rules # available in suricata sources under rules dir
+# - stream-events.rules  # available in suricata sources under rules dir
+ - http-events.rules    # available in suricata sources under rules dir
+ - smtp-events.rules    # available in suricata sources under rules dir
+ - dns-events.rules     # available in suricata sources under rules dir
+ - tls-events.rules     # available in suricata sources under rules dir
+# - modbus-events.rules  # available in suricata sources under rules dir
+# - app-layer-events.rules  # available in suricata sources under rules dir
+
+
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
 # impact caching.
@@ -618,10 +680,6 @@ netmap:
 legacy:
   uricontent: enabled
 
-# You can specify a threshold config file by setting "threshold-file"
-# to the path of the threshold config file:
-# threshold-file: /etc/suricata/threshold.config
-
 # The detection engine builds internal groups of signatures. The engine
 # allow us to specify the profile to use for them, to manage memory on an
 # efficient way keeping a good performance. For the profile keyword you
@@ -1173,64 +1231,6 @@ ipfw:
   # back into the ipfw firewall AT rule number 5500:
   #
   # ipfw-reinjection-rule-number: 5500
-
-# Set the default rule path here to search for the files.
-# if not set, it will look at the current working dir
-default-rule-path: @e_sysconfdir@rules
-rule-files:
- - botcc.rules
- - ciarmy.rules
- - compromised.rules
- - drop.rules
- - dshield.rules
-# - emerging-activex.rules
- - emerging-attack_response.rules
- - emerging-chat.rules
- - emerging-current_events.rules
- - emerging-dns.rules
- - emerging-dos.rules
- - emerging-exploit.rules
- - emerging-ftp.rules
-# - emerging-games.rules
-# - emerging-icmp_info.rules
-# - emerging-icmp.rules
- - emerging-imap.rules
-# - emerging-inappropriate.rules
- - emerging-malware.rules
- - emerging-misc.rules
- - emerging-mobile_malware.rules
- - emerging-netbios.rules
- - emerging-p2p.rules
- - emerging-policy.rules
- - emerging-pop3.rules
- - emerging-rpc.rules
- - emerging-scada.rules
- - emerging-scan.rules
-# - emerging-shellcode.rules
- - emerging-smtp.rules
- - emerging-snmp.rules
- - emerging-sql.rules
- - emerging-telnet.rules
- - emerging-tftp.rules
- - emerging-trojan.rules
- - emerging-user_agents.rules
- - emerging-voip.rules
- - emerging-web_client.rules
- - emerging-web_server.rules
-# - emerging-web_specific_apps.rules
- - emerging-worm.rules
- - tor.rules
- - decoder-events.rules # available in suricata sources under rules dir
- - stream-events.rules  # available in suricata sources under rules dir
- - http-events.rules    # available in suricata sources under rules dir
- - smtp-events.rules    # available in suricata sources under rules dir
- - dns-events.rules     # available in suricata sources under rules dir
- - tls-events.rules     # available in suricata sources under rules dir
-# - modbus-events.rules  # available in suricata sources under rules dir
- - app-layer-events.rules  # available in suricata sources under rules dir
-
-classification-file: @e_sysconfdir@classification.config
-reference-config-file: @e_sysconfdir@reference.config
 
 # Set the order of alerts bassed on actions
 # The default order is pass, drop, reject, alert

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -42,6 +42,7 @@ vars:
     DNP3_PORTS: 20000
     MODBUS_PORTS: 502
 
+
 ##
 ## Step 2: select the rules to enable or disable
 ##
@@ -102,6 +103,7 @@ rule-files:
  - tls-events.rules     # available in suricata sources under rules dir
 # - modbus-events.rules  # available in suricata sources under rules dir
 # - app-layer-events.rules  # available in suricata sources under rules dir
+
 
 ##
 ## Step 3: select outputs to enable
@@ -469,6 +471,7 @@ logging:
       format: "[%i] <%d> -- "
       # type: json
 
+
 ##
 ## Step 4: configure capture settings
 ##
@@ -597,6 +600,7 @@ pcap-file:
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
   checksum-checks: auto
+
 
 ##
 ## Step 5: App Layer Protocol Configuration
@@ -896,90 +900,6 @@ legacy:
 ## Detection settings
 ##
 
-# The detection engine builds internal groups of signatures. The engine
-# allow us to specify the profile to use for them, to manage memory on an
-# efficient way keeping a good performance. For the profile keyword you
-# can use the words "low", "medium", "high" or "custom". If you use custom
-# make sure to define the values at "- custom-values" as your convenience.
-# Usually you would prefer medium/high/low.
-#
-# "sgh mpm-context", indicates how the staging should allot mpm contexts for
-# the signature groups.  "single" indicates the use of a single context for
-# all the signature group heads.  "full" indicates a mpm-context for each
-# group head.  "auto" lets the engine decide the distribution of contexts
-# based on the information the engine gathers on the patterns from each
-# group head.
-#
-# The option inspection-recursion-limit is used to limit the recursive calls
-# in the content inspection code.  For certain payload-sig combinations, we
-# might end up taking too much time in the content inspection code.
-# If the argument specified is 0, the engine uses an internally defined
-# default limit.  On not specifying a value, we use no limits on the recursion.
-detect:
-  profile: medium
-  custom-values:
-    toclient-groups: 3
-    toserver-groups: 25
-  sgh-mpm-context: auto
-  inspection-recursion-limit: 3000
-  # If set to yes, the loading of signatures will be made after the capture
-  # is started. This will limit the downtime in IPS mode.
-  #delayed-detect: yes
-
-  # the grouping values above control how many groups are created per
-  # direction. Port whitelisting forces that port to get it's own group.
-  # Very common ports will benefit, as well as ports with many expensive
-  # rules.
-  grouping:
-    #tcp-whitelist: 53, 80, 139, 443, 445, 1433, 3306, 3389, 6666, 6667, 8080
-    #udp-whitelist: 53, 135, 5060
-
-  profiling:
-    # Log the rules that made it past the prefilter stage, per packet
-    # default is off. The threshold setting determines how many rules
-    # must have made it past pre-filter for that rule to trigger the
-    # logging.
-    #inspect-logging-threshold: 200
-    grouping:
-      dump-to-disk: false
-      include-rules: false      # very verbose
-      include-mpm-stats: false
-
-# Select the multi pattern algorithm you want to run for scan/search the
-# in the engine.
-#
-# The supported algorithms are:
-# "ac"      - Aho-Corasick, default implementation
-# "ac-bs"   - Aho-Corasick, reduced memory implementation
-# "ac-cuda" - Aho-Corasick, CUDA implementation
-# "ac-tile" - Aho-Corasick, optimized for Tilera architecture
-# "hs"      - Hyperscan, available when built with Hyperscan support
-#
-# The default mpm-algo value of "auto" will use "hs" if Hyperscan is available,
-# "ac-tile" on Tilera platforms, and "ac" otherwise.
-#
-# The mpm you choose also decides the distribution of mpm contexts for
-# signature groups, specified by the conf - "detect.sgh-mpm-context".
-# Selecting "ac" as the mpm would require "detect.sgh-mpm-context"
-# to be set to "single", because of ac's memory requirements, unless the
-# ruleset is small enough to fit in one's memory, in which case one can
-# use "full" with "ac".  Rest of the mpms can be run in "full" mode.
-#
-# There is also a CUDA pattern matcher (only available if Suricata was
-# compiled with --enable-cuda: b2g_cuda. Make sure to update your
-# max-pending-packets setting above as well if you use b2g_cuda.
-
-mpm-algo: auto
-
-# Select the matching algorithm you want to use for single-pattern searches.
-#
-# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
-# available if Suricata has been built with Hyperscan support).
-#
-# The default of "auto" will use "hs" if available, otherwise "bm".
-
-spm-algo: auto
-
 # Set the order of alerts bassed on actions
 # The default order is pass, drop, reject, alert
 # action-order:
@@ -1009,66 +929,6 @@ engine-analysis:
 pcre:
   match-limit: 3500
   match-limit-recursion: 1500
-
-##
-## Threading
-##
-
-# Suricata is multi-threaded. Here the threading can be influenced.
-threading:
-  # On some cpu's/architectures it is beneficial to tie individual threads
-  # to specific CPU's/CPU cores. In this case all threads are tied to CPU0,
-  # and each extra CPU/core has one "detect" thread.
-  #
-  # On Intel Core2 and Nehalem CPU's enabling this will degrade performance.
-  #
-  set-cpu-affinity: no
-  # Tune cpu affinity of suricata threads. Each family of threads can be bound
-  # on specific CPUs.
-  cpu-affinity:
-    - management-cpu-set:
-        cpu: [ 0 ]  # include only these cpus in affinity settings
-    - receive-cpu-set:
-        cpu: [ 0 ]  # include only these cpus in affinity settings
-    - decode-cpu-set:
-        cpu: [ 0, 1 ]
-        mode: "balanced"
-    - stream-cpu-set:
-        cpu: [ "0-1" ]
-    - detect-cpu-set:
-        cpu: [ "all" ]
-        mode: "exclusive" # run detect threads in these cpus
-        # Use explicitely 3 threads and don't compute number by using
-        # detect-thread-ratio variable:
-        # threads: 3
-        prio:
-          low: [ 0 ]
-          medium: [ "1-2" ]
-          high: [ 3 ]
-          default: "medium"
-    - verdict-cpu-set:
-        cpu: [ 0 ]
-        prio:
-          default: "high"
-    - reject-cpu-set:
-        cpu: [ 0 ]
-        prio:
-          default: "low"
-    - output-cpu-set:
-        cpu: [ "all" ]
-        prio:
-           default: "medium"
-  #
-  # By default Suricata creates one "detect" thread per available CPU/CPU core.
-  # This setting allows controlling this behaviour. A ratio setting of 2 will
-  # create 2 detect threads for each CPU/CPU core. So for a dual core CPU this
-  # will result in 4 detect threads. If values below 1 are used, less threads
-  # are created. So on a dual core CPU a setting of 0.5 results in 1 detect
-  # thread being created. Regardless of the setting at a minimum 1 detect
-  # thread will always be created.
-  #
-  detect-thread-ratio: 1.5
-
 
 ##
 ## Advanced Traffic Tracking and Reconstruction Settings
@@ -1304,7 +1164,148 @@ host:
 #  prealloc: 1000
 #  memcap: 16777216
 
+##
+## Performance tuning and profiling
+##
 
+# The detection engine builds internal groups of signatures. The engine
+# allow us to specify the profile to use for them, to manage memory on an
+# efficient way keeping a good performance. For the profile keyword you
+# can use the words "low", "medium", "high" or "custom". If you use custom
+# make sure to define the values at "- custom-values" as your convenience.
+# Usually you would prefer medium/high/low.
+#
+# "sgh mpm-context", indicates how the staging should allot mpm contexts for
+# the signature groups.  "single" indicates the use of a single context for
+# all the signature group heads.  "full" indicates a mpm-context for each
+# group head.  "auto" lets the engine decide the distribution of contexts
+# based on the information the engine gathers on the patterns from each
+# group head.
+#
+# The option inspection-recursion-limit is used to limit the recursive calls
+# in the content inspection code.  For certain payload-sig combinations, we
+# might end up taking too much time in the content inspection code.
+# If the argument specified is 0, the engine uses an internally defined
+# default limit.  On not specifying a value, we use no limits on the recursion.
+detect:
+  profile: medium
+  custom-values:
+    toclient-groups: 3
+    toserver-groups: 25
+  sgh-mpm-context: auto
+  inspection-recursion-limit: 3000
+  # If set to yes, the loading of signatures will be made after the capture
+  # is started. This will limit the downtime in IPS mode.
+  #delayed-detect: yes
+
+  # the grouping values above control how many groups are created per
+  # direction. Port whitelisting forces that port to get it's own group.
+  # Very common ports will benefit, as well as ports with many expensive
+  # rules.
+  grouping:
+    #tcp-whitelist: 53, 80, 139, 443, 445, 1433, 3306, 3389, 6666, 6667, 8080
+    #udp-whitelist: 53, 135, 5060
+
+  profiling:
+    # Log the rules that made it past the prefilter stage, per packet
+    # default is off. The threshold setting determines how many rules
+    # must have made it past pre-filter for that rule to trigger the
+    # logging.
+    #inspect-logging-threshold: 200
+    grouping:
+      dump-to-disk: false
+      include-rules: false      # very verbose
+      include-mpm-stats: false
+
+# Select the multi pattern algorithm you want to run for scan/search the
+# in the engine.
+#
+# The supported algorithms are:
+# "ac"      - Aho-Corasick, default implementation
+# "ac-bs"   - Aho-Corasick, reduced memory implementation
+# "ac-cuda" - Aho-Corasick, CUDA implementation
+# "ac-tile" - Aho-Corasick, optimized for Tilera architecture
+# "hs"      - Hyperscan, available when built with Hyperscan support
+#
+# The default mpm-algo value of "auto" will use "hs" if Hyperscan is available,
+# "ac-tile" on Tilera platforms, and "ac" otherwise.
+#
+# The mpm you choose also decides the distribution of mpm contexts for
+# signature groups, specified by the conf - "detect.sgh-mpm-context".
+# Selecting "ac" as the mpm would require "detect.sgh-mpm-context"
+# to be set to "single", because of ac's memory requirements, unless the
+# ruleset is small enough to fit in one's memory, in which case one can
+# use "full" with "ac".  Rest of the mpms can be run in "full" mode.
+#
+# There is also a CUDA pattern matcher (only available if Suricata was
+# compiled with --enable-cuda: b2g_cuda. Make sure to update your
+# max-pending-packets setting above as well if you use b2g_cuda.
+
+mpm-algo: auto
+
+# Select the matching algorithm you want to use for single-pattern searches.
+#
+# Supported algorithms are "bm" (Boyer-Moore) and "hs" (Hyperscan, only
+# available if Suricata has been built with Hyperscan support).
+#
+# The default of "auto" will use "hs" if available, otherwise "bm".
+
+spm-algo: auto
+
+# Suricata is multi-threaded. Here the threading can be influenced.
+threading:
+  # On some cpu's/architectures it is beneficial to tie individual threads
+  # to specific CPU's/CPU cores. In this case all threads are tied to CPU0,
+  # and each extra CPU/core has one "detect" thread.
+  #
+  # On Intel Core2 and Nehalem CPU's enabling this will degrade performance.
+  #
+  set-cpu-affinity: no
+  # Tune cpu affinity of suricata threads. Each family of threads can be bound
+  # on specific CPUs.
+  cpu-affinity:
+    - management-cpu-set:
+        cpu: [ 0 ]  # include only these cpus in affinity settings
+    - receive-cpu-set:
+        cpu: [ 0 ]  # include only these cpus in affinity settings
+    - decode-cpu-set:
+        cpu: [ 0, 1 ]
+        mode: "balanced"
+    - stream-cpu-set:
+        cpu: [ "0-1" ]
+    - detect-cpu-set:
+        cpu: [ "all" ]
+        mode: "exclusive" # run detect threads in these cpus
+        # Use explicitely 3 threads and don't compute number by using
+        # detect-thread-ratio variable:
+        # threads: 3
+        prio:
+          low: [ 0 ]
+          medium: [ "1-2" ]
+          high: [ 3 ]
+          default: "medium"
+    - verdict-cpu-set:
+        cpu: [ 0 ]
+        prio:
+          default: "high"
+    - reject-cpu-set:
+        cpu: [ 0 ]
+        prio:
+          default: "low"
+    - output-cpu-set:
+        cpu: [ "all" ]
+        prio:
+           default: "medium"
+  #
+  # By default Suricata creates one "detect" thread per available CPU/CPU core.
+  # This setting allows controlling this behaviour. A ratio setting of 2 will
+  # create 2 detect threads for each CPU/CPU core. So for a dual core CPU this
+  # will result in 4 detect threads. If values below 1 are used, less threads
+  # are created. So on a dual core CPU a setting of 0.5 results in 1 detect
+  # thread being created. Regardless of the setting at a minimum 1 detect
+  # thread will always be created.
+  #
+  detect-thread-ratio: 1.5
 
 # Profiling settings. Only effective if Suricata has been built with the
 # the --enable-profiling configure flag.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -107,6 +107,329 @@ rule-files:
 ## Step 3: select outputs to enable
 ##
 
+# The default logging directory.  Any log or output file will be
+# placed here if its not specified with a full path name. This can be
+# overridden with the -l command line parameter.
+default-log-dir: @e_logdir@
+
+# global stats configuration
+stats:
+  enabled: yes
+  # The interval field (in seconds) controls at what interval
+  # the loggers are invoked.
+  interval: 8
+
+# Configure the type of alert (and other) logging you would like.
+outputs:
+  # a line based alerts log similar to Snort's fast.log
+  - fast:
+      enabled: yes
+      filename: fast.log
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+  # Extensible Event Format (nicknamed EVE) event log in JSON format
+  - eve-log:
+      enabled: yes
+      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
+      filename: eve.json
+      #prefix: "@cee: " # prefix to prepend to each log entry
+      # the following are valid when type: syslog above
+      #identity: "suricata"
+      #facility: local5
+      #level: Info ## possible levels: Emergency, Alert, Critical,
+                   ## Error, Warning, Notice, Info, Debug
+      #redis:
+      #  server: 127.0.0.1
+      #  port: 6379
+      #  mode: list ## possible values: list (default), channel
+      #  key: suricata ## key or channel to use (default to suricata)
+      # Redis pipelining set up. This will enable to only do a query every
+      # 'batch-size' events. This should lower the latency induced by network
+      # connection at the cost of some memory. There is no flushing implemented
+      # so this setting as to be reserved to high traffic suricata.
+      #  pipelining:
+      #    enabled: yes ## set enable to yes to enable query pipelining
+      #    batch-size: 10 ## number of entry to keep in buffer
+      types:
+        - alert:
+            # payload: yes             # enable dumping payload in Base64
+            # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
+            # payload-printable: yes   # enable dumping payload in printable (lossy) format
+            # packet: yes              # enable dumping of packet (without stream segments)
+            # http: yes                # enable dumping of http fields
+            # tls: yes                 # enable dumping of tls fields
+            # ssh: yes                 # enable dumping of ssh fields
+            # smtp: yes                # enable dumping of smtp fields
+
+            # HTTP X-Forwarded-For support by adding an extra field or overwriting
+            # the source or destination IP address (depending on flow direction)
+            # with the one reported in the X-Forwarded-For HTTP header. This is
+            # helpful when reviewing alerts for traffic that is being reverse
+            # or forward proxied.
+            xff:
+              enabled: no
+              # Two operation modes are available, "extra-data" and "overwrite".
+              mode: extra-data
+              # Two proxy deployments are supported, "reverse" and "forward". In
+              # a "reverse" deployment the IP address used is the last one, in a
+              # "forward" deployment the first IP address is used.
+              deployment: reverse
+              # Header name where the actual IP address will be reported, if more
+              # than one IP address is present, the last IP address will be the
+              # one taken into consideration.
+              header: X-Forwarded-For
+        - http:
+            extended: yes     # enable this for extended logging information
+            # custom allows additional http fields to be included in eve-log
+            # the example below adds three additional fields when uncommented
+            #custom: [Accept-Encoding, Accept-Language, Authorization]
+        - dns
+        - tls:
+            extended: yes     # enable this for extended logging information
+        - files:
+            force-magic: no   # force logging magic on all logged files
+            force-md5: no     # force logging of md5 checksums
+        #- drop:
+        #    alerts: no       # log alerts that caused drops
+        - smtp:
+            #extended: yes # enable this for extended logging information
+            # this includes: bcc, message-id, subject, x_mailer, user-agent
+            # custom fields logging from the list:
+            #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
+            #  x-originating-ip, in-reply-to, references, importance, priority,
+            #  sensitivity, organization, content-md5, date
+            #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
+            # output md5 of fields: body, subject
+            # for the body you need to set app-layer.protocols.smtp.mime.body-md5
+            # to yes
+            #md5: [body, subject]
+
+        - ssh
+        - stats:
+            totals: yes       # stats for all threads merged together
+            threads: no       # per thread stats
+            deltas: no        # include delta values
+        # bi-directional flows
+        #- flow
+        # uni-directional flows
+        #- netflow
+
+  # alert output for use with Barnyard2
+  - unified2-alert:
+      enabled: no
+      filename: unified2.alert
+
+      # File size limit.  Can be specified in kb, mb, gb.  Just a number
+      # is parsed as bytes.
+      #limit: 32mb
+
+      # Sensor ID field of unified2 alerts.
+      #sensor-id: 0
+
+      # Include payload of packets related to alerts. Defaults to true, set to
+      # false if payload is not required.
+      #payload: yes
+
+      # HTTP X-Forwarded-For support by adding the unified2 extra header or
+      # overwriting the source or destination IP address (depending on flow
+      # direction) with the one reported in the X-Forwarded-For HTTP header.
+      # This is helpful when reviewing alerts for traffic that is being reverse
+      # or forward proxied.
+      xff:
+        enabled: no
+        # Two operation modes are available, "extra-data" and "overwrite". Note
+        # that in the "overwrite" mode, if the reported IP address in the HTTP
+        # X-Forwarded-For header is of a different version of the packet
+        # received, it will fall-back to "extra-data" mode.
+        mode: extra-data
+        # Two proxy deployments are supported, "reverse" and "forward". In
+        # a "reverse" deployment the IP address used is the last one, in a
+        # "forward" deployment the first IP address is used.
+        deployment: reverse
+        # Header name where the actual IP address will be reported, if more
+        # than one IP address is present, the last IP address will be the
+        # one taken into consideration.
+        header: X-Forwarded-For
+
+  # a line based log of HTTP requests (no alerts)
+  - http-log:
+      enabled: yes
+      filename: http.log
+      append: yes
+      #extended: yes     # enable this for extended logging information
+      #custom: yes       # enabled the custom logging format (defined by customformat)
+      #customformat: "%{%D-%H:%M:%S}t.%z %{X-Forwarded-For}i %H %m %h %u %s %B %a:%p -> %A:%P"
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+  # a line based log of TLS handshake parameters (no alerts)
+  - tls-log:
+      enabled: no  # Log TLS connections.
+      filename: tls.log # File to store TLS logs.
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+      #extended: yes # Log extended information like fingerprint
+
+  # output module to store certificates chain to disk
+  - tls-store:
+      enabled: no
+      #certs-log-dir: certs # directory to store the certificates files
+
+  # a line based log of DNS requests and/or replies (no alerts)
+  - dns-log:
+      enabled: no
+      filename: dns.log
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+  # Packet log... log packets in pcap format. 3 modes of operation: "normal"
+  # "multi" and "sguil".
+  #
+  # In normal mode a pcap file "filename" is created in the default-log-dir,
+  # or are as specified by "dir".
+  # In multi mode, a file is created per thread. This will perform much
+  # better, but will create multiple files where 'normal' would create one.
+  # In multi mode the filename takes a few special variables:
+  # - %n -- thread number
+  # - %i -- thread id
+  # - %t -- timestamp (secs or secs.usecs based on 'ts-format'
+  # E.g. filename: pcap.%n.%t
+  #
+  # Note that it's possible to use directories, but the directories are not
+  # created by Suricata. E.g. filename: pcaps/%n/log.%s will log into the
+  # per thread directory.
+  #
+  # Also note that the limit and max-files settings are enforced per thread.
+  # So the size limit when using 8 threads with 1000mb files and 2000 files
+  # is: 8*1000*2000 ~ 16TiB.
+  #
+  # In Sguil mode "dir" indicates the base directory. In this base dir the
+  # pcaps are created in th directory structure Sguil expects:
+  #
+  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>
+  #
+  # By default all packets are logged except:
+  # - TCP streams beyond stream.reassembly.depth
+  # - encrypted streams after the key exchange
+  #
+  - pcap-log:
+      enabled:  no
+      filename: log.pcap
+
+      # File size limit.  Can be specified in kb, mb, gb.  Just a number
+      # is parsed as bytes.
+      limit: 1000mb
+
+      # If set to a value will enable ring buffer mode. Will keep Maximum of "max-files" of size "limit"
+      max-files: 2000
+
+      mode: normal # normal, multi or sguil.
+      #sguil-base-dir: /nsm_data/
+      #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
+      use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
+      honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stopped being logged.
+
+  # a full alerts log containing much information for signature writers
+  # or for investigating suspected false positives.
+  - alert-debug:
+      enabled: no
+      filename: alert-debug.log
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+  # alert output to prelude (http://www.prelude-technologies.com/) only
+  # available if Suricata has been compiled with --enable-prelude
+  - alert-prelude:
+      enabled: no
+      profile: suricata
+      log-packet-content: no
+      log-packet-header: yes
+
+  # Stats.log contains data from various counters of the suricata engine.
+  - stats:
+      enabled: yes
+      filename: stats.log
+      totals: yes       # stats for all threads merged together
+      threads: no       # per thread stats
+      #null-values: yes  # print counters that have value 0
+
+  # a line based alerts log similar to fast.log into syslog
+  - syslog:
+      enabled: no
+      # reported identity to syslog. If ommited the program name (usually
+      # suricata) will be used.
+      #identity: "suricata"
+      facility: local5
+      #level: Info ## possible levels: Emergency, Alert, Critical,
+                   ## Error, Warning, Notice, Info, Debug
+
+  # a line based information for dropped packets in IPS mode
+  - drop:
+      enabled: no
+      filename: drop.log
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+  # output module to store extracted files to disk
+  #
+  # The files are stored to the log-dir in a format "file.<id>" where <id> is
+  # an incrementing number starting at 1. For each file "file.<id>" a meta
+  # file "file.<id>.meta" is created.
+  #
+  # File extraction depends on a lot of things to be fully done:
+  # - stream reassembly depth. For optimal results, set this to 0 (unlimited)
+  # - http request / response body sizes. Again set to 0 for optimal results.
+  # - rules that contain the "filestore" keyword.
+  - file-store:
+      enabled: no       # set to yes to enable
+      log-dir: files    # directory to store the files
+      force-magic: no   # force logging magic on all stored files
+      force-md5: no     # force logging of md5 checksums
+      force-filestore: no # force storing of all files
+      #waldo: file.waldo # waldo file to store the file_id across runs
+
+  # output module to log files tracked in a easily parsable json format
+  - file-log:
+      enabled: no
+      filename: files-json.log
+      append: yes
+      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
+
+      force-magic: no   # force logging magic on all logged files
+      force-md5: no     # force logging of md5 checksums
+
+  # Log TCP data after stream normalization
+  # 2 types: file or dir. File logs into a single logfile. Dir creates
+  # 2 files per TCP session and stores the raw TCP data into them.
+  # Using 'both' will enable both file and dir modes.
+  #
+  # Note: limited by stream.depth
+  - tcp-data:
+      enabled: no
+      type: file
+      filename: tcp-data.log
+
+  # Log HTTP body data after normalization, dechunking and unzipping.
+  # 2 types: file or dir. File logs into a single logfile. Dir creates
+  # 2 files per HTTP session and stores the normalized data into them.
+  # Using 'both' will enable both file and dir modes.
+  #
+  # Note: limited by the body limit settings
+  - http-body-data:
+      enabled: no
+      type: file
+      filename: http-data.log
+
+  # Lua Output Support - execute lua script to generate alert and event
+  # output.
+  # Documented at:
+  # https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Lua_Output
+  - lua:
+      enabled: no
+      #scripts-dir: /etc/suricata/lua-output/
+      scripts:
+      #   - script1.lua
+
 # Logging configuration.  This is not about logging IDS alerts, but
 # output about what Suricata is doing, like startup messages, errors, etc.
 logging:
@@ -554,11 +877,6 @@ host-mode: auto
 # packet size (MTU + hardware header) on your system.
 #default-packet-size: 1514
 
-# The default logging directory.  Any log or output file will be
-# placed here if its not specified with a full path name.  This can be
-# overridden with the -l command line parameter.
-default-log-dir: @e_logdir@
-
 # Unix command socket can be used to pass commands to suricata.
 # An external tool can then connect to get information from suricata
 # or trigger some modifications of the engine. Set enabled to yes
@@ -567,325 +885,6 @@ default-log-dir: @e_logdir@
 unix-command:
   enabled: no
   #filename: custom.socket
-
-# global stats configuration
-stats:
-  enabled: yes
-  # The interval field (in seconds) controls at what interval
-  # the loggers are invoked.
-  interval: 8
-
-# Configure the type of alert (and other) logging you would like.
-outputs:
-
-  # a line based alerts log similar to Snort's fast.log
-  - fast:
-      enabled: yes
-      filename: fast.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-  # Extensible Event Format (nicknamed EVE) event log in JSON format
-  - eve-log:
-      enabled: yes
-      filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
-      filename: eve.json
-      #prefix: "@cee: " # prefix to prepend to each log entry
-      # the following are valid when type: syslog above
-      #identity: "suricata"
-      #facility: local5
-      #level: Info ## possible levels: Emergency, Alert, Critical,
-                   ## Error, Warning, Notice, Info, Debug
-      #redis:
-      #  server: 127.0.0.1
-      #  port: 6379
-      #  mode: list ## possible values: list (default), channel
-      #  key: suricata ## key or channel to use (default to suricata)
-      # Redis pipelining set up. This will enable to only do a query every
-      # 'batch-size' events. This should lower the latency induced by network
-      # connection at the cost of some memory. There is no flushing implemented
-      # so this setting as to be reserved to high traffic suricata.
-      #  pipelining:
-      #    enabled: yes ## set enable to yes to enable query pipelining
-      #    batch-size: 10 ## number of entry to keep in buffer
-      types:
-        - alert:
-            # payload: yes             # enable dumping payload in Base64
-            # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
-            # payload-printable: yes   # enable dumping payload in printable (lossy) format
-            # packet: yes              # enable dumping of packet (without stream segments)
-            # http: yes                # enable dumping of http fields
-            # tls: yes                 # enable dumping of tls fields
-            # ssh: yes                 # enable dumping of ssh fields
-            # smtp: yes                # enable dumping of smtp fields
-
-            # HTTP X-Forwarded-For support by adding an extra field or overwriting
-            # the source or destination IP address (depending on flow direction)
-            # with the one reported in the X-Forwarded-For HTTP header. This is
-            # helpful when reviewing alerts for traffic that is being reverse
-            # or forward proxied.
-            xff:
-              enabled: no
-              # Two operation modes are available, "extra-data" and "overwrite".
-              mode: extra-data
-              # Two proxy deployments are supported, "reverse" and "forward". In
-              # a "reverse" deployment the IP address used is the last one, in a
-              # "forward" deployment the first IP address is used.
-              deployment: reverse
-              # Header name where the actual IP address will be reported, if more
-              # than one IP address is present, the last IP address will be the
-              # one taken into consideration.
-              header: X-Forwarded-For
-        - http:
-            extended: yes     # enable this for extended logging information
-            # custom allows additional http fields to be included in eve-log
-            # the example below adds three additional fields when uncommented
-            #custom: [Accept-Encoding, Accept-Language, Authorization]
-        - dns
-        - tls:
-            extended: yes     # enable this for extended logging information
-        - files:
-            force-magic: no   # force logging magic on all logged files
-            force-md5: no     # force logging of md5 checksums
-        #- drop:
-        #    alerts: no       # log alerts that caused drops
-        - smtp:
-            #extended: yes # enable this for extended logging information
-            # this includes: bcc, message-id, subject, x_mailer, user-agent
-            # custom fields logging from the list:
-            #  reply-to, bcc, message-id, subject, x-mailer, user-agent, received,
-            #  x-originating-ip, in-reply-to, references, importance, priority,
-            #  sensitivity, organization, content-md5, date
-            #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
-            # output md5 of fields: body, subject
-            # for the body you need to set app-layer.protocols.smtp.mime.body-md5
-            # to yes
-            #md5: [body, subject]
-
-        - ssh
-        - stats:
-            totals: yes       # stats for all threads merged together
-            threads: no       # per thread stats
-            deltas: no        # include delta values
-        # bi-directional flows
-        #- flow
-        # uni-directional flows
-        #- netflow
-
-  # alert output for use with Barnyard2
-  - unified2-alert:
-      enabled: no
-      filename: unified2.alert
-
-      # File size limit.  Can be specified in kb, mb, gb.  Just a number
-      # is parsed as bytes.
-      #limit: 32mb
-
-      # Sensor ID field of unified2 alerts.
-      #sensor-id: 0
-
-      # Include payload of packets related to alerts. Defaults to true, set to
-      # false if payload is not required.
-      #payload: yes
-
-      # HTTP X-Forwarded-For support by adding the unified2 extra header or
-      # overwriting the source or destination IP address (depending on flow
-      # direction) with the one reported in the X-Forwarded-For HTTP header.
-      # This is helpful when reviewing alerts for traffic that is being reverse
-      # or forward proxied.
-      xff:
-        enabled: no
-        # Two operation modes are available, "extra-data" and "overwrite". Note
-        # that in the "overwrite" mode, if the reported IP address in the HTTP
-        # X-Forwarded-For header is of a different version of the packet
-        # received, it will fall-back to "extra-data" mode.
-        mode: extra-data
-        # Two proxy deployments are supported, "reverse" and "forward". In
-        # a "reverse" deployment the IP address used is the last one, in a
-        # "forward" deployment the first IP address is used.
-        deployment: reverse
-        # Header name where the actual IP address will be reported, if more
-        # than one IP address is present, the last IP address will be the
-        # one taken into consideration.
-        header: X-Forwarded-For
-
-  # a line based log of HTTP requests (no alerts)
-  - http-log:
-      enabled: yes
-      filename: http.log
-      append: yes
-      #extended: yes     # enable this for extended logging information
-      #custom: yes       # enabled the custom logging format (defined by customformat)
-      #customformat: "%{%D-%H:%M:%S}t.%z %{X-Forwarded-For}i %H %m %h %u %s %B %a:%p -> %A:%P"
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-  # a line based log of TLS handshake parameters (no alerts)
-  - tls-log:
-      enabled: no  # Log TLS connections.
-      filename: tls.log # File to store TLS logs.
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-      #extended: yes # Log extended information like fingerprint
-
-  # output module to store certificates chain to disk
-  - tls-store:
-      enabled: no
-      #certs-log-dir: certs # directory to store the certificates files
-
-  # a line based log of DNS requests and/or replies (no alerts)
-  - dns-log:
-      enabled: no
-      filename: dns.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-  # Packet log... log packets in pcap format. 3 modes of operation: "normal"
-  # "multi" and "sguil".
-  #
-  # In normal mode a pcap file "filename" is created in the default-log-dir,
-  # or are as specified by "dir".
-  # In multi mode, a file is created per thread. This will perform much
-  # better, but will create multiple files where 'normal' would create one.
-  # In multi mode the filename takes a few special variables:
-  # - %n -- thread number
-  # - %i -- thread id
-  # - %t -- timestamp (secs or secs.usecs based on 'ts-format'
-  # E.g. filename: pcap.%n.%t
-  #
-  # Note that it's possible to use directories, but the directories are not
-  # created by Suricata. E.g. filename: pcaps/%n/log.%s will log into the
-  # per thread directory.
-  #
-  # Also note that the limit and max-files settings are enforced per thread.
-  # So the size limit when using 8 threads with 1000mb files and 2000 files
-  # is: 8*1000*2000 ~ 16TiB.
-  #
-  # In Sguil mode "dir" indicates the base directory. In this base dir the
-  # pcaps are created in th directory structure Sguil expects:
-  #
-  # $sguil-base-dir/YYYY-MM-DD/$filename.<timestamp>
-  #
-  # By default all packets are logged except:
-  # - TCP streams beyond stream.reassembly.depth
-  # - encrypted streams after the key exchange
-  #
-  - pcap-log:
-      enabled:  no
-      filename: log.pcap
-
-      # File size limit.  Can be specified in kb, mb, gb.  Just a number
-      # is parsed as bytes.
-      limit: 1000mb
-
-      # If set to a value will enable ring buffer mode. Will keep Maximum of "max-files" of size "limit"
-      max-files: 2000
-
-      mode: normal # normal, multi or sguil.
-      #sguil-base-dir: /nsm_data/
-      #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
-      use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
-      honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stopped being logged.
-
-  # a full alerts log containing much information for signature writers
-  # or for investigating suspected false positives.
-  - alert-debug:
-      enabled: no
-      filename: alert-debug.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-  # alert output to prelude (http://www.prelude-technologies.com/) only
-  # available if Suricata has been compiled with --enable-prelude
-  - alert-prelude:
-      enabled: no
-      profile: suricata
-      log-packet-content: no
-      log-packet-header: yes
-
-  # Stats.log contains data from various counters of the suricata engine.
-  - stats:
-      enabled: yes
-      filename: stats.log
-      totals: yes       # stats for all threads merged together
-      threads: no       # per thread stats
-      #null-values: yes  # print counters that have value 0
-
-  # a line based alerts log similar to fast.log into syslog
-  - syslog:
-      enabled: no
-      # reported identity to syslog. If ommited the program name (usually
-      # suricata) will be used.
-      #identity: "suricata"
-      facility: local5
-      #level: Info ## possible levels: Emergency, Alert, Critical,
-                   ## Error, Warning, Notice, Info, Debug
-
-  # a line based information for dropped packets in IPS mode
-  - drop:
-      enabled: no
-      filename: drop.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-  # output module to store extracted files to disk
-  #
-  # The files are stored to the log-dir in a format "file.<id>" where <id> is
-  # an incrementing number starting at 1. For each file "file.<id>" a meta
-  # file "file.<id>.meta" is created.
-  #
-  # File extraction depends on a lot of things to be fully done:
-  # - stream reassembly depth. For optimal results, set this to 0 (unlimited)
-  # - http request / response body sizes. Again set to 0 for optimal results.
-  # - rules that contain the "filestore" keyword.
-  - file-store:
-      enabled: no       # set to yes to enable
-      log-dir: files    # directory to store the files
-      force-magic: no   # force logging magic on all stored files
-      force-md5: no     # force logging of md5 checksums
-      force-filestore: no # force storing of all files
-      #waldo: file.waldo # waldo file to store the file_id across runs
-
-  # output module to log files tracked in a easily parsable json format
-  - file-log:
-      enabled: no
-      filename: files-json.log
-      append: yes
-      #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-
-      force-magic: no   # force logging magic on all logged files
-      force-md5: no     # force logging of md5 checksums
-
-  # Log TCP data after stream normalization
-  # 2 types: file or dir. File logs into a single logfile. Dir creates
-  # 2 files per TCP session and stores the raw TCP data into them.
-  # Using 'both' will enable both file and dir modes.
-  #
-  # Note: limited by stream.depth
-  - tcp-data:
-      enabled: no
-      type: file
-      filename: tcp-data.log
-
-  # Log HTTP body data after normalization, dechunking and unzipping.
-  # 2 types: file or dir. File logs into a single logfile. Dir creates
-  # 2 files per HTTP session and stores the normalized data into them.
-  # Using 'both' will enable both file and dir modes.
-  #
-  # Note: limited by the body limit settings
-  - http-body-data:
-      enabled: no
-      type: file
-      filename: http-data.log
-
-  # Lua Output Support - execute lua script to generate alert and event
-  # output.
-  # Documented at:
-  # https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Lua_Output
-  - lua:
-      enabled: no
-      #scripts-dir: /etc/suricata/lua-output/
-      scripts:
-      #   - script1.lua
 
 # Magic file. The extension .mgc is added to the value here.
 #magic-file: /usr/share/file/magic

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -5,6 +5,42 @@
 # options in this file, full documentation can be found at:
 # https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Suricatayaml
 
+##
+## Step 1: inform Suricata about your network
+##
+
+vars:
+  # more specifc is better for alert accuracy and performance
+  address-groups:
+    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
+    #HOME_NET: "[192.168.0.0/16]"
+    #HOME_NET: "[10.0.0.0/8]"
+    #HOME_NET: "[172.16.0.0/12]"
+    #HOME_NET: "any"
+
+    EXTERNAL_NET: "!$HOME_NET"
+    #EXTERNAL_NET: "any"
+
+    HTTP_SERVERS: "$HOME_NET"
+    SMTP_SERVERS: "$HOME_NET"
+    SQL_SERVERS: "$HOME_NET"
+    DNS_SERVERS: "$HOME_NET"
+    TELNET_SERVERS: "$HOME_NET"
+    AIM_SERVERS: "$EXTERNAL_NET"
+    DNP3_SERVER: "$HOME_NET"
+    DNP3_CLIENT: "$HOME_NET"
+    MODBUS_CLIENT: "$HOME_NET"
+    MODBUS_SERVER: "$HOME_NET"
+    ENIP_CLIENT: "$HOME_NET"
+    ENIP_SERVER: "$HOME_NET"
+
+  port-groups:
+    HTTP_PORTS: "80"
+    SHELLCODE_PORTS: "!80"
+    ORACLE_PORTS: 1521
+    SSH_PORTS: 22
+    DNP3_PORTS: 20000
+    MODBUS_PORTS: 502
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
 # will make sure each CPU will be more easily kept busy, but may negatively 
@@ -1195,57 +1231,6 @@ rule-files:
 
 classification-file: @e_sysconfdir@classification.config
 reference-config-file: @e_sysconfdir@reference.config
-
-# Holds variables that would be used by the engine.
-vars:
-
-  # Holds the address group vars that would be passed in a Signature.
-  # These would be retrieved during the Signature address parsing stage.
-  address-groups:
-
-    HOME_NET: "[192.168.0.0/16,10.0.0.0/8,172.16.0.0/12]"
-
-    EXTERNAL_NET: "!$HOME_NET"
-
-    HTTP_SERVERS: "$HOME_NET"
-
-    SMTP_SERVERS: "$HOME_NET"
-
-    SQL_SERVERS: "$HOME_NET"
-
-    DNS_SERVERS: "$HOME_NET"
-
-    TELNET_SERVERS: "$HOME_NET"
-
-    AIM_SERVERS: "$EXTERNAL_NET"
-
-    DNP3_SERVER: "$HOME_NET"
-
-    DNP3_CLIENT: "$HOME_NET"
-
-    MODBUS_CLIENT: "$HOME_NET"
-
-    MODBUS_SERVER: "$HOME_NET"
-
-    ENIP_CLIENT: "$HOME_NET"
-
-    ENIP_SERVER: "$HOME_NET"
-
-  # Holds the port group vars that would be passed in a Signature.
-  # These would be retrieved during the Signature port parsing stage.
-  port-groups:
-
-    HTTP_PORTS: "80"
-
-    SHELLCODE_PORTS: "!80"
-
-    ORACLE_PORTS: 1521
-
-    SSH_PORTS: 22
-
-    DNP3_PORTS: 20000
-
-    MODBUS_PORTS: 502
 
 # Set the order of alerts bassed on actions
 # The default order is pass, drop, reject, alert

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -159,10 +159,10 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            # http: yes                # enable dumping of http fields
-            # tls: yes                 # enable dumping of tls fields
-            # ssh: yes                 # enable dumping of ssh fields
-            # smtp: yes                # enable dumping of smtp fields
+            http: yes                # enable dumping of http fields
+            tls: yes                 # enable dumping of tls fields
+            ssh: yes                 # enable dumping of ssh fields
+            smtp: yes                # enable dumping of smtp fields
 
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)
@@ -315,7 +315,7 @@ outputs:
   # - encrypted streams after the key exchange
   #
   - pcap-log:
-      enabled:  no
+      enabled: no
       filename: log.pcap
 
       # File size limit.  Can be specified in kb, mb, gb.  Just a number
@@ -432,7 +432,7 @@ outputs:
       scripts:
       #   - script1.lua
 
-# Logging configuration.  This is not about logging IDS alerts, but
+# Logging configuration.  This is not about logging IDS alerts/events, but
 # output about what Suricata is doing, like startup messages, errors, etc.
 logging:
   # The default log level, can be overridden in an output section.
@@ -481,7 +481,7 @@ af-packet:
   - interface: eth0
     # Number of receive threads. "auto" uses the number of cores
     #threads: auto
-    # Default clusterid.  AF_PACKET will load balance packets based on flow.
+    # Default clusterid. AF_PACKET will load balance packets based on flow.
     cluster-id: 99
     # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
     # This is only supported for Linux kernel > 3.1
@@ -600,6 +600,9 @@ pcap-file:
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
   checksum-checks: auto
+
+# See "Advanced Capture Options" below for more options, including NETMAP
+# and PF_RING.
 
 
 ##
@@ -935,7 +938,7 @@ pcre:
 ##
 
 # Host specific policies for defragmentation and TCP stream
-# reassembly.  The host OS lookup is done using a radix tree, just
+# reassembly. The host OS lookup is done using a radix tree, just
 # like a routing table so the most specific entry matches.
 host-os-policy:
   # Make the default policy windows.
@@ -943,9 +946,9 @@ host-os-policy:
   bsd: []
   bsd-right: []
   old-linux: []
-  linux: [10.0.0.0/8, 192.168.1.100, "8762:2352:6241:7245:E000:0000:0000:0000"]
+  linux: []
   old-solaris: []
-  solaris: ["::1"]
+  solaris: []
   hpux10: []
   hpux11: []
   irix: []
@@ -998,7 +1001,7 @@ defrag:
 # in bytes.
 
 flow:
-  memcap: 64mb
+  memcap: 128mb
   hash-size: 65536
   prealloc: 10000
   emergency-recovery: 30
@@ -1039,11 +1042,11 @@ flow-timeouts:
     emergency-closed: 0
   tcp:
     new: 60
-    established: 3600
-    closed: 120
-    emergency-new: 10
-    emergency-established: 300
-    emergency-closed: 20
+    established: 600
+    closed: 60
+    emergency-new: 5
+    emergency-established: 100
+    emergency-closed: 10
   udp:
     new: 30
     established: 300
@@ -1115,11 +1118,11 @@ flow-timeouts:
 #                               # on directly.
 #
 stream:
-  memcap: 32mb
+  memcap: 64mb
   checksum-validation: yes      # reject wrong csums
   inline: auto                  # auto will use inline mode in IPS mode, yes or no set it statically
   reassembly:
-    memcap: 128mb
+    memcap: 256mb
     depth: 1mb                  # reassemble 1mb into a stream
     toserver-chunk-size: 2560
     toclient-chunk-size: 2560
@@ -1153,7 +1156,7 @@ stream:
 host:
   hash-size: 4096
   prealloc: 1000
-  memcap: 16777216
+  memcap: 32mb
 
 # IP Pair table:
 #
@@ -1162,7 +1165,8 @@ host:
 #ippair:
 #  hash-size: 4096
 #  prealloc: 1000
-#  memcap: 16777216
+#  memcap: 32mb
+
 
 ##
 ## Performance tuning and profiling
@@ -1610,6 +1614,9 @@ cuda:
     # For this option you need a device with Compute Capability > 1.0.
     cuda-streams: 2
 
+##
+## Include other configs
+##
 
 # Includes.  Files included here will be handled as if they were
 # inlined in this configuration file.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -146,6 +146,134 @@ logging:
       format: "[%i] <%d> -- "
       # type: json
 
+##
+## Step 4: configure capture settings
+##
+
+# af-packet support
+af-packet:
+  - interface: eth0
+    # Number of receive threads. "auto" uses the number of cores
+    #threads: auto
+    # Default clusterid.  AF_PACKET will load balance packets based on flow.
+    cluster-id: 99
+    # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
+    # This is only supported for Linux kernel > 3.1
+    # possible value are:
+    #  * cluster_round_robin: round robin load balancing
+    #  * cluster_flow: all packets of a given flow are send to the same socket
+    #  * cluster_cpu: all packets treated in kernel by a CPU are send to the same socket
+    #  * cluster_qm: all packets linked by network card to a RSS queue are sent to the same
+    #  socket. Requires at least Linux 3.14.
+    #  * cluster_random: packets are sent randomly to sockets but with an equipartition.
+    #  Requires at least Linux 3.14.
+    #  * cluster_rollover: kernel rotates between sockets filling each socket before moving
+    #  to the next. Requires at least Linux 3.10.
+    # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
+    # with capture card using RSS (require cpu affinity tuning and system irq tuning)
+    cluster-type: cluster_flow
+    # In some fragmentation case, the hash can not be computed. If "defrag" is set
+    # to yes, the kernel will do the needed defragmentation before sending the packets.
+    defrag: yes
+    # After Linux kernel 3.10 it is possible to activate the rollover option: if a socket is
+    # full then kernel will send the packet on the next socket with room available. This option
+    # can minimize packet drop and increase the treated bandwidth on single intensive flow.
+    #rollover: yes
+    # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
+    #use-mmap: yes
+    # Lock memory map to avoid it goes to swap. Be careful that over suscribing could lock
+    # your system
+    #mmap-locked: yes
+    # Use tpacket_v3, capture mode, only active if user-mmap is true
+    tpacket-v3: yes
+    # Ring size will be computed with respect to max_pending_packets and number
+    # of threads. You can set manually the ring size in number of packets by setting
+    # the following value. If you are using flow cluster-type and have really network
+    # intensive single-flow you could want to set the ring-size independently of the number
+    # of threads:
+    #ring-size: 2048
+    # Block size is used by tpacket_v3 only. It should set to a value high enough to contain
+    # a decent number of packets. Size is in bytes so please consider your MTU. It should be
+    # a power of 2 and it must be multiple of page size (usually 4096).
+    #block-size: 32768
+    # tpacket_v3 block timeout: an open block is passed to userspace if it is not
+    # filled after block-timeout milliseconds.
+    #block-timeout: 10
+    # On busy system, this could help to set it to yes to recover from a packet drop
+    # phase. This will result in some packets (at max a ring flush) being non treated.
+    #use-emergency-flush: yes
+    # recv buffer size, increase value could improve performance
+    # buffer-size: 32768
+    # Set to yes to disable promiscuous mode
+    # disable-promisc: no
+    # Choose checksum verification mode for the interface. At the moment
+    # of the capture, some packets may be with an invalid checksum due to
+    # offloading to the network card of the checksum computation.
+    # Possible values are:
+    #  - kernel: use indication sent by kernel for each packet (default)
+    #  - yes: checksum validation is forced
+    #  - no: checksum validation is disabled
+    #  - auto: suricata uses a statistical approach to detect when
+    #  checksum off-loading is used.
+    # Warning: 'checksum-validation' must be set to yes to have any validation
+    #checksum-checks: kernel
+    # BPF filter to apply to this interface. The pcap filter syntax apply here.
+    #bpf-filter: port 80 or udp
+    # You can use the following variables to activate AF_PACKET tap or IPS mode.
+    # If copy-mode is set to ips or tap, the traffic coming to the current
+    # interface will be copied to the copy-iface interface. If 'tap' is set, the
+    # copy is complete. If 'ips' is set, the packet matching a 'drop' action
+    # will not be copied.
+    #copy-mode: ips
+    #copy-iface: eth1
+
+  # Put default values here. These will be used for an interface that is not
+  # in the list above.
+  - interface: default
+    #threads: auto
+    #use-mmap: no
+    #rollover: yes
+    tpacket-v3: yes
+
+pcap:
+  - interface: eth0
+    # On Linux, pcap will try to use mmaped capture and will use buffer-size
+    # as total of memory used by the ring. So set this to something bigger
+    # than 1% of your bandwidth.
+    #buffer-size: 16777216
+    #bpf-filter: "tcp and port 25"
+    # Choose checksum verification mode for the interface. At the moment
+    # of the capture, some packets may be with an invalid checksum due to
+    # offloading to the network card of the checksum computation.
+    # Possible values are:
+    #  - yes: checksum validation is forced
+    #  - no: checksum validation is disabled
+    #  - auto: suricata uses a statistical approach to detect when
+    #  checksum off-loading is used. (default)
+    # Warning: 'checksum-validation' must be set to yes to have any validation
+    #checksum-checks: auto
+    # With some accelerator cards using a modified libpcap (like myricom), you
+    # may want to have the same number of capture threads as the number of capture
+    # rings. In this case, set up the threads variable to N to start N threads
+    # listening on the same interface.
+    #threads: 16
+    # set to no to disable promiscuous mode:
+    #promisc: no
+    # set snaplen, if not set it defaults to MTU if MTU can be known
+    # via ioctl call and to full capture if not.
+    #snaplen: 1518
+  # Put default values here
+  - interface: default
+    #checksum-checks: auto
+
+pcap-file:
+  # Possible values are:
+  #  - yes: checksum validation is forced
+  #  - no: checksum validation is disabled
+  #  - auto: suricata uses a statistical approach to detect when
+  #  checksum off-loading is used. (default)
+  # Warning: 'checksum-validation' must be set to yes to have checksum tested
+  checksum-checks: auto
 
 
 # Number of packets preallocated per thread. The default is 1024. A higher number 
@@ -577,99 +705,6 @@ nflog:
     qtimeout: 100
     # netlink max buffer size
     max-size: 20000
-
-# af-packet support
-# Set threads to > 1 to use PACKET_FANOUT support
-af-packet:
-  - interface: eth0
-    # Number of receive threads. "auto" uses the number of cores
-    threads: auto
-    # Default clusterid.  AF_PACKET will load balance packets based on flow.
-    # All threads/processes that will participate need to have the same
-    # clusterid.
-    cluster-id: 99
-    # Default AF_PACKET cluster type. AF_PACKET can load balance per flow or per hash.
-    # This is only supported for Linux kernel > 3.1
-    # possible value are:
-    #  * cluster_round_robin: round robin load balancing
-    #  * cluster_flow: all packets of a given flow are send to the same socket
-    #  * cluster_cpu: all packets treated in kernel by a CPU are send to the same socket
-    #  * cluster_qm: all packets linked by network card to a RSS queue are sent to the same
-    #  socket. Requires at least Linux 3.14.
-    #  * cluster_random: packets are sent randomly to sockets but with an equipartition.
-    #  Requires at least Linux 3.14.
-    #  * cluster_rollover: kernel rotates between sockets filling each socket before moving
-    #  to the next. Requires at least Linux 3.10.
-    # Recommended modes are cluster_flow on most boxes and cluster_cpu or cluster_qm on system
-    # with capture card using RSS (require cpu affinity tuning and system irq tuning)
-    cluster-type: cluster_flow
-    # In some fragmentation case, the hash can not be computed. If "defrag" is set
-    # to yes, the kernel will do the needed defragmentation before sending the packets.
-    defrag: yes
-    # After Linux kernel 3.10 it is possible to activate the rollover option: if a socket is
-    # full then kernel will send the packet on the next socket with room available. This option
-    # can minimize packet drop and increase the treated bandwidth on single intensive flow.
-    #rollover: yes
-    # To use the ring feature of AF_PACKET, set 'use-mmap' to yes
-    use-mmap: yes
-    # Lock memory map to avoid it goes to swap. Be careful that over suscribing could lock
-    # your system
-    #mmap-locked: yes
-    # Use tpacket_v3, capture mode, only active if user-mmap is true
-    #tpacket-v3: yes
-    # Ring size will be computed with respect to max_pending_packets and number
-    # of threads. You can set manually the ring size in number of packets by setting
-    # the following value. If you are using flow cluster-type and have really network
-    # intensive single-flow you could want to set the ring-size independently of the number
-    # of threads:
-    #ring-size: 2048
-    # Block size is used by tpacket_v3 only. It should set to a value high enough to contain
-    # a decent number of packets. Size is in bytes so please consider your MTU. It should be
-    # a power of 2 and it must be multiple of page size (usually 4096).
-    #block-size: 32768
-    # tpacket_v3 block timeout: an open block is passed to userspace if it is not
-    # filled after block-timeout milliseconds.
-    #block-timeout: 10
-    # On busy system, this could help to set it to yes to recover from a packet drop
-    # phase. This will result in some packets (at max a ring flush) being non treated.
-    #use-emergency-flush: yes
-    # recv buffer size, increase value could improve performance
-    # buffer-size: 32768
-    # Set to yes to disable promiscuous mode
-    # disable-promisc: no
-    # Choose checksum verification mode for the interface. At the moment
-    # of the capture, some packets may be with an invalid checksum due to
-    # offloading to the network card of the checksum computation.
-    # Possible values are:
-    #  - kernel: use indication sent by kernel for each packet (default)
-    #  - yes: checksum validation is forced
-    #  - no: checksum validation is disabled
-    #  - auto: suricata uses a statistical approach to detect when
-    #  checksum off-loading is used.
-    # Warning: 'checksum-validation' must be set to yes to have any validation
-    #checksum-checks: kernel
-    # BPF filter to apply to this interface. The pcap filter syntax apply here.
-    #bpf-filter: port 80 or udp
-    # You can use the following variables to activate AF_PACKET tap or IPS mode.
-    # If copy-mode is set to ips or tap, the traffic coming to the current
-    # interface will be copied to the copy-iface interface. If 'tap' is set, the
-    # copy is complete. If 'ips' is set, the packet matching a 'drop' action
-    # will not be copied.
-    #copy-mode: ips
-    #copy-iface: eth1
-  - interface: eth1
-    threads: auto
-    cluster-id: 98
-    cluster-type: cluster_flow
-    defrag: yes
-    # buffer-size: 32768
-    # disable-promisc: no
-  # Put default values here
-  - interface: default
-    #threads: auto
-    #use-mmap: no
-    #rollover: yes
-    tpacket-v3: yes
 
 # Netmap support
 #
@@ -1169,46 +1204,6 @@ pfring:
   # Put default values here
   - interface: default
     #threads: 2
-
-pcap:
-  - interface: eth0
-    # On Linux, pcap will try to use mmaped capture and will use buffer-size
-    # as total of memory used by the ring. So set this to something bigger
-    # than 1% of your bandwidth.
-    #buffer-size: 16777216
-    #bpf-filter: "tcp and port 25"
-    # Choose checksum verification mode for the interface. At the moment
-    # of the capture, some packets may be with an invalid checksum due to
-    # offloading to the network card of the checksum computation.
-    # Possible values are:
-    #  - yes: checksum validation is forced
-    #  - no: checksum validation is disabled
-    #  - auto: suricata uses a statistical approach to detect when
-    #  checksum off-loading is used. (default)
-    # Warning: 'checksum-validation' must be set to yes to have any validation
-    #checksum-checks: auto
-    # With some accelerator cards using a modified libpcap (like myricom), you
-    # may want to have the same number of capture threads as the number of capture
-    # rings. In this case, set up the threads variable to N to start N threads
-    # listening on the same interface.
-    #threads: 16
-    # set to no to disable promiscuous mode:
-    #promisc: no
-    # set snaplen, if not set it defaults to MTU if MTU can be known
-    # via ioctl call and to full capture if not.
-    #snaplen: 1518
-  # Put default values here
-  - interface: default
-    #checksum-checks: auto
-
-pcap-file:
-  # Possible values are:
-  #  - yes: checksum validation is forced
-  #  - no: checksum validation is disabled
-  #  - auto: suricata uses a statistical approach to detect when
-  #  checksum off-loading is used. (default)
-  # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"


### PR DESCRIPTION
Addresses @jasonish 's comments from #2120, so:
- move classification and friends below the rules list
- add comments on addition capture methods
- disable http.log by default

Additional changes:
- enabled eve-log only if libjansson support enabled
- enable flow records in eve by default
- fix a memory leak when 'file logging' fails to open the file

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/438
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/443

Tickets:
https://redmine.openinfosecfoundation.org/issues/1344 https://redmine.openinfosecfoundation.org/issues/1343