### PR TITLE
Netmap v4

### DIFF
--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -180,7 +180,7 @@ static void *ParseNetmapConfig(const char *iface_name)
         aconf->threads = 1;
     } else {
         if (strcmp(threadsstr, "auto") == 0) {
-            aconf->threads = GetIfaceRSSQueuesNum(aconf->iface);
+            aconf->threads = NetmapGetRSSCount(aconf->iface);
         } else {
             aconf->threads = (uint8_t)atoi(threadsstr);
         }

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -255,7 +255,12 @@ static void *ParseNetmapConfig(const char *iface_name)
 finalize:
 
     if (aconf->threads == 0) {
-        aconf->threads = NetmapGetRSSCount(aconf->iface);
+        /* As NetmapGetRSSCount is broken on Linux, first run
+         * GetIfaceRSSQueuesNum. If that fails, run NetmapGetRSSCount */
+        aconf->threads = GetIfaceRSSQueuesNum(aconf->iface);
+        if (aconf->threads == 0) {
+            aconf->threads = NetmapGetRSSCount(aconf->iface);
+        }
     }
     if (aconf->threads <= 0) {
         aconf->threads = 1;

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -381,7 +381,7 @@ int RunModeIdsNetmapAutoFp(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsNetmapAutoFp initialised");
+    SCLogDebug("RunModeIdsNetmapAutoFp initialised");
 #endif /* HAVE_NETMAP */
 
     SCReturnInt(0);
@@ -414,7 +414,7 @@ int RunModeIdsNetmapSingle(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsNetmapSingle initialised");
+    SCLogDebug("RunModeIdsNetmapSingle initialised");
 
 #endif /* HAVE_NETMAP */
     SCReturnInt(0);
@@ -450,7 +450,7 @@ int RunModeIdsNetmapWorkers(void)
         exit(EXIT_FAILURE);
     }
 
-    SCLogInfo("RunModeIdsNetmapWorkers initialised");
+    SCLogDebug("RunModeIdsNetmapWorkers initialised");
 
 #endif /* HAVE_NETMAP */
     SCReturnInt(0);

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -127,7 +127,7 @@ static void *ParseNetmapConfig(const char *iface_name)
 
     memset(aconf, 0, sizeof(*aconf));
     aconf->DerefFunc = NetmapDerefConfig;
-    aconf->threads = 1;
+    aconf->threads = 0;
     aconf->promisc = 1;
     aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
     aconf->copy_mode = NETMAP_COPY_MODE_NONE;
@@ -156,7 +156,7 @@ static void *ParseNetmapConfig(const char *iface_name)
     netmap_node = ConfGetNode("netmap");
     if (netmap_node == NULL) {
         SCLogInfo("Unable to find netmap config using default value");
-        return aconf;
+        goto finalize;
     }
 
     if_root = ConfFindDeviceConfig(netmap_node, aconf->iface_name);
@@ -167,7 +167,7 @@ static void *ParseNetmapConfig(const char *iface_name)
         SCLogInfo("Unable to find netmap config for "
                 "interface \"%s\" or \"default\", using default value",
                 aconf->iface_name);
-        return aconf;
+        goto finalize;
     }
 
     /* If there is no setting for current interface use default one as main iface */
@@ -177,21 +177,13 @@ static void *ParseNetmapConfig(const char *iface_name)
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "threads", &threadsstr) != 1) {
-        aconf->threads = 1;
+        aconf->threads = 0;
     } else {
         if (strcmp(threadsstr, "auto") == 0) {
-            aconf->threads = NetmapGetRSSCount(aconf->iface);
+            aconf->threads = 0;
         } else {
             aconf->threads = (uint8_t)atoi(threadsstr);
         }
-    }
-
-    if (aconf->threads <= 0) {
-        aconf->threads = 1;
-    }
-    if (aconf->threads) {
-        SCLogInfo("Using %d threads for interface %s", aconf->threads,
-                  aconf->iface_name);
     }
 
     if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
@@ -231,9 +223,6 @@ static void *ParseNetmapConfig(const char *iface_name)
         }
     }
 
-    SC_ATOMIC_RESET(aconf->ref);
-    (void) SC_ATOMIC_ADD(aconf->ref, aconf->threads);
-
     /* load netmap bpf filter */
     /* command line value has precedence */
     if (ConfGet("bpf-filter", &bpf_filter) != 1) {
@@ -262,6 +251,19 @@ static void *ParseNetmapConfig(const char *iface_name)
             SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for checksum-checks for %s", aconf->iface_name);
         }
     }
+
+finalize:
+
+    if (aconf->threads == 0) {
+        aconf->threads = NetmapGetRSSCount(aconf->iface);
+    }
+    if (aconf->threads <= 0) {
+        aconf->threads = 1;
+    }
+    SC_ATOMIC_RESET(aconf->ref);
+    (void) SC_ATOMIC_ADD(aconf->ref, aconf->threads);
+    SCLogInfo("Using %d threads for interface %s", aconf->threads,
+            aconf->iface_name);
 
     return aconf;
 }

--- a/src/source-netmap.h
+++ b/src/source-netmap.h
@@ -67,6 +67,8 @@ typedef struct NetmapPacketVars_
     void *ntv;
 } NetmapPacketVars;
 
+int NetmapGetRSSCount(const char *ifname);
+
 void TmModuleReceiveNetmapRegister (void);
 void TmModuleDecodeNetmapRegister (void);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1445,7 +1445,7 @@ netmap:
    # To specify OS endpoint add plus sign at the end (e.g. "eth0+")
  - interface: eth2
    # Number of receive threads. "auto" uses number of RSS queues on interface.
-   threads: auto
+   #threads: auto
    # You can use the following variables to activate netmap tap or IPS mode.
    # If copy-mode is set to ips or tap, the traffic coming to the current
    # interface will be copied to the copy-iface interface. If 'tap' is set, the


### PR DESCRIPTION
As #2133, with the addition of offloading checks. Tested on FreeBSD 10.3. It tests for rxcsum, tso, lro and toe. Not sure if that last one is relevant.

On Linux using the generic (ethtool) based offloading check also used by AF_PACKET.

Again @gureedo your comments would be welcomed :)