### PR TITLE
Unix socket auto

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -244,10 +244,7 @@ static void StatsInitCtx(void)
 
         /* if the unix command socket is enabled we do the background
          * stats sync just in case someone runs 'dump-counters' */
-        int unix_socket = 0;
-        if (ConfGetBool("unix-command.enabled", &unix_socket) != 1)
-            unix_socket = 0;
-        if (unix_socket == 0) {
+        if (!ConfUnixSocketIsEnable()) {
             SCLogWarning(SC_WARN_NO_STATS_LOGGERS, "stats are enabled but no loggers are active");
             stats_enabled = FALSE;
             SCReturn;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -2081,8 +2081,7 @@ int DetectEngineMultiTenantSetup(void)
     enum DetectEngineTenantSelectors tenant_selector = TENANT_SELECTOR_UNKNOWN;
     DetectEngineMasterCtx *master = &g_master_de_ctx;
 
-    int unix_socket = 0;
-    (void)ConfGetBool("unix-command.enabled", &unix_socket);
+    int unix_socket = ConfUnixSocketIsEnable();
 
     int failure_fatal = 0;
     (void)ConfGetBool("engine.init-failure-fatal", &failure_fatal);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2548,9 +2548,7 @@ int main(int argc, char **argv)
     /* In Unix socket runmode, Flow manager is started on demand */
     if (suri.run_mode != RUNMODE_UNIX_SOCKET) {
         /* Spawn the unix socket manager thread */
-        int unix_socket = 0;
-        if (ConfGetBool("unix-command.enabled", &unix_socket) != 1)
-            unix_socket = 0;
+        int unix_socket = ConfUnixSocketIsEnable();
         if (unix_socket == 1) {
             UnixManagerThreadSpawn(0);
 #ifdef BUILD_UNIX_SOCKET

--- a/src/util-conf.c
+++ b/src/util-conf.c
@@ -91,3 +91,31 @@ ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface)
 
     return NULL;
 }
+
+int ConfUnixSocketIsEnable(void)
+{
+    char *value;
+
+    if (ConfGet("unix-command.enabled", &value) != 1) {
+        return 0;
+    }
+
+    if (!strcmp(value, "auto")) {
+#ifdef HAVE_LIBJANSSON
+#ifdef OS_WIN32   
+        return 0;
+#else
+        if (TimeModeIsLive()) {
+            SCLogInfo("Running in live mode, activating unix socket");
+            return 1;
+        } else {
+            return 0;
+        }
+#endif
+#else
+        return 0;
+#endif
+    }
+
+    return ConfValIsTrue(value);
+}

--- a/src/util-conf.h
+++ b/src/util-conf.h
@@ -33,4 +33,6 @@ TmEcode ConfigCheckLogDirectory(char *log_dir);
 
 ConfNode *ConfFindDeviceConfig(ConfNode *node, const char *iface);
 
+int ConfUnixSocketIsEnable(void);
+
 #endif /* __UTIL_UTIL_CONF_H__ */

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -90,6 +90,11 @@ void TimeModeSetOffline (void)
     SCLogDebug("offline time mode enabled");
 }
 
+int TimeModeIsLive(void)
+{
+    return live;
+}
+
 void TimeSetByThread(const int thread_id, const struct timeval *tv)
 {
     if (live == TRUE)

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -48,6 +48,7 @@ void TimeSetIncrementTime(uint32_t);
 
 void TimeModeSetLive(void);
 void TimeModeSetOffline (void);
+int TimeModeIsLive(void);
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
 void CreateTimeString (const struct timeval *ts, char *str, size_t size);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -892,10 +892,11 @@ host-mode: auto
 # Unix command socket can be used to pass commands to suricata.
 # An external tool can then connect to get information from suricata
 # or trigger some modifications of the engine. Set enabled to yes
-# to activate the feature. You can use the filename variable to set
+# to activate the feature. In auto mode, the feature will only be
+# activated in live capture mode. You can use the filename variable to set
 # the file name of the socket.
 unix-command:
-  enabled: no
+  enabled: auto
   #filename: custom.socket
 
 # Magic file. The extension .mgc is added to the value here.


### PR DESCRIPTION
Implement 'auto' value for unix socket command configuration to have it activated when running in live mode.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/180
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/176