### PR TITLE
util-ioctcl: increase header size

### DIFF
--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -61,13 +61,16 @@ int GetIfaceMaxHWHeaderLength(const char *pcap_dev)
             ||
             (!strcmp("tap", pcap_dev))
             ||
-            (!strcmp("lo", pcap_dev)))
-        return ETHERNET_HEADER_LEN;
+            (!strcmp("lo", pcap_dev))) {
+        /* Add possible VLAN tag or Qing headers */       
+        return 8 + ETHERNET_HEADER_LEN;
+    }
 
     if (!strcmp("ppp", pcap_dev))
         return SLL_HEADER_LEN;
-    /* SLL_HEADER_LEN is the biggest one */
-    return SLL_HEADER_LEN;
+    /* SLL_HEADER_LEN is the biggest one and
+       add possible VLAN tag and Qing headers */       
+    return 8 + SLL_HEADER_LEN;
 }
 
 /**


### PR DESCRIPTION
Headers can contain VLAN or Qing so we need to increase the value
returned by GetIfaceMaxHWHeaderLength.

Redmine ticket: https://redmine.openinfosecfoundation.org/issues/1665

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/181
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/177