### PR TITLE
minor issue fixed about unix-manager.c

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -153,8 +153,8 @@ int UnixNew(UnixCommand * this)
     /* set address */
     addr.sun_family = AF_UNIX;
     strlcpy(addr.sun_path, sockettarget, sizeof(addr.sun_path));
-    addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
-    len = strlen(addr.sun_path) + sizeof(addr.sun_family);
+    addr.sun_path[sizeof(addr.sun_path) - 1] = 0;    
+    len = SUN_LEN (&addr);
 
     /* create socket */
     this->socket = socket(AF_UNIX, SOCK_STREAM, 0);


### PR DESCRIPTION
the LEN calculation of unix socket address is incorrect, it will cause the last character get cut off.
by referencing the unix manual, its recommended to use SUN_LEN Marco instead of do it manually

reference link:
https://www.freebsd.org/cgi/man.cgi?query=unix&sektion=4&manpath=FreeBSD+7.2-RELEASE
"The length	of UNIX-domain address,	required by bind(2) and	connect(2),
     can be calculated by the macro SUN_LEN() defined in <sys/un.h>.  The
     sun_path field must be terminated by a NUL	character to be	used with
     SUN_LEN(),	but the	terminating NUL	is not part of the address."