### PR TITLE
configure: enable nfqueue by default and set flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -755,6 +755,12 @@
             AS_HELP_STRING([--enable-nflog],[Enable libnetfilter_log support]),
                            [ enable_nflog="yes"],
                            [ enable_nflog="no"])
+
+    PKG_CHECK_MODULES([libnetfilter_queue], [libnetfilter_queue >= 1.0], [enable_nfqueue=yes])
+    if test "$enable_nfqueue" != "no"; then
+        CPPFLAGS="${CPPFLAGS} ${libnetfilter_queue_CFLAGS}"
+    fi
+
     AC_ARG_ENABLE(nfqueue,
            AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),[enable_nfqueue=yes],[enable_nfqueue=no])
 


### PR DESCRIPTION
This change enables nfqueue by default if the needed lib is installed
and also sets the correct CPPFLAGS which is necessary for some systems
like OpenSuse.

This should solve: https://redmine.openinfosecfoundation.org/issues/1525

But fails on our buildbot due to old libnetfilter_queue version:

Build failure for norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/25
Build failure for norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/25