### PR TITLE
detect-filemagic: fix heap-user-after-free

### DIFF
--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -374,8 +374,10 @@ static int DetectFilemagicSetup (DetectEngineCtx *de_ctx, Signature *s, char *st
 error:
     if (filemagic != NULL)
         DetectFilemagicFree(filemagic);
-    if (sm != NULL)
+    if (sm != NULL) {
+        SigMatchRemoveSMFromList(s, sm, DETECT_SM_LIST_FILEMATCH);
         SCFree(sm);
+    }
     return -1;
 }
 


### PR DESCRIPTION
With one wrong filemagic rule there will be a heap-user-after-free since
the signaturmatch (sm) got added to the signature list (s) but gets
freed in error case but not removed from the list before (s) is freed as
well. So just remove (sm) again in error case.

This fixes https://redmine.openinfosecfoundation.org/issues/1584

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/22
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/22