### PR TITLE
[preview] output cleanup v4

### DIFF
--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -233,7 +233,7 @@ void AlertFastLogExitPrintStats(ThreadVars *tv, void *data)
         return;
     }
 
-    SCLogInfo("Fast log output wrote %" PRIu64 " alerts", aft->file_ctx->alerts);
+    //SCLogInfo("Fast log output wrote %" PRIu64 " alerts", aft->file_ctx->alerts);
 }
 
 /**

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -1211,8 +1211,8 @@ TmEcode Unified2AlertThreadDeinit(ThreadVars *t, void *data)
     }
 
     if (!(aun->unified2alert_ctx->file_ctx->flags & LOGFILE_ALERTS_PRINTED)) {
-        SCLogInfo("Alert unified2 module wrote %"PRIu64" alerts",
-                aun->unified2alert_ctx->file_ctx->alerts);
+        //SCLogInfo("Alert unified2 module wrote %"PRIu64" alerts",
+        //        aun->unified2alert_ctx->file_ctx->alerts);
 
         /* Do not print it for each thread */
         aun->unified2alert_ctx->file_ctx->flags |= LOGFILE_ALERTS_PRINTED;

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -336,7 +336,7 @@ static void DNSUDPConfigure(void)
             request_flood = value;
         }
     }
-    SCLogInfo("DNS request flood protection level: %u", request_flood);
+    SCLogConfig("DNS request flood protection level: %u", request_flood);
     DNSConfigSetRequestFlood(request_flood);
 
     p = ConfGetNode("app-layer.protocols.dns.state-memcap");
@@ -348,7 +348,7 @@ static void DNSUDPConfigure(void)
             state_memcap = value;
         }
     }
-    SCLogInfo("DNS per flow memcap (state-memcap): %u", state_memcap);
+    SCLogConfig("DNS per flow memcap (state-memcap): %u", state_memcap);
     DNSConfigSetStateMemcap(state_memcap);
 
     p = ConfGetNode("app-layer.protocols.dns.global-memcap");
@@ -360,7 +360,7 @@ static void DNSUDPConfigure(void)
             global_memcap = value;
         }
     }
-    SCLogInfo("DNS global memcap: %"PRIu64, global_memcap);
+    SCLogConfig("DNS global memcap: %"PRIu64, global_memcap);
     DNSConfigSetGlobalMemcap(global_memcap);
 }
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2184,7 +2184,7 @@ static void HTPConfigSetDefaultsPhase2(char *name, HTPCfgRec *cfg_prec)
         cfg_prec->request.inspect_window +=
             (int) (cfg_prec->request.inspect_window *
                    (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
-        SCLogInfo("'%s' server has 'request-body-minimal-inspect-size' set to"
+        SCLogConfig("'%s' server has 'request-body-minimal-inspect-size' set to"
                   " %d and 'request-body-inspect-window' set to %d after"
                   " randomization.",
                   name,
@@ -2199,7 +2199,7 @@ static void HTPConfigSetDefaultsPhase2(char *name, HTPCfgRec *cfg_prec)
             (int) (cfg_prec->response.inspect_window *
                    (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
 
-        SCLogInfo("'%s' server has 'response-body-minimal-inspect-size' set to"
+        SCLogConfig("'%s' server has 'response-body-minimal-inspect-size' set to"
                   " %d and 'response-body-inspect-window' set to %d after"
                   " randomization.",
                   name,
@@ -2546,7 +2546,7 @@ void AppLayerHtpPrintStats(void)
 {
 #ifdef DEBUG
     SCMutexLock(&htp_state_mem_lock);
-    SCLogInfo("htp memory %"PRIu64" (%"PRIu64")", htp_state_memuse, htp_state_memcnt);
+    SCLogPerf("htp memory %"PRIu64" (%"PRIu64")", htp_state_memuse, htp_state_memcnt);
     SCMutexUnlock(&htp_state_mem_lock);
 #endif
 }

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1472,10 +1472,10 @@ void RegisterModbusParsers(void)
                 request_flood = value;
             }
         }
-        SCLogInfo("Modbus request flood protection level: %u", request_flood);
+        SCLogConfig("Modbus request flood protection level: %u", request_flood);
     } else {
 #ifndef AFLFUZZ_APPLAYER
-        SCLogInfo("Protocol detection and parser disabled for %s protocol.", proto_name);
+        SCLogConfig("Protocol detection and parser disabled for %s protocol.", proto_name);
         return;
 #endif
     }
@@ -1507,7 +1507,7 @@ void RegisterModbusParsers(void)
 
         AppLayerParserRegisterParserAcceptableDataDirection(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER);
     } else {
-        SCLogInfo("Parsed disabled for %s protocol. Protocol detection" "still on.", proto_name);
+        SCLogConfig("Parsed disabled for %s protocol. Protocol detection" "still on.", proto_name);
     }
 #ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_MODBUS, ModbusParserRegisterTests);

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -204,7 +204,7 @@ void DefragInitConfig(char quiet)
     (void) SC_ATOMIC_ADD(defrag_memuse, (defrag_config.hash_size * sizeof(DefragTrackerHashRow)));
 
     if (quiet == FALSE) {
-        SCLogInfo("allocated %llu bytes of memory for the defrag hash... "
+        SCLogConfig("allocated %llu bytes of memory for the defrag hash... "
                   "%" PRIu32 " buckets of size %" PRIuMAX "",
                   SC_ATOMIC_GET(defrag_memuse), defrag_config.hash_size,
                   (uintmax_t)sizeof(DefragTrackerHashRow));
@@ -231,14 +231,14 @@ void DefragInitConfig(char quiet)
                 DefragTrackerEnqueue(&defragtracker_spare_q,h);
             }
             if (quiet == FALSE) {
-                SCLogInfo("preallocated %" PRIu32 " defrag trackers of size %" PRIuMAX "",
+                SCLogConfig("preallocated %" PRIu32 " defrag trackers of size %" PRIuMAX "",
                         defragtracker_spare_q.len, (uintmax_t)sizeof(DefragTracker));
             }
         }
     }
 
     if (quiet == FALSE) {
-        SCLogInfo("defrag memory usage: %llu bytes, maximum: %"PRIu64,
+        SCLogConfig("defrag memory usage: %llu bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(defrag_memuse), defrag_config.memcap);
     }
 

--- a/src/detect-engine-mpm.c
+++ b/src/detect-engine-mpm.c
@@ -130,12 +130,12 @@ void DetectMpmInitializeAppMpms(DetectEngineCtx *de_ctx)
 
         if (shared == 0) {
             if (!(de_ctx->flags & DE_QUIET)) {
-                SCLogInfo("using unique mpm ctx' for %s", am->name);
+                SCLogPerf("using unique mpm ctx' for %s", am->name);
             }
             am->sgh_mpm_context = MPM_CTX_FACTORY_UNIQUE_CONTEXT;
         } else {
             if (!(de_ctx->flags & DE_QUIET)) {
-                SCLogInfo("using shared mpm ctx' for %s", am->name);
+                SCLogPerf("using shared mpm ctx' for %s", am->name);
             }
             am->sgh_mpm_context = MpmFactoryRegisterMpmCtxProfile(de_ctx, am->name);
         }
@@ -184,10 +184,10 @@ static int32_t SetupBuiltinMpm(DetectEngineCtx *de_ctx, const char *name)
     int32_t ctx;
     if (shared == 0) {
         ctx = MPM_CTX_FACTORY_UNIQUE_CONTEXT;
-        SCLogInfo("using unique mpm ctx' for %s", name);
+        SCLogPerf("using unique mpm ctx' for %s", name);
     } else {
         ctx = MpmFactoryRegisterMpmCtxProfile(de_ctx, name);
-        SCLogInfo("using shared mpm ctx' for %s", name);
+        SCLogPerf("using shared mpm ctx' for %s", name);
     }
     return ctx;
 }
@@ -839,14 +839,14 @@ void MpmStoreReportStats(const DetectEngineCtx *de_ctx)
     if (!(de_ctx->flags & DE_QUIET)) {
         uint32_t x;
         for (x = 0; x < MPMB_MAX; x++) {
-            SCLogInfo("Builtin MPM \"%s\": %u", builtin_mpms[x], stats[x]);
+            SCLogPerf("Builtin MPM \"%s\": %u", builtin_mpms[x], stats[x]);
         }
         for (x = 0; x < APP_MPMS_MAX; x++) {
             if (appstats[x] == 0)
                 continue;
             const char *name = app_mpms[x].name;
             char *direction = app_mpms[x].direction == SIG_FLAG_TOSERVER ? "toserver" : "toclient";
-            SCLogInfo("AppLayer MPM \"%s %s\": %u", direction, name, appstats[x]);
+            SCLogPerf("AppLayer MPM \"%s %s\": %u", direction, name, appstats[x]);
         }
     }
 }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -840,7 +840,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
 
     de_ctx->mpm_matcher = PatternMatchDefaultMatcher();
     de_ctx->spm_matcher = SinglePatternMatchDefaultMatcher();
-    SCLogInfo("pattern matchers: MPM: %s, SPM: %s",
+    SCLogConfig("pattern matchers: MPM: %s, SPM: %s",
         mpm_table[de_ctx->mpm_matcher].name,
         spm_table[de_ctx->spm_matcher].name);
 
@@ -1211,10 +1211,10 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
     char *ports = NULL;
     (void)ConfGet("detect.grouping.tcp-whitelist", &ports);
     if (ports) {
-        SCLogInfo("grouping: tcp-whitelist %s", ports);
+        SCLogConfig("grouping: tcp-whitelist %s", ports);
     } else {
         ports = "53, 80, 139, 443, 445, 1433, 3306, 3389, 6666, 6667, 8080";
-        SCLogInfo("grouping: tcp-whitelist (default) %s", ports);
+        SCLogConfig("grouping: tcp-whitelist (default) %s", ports);
 
     }
     if (DetectPortParse(de_ctx, &de_ctx->tcp_whitelist, ports) != 0) {
@@ -1235,10 +1235,10 @@ static int DetectEngineCtxLoadConf(DetectEngineCtx *de_ctx)
     ports = NULL;
     (void)ConfGet("detect.grouping.udp-whitelist", &ports);
     if (ports) {
-        SCLogInfo("grouping: udp-whitelist %s", ports);
+        SCLogConfig("grouping: udp-whitelist %s", ports);
     } else {
         ports = "53, 135, 5060";
-        SCLogInfo("grouping: udp-whitelist (default) %s", ports);
+        SCLogConfig("grouping: udp-whitelist (default) %s", ports);
 
     }
     if (DetectPortParse(de_ctx, &de_ctx->udp_whitelist, ports) != 0) {

--- a/src/detect.c
+++ b/src/detect.c
@@ -3236,7 +3236,8 @@ int RulesGroupByProto(DetectEngineCtx *de_ctx)
             ref++;
         }
     }
-    SCLogInfo("OTHER %s: %u proto groups, %u unique SGH's, %u copies", "toserver", cnt, own, ref);
+    SCLogPerf("OTHER %s: %u proto groups, %u unique SGH's, %u copies",
+            "toserver", cnt, own, ref);
 
     cnt = 0;
     own = 0;
@@ -3272,7 +3273,8 @@ int RulesGroupByProto(DetectEngineCtx *de_ctx)
             ref++;
         }
     }
-    SCLogInfo("OTHER %s: %u proto groups, %u unique SGH's, %u copies", "toclient", cnt, own, ref);
+    SCLogPerf("OTHER %s: %u proto groups, %u unique SGH's, %u copies",
+            "toclient", cnt, own, ref);
 
     for (p = 0; p < 256; p++) {
         if (p == IPPROTO_TCP || p == IPPROTO_UDP)
@@ -3486,7 +3488,7 @@ static DetectPort *RulesGroupByPorts(DetectEngineCtx *de_ctx, int ipproto, uint3
                 iter->sh->init->whitelist);
     }
 #endif
-    SCLogInfo("%s %s: %u port groups, %u unique SGH's, %u copies",
+    SCLogPerf("%s %s: %u port groups, %u unique SGH's, %u copies",
             ipproto == 6 ? "TCP" : "UDP",
             direction == SIG_FLAG_TOSERVER ? "toserver" : "toclient",
             cnt, own, ref);
@@ -3614,7 +3616,7 @@ int SigAddressPrepareStage1(DetectEngineCtx *de_ctx)
                 de_ctx->sig_cnt, cnt_iponly, cnt_payload, cnt_applayer,
                 cnt_deonly);
 
-        SCLogInfo("building signature grouping structure, stage 1: "
+        SCLogConfig("building signature grouping structure, stage 1: "
                "preprocessing rules... complete");
     }
     return 0;
@@ -4002,7 +4004,7 @@ int SigAddressPrepareStage4(DetectEngineCtx *de_ctx)
         sgh->id = idx;
         cnt++;
     }
-    SCLogInfo("Unique rule groups: %u", cnt);
+    SCLogPerf("Unique rule groups: %u", cnt);
 
     MpmStoreReportStats(de_ctx);
 

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -688,7 +688,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         StatsSyncCountersIfSignalled(th_v);
     }
 
-    SCLogInfo("%" PRIu32 " new flows, %" PRIu32 " established flows were "
+    SCLogPerf("%" PRIu32 " new flows, %" PRIu32 " established flows were "
               "timed out, %"PRIu32" flows in closed state", new_cnt,
               established_cnt, closing_cnt);
 
@@ -717,7 +717,7 @@ void FlowManagerThreadSpawn()
     }
     flowmgr_number = (uint32_t)setting;
 
-    SCLogInfo("using %u flow manager threads", flowmgr_number);
+    SCLogConfig("using %u flow manager threads", flowmgr_number);
     SCCtrlCondInit(&flow_manager_ctrl_cond, NULL);
     SCCtrlMutexInit(&flow_manager_ctrl_mutex, NULL);
 
@@ -850,7 +850,7 @@ static TmEcode FlowRecycler(ThreadVars *th_v, void *thread_data)
         StatsSyncCountersIfSignalled(th_v);
     }
 
-    SCLogInfo("%"PRIu64" flows processed", recycled_cnt);
+    SCLogPerf("%"PRIu64" flows processed", recycled_cnt);
 
     return TM_ECODE_OK;
 }
@@ -881,7 +881,7 @@ void FlowRecyclerThreadSpawn()
     }
     flowrec_number = (uint32_t)setting;
 
-    SCLogInfo("using %u flow recycler threads", flowrec_number);
+    SCLogConfig("using %u flow recycler threads", flowrec_number);
 
     SCCtrlCondInit(&flow_recycler_ctrl_cond, NULL);
     SCCtrlMutexInit(&flow_recycler_ctrl_mutex, NULL);

--- a/src/flow.c
+++ b/src/flow.c
@@ -384,7 +384,7 @@ void FlowInitConfig(char quiet)
     (void) SC_ATOMIC_ADD(flow_memuse, (flow_config.hash_size * sizeof(FlowBucket)));
 
     if (quiet == FALSE) {
-        SCLogInfo("allocated %llu bytes of memory for the flow hash... "
+        SCLogConfig("allocated %llu bytes of memory for the flow hash... "
                   "%" PRIu32 " buckets of size %" PRIuMAX "",
                   SC_ATOMIC_GET(flow_memuse), flow_config.hash_size,
                   (uintmax_t)sizeof(FlowBucket));
@@ -410,9 +410,9 @@ void FlowInitConfig(char quiet)
     }
 
     if (quiet == FALSE) {
-        SCLogInfo("preallocated %" PRIu32 " flows of size %" PRIuMAX "",
+        SCLogConfig("preallocated %" PRIu32 " flows of size %" PRIuMAX "",
                 flow_spare_q.len, (uintmax_t)(sizeof(Flow) + + FlowStorageSize()));
-        SCLogInfo("flow memory usage: %llu bytes, maximum: %"PRIu64,
+        SCLogConfig("flow memory usage: %llu bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(flow_memuse), flow_config.memcap);
     }
 

--- a/src/host.c
+++ b/src/host.c
@@ -210,7 +210,7 @@ void HostInitConfig(char quiet)
     (void) SC_ATOMIC_ADD(host_memuse, (host_config.hash_size * sizeof(HostHashRow)));
 
     if (quiet == FALSE) {
-        SCLogInfo("allocated %llu bytes of memory for the host hash... "
+        SCLogConfig("allocated %llu bytes of memory for the host hash... "
                   "%" PRIu32 " buckets of size %" PRIuMAX "",
                   SC_ATOMIC_GET(host_memuse), host_config.hash_size,
                   (uintmax_t)sizeof(HostHashRow));
@@ -235,9 +235,9 @@ void HostInitConfig(char quiet)
     }
 
     if (quiet == FALSE) {
-        SCLogInfo("preallocated %" PRIu32 " hosts of size %" PRIu16 "",
+        SCLogConfig("preallocated %" PRIu32 " hosts of size %" PRIu16 "",
                 host_spare_q.len, g_host_size);
-        SCLogInfo("host memory usage: %llu bytes, maximum: %"PRIu64,
+        SCLogConfig("host memory usage: %llu bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(host_memuse), host_config.memcap);
     }
 
@@ -249,10 +249,10 @@ void HostInitConfig(char quiet)
 void HostPrintStats (void)
 {
 #ifdef HOSTBITS_STATS
-    SCLogInfo("hostbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
+    SCLogPerf("hostbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
         hostbits_added, hostbits_removed, hostbits_memuse_max);
 #endif /* HOSTBITS_STATS */
-    SCLogInfo("host memory usage: %llu bytes, maximum: %"PRIu64,
+    SCLogPerf("host memory usage: %llu bytes, maximum: %"PRIu64,
             SC_ATOMIC_GET(host_memuse), host_config.memcap);
     return;
 }

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -206,7 +206,7 @@ void IPPairInitConfig(char quiet)
     (void) SC_ATOMIC_ADD(ippair_memuse, (ippair_config.hash_size * sizeof(IPPairHashRow)));
 
     if (quiet == FALSE) {
-        SCLogInfo("allocated %llu bytes of memory for the ippair hash... "
+        SCLogConfig("allocated %llu bytes of memory for the ippair hash... "
                   "%" PRIu32 " buckets of size %" PRIuMAX "",
                   SC_ATOMIC_GET(ippair_memuse), ippair_config.hash_size,
                   (uintmax_t)sizeof(IPPairHashRow));
@@ -231,9 +231,9 @@ void IPPairInitConfig(char quiet)
     }
 
     if (quiet == FALSE) {
-        SCLogInfo("preallocated %" PRIu32 " ippairs of size %" PRIu16 "",
+        SCLogConfig("preallocated %" PRIu32 " ippairs of size %" PRIu16 "",
                 ippair_spare_q.len, g_ippair_size);
-        SCLogInfo("ippair memory usage: %llu bytes, maximum: %"PRIu64,
+        SCLogConfig("ippair memory usage: %llu bytes, maximum: %"PRIu64,
                 SC_ATOMIC_GET(ippair_memuse), ippair_config.memcap);
     }
 
@@ -245,10 +245,10 @@ void IPPairInitConfig(char quiet)
 void IPPairPrintStats (void)
 {
 #ifdef IPPAIRBITS_STATS
-    SCLogInfo("ippairbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
+    SCLogPerf("ippairbits added: %" PRIu32 ", removed: %" PRIu32 ", max memory usage: %" PRIu32 "",
         ippairbits_added, ippairbits_removed, ippairbits_memuse_max);
 #endif /* IPPAIRBITS_STATS */
-    SCLogInfo("ippair memory usage: %llu bytes, maximum: %"PRIu64,
+    SCLogPerf("ippair memory usage: %llu bytes, maximum: %"PRIu64,
             SC_ATOMIC_GET(ippair_memuse), ippair_config.memcap);
     return;
 }

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -582,7 +582,7 @@ void LogHttpLogExitPrintStats(ThreadVars *tv, void *data)
         return;
     }
 
-    SCLogInfo("HTTP logger logged %" PRIu32 " requests", aft->uri_cnt);
+    //SCLogInfo("HTTP logger logged %" PRIu32 " requests", aft->uri_cnt);
 }
 
 /** \brief Create a new http log LogFileCtx.

--- a/src/reputation.c
+++ b/src/reputation.c
@@ -617,7 +617,7 @@ int SRepInit(DetectEngineCtx *de_ctx)
     (void)ConfGet("reputation-categories-file", &filename);
     files = ConfGetNode("reputation-files");
     if (filename == NULL && files == NULL) {
-        SCLogInfo("IP reputation disabled");
+        SCLogConfig("IP reputation disabled");
         return 0;
     }
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -152,7 +152,7 @@ void *ParseAFPConfig(const char *iface)
     if (ConfGet("bpf-filter", &bpf_filter) == 1) {
         if (strlen(bpf_filter) > 0) {
             aconf->bpf_filter = bpf_filter;
-            SCLogInfo("Going to use command-line provided bpf filter '%s'",
+            SCLogConfig("Going to use command-line provided bpf filter '%s'",
                        aconf->bpf_filter);
         }
     }
@@ -202,7 +202,7 @@ void *ParseAFPConfig(const char *iface)
         if (boolval) {
             aconf->flags |= AFP_RING_MODE;
         } else {
-            SCLogInfo("Disabling mmaped capture on iface %s",
+            SCLogConfig("Disabling mmaped capture on iface %s",
                     aconf->iface);
             aconf->flags &= ~AFP_RING_MODE;
         }
@@ -214,7 +214,7 @@ void *ParseAFPConfig(const char *iface)
         (void)ConfGetChildValueBoolWithDefault(if_root, if_default,
                                                "mmap-locked", (int *)&boolval);
         if (boolval) {
-            SCLogInfo("Enabling locked memory for mmap on iface %s",
+            SCLogConfig("Enabling locked memory for mmap on iface %s",
                     aconf->iface);
             aconf->flags |= AFP_MMAP_LOCKED;
         }
@@ -223,7 +223,7 @@ void *ParseAFPConfig(const char *iface)
         if (boolval) {
             if (strcasecmp(RunmodeGetActive(), "workers") == 0) {
 #ifdef HAVE_TPACKET_V3
-                SCLogInfo("Enabling tpacket v3 capture on iface %s",
+                SCLogConfig("Enabling tpacket v3 capture on iface %s",
                         aconf->iface);
                 aconf->flags |= AFP_TPACKET_V3;
 #else
@@ -240,7 +240,7 @@ void *ParseAFPConfig(const char *iface)
         (void)ConfGetChildValueBoolWithDefault(if_root, if_default,
                                                "use-emergency-flush", (int *)&boolval);
         if (boolval) {
-            SCLogInfo("Enabling ring emergency flush on iface %s",
+            SCLogConfig("Enabling ring emergency flush on iface %s",
                     aconf->iface);
             aconf->flags |= AFP_EMERGENCY_MODE;
         }
@@ -282,7 +282,7 @@ void *ParseAFPConfig(const char *iface)
         /* default to our safest choice: flow hashing + defrag enabled */
         aconf->cluster_type = PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG;
     } else if (strcmp(tmpctype, "cluster_round_robin") == 0) {
-        SCLogInfo("Using round-robin cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using round-robin cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_LB;
     } else if (strcmp(tmpctype, "cluster_flow") == 0) {
@@ -290,29 +290,29 @@ void *ParseAFPConfig(const char *iface)
          * compute the hash */
         uint16_t defrag = 0;
         int conf_val = 0;
-        SCLogInfo("Using flow cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using flow cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         ConfGetChildValueBoolWithDefault(if_root, if_default, "defrag", &conf_val);
         if (conf_val) {
-            SCLogInfo("Using defrag kernel functionality for AF_PACKET (iface %s)",
+            SCLogConfig("Using defrag kernel functionality for AF_PACKET (iface %s)",
                     aconf->iface);
             defrag = PACKET_FANOUT_FLAG_DEFRAG;
         }
         aconf->cluster_type = PACKET_FANOUT_HASH | defrag;
     } else if (strcmp(tmpctype, "cluster_cpu") == 0) {
-        SCLogInfo("Using cpu cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using cpu cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_CPU;
     } else if (strcmp(tmpctype, "cluster_qm") == 0) {
-        SCLogInfo("Using queue based cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using queue based cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_QM;
     } else if (strcmp(tmpctype, "cluster_random") == 0) {
-        SCLogInfo("Using random based cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using random based cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_RND;
     } else if (strcmp(tmpctype, "cluster_rollover") == 0) {
-        SCLogInfo("Using rollover based cluster mode for AF_PACKET (iface %s)",
+        SCLogConfig("Using rollover based cluster mode for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type = PACKET_FANOUT_ROLLOVER;
 
@@ -323,7 +323,7 @@ void *ParseAFPConfig(const char *iface)
     int conf_val = 0;
     ConfGetChildValueBoolWithDefault(if_root, if_default, "rollover", &conf_val);
     if (conf_val) {
-        SCLogInfo("Using rollover kernel functionality for AF_PACKET (iface %s)",
+        SCLogConfig("Using rollover kernel functionality for AF_PACKET (iface %s)",
                 aconf->iface);
         aconf->cluster_type |= PACKET_FANOUT_FLAG_ROLLOVER;
     }
@@ -334,7 +334,7 @@ void *ParseAFPConfig(const char *iface)
         if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
             if (strlen(bpf_filter) > 0) {
                 aconf->bpf_filter = bpf_filter;
-                SCLogInfo("Going to use bpf filter %s", aconf->bpf_filter);
+                SCLogConfig("Going to use bpf filter %s", aconf->bpf_filter);
             }
         }
     }
@@ -364,7 +364,7 @@ void *ParseAFPConfig(const char *iface)
 
     (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "disable-promisc", (int *)&boolval);
     if (boolval) {
-        SCLogInfo("Disabling promiscuous mode on iface %s",
+        SCLogConfig("Disabling promiscuous mode on iface %s",
                 aconf->iface);
         aconf->promisc = 0;
     }
@@ -398,7 +398,7 @@ finalize:
             }
         }
         if (aconf->threads)
-            SCLogInfo("Using %d AF_PACKET threads for interface %s", aconf->threads, iface);
+            SCLogPerf("Using %d AF_PACKET threads for interface %s", aconf->threads, iface);
     }
     if (aconf->threads <= 0) {
         aconf->threads = 1;
@@ -448,7 +448,7 @@ finalize:
     }
 
     if (aconf->flags & AFP_ZERO_COPY) {
-        SCLogInfo("%s: enabling zero copy mode by using data release call", iface);
+        SCLogConfig("%s: enabling zero copy mode by using data release call", iface);
     }
 
     return aconf;

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -813,7 +813,7 @@ void RunModeInitializeOutputs(void)
             if (types != NULL) {
                 ConfNode *type = NULL;
                 TAILQ_FOREACH(type, &types->head, next) {
-                    SCLogInfo("enabling 'eve-log' module '%s'", type->val);
+                    SCLogConfig("enabling 'eve-log' module '%s'", type->val);
 
                     char subname[256];
                     snprintf(subname, sizeof(subname), "%s.%s", output->val, type->val);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1587,7 +1587,7 @@ frame size: TPACKET_ALIGN(snaplen + TPACKET_ALIGN(TPACKET_ALIGN(tp_hdrlen) + siz
     ptv->req.tp_block_nr = ptv->req.tp_frame_nr / frames_per_block + 1;
     /* exact division */
     ptv->req.tp_frame_nr = ptv->req.tp_block_nr * frames_per_block;
-    SCLogInfo("AF_PACKET RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d",
+    SCLogPerf("AF_PACKET RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d",
               ptv->req.tp_block_size, ptv->req.tp_block_nr,
               ptv->req.tp_frame_size, ptv->req.tp_frame_nr);
     return 1;
@@ -1625,7 +1625,7 @@ static int AFPComputeRingParamsV3(AFPThreadVars *ptv)
     ptv->req3.tp_frame_nr = ptv->req3.tp_block_nr * frames_per_block;
     ptv->req3.tp_retire_blk_tov = ptv->block_timeout;
     ptv->req3.tp_feature_req_word = TP_FT_REQ_FILL_RXHASH;
-    SCLogInfo("AF_PACKET V3 RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d (mem: %d)",
+    SCLogPerf("AF_PACKET V3 RX Ring params: block_size=%d block_nr=%d frame_size=%d frame_nr=%d (mem: %d)",
               ptv->req3.tp_block_size, ptv->req3.tp_block_nr,
               ptv->req3.tp_frame_size, ptv->req3.tp_frame_nr,
               ptv->req3.tp_block_size * ptv->req3.tp_block_nr
@@ -1865,7 +1865,7 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
         /*
          * Set the socket buffer size to the specified value.
          */
-        SCLogInfo("Setting AF_PACKET socket buffer to %d", ptv->buffer_size);
+        SCLogPerf("Setting AF_PACKET socket buffer to %d", ptv->buffer_size);
         if (setsockopt(ptv->socket, SOL_SOCKET, SO_RCVBUF,
                        &ptv->buffer_size,
                        sizeof(ptv->buffer_size)) == -1) {
@@ -2151,13 +2151,11 @@ void ReceiveAFPThreadExitStats(ThreadVars *tv, void *data)
 
 #ifdef PACKET_STATISTICS
     AFPDumpCounters(ptv);
-    SCLogInfo("(%s) Kernel: Packets %" PRIu64 ", dropped %" PRIu64 "",
+    SCLogPerf("(%s) Kernel: Packets %" PRIu64 ", dropped %" PRIu64 "",
             tv->name,
             StatsGetLocalCounterValue(tv, ptv->capture_kernel_packets),
             StatsGetLocalCounterValue(tv, ptv->capture_kernel_drops));
 #endif
-
-    SCLogInfo("(%s) Packets %" PRIu64, tv->name, ptv->pkts);
 }
 
 /**

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -375,7 +375,7 @@ int StreamTcpReassemblyConfig(char quiet)
             sizes[npools].pktsize = 0xffff;
             sizes[npools].prealloc = 8;
             npools++;
-            SCLogInfo("appended a segment pool for pktsize 65536");
+            SCLogConfig("appended a segment pool for pktsize 65536");
         }
     } else if (npools == 0) {
         /* defaults */
@@ -447,7 +447,7 @@ int StreamTcpReassemblyConfig(char quiet)
         SCLogDebug("my_segment_pktsizes[i] %u, my_segment_poolsizes[i] %u",
                 my_segment_pktsizes[i], my_segment_poolsizes[i]);
         if (!quiet)
-            SCLogInfo("segment pool: pktsize %u, prealloc %u",
+            SCLogConfig("segment pool: pktsize %u, prealloc %u",
                     my_segment_pktsizes[i], my_segment_poolsizes[i]);
     }
 
@@ -484,7 +484,7 @@ int StreamTcpReassemblyConfig(char quiet)
         stream_chunk_prealloc = prealloc;
     }
     if (!quiet)
-        SCLogInfo("stream.reassembly \"chunk-prealloc\": %u", stream_chunk_prealloc);
+        SCLogConfig("stream.reassembly \"chunk-prealloc\": %u", stream_chunk_prealloc);
     StreamMsgQueuesInit(stream_chunk_prealloc);
 
     intmax_t zero_copy_size = 128;
@@ -497,7 +497,7 @@ int StreamTcpReassemblyConfig(char quiet)
     }
     stream_config.zero_copy_size = (uint16_t)zero_copy_size;
     if (!quiet)
-        SCLogInfo("stream.reassembly \"zero-copy-size\": %u", stream_config.zero_copy_size);
+        SCLogConfig("stream.reassembly \"zero-copy-size\": %u", stream_config.zero_copy_size);
 
     return 0;
 }
@@ -539,7 +539,7 @@ void StreamTcpReassembleFree(char quiet)
                        segment_pool[u16]->allocated);
 
             if (segment_pool[u16]->max_outstanding > segment_pool[u16]->allocated) {
-                SCLogInfo("TCP segment pool of size %u had a peak use of %u segments, "
+                SCLogPerf("TCP segment pool of size %u had a peak use of %u segments, "
                         "more than the prealloc setting of %u", segment_pool_pktsizes[u16],
                         segment_pool[u16]->max_outstanding, segment_pool[u16]->allocated);
             }
@@ -564,8 +564,8 @@ void StreamTcpReassembleFree(char quiet)
     SCLogDebug("segment_pool_memcnt %"PRIu64"", segment_pool_memcnt);
     SCMutexDestroy(&segment_pool_memuse_mutex);
     SCMutexDestroy(&segment_pool_cnt_mutex);
-    SCLogInfo("dbg_app_layer_gap %u", dbg_app_layer_gap);
-    SCLogInfo("dbg_app_layer_gap_candidate %u", dbg_app_layer_gap_candidate);
+    SCLogPerf("dbg_app_layer_gap %u", dbg_app_layer_gap);
+    SCLogPerf("dbg_app_layer_gap_candidate %u", dbg_app_layer_gap_candidate);
 #endif
 }
 

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -335,7 +335,7 @@ void StreamTcpInitConfig(char quiet)
         }
     }
     if (!quiet) {
-        SCLogInfo("stream \"prealloc-sessions\": %"PRIu32" (per thread)",
+        SCLogConfig("stream \"prealloc-sessions\": %"PRIu32" (per thread)",
                 stream_config.prealloc_sessions);
     }
 
@@ -352,19 +352,19 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (!quiet) {
-        SCLogInfo("stream \"memcap\": %"PRIu64, stream_config.memcap);
+        SCLogConfig("stream \"memcap\": %"PRIu64, stream_config.memcap);
     }
 
     ConfGetBool("stream.midstream", &stream_config.midstream);
 
     if (!quiet) {
-        SCLogInfo("stream \"midstream\" session pickups: %s", stream_config.midstream ? "enabled" : "disabled");
+        SCLogConfig("stream \"midstream\" session pickups: %s", stream_config.midstream ? "enabled" : "disabled");
     }
 
     ConfGetBool("stream.async-oneside", &stream_config.async_oneside);
 
     if (!quiet) {
-        SCLogInfo("stream \"async-oneside\": %s", stream_config.async_oneside ? "enabled" : "disabled");
+        SCLogConfig("stream \"async-oneside\": %s", stream_config.async_oneside ? "enabled" : "disabled");
     }
 
     int csum = 0;
@@ -379,7 +379,7 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (!quiet) {
-        SCLogInfo("stream \"checksum-validation\": %s",
+        SCLogConfig("stream \"checksum-validation\": %s",
                 stream_config.flags & STREAMTCP_INIT_FLAG_CHECKSUM_VALIDATION ?
                 "enabled" : "disabled");
     }
@@ -409,7 +409,7 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (!quiet) {
-        SCLogInfo("stream.\"inline\": %s", stream_inline ? "enabled" : "disabled");
+        SCLogConfig("stream.\"inline\": %s", stream_inline ? "enabled" : "disabled");
     }
 
     if ((ConfGetInt("stream.max-synack-queued", &value)) == 1) {
@@ -422,7 +422,7 @@ void StreamTcpInitConfig(char quiet)
         stream_config.max_synack_queued = (uint8_t)STREAMTCP_DEFAULT_MAX_SYNACK_QUEUED;
     }
     if (!quiet) {
-        SCLogInfo("stream \"max-synack-queued\": %"PRIu8, stream_config.max_synack_queued);
+        SCLogConfig("stream \"max-synack-queued\": %"PRIu8, stream_config.max_synack_queued);
     }
 
     char *temp_stream_reassembly_memcap_str;
@@ -440,7 +440,7 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (!quiet) {
-        SCLogInfo("stream.reassembly \"memcap\": %"PRIu64"", stream_config.reassembly_memcap);
+        SCLogConfig("stream.reassembly \"memcap\": %"PRIu64"", stream_config.reassembly_memcap);
     }
 
     char *temp_stream_reassembly_depth_str;
@@ -458,7 +458,7 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (!quiet) {
-        SCLogInfo("stream.reassembly \"depth\": %"PRIu32"", stream_config.reassembly_depth);
+        SCLogConfig("stream.reassembly \"depth\": %"PRIu32"", stream_config.reassembly_depth);
     }
 
     int randomize = 0;
@@ -540,9 +540,9 @@ void StreamTcpInitConfig(char quiet)
             stream_config.reassembly_toclient_chunk_size);
 
     if (!quiet) {
-        SCLogInfo("stream.reassembly \"toserver-chunk-size\": %"PRIu16,
+        SCLogConfig("stream.reassembly \"toserver-chunk-size\": %"PRIu16,
             stream_config.reassembly_toserver_chunk_size);
-        SCLogInfo("stream.reassembly \"toclient-chunk-size\": %"PRIu16,
+        SCLogConfig("stream.reassembly \"toclient-chunk-size\": %"PRIu16,
             stream_config.reassembly_toclient_chunk_size);
     }
 
@@ -556,7 +556,7 @@ void StreamTcpInitConfig(char quiet)
         enable_raw = 1;
     }
     if (!quiet)
-        SCLogInfo("stream.reassembly.raw: %s", enable_raw ? "enabled" : "disabled");
+        SCLogConfig("stream.reassembly.raw: %s", enable_raw ? "enabled" : "disabled");
 
     /* init the memcap/use tracking */
     SC_ATOMIC_INIT(st_memuse);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2138,7 +2138,7 @@ static void SetupDelayedDetect(SCInstance *suri)
         }
     }
 
-    SCLogInfo("Delayed detect %s", suri->delayed_detect ? "enabled" : "disabled");
+    SCLogConfig("Delayed detect %s", suri->delayed_detect ? "enabled" : "disabled");
     if (suri->delayed_detect) {
         SCLogInfo("Packets will start being processed before signatures are active.");
     }

--- a/src/tmqh-flow.c
+++ b/src/tmqh-flow.c
@@ -83,7 +83,7 @@ void TmqhFlowPrintAutofpHandler(void)
 {
 #define PRINT_IF_FUNC(f, msg)                       \
     if (tmqh_table[TMQH_FLOW].OutHandler == (f))    \
-        SCLogInfo("AutoFP mode using \"%s\" flow load balancer", (msg))
+        SCLogConfig("AutoFP mode using \"%s\" flow load balancer", (msg))
 
     PRINT_IF_FUNC(TmqhOutputFlowHash, "Hash");
     PRINT_IF_FUNC(TmqhOutputFlowIPPair, "IPPair");
@@ -212,7 +212,7 @@ void TmqhOutputFlowFreeCtx(void *ctx)
 {
     TmqhFlowCtx *fctx = (TmqhFlowCtx *)ctx;
 
-    SCLogInfo("AutoFP - Total flow handler queues - %" PRIu16,
+    SCLogPerf("AutoFP - Total flow handler queues - %" PRIu16,
               fctx->size);
     SCFree(fctx->queues);
     SCFree(fctx);

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -394,9 +394,9 @@ void PacketPoolInit(void)
         }
         PacketPoolStorePacket(p);
     }
-    SCLogInfo("preallocated %"PRIiMAX" packets. Total memory %"PRIuMAX"",
-            max_pending_packets, (uintmax_t)(max_pending_packets*SIZE_OF_PACKET));
 
+    //SCLogInfo("preallocated %"PRIiMAX" packets. Total memory %"PRIuMAX"",
+    //        max_pending_packets, (uintmax_t)(max_pending_packets*SIZE_OF_PACKET));
 }
 
 void PacketPoolDestroy(void)

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -55,6 +55,8 @@ SCEnumCharMap sc_log_level_map[ ] = {
     { "Warning",        SC_LOG_WARNING },
     { "Notice",         SC_LOG_NOTICE },
     { "Info",           SC_LOG_INFO },
+    { "Perf",           SC_LOG_PERF },
+    { "Config",         SC_LOG_CONFIG },
     { "Debug",          SC_LOG_DEBUG },
     { NULL,             -1 }
 };

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -475,8 +475,12 @@ static SCError SCLogMessageGetBuffer(
         }
     }
 
-    char *xyellow = error_code > SC_OK ? yellow : "";
-    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s%s", xyellow, message, reset);
+    char *hi = "";
+    if (error_code > SC_OK)
+        hi = red;
+    else if (log_level <= SC_LOG_NOTICE)
+        hi = yellow;
+    cw = snprintf(temp, SC_LOG_MAX_LOG_MSG_LEN - (temp - buffer), "%s%s%s", hi, message, reset);
     if (cw < 0)
         goto error;
     temp += cw;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -56,6 +56,8 @@ typedef enum {
     SC_LOG_WARNING,
     SC_LOG_NOTICE,
     SC_LOG_INFO,
+    SC_LOG_PERF,
+    SC_LOG_CONFIG,
     SC_LOG_DEBUG,
     SC_LOG_LEVEL_MAX,
 } SCLogLevel;
@@ -241,6 +243,11 @@ extern int sc_log_module_cleaned;
         __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define SCLogInfoRaw(file, func, line, ...) SCLog(SC_LOG_INFO, \
         (file), (func), (line), __VA_ARGS__)
+
+#define SCLogConfig(...) SCLog(SC_LOG_CONFIG, \
+        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define SCLogPerf(...) SCLog(SC_LOG_PERF, \
+        __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 
 /**
  * \brief Macro used to log NOTICE messages.

--- a/src/util-profiling-keywords.c
+++ b/src/util-profiling-keywords.c
@@ -206,7 +206,7 @@ SCProfilingKeywordDump(DetectEngineCtx *de_ctx)
     if (fp != stdout)
         fclose(fp);
 
-    SCLogInfo("Done dumping keyword profiling data.");
+    SCLogPerf("Done dumping keyword profiling data.");
 }
 
 /**
@@ -384,7 +384,7 @@ SCProfilingKeywordInitCounters(DetectEngineCtx *de_ctx)
         memset(de_ctx->profile_keyword_ctx_per_list[i]->data, 0x00, sizeof(SCProfileKeywordData) * DETECT_TBLSIZE);
     }
 
-    SCLogInfo("Registered %"PRIu32" keyword profiling counters.", DETECT_TBLSIZE);
+    SCLogPerf("Registered %"PRIu32" keyword profiling counters.", DETECT_TBLSIZE);
 }
 
 #endif /* PROFILING */

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -267,7 +267,7 @@ SCProfilingSghDump(DetectEngineCtx *de_ctx)
     if (fp != stdout)
         fclose(fp);
 
-    SCLogInfo("Done dumping rulegroup profiling data.");
+    SCLogPerf("Done dumping rulegroup profiling data.");
 }
 
 /**
@@ -401,7 +401,7 @@ SCProfilingSghInitCounters(DetectEngineCtx *de_ctx)
 
     de_ctx->profile_sgh_ctx->cnt = de_ctx->sgh_array_cnt;
 
-    SCLogInfo("Registered %"PRIu32" rulegroup profiling counters.", de_ctx->sgh_array_cnt);
+    SCLogPerf("Registered %"PRIu32" rulegroup profiling counters.", de_ctx->sgh_array_cnt);
 }
 
 #endif /* PROFILING */

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -447,7 +447,7 @@ SCProfilingRuleDump(SCProfileDetectCtx *rules_ctx)
     uint32_t count = rules_ctx->size;
     uint64_t total_ticks = 0;
 
-    SCLogInfo("Dumping profiling data for %u rules.", count);
+    SCLogPerf("Dumping profiling data for %u rules.", count);
 
     memset(summary, 0, summary_size);
     for (i = 0; i < count; i++) {
@@ -520,7 +520,7 @@ SCProfilingRuleDump(SCProfileDetectCtx *rules_ctx)
     if (fp != stdout)
         fclose(fp);
     SCFree(summary);
-    SCLogInfo("Done dumping profiling data.");
+    SCLogPerf("Done dumping profiling data.");
 }
 
 /**
@@ -667,7 +667,7 @@ SCProfilingRuleInitCounters(DetectEngineCtx *de_ctx)
         }
     }
 
-    SCLogInfo("Registered %"PRIu32" rule profiling counters.", count);
+    SCLogPerf("Registered %"PRIu32" rule profiling counters.", count);
 }
 
 #endif /* PROFILING */

--- a/src/util-profiling.c
+++ b/src/util-profiling.c
@@ -308,7 +308,7 @@ void
 SCProfilingDump(void)
 {
     SCProfilingDumpPacketStats();
-    SCLogInfo("Done dumping profiling data.");
+    SCLogPerf("Done dumping profiling data.");
 }
 
 static void DumpFlowWorkerIP(FILE *fp, int ipv, uint64_t total)


### PR DESCRIPTION
Add 2 new log levels: PERF and CONFIG. SCLogConfig is used to log configuration settings, like in the stream engine. SCLogPerf would be used to things related to performance, like profiling, afpacket info, etc.

Goal is to shrink the default output.

By default:
-v info
-vv perf
-vvv config
