### PR TITLE
TEST check if zero copy works correcty

### DIFF
--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -52,6 +52,8 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
     if (unlikely(p->ethh == NULL))
         return TM_ECODE_FAILED;
 
+    memcpy(&p->ethhs, p->ethh, sizeof(EthernetHdr));
+
     SCLogDebug("p %p pkt %p ether type %04x", p, pkt, ntohs(p->ethh->eth_type));
 
     switch (ntohs(p->ethh->eth_type)) {

--- a/src/decode.h
+++ b/src/decode.h
@@ -446,6 +446,7 @@ typedef struct Packet_
 
     /* header pointers */
     EthernetHdr *ethh;
+    EthernetHdr ethhs;
 
     /* Checksum for IP packets. */
     int32_t level3_comp_csum;
@@ -732,6 +733,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
             (p)->pktvar = NULL;                 \
         }                                       \
         (p)->ethh = NULL;                       \
+	memset(&(p)->ethhs, 0, sizeof(EthernetHdr)); \
         if ((p)->ip4h != NULL) {                \
             CLEAR_IPV4_PACKET((p));             \
         }                                       \

--- a/src/tmqh-packetpool.c
+++ b/src/tmqh-packetpool.c
@@ -540,6 +540,8 @@ void TmqhOutputPacketpool(ThreadVars *t, Packet *p)
 
     PACKET_PROFILING_END(p);
 
+    BUG_ON(p->ethh != NULL && memcmp(p->ethh, &p->ethhs, sizeof(EthernetHdr)) != 0);
+
     p->ReleasePacket(p);
 
     SCReturn;


### PR DESCRIPTION
This is TEST/DEBUG code to validate that the buffer we get from packet
capture (p->ext_pkt in 0copy) remains valid.

The idea is that at the end of the lifetime of the packet we check if
the Ethernet pointer into ext_pkt still contains the same data as our
local copy of it.

With PF_RING it has been observed that this is not the case, which is
a violation of our expectations. We expect the pointer to remain valid
until the next call to pfring_recv.