### PR TITLE
configure: set correct cppflags for enabled nfqueue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -757,6 +757,10 @@
                            [ enable_nflog="no"])
     AC_ARG_ENABLE(nfqueue,
            AS_HELP_STRING([--enable-nfqueue], [Enable NFQUEUE support for inline IDP]),[enable_nfqueue=yes],[enable_nfqueue=no])
+    if test "$enable_nfqueue" != "no"; then
+        PKG_CHECK_MODULES([libnetfilter_queue], [libnetfilter_queue], [enable_nfqueue=yes], [enable_nfqueue=no])
+        CPPFLAGS="${CPPFLAGS} ${libnetfilter_queue_CFLAGS}"
+    fi
 
     if test "x$enable_nflog" = "xyes" || test  "x$enable_nfqueue" = "xyes"; then
   # libnfnetlink


### PR DESCRIPTION
This change sets the correct CPPFLAGS received by PKG_CHECK to resolve
building issues with some systems like OpenSuse.

This fixes https://redmine.openinfosecfoundation.org/issues/1525

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/26
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/26