### PR TITLE
suricata: fix double packet processing threads

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2533,10 +2533,6 @@ int main(int argc, char **argv)
         StatsSetupPostConfig();
     }
 
-    if (ParseInterfacesList(suri.run_mode, suri.pcap_dev) != TM_ECODE_OK) {
-        exit(EXIT_FAILURE);
-    }
-
     if (suri.run_mode == RUNMODE_CONF_TEST){
         SCLogNotice("Configuration provided was successfully loaded. Exiting.");
         MagicDeinit();


### PR DESCRIPTION
With the additional ParseInterfacesList the packet processing threads
were doubled since the Interface was included twice unless the device
was passed via the commandline with af-packet=IF.
The additonal ParseInterfacesList isn't necessary so remove it again.

This fixes https://redmine.openinfosecfoundation.org/issues/1768

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/23
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/23