### PR TITLE
Next 20160613 v2

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -389,18 +389,16 @@ static int ProcessSigFiles(DetectEngineCtx *de_ctx, char *pattern,
 
     for (size_t i = 0; i < (size_t)files.gl_pathc; i++) {
         char *fname = files.gl_pathv[i];
-        SCLogInfo("Loading rule file: %s", fname);
+        if (strcmp("/dev/null", fname) == 0)
+            continue;
+
+        SCLogConfig("Loading rule file: %s", fname);
         r = DetectLoadSigFile(de_ctx, fname, good_sigs, bad_sigs);
         if (r < 0) {
             ++(st->bad_files);
         }
 
         ++(st->total_files);
-
-        if (*good_sigs == 0) {
-            SCLogWarning(SC_ERR_NO_RULES,
-                "No rules loaded from %s", fname);
-        }
 
         st->good_sigs_total += *good_sigs;
         st->bad_sigs_total += *bad_sigs;
@@ -479,11 +477,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
         }
 
         if (good_sigs == 0) {
-            SCLogError(SC_ERR_NO_RULES, "No rules loaded from %s", sig_file);
-
-            if (de_ctx->failure_fatal == 1) {
-                exit(EXIT_FAILURE);
-            }
+            SCLogConfig("No rules loaded from %s", sig_file);
         }
     }
 

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -424,7 +424,8 @@ finalize:
     int ltype = AFPGetLinkType(iface);
     switch (ltype) {
         case LINKTYPE_ETHERNET:
-            if (GetIfaceOffloading(iface) == 1) {
+            /* af-packet can handle csum offloading */
+            if (GetIfaceOffloading(iface, 0, 1) == 1) {
                 SCLogWarning(SC_ERR_AFP_CREATE,
                     "Using AF_PACKET with offloading activated leads to capture problems");
             }

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -426,7 +426,7 @@ finalize:
         case LINKTYPE_ETHERNET:
             if (GetIfaceOffloading(iface) == 1) {
                 SCLogWarning(SC_ERR_AFP_CREATE,
-                    "Using AF_PACKET with GRO or LRO activated can lead to capture problems");
+                    "Using AF_PACKET with offloading activated leads to capture problems");
             }
         case -1:
         default:

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -93,6 +93,123 @@ static void NetmapDerefConfig(void *conf)
     }
 }
 
+static int ParseNetmapSettings(NetmapIfaceSettings *ns, const char *iface,
+        ConfNode *if_root, ConfNode *if_default)
+{
+    ns->threads = 0;
+    ns->promisc = 1;
+    ns->checksum_mode = CHECKSUM_VALIDATION_AUTO;
+    ns->copy_mode = NETMAP_COPY_MODE_NONE;
+
+    strlcpy(ns->iface, iface, sizeof(ns->iface));
+    if (ns->iface[0]) {
+        size_t len = strlen(ns->iface);
+        if (ns->iface[len-1] == '+') {
+            ns->iface[len-1] = '\0';
+            ns->sw_ring = 1;
+        }
+    }
+
+    char *bpf_filter = NULL;
+    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
+        if (strlen(bpf_filter) > 0) {
+            ns->bpf_filter = bpf_filter;
+            SCLogInfo("Going to use command-line provided bpf filter '%s'",
+                    ns->bpf_filter);
+        }
+    }
+
+    if (if_root == NULL && if_default == NULL) {
+        SCLogInfo("Unable to find netmap config for "
+                "interface \"%s\" or \"default\", using default values",
+                iface);
+        goto finalize;
+
+    /* If there is no setting for current interface use default one as main iface */
+    } else if (if_root == NULL) {
+        if_root = if_default;
+        if_default = NULL;
+    }
+
+    char *threadsstr = NULL;
+    if (ConfGetChildValueWithDefault(if_root, if_default, "threads", &threadsstr) != 1) {
+        ns->threads = 0;
+    } else {
+        if (strcmp(threadsstr, "auto") == 0) {
+            ns->threads = 0;
+        } else {
+            ns->threads = (uint8_t)atoi(threadsstr);
+        }
+    }
+
+    /* load netmap bpf filter */
+    /* command line value has precedence */
+    if (ns->bpf_filter == NULL) {
+        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
+            if (strlen(bpf_filter) > 0) {
+                ns->bpf_filter = bpf_filter;
+                SCLogInfo("Going to use bpf filter %s", ns->bpf_filter);
+            }
+        }
+    }
+
+    int boolval = 0;
+    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "disable-promisc", (int *)&boolval);
+    if (boolval) {
+        SCLogInfo("Disabling promiscuous mode on iface %s", ns->iface);
+        ns->promisc = 0;
+    }
+
+    char *tmpctype;
+    if (ConfGetChildValueWithDefault(if_root, if_default,
+                "checksum-checks", &tmpctype) == 1)
+    {
+        if (strcmp(tmpctype, "auto") == 0) {
+            ns->checksum_mode = CHECKSUM_VALIDATION_AUTO;
+        } else if (ConfValIsTrue(tmpctype)) {
+            ns->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
+        } else if (ConfValIsFalse(tmpctype)) {
+            ns->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
+        } else {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid value for "
+                    "checksum-checks for %s", iface);
+        }
+    }
+
+    char *copymodestr;
+    if (ConfGetChildValueWithDefault(if_root, if_default,
+                "copy-mode", &copymodestr) == 1)
+    {
+        if (strcmp(copymodestr, "ips") == 0) {
+            ns->copy_mode = NETMAP_COPY_MODE_IPS;
+        } else if (strcmp(copymodestr, "tap") == 0) {
+            ns->copy_mode = NETMAP_COPY_MODE_TAP;
+        } else {
+            SCLogWarning(SC_ERR_INVALID_ARGUMENT, "Invalid copy-mode "
+                    "(valid are tap, ips)");
+        }
+    }
+
+finalize:
+
+    if (ns->sw_ring) {
+        /* just one thread per interface supported */
+        ns->threads = 1;
+    } else if (ns->threads == 0) {
+        /* As NetmapGetRSSCount is broken on Linux, first run
+         * GetIfaceRSSQueuesNum. If that fails, run NetmapGetRSSCount */
+        ns->threads = GetIfaceRSSQueuesNum(ns->iface);
+        if (ns->threads == 0) {
+            ns->threads = NetmapGetRSSCount(ns->iface);
+        }
+    }
+    if (ns->threads <= 0) {
+        ns->threads = 1;
+    }
+
+    return 0;
+}
+
 /**
 * \brief extract information from config file
 *
@@ -105,14 +222,9 @@ static void NetmapDerefConfig(void *conf)
 */
 static void *ParseNetmapConfig(const char *iface_name)
 {
-    char *threadsstr = NULL;
-    ConfNode *if_root;
+    ConfNode *if_root = NULL;
     ConfNode *if_default = NULL;
     ConfNode *netmap_node;
-    char *tmpctype;
-    char *copymodestr;
-    int boolval;
-    char *bpf_filter = NULL;
     char *out_iface = NULL;
 
     if (iface_name == NULL) {
@@ -126,150 +238,33 @@ static void *ParseNetmapConfig(const char *iface_name)
 
     memset(aconf, 0, sizeof(*aconf));
     aconf->DerefFunc = NetmapDerefConfig;
-    aconf->threads = 0;
-    aconf->promisc = 1;
-    aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-    aconf->copy_mode = NETMAP_COPY_MODE_NONE;
     strlcpy(aconf->iface_name, iface_name, sizeof(aconf->iface_name));
     SC_ATOMIC_INIT(aconf->ref);
     (void) SC_ATOMIC_ADD(aconf->ref, 1);
-
-    strlcpy(aconf->iface, aconf->iface_name, sizeof(aconf->iface));
-    if (aconf->iface[0]) {
-        size_t len = strlen(aconf->iface);
-        if (aconf->iface[len-1] == '+') {
-            aconf->iface[len-1] = '\0';
-            aconf->iface_sw = 1;
-        }
-    }
-
-    if (ConfGet("bpf-filter", &bpf_filter) == 1) {
-        if (strlen(bpf_filter) > 0) {
-            aconf->bpf_filter = bpf_filter;
-            SCLogInfo("Going to use command-line provided bpf filter '%s'",
-                    aconf->bpf_filter);
-        }
-    }
 
     /* Find initial node */
     netmap_node = ConfGetNode("netmap");
     if (netmap_node == NULL) {
         SCLogInfo("Unable to find netmap config using default value");
-        goto finalize;
-    }
-
-    if_root = ConfFindDeviceConfig(netmap_node, aconf->iface_name);
-
-    if_default = ConfFindDeviceConfig(netmap_node, "default");
-
-    if (if_root == NULL && if_default == NULL) {
-        SCLogInfo("Unable to find netmap config for "
-                "interface \"%s\" or \"default\", using default value",
-                aconf->iface_name);
-        goto finalize;
-    }
-
-    /* If there is no setting for current interface use default one as main iface */
-    if (if_root == NULL) {
-        if_root = if_default;
-        if_default = NULL;
-    }
-
-    if (ConfGetChildValueWithDefault(if_root, if_default, "threads", &threadsstr) != 1) {
-        aconf->threads = 0;
     } else {
-        if (strcmp(threadsstr, "auto") == 0) {
-            aconf->threads = 0;
-        } else {
-            aconf->threads = (uint8_t)atoi(threadsstr);
-        }
+        if_root = ConfFindDeviceConfig(netmap_node, aconf->iface_name);
+        if_default = ConfFindDeviceConfig(netmap_node, "default");
     }
 
+    /* parse settings for capture iface */
+    ParseNetmapSettings(&aconf->in, aconf->iface_name, if_root, if_default);
+
+    /* if we have a copy iface, parse that as well */
     if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
         if (strlen(out_iface) > 0) {
-            aconf->out_iface_name = out_iface;
+            if_root = ConfFindDeviceConfig(netmap_node, out_iface);
+            ParseNetmapSettings(&aconf->out, out_iface, if_root, if_default);
         }
     }
 
-    if (ConfGetChildValueWithDefault(if_root, if_default, "copy-mode", &copymodestr) == 1) {
-        if (aconf->out_iface_name == NULL) {
-            SCLogInfo("Copy mode activated but no destination"
-                    " iface. Disabling feature");
-        } else if (strlen(copymodestr) <= 0) {
-            aconf->out_iface_name = NULL;
-        } else if (strcmp(copymodestr, "ips") == 0) {
-            SCLogInfo("Netmap IPS mode activated %s->%s",
-                    aconf->iface_name,
-                    aconf->out_iface_name);
-            aconf->copy_mode = NETMAP_COPY_MODE_IPS;
-        } else if (strcmp(copymodestr, "tap") == 0) {
-            SCLogInfo("Netmap TAP mode activated %s->%s",
-                    aconf->iface_name,
-                    aconf->out_iface_name);
-            aconf->copy_mode = NETMAP_COPY_MODE_TAP;
-        } else {
-            SCLogInfo("Invalid mode (not in tap, ips)");
-        }
-    }
-
-    if (aconf->out_iface_name && aconf->out_iface_name[0]) {
-        strlcpy(aconf->out_iface, aconf->out_iface_name,
-                sizeof(aconf->out_iface));
-        size_t len = strlen(aconf->out_iface);
-        if (aconf->out_iface[len-1] == '+') {
-            aconf->out_iface[len-1] = '\0';
-            aconf->out_iface_sw = 1;
-        }
-    }
-
-    /* load netmap bpf filter */
-    /* command line value has precedence */
-    if (ConfGet("bpf-filter", &bpf_filter) != 1) {
-        if (ConfGetChildValueWithDefault(if_root, if_default, "bpf-filter", &bpf_filter) == 1) {
-            if (strlen(bpf_filter) > 0) {
-                aconf->bpf_filter = bpf_filter;
-                SCLogInfo("Going to use bpf filter %s", aconf->bpf_filter);
-            }
-        }
-    }
-
-    (void)ConfGetChildValueBoolWithDefault(if_root, if_default, "disable-promisc", (int *)&boolval);
-    if (boolval) {
-        SCLogInfo("Disabling promiscuous mode on iface %s", aconf->iface);
-        aconf->promisc = 0;
-    }
-
-    if (ConfGetChildValueWithDefault(if_root, if_default, "checksum-checks", &tmpctype) == 1) {
-        if (strcmp(tmpctype, "auto") == 0) {
-            aconf->checksum_mode = CHECKSUM_VALIDATION_AUTO;
-        } else if (ConfValIsTrue(tmpctype)) {
-            aconf->checksum_mode = CHECKSUM_VALIDATION_ENABLE;
-        } else if (ConfValIsFalse(tmpctype)) {
-            aconf->checksum_mode = CHECKSUM_VALIDATION_DISABLE;
-        } else {
-            SCLogError(SC_ERR_INVALID_ARGUMENT, "Invalid value for checksum-checks for %s", aconf->iface_name);
-        }
-    }
-
-finalize:
-
-    if (aconf->iface_sw) {
-        /* just one thread per interface supported */
-        aconf->threads = 1;
-    } else if (aconf->threads == 0) {
-        /* As NetmapGetRSSCount is broken on Linux, first run
-         * GetIfaceRSSQueuesNum. If that fails, run NetmapGetRSSCount */
-        aconf->threads = GetIfaceRSSQueuesNum(aconf->iface);
-        if (aconf->threads == 0) {
-            aconf->threads = NetmapGetRSSCount(aconf->iface);
-        }
-    }
-    if (aconf->threads <= 0) {
-        aconf->threads = 1;
-    }
     SC_ATOMIC_RESET(aconf->ref);
-    (void) SC_ATOMIC_ADD(aconf->ref, aconf->threads);
-    SCLogPerf("Using %d threads for interface %s", aconf->threads,
+    (void) SC_ATOMIC_ADD(aconf->ref, aconf->in.threads);
+    SCLogPerf("Using %d threads for interface %s", aconf->in.threads,
             aconf->iface_name);
 
     return aconf;
@@ -278,7 +273,7 @@ finalize:
 static int NetmapConfigGeThreadsCount(void *conf)
 {
     NetmapIfaceConfig *aconf = (NetmapIfaceConfig *)conf;
-    return aconf->threads;
+    return aconf->in.threads;
 }
 
 int NetmapRunModeIsIPS()

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -622,8 +622,8 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     memset(ntv, 0, sizeof(*ntv));
 
     ntv->tv = tv;
-    ntv->checksum_mode = aconf->checksum_mode;
-    ntv->copy_mode = aconf->copy_mode;
+    ntv->checksum_mode = aconf->in.checksum_mode;
+    ntv->copy_mode = aconf->in.copy_mode;
 
     ntv->livedev = LiveGetDevice(aconf->iface_name);
     if (ntv->livedev == NULL) {
@@ -631,32 +631,32 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
         goto error_ntv;
     }
 
-    if (NetmapOpen(aconf->iface, aconf->promisc, &ntv->ifsrc, 1) != 0) {
+    if (NetmapOpen(aconf->in.iface, aconf->in.promisc, &ntv->ifsrc, 1) != 0) {
         goto error_ntv;
     }
 
-    if (unlikely(!aconf->iface_sw && !ntv->ifsrc->rx_rings_cnt)) {
+    if (unlikely(!aconf->in.sw_ring && !ntv->ifsrc->rx_rings_cnt)) {
         SCLogError(SC_ERR_NETMAP_CREATE,
                    "Input interface '%s' does not have Rx rings",
                    aconf->iface_name);
         goto error_src;
     }
 
-    if (unlikely(aconf->iface_sw && aconf->threads > 1)) {
+    if (unlikely(aconf->in.sw_ring && aconf->in.threads > 1)) {
         SCLogError(SC_ERR_INVALID_VALUE,
                    "Interface '%s+'. "
                    "Thread count can't be greater than 1 for SW ring.",
                    aconf->iface_name);
         goto error_src;
-    } else if (unlikely(aconf->threads > ntv->ifsrc->rx_rings_cnt)) {
+    } else if (unlikely(aconf->in.threads > ntv->ifsrc->rx_rings_cnt)) {
         SCLogError(SC_ERR_INVALID_VALUE,
                    "Thread count can't be greater than Rx ring count. "
                    "Configured %d threads for interface '%s' with %d Rx rings.",
-                   aconf->threads, aconf->iface_name, ntv->ifsrc->rx_rings_cnt);
+                   aconf->in.threads, aconf->iface_name, ntv->ifsrc->rx_rings_cnt);
         goto error_src;
     }
 
-    if (aconf->iface_sw) {
+    if (aconf->in.sw_ring) {
         ntv->thread_idx = 0;
     } else {
         do {
@@ -665,35 +665,35 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     }
 
     /* calculate thread rings binding */
-    if (aconf->iface_sw) {
+    if (aconf->in.sw_ring) {
         ntv->src_ring_from = ntv->src_ring_to = ntv->ifsrc->rings_cnt;
     } else {
-        int tmp = (ntv->ifsrc->rx_rings_cnt + 1) / aconf->threads;
+        int tmp = (ntv->ifsrc->rx_rings_cnt + 1) / aconf->in.threads;
         ntv->src_ring_from = ntv->thread_idx * tmp;
         ntv->src_ring_to = ntv->src_ring_from + tmp - 1;
-        if (ntv->thread_idx == (aconf->threads - 1)) {
+        if (ntv->thread_idx == (aconf->in.threads - 1)) {
             ntv->src_ring_to = ntv->ifsrc->rx_rings_cnt - 1;
         }
     }
     SCLogDebug("netmap: %s thread:%d rings:%d-%d", aconf->iface_name,
                ntv->thread_idx, ntv->src_ring_from, ntv->src_ring_to);
 
-    if (aconf->copy_mode != NETMAP_COPY_MODE_NONE) {
-        if (NetmapOpen(aconf->out_iface, 0, &ntv->ifdst, 1) != 0) {
+    if (aconf->in.copy_mode != NETMAP_COPY_MODE_NONE) {
+        if (NetmapOpen(aconf->out.iface, aconf->out.promisc, &ntv->ifdst, 1) != 0) {
             goto error_src;
         }
 
-        if (unlikely(!aconf->out_iface_sw && !ntv->ifdst->tx_rings_cnt)) {
+        if (unlikely(!aconf->out.sw_ring && !ntv->ifdst->tx_rings_cnt)) {
             SCLogError(SC_ERR_NETMAP_CREATE,
                        "Output interface '%s' does not have Tx rings",
-                       aconf->out_iface_name);
+                       aconf->out.iface);
             goto error_dst;
         }
 
         /* calculate dst rings bindings */
         for (int i = ntv->src_ring_from; i <= ntv->src_ring_to; i++) {
             NetmapRing *ring = &ntv->ifsrc->rings[i];
-            if (aconf->out_iface_sw) {
+            if (aconf->out.sw_ring) {
                 ring->dst_ring_from = ring->dst_ring_to = ntv->ifdst->rings_cnt;
             } else if (ntv->ifdst->tx_rings_cnt > ntv->ifsrc->rx_rings_cnt) {
                 int tmp = (ntv->ifdst->tx_rings_cnt + 1) / ntv->ifsrc->rx_rings_cnt;
@@ -709,7 +709,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
             ring->dst_next_ring = ring->dst_ring_from;
 
             SCLogDebug("netmap: %s(%d)->%s(%d-%d)",
-                       aconf->iface_name, i, aconf->out_iface_name,
+                       aconf->in.iface, i, aconf->out.iface,
                        ring->dst_ring_from, ring->dst_ring_to);
         }
     }
@@ -722,11 +722,11 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
 
     /* enable zero-copy mode for workers runmode */
     char const *active_runmode = RunmodeGetActive();
-    if ((aconf->copy_mode != NETMAP_COPY_MODE_NONE) && active_runmode
-            && !strcmp("workers", active_runmode)) {
+    if ((aconf->in.copy_mode != NETMAP_COPY_MODE_NONE) && active_runmode &&
+            strcmp("workers", active_runmode) == 0) {
         ntv->flags |= NETMAP_FLAG_ZERO_COPY;
         SCLogPerf("Enabling zero copy mode for %s->%s",
-                  aconf->iface_name, aconf->out_iface_name);
+                  aconf->in.iface, aconf->out.iface);
     } else {
         uint16_t ring_size = ntv->ifsrc->rings[0].rx->num_slots;
         if (ring_size > max_pending_packets) {
@@ -738,16 +738,17 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
         }
     }
 
-    if (aconf->bpf_filter) {
+    if (aconf->in.bpf_filter) {
         SCLogConfig("Using BPF '%s' on iface '%s'",
-                  aconf->bpf_filter, ntv->ifsrc->ifname);
+                  aconf->in.bpf_filter, ntv->ifsrc->ifname);
         if (pcap_compile_nopcap(default_packet_size,  /* snaplen_arg */
                     LINKTYPE_ETHERNET,    /* linktype_arg */
                     &ntv->bpf_prog,       /* program */
-                    aconf->bpf_filter,    /* const char *buf */
+                    aconf->in.bpf_filter, /* const char *buf */
                     1,                    /* optimize */
                     PCAP_NETMASK_UNKNOWN  /* mask */
-                    ) == -1) {
+                    ) == -1)
+        {
             SCLogError(SC_ERR_NETMAP_CREATE, "Filter compilation failed.");
             goto error_dst;
         }
@@ -758,7 +759,7 @@ static TmEcode ReceiveNetmapThreadInit(ThreadVars *tv, void *initdata, void **da
     SCReturnInt(TM_ECODE_OK);
 
 error_dst:
-    if (aconf->copy_mode != NETMAP_COPY_MODE_NONE) {
+    if (aconf->in.copy_mode != NETMAP_COPY_MODE_NONE) {
         NetmapClose(ntv->ifdst);
     }
 error_src:

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -293,7 +293,8 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
         }
     }
 
-    (void)GetIfaceOffloading(ifname);
+    /* netmap needs all offloading to be disabled */
+    (void)GetIfaceOffloading(ifname, 1, 1);
 
     /* not found, create new record */
     pdev = SCMalloc(sizeof(*pdev));

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -133,6 +133,11 @@ TmEcode NoNetmapSupportExit(ThreadVars *tv, void *initdata, void **data)
 
 #if defined(__linux__)
 #define POLL_EVENTS (POLLHUP|POLLRDHUP|POLLERR|POLLNVAL)
+
+#ifndef IFF_PPROMISC
+#define IFF_PPROMISC IFF_PROMISC
+#endif
+
 #else
 #define POLL_EVENTS (POLLHUP|POLLERR|POLLNVAL)
 #endif
@@ -438,8 +443,9 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
         close(if_fd);
         goto error_fd;
     }
-    if (promisc) {
-        if_flags |= IFF_PROMISC;
+    /* if needed, try to set iface in promisc mode */
+    if (promisc && (if_flags & (IFF_PROMISC|IFF_PPROMISC)) == 0) {
+        if_flags |= IFF_PPROMISC;
         NetmapSetIfaceFlags(if_fd, ifname, if_flags);
     }
 

--- a/src/source-netmap.h
+++ b/src/source-netmap.h
@@ -35,25 +35,34 @@ enum {
 
 #define NETMAP_IFACE_NAME_LENGTH    48
 
-typedef struct NetmapIfaceConfig_
+typedef struct NetmapIfaceSettings_
 {
-    /* semantic interface name */
-    char iface_name[NETMAP_IFACE_NAME_LENGTH];
     /* real inner interface name */
     char iface[NETMAP_IFACE_NAME_LENGTH];
-    /* sw ring flag for iface */
-    int iface_sw;
+
     int threads;
+    /* sw ring flag for out_iface */
+    int sw_ring;
     int promisc;
     int copy_mode;
     ChecksumValidationMode checksum_mode;
     char *bpf_filter;
+} NetmapIfaceSettings;
+
+typedef struct NetmapIfaceConfig_
+{
+    /* semantic interface name */
+    char iface_name[NETMAP_IFACE_NAME_LENGTH];
+
+    /* settings for out capture device*/
+    NetmapIfaceSettings in;
+
     /* semantic interface name */
     char *out_iface_name;
-    /* real inner interface name */
-    char out_iface[NETMAP_IFACE_NAME_LENGTH];
-    /* sw ring flag for out_iface */
-    int out_iface_sw;
+
+    /* settings for outgoing iface for IPS/TAP */
+    NetmapIfaceSettings out;
+
     SC_ATOMIC_DECLARE(unsigned int, ref);
     void (*DerefFunc)(void *);
 } NetmapIfaceConfig;

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -510,7 +510,8 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCMutexUnlock(&pcap_bpf_compile_lock);
     }
 
-    (void)GetIfaceOffloading(pcapconfig->iface);
+    /* no offloading supported at all */
+    (void)GetIfaceOffloading(pcapconfig->iface, 1, 1);
 
     ptv->datalink = pcap_datalink(ptv->pcap_handle);
 

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -510,15 +510,7 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
         SCMutexUnlock(&pcap_bpf_compile_lock);
     }
 
-    /* Making it conditional to Linux even if GetIfaceOffloading return 0
-     * for non Linux. */
-#ifdef HAVE_LINUX_ETHTOOL_H
-    if (GetIfaceOffloading(pcapconfig->iface) == 1) {
-        SCLogWarning(SC_ERR_PCAP_CREATE,
-                "Using Pcap capture with GRO or LRO activated can lead to "
-                "capture problems.");
-    }
-#endif /* HAVE_LINUX_ETHTOOL_H */
+    (void)GetIfaceOffloading(pcapconfig->iface);
 
     ptv->datalink = pcap_datalink(ptv->pcap_handle);
 

--- a/src/source-pfring.c
+++ b/src/source-pfring.c
@@ -469,7 +469,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
     /* enable zero-copy mode for workers runmode */
     if (active_runmode && strcmp("workers", active_runmode) == 0) {
         ptv->flags |= PFRING_FLAGS_ZERO_COPY;
-        SCLogInfo("Enabling zero-copy for %s", ptv->interface);
+        SCLogPerf("Enabling zero-copy for %s", ptv->interface);
     }
 
     ptv->checksum_mode = pfconf->checksum_mode;
@@ -532,11 +532,11 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
     }
 
     if (ptv->threads > 1) {
-        SCLogInfo("(%s) Using PF_RING v.%d.%d.%d, interface %s, cluster-id %d",
+        SCLogPerf("(%s) Using PF_RING v.%d.%d.%d, interface %s, cluster-id %d",
                 tv->name, (version & 0xFFFF0000) >> 16, (version & 0x0000FF00) >> 8,
                 version & 0x000000FF, ptv->interface, ptv->cluster_id);
     } else {
-        SCLogInfo("(%s) Using PF_RING v.%d.%d.%d, interface %s, cluster-id %d, single-pfring-thread",
+        SCLogPerf("(%s) Using PF_RING v.%d.%d.%d, interface %s, cluster-id %d, single-pfring-thread",
                 tv->name, (version & 0xFFFF0000) >> 16, (version & 0x0000FF00) >> 8,
                 version & 0x000000FF, ptv->interface, ptv->cluster_id);
     }
@@ -581,7 +581,7 @@ TmEcode ReceivePfringThreadInit(ThreadVars *tv, void *initdata, void **data)
      * ZC interface, do nothing */
     if (ptv->vlan_disabled && ptv->ctype == CLUSTER_FLOW &&
             strncmp(ptv->interface, "zc", 2) != 0) {
-        SCLogInfo("VLAN disabled, setting cluster type to CLUSTER_FLOW_5_TUPLE");
+        SCLogPerf("VLAN disabled, setting cluster type to CLUSTER_FLOW_5_TUPLE");
         rc = pfring_set_cluster(ptv->pd, ptv->cluster_id, CLUSTER_FLOW_5_TUPLE);
 
         if (rc != 0) {
@@ -608,11 +608,11 @@ void ReceivePfringThreadExitStats(ThreadVars *tv, void *data)
     PfringThreadVars *ptv = (PfringThreadVars *)data;
 
     PfringDumpCounters(ptv);
-    SCLogInfo("(%s) Kernel: Packets %" PRIu64 ", dropped %" PRIu64 "",
+    SCLogPerf("(%s) Kernel: Packets %" PRIu64 ", dropped %" PRIu64 "",
             tv->name,
             StatsGetLocalCounterValue(tv, ptv->capture_kernel_packets),
             StatsGetLocalCounterValue(tv, ptv->capture_kernel_drops));
-    SCLogInfo("(%s) Packets %" PRIu64 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
+    SCLogPerf("(%s) Packets %" PRIu64 ", bytes %" PRIu64 "", tv->name, ptv->pkts, ptv->bytes);
 }
 
 /**

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -324,6 +324,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_NETFLOW_LOG_GENERIC);
         CASE_CODE (SC_ERR_SMTP_LOG_GENERIC);
         CASE_CODE (SC_ERR_SSH_LOG_GENERIC);
+        CASE_CODE (SC_ERR_NIC_OFFLOADING);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -314,6 +314,7 @@ typedef enum {
     SC_ERR_NETFLOW_LOG_GENERIC,
     SC_ERR_SMTP_LOG_GENERIC,
     SC_ERR_SSH_LOG_GENERIC,
+    SC_ERR_NIC_OFFLOADING,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -305,7 +305,7 @@ static int GetIfaceOffloadingLinux(const char *dev)
     }
 #endif
     if (ret == 0) {
-        SCLogInfo("NIC offloading on %s: SG: %s, GRO: %s, LRO: %s, "
+        SCLogPerf("NIC offloading on %s: SG: %s, GRO: %s, LRO: %s, "
                 "TSO: %s, GSO: %s", dev, sg, gro, lro, tso, gso);
     } else {
         SCLogWarning(SC_ERR_NIC_OFFLOADING, "NIC offloading on %s: SG: %s, "

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -164,26 +164,12 @@ static int GetEthtoolValue(const char *dev, int cmd, uint32_t *value)
     close(fd);
     return 0;
 }
-#endif
 
-/**
- * \brief output offloading status of the link
- *
- * Test interface for offloading features. If one of them is
- * activated then suricata mays received packets merge at reception.
- * The result is oversized packets and this may cause some serious
- * problem in some capture mode where the size of the packet is
- * limited (AF_PACKET in V2 more for example).
- *
- * \param Name of link
- * \retval -1 in case of error, 0 if none, 1 if some
- */
-int GetIfaceOffloading(const char *dev)
+static int GetIfaceOffloadingLinux(const char *dev)
 {
     int ret = 0;
     char *lro = "unset", *gro = "unset", *tso = "unset", *gso = "unset";
     char *sg = "unset";
-#if defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL
     uint32_t value = 0;
 
 #ifdef ETHTOOL_GGRO
@@ -218,10 +204,31 @@ int GetIfaceOffloading(const char *dev)
         }
     }
 #endif
-#endif
     SCLogInfo("NIC offloading on %s: SG: %s, GRO: %s, LRO: %s, "
             "TSO: %s, GSO: %s", dev, sg, gro, lro, tso, gso);
     return ret;
+}
+
+#endif /* defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL */
+
+/**
+ * \brief output offloading status of the link
+ *
+ * Test interface for offloading features. If one of them is
+ * activated then suricata mays received packets merge at reception.
+ * The result is oversized packets and this may cause some serious
+ * problem in some capture mode where the size of the packet is
+ * limited (AF_PACKET in V2 more for example).
+ *
+ * \param Name of link
+ * \retval -1 in case of error, 0 if none, 1 if some
+ */
+int GetIfaceOffloading(const char *dev)
+{
+#if defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL
+    return GetIfaceOffloadingLinux(dev);
+#endif
+    return 0;
 }
 
 int GetIfaceRSSQueuesNum(const char *pcap_dev)

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -137,6 +137,106 @@ int GetIfaceMaxPacketSize(const char *pcap_dev)
     return ll_header + mtu;
 }
 
+#ifdef SIOCGIFFLAGS
+/**
+ * \brief Get interface flags.
+ * \param ifname Inteface name.
+ * \return Interface flags or -1 on error
+ */
+int GetIfaceFlags(const char *ifname)
+{
+    struct ifreq ifr;
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) == -1) {
+        SCLogError(SC_ERR_SYSCALL,
+                   "Unable to get flags for iface \"%s\": %s",
+                   ifname, strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+#ifdef OS_FREEBSD
+    int flags = (ifr.ifr_flags & 0xffff) | (ifr.ifr_flagshigh << 16);
+    return flags;
+#else
+    return ifr.ifr_flags;
+#endif
+}
+#endif
+
+#ifdef SIOCSIFFLAGS
+/**
+ * \brief Set interface flags.
+ * \param ifname Inteface name.
+ * \param flags Flags to set.
+ * \return Zero on success.
+ */
+int SetIfaceFlags(const char *ifname, int flags)
+{
+    struct ifreq ifr;
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+#ifdef OS_FREEBSD
+    ifr.ifr_flags = flags & 0xffff;
+    ifr.ifr_flagshigh = flags >> 16;
+#else
+    ifr.ifr_flags = flags;
+#endif
+
+    if (ioctl(fd, SIOCSIFFLAGS, &ifr) == -1) {
+        SCLogError(SC_ERR_SYSCALL,
+                   "Unable to set flags for iface \"%s\": %s",
+                   ifname, strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+#endif /* SIOCGIFFLAGS */
+
+#ifdef SIOCGIFCAP
+int GetIfaceCaps(const char *ifname)
+{
+    struct ifreq ifr;
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        return -1;
+    }
+
+    memset(&ifr, 0, sizeof(ifr));
+    strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+
+    if (ioctl(fd, SIOCGIFCAP, &ifr) == -1) {
+        SCLogError(SC_ERR_SYSCALL,
+                   "Unable to get caps for iface \"%s\": %s",
+                   ifname, strerror(errno));
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return ifr.ifr_curcap;
+}
+#endif
+
 #if defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL
 static int GetEthtoolValue(const char *dev, int cmd, uint32_t *value)
 {
@@ -204,12 +304,46 @@ static int GetIfaceOffloadingLinux(const char *dev)
         }
     }
 #endif
-    SCLogInfo("NIC offloading on %s: SG: %s, GRO: %s, LRO: %s, "
-            "TSO: %s, GSO: %s", dev, sg, gro, lro, tso, gso);
+    if (ret == 0) {
+        SCLogInfo("NIC offloading on %s: SG: %s, GRO: %s, LRO: %s, "
+                "TSO: %s, GSO: %s", dev, sg, gro, lro, tso, gso);
+    } else {
+        SCLogWarning(SC_ERR_NIC_OFFLOADING, "NIC offloading on %s: SG: %s, "
+                " GRO: %s, LRO: %s, TSO: %s, GSO: %s: "
+                "ethtool -K %s sg off gro off lro off tso off gso off",
+                dev, sg, gro, lro, tso, gso, dev);
+    }
     return ret;
 }
 
 #endif /* defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL */
+
+#ifdef SIOCGIFCAP
+static int GetIfaceOffloadingBSD(const char *ifname)
+{
+    int ret = 0;
+    int if_caps = GetIfaceCaps(ifname);
+    if (if_caps == -1) {
+        return -1;
+    }
+    SCLogDebug("if_caps %X", if_caps);
+
+    if (if_caps & IFCAP_RXCSUM) {
+        SCLogWarning(SC_ERR_NIC_OFFLOADING,
+                "Using %s with RXCSUM activated can lead to capture "
+                "problems: ifconfig %s -rxcsum", ifname, ifname);
+        ret = 1;
+    }
+    if (if_caps & (IFCAP_TSO|IFCAP_TOE|IFCAP_LRO)) {
+        SCLogWarning(SC_ERR_NIC_OFFLOADING,
+                "Using %s with TSO, TOE or LRO activated can lead to "
+                "capture problems: ifconfig %s -tso -toe -lro",
+                ifname, ifname);
+        ret = 1;
+    }
+    return ret;
+}
+#endif
 
 /**
  * \brief output offloading status of the link
@@ -227,8 +361,11 @@ int GetIfaceOffloading(const char *dev)
 {
 #if defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL
     return GetIfaceOffloadingLinux(dev);
-#endif
+#elif defined SIOCGIFCAP
+    return GetIfaceOffloadingBSD(dev);
+#else
     return 0;
+#endif
 }
 
 int GetIfaceRSSQueuesNum(const char *pcap_dev)
@@ -267,3 +404,4 @@ int GetIfaceRSSQueuesNum(const char *pcap_dev)
     return 0;
 #endif
 }
+

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -363,6 +363,7 @@ static int GetIfaceOffloadingBSD(const char *ifname)
                 "problems. Run: ifconfig %s -rxcsum", ifname, ifname);
         ret = 1;
     }
+#ifdef IFCAP_TOE
     if (if_caps & (IFCAP_TSO|IFCAP_TOE|IFCAP_LRO)) {
         SCLogWarning(SC_ERR_NIC_OFFLOADING,
                 "Using %s with TSO, TOE or LRO activated can lead to "
@@ -370,6 +371,15 @@ static int GetIfaceOffloadingBSD(const char *ifname)
                 ifname, ifname);
         ret = 1;
     }
+#else
+    if (if_caps & (IFCAP_TSO|IFCAP_LRO)) {
+        SCLogWarning(SC_ERR_NIC_OFFLOADING,
+                "Using %s with TSO or LRO activated can lead to "
+                "capture problems. Run: ifconfig %s -tso -lro",
+                ifname, ifname);
+        ret = 1;
+    }
+#endif
     return ret;
 }
 #endif

--- a/src/util-ioctl.h
+++ b/src/util-ioctl.h
@@ -23,7 +23,7 @@
 
 int GetIfaceMTU(const char *pcap_dev);
 int GetIfaceMaxPacketSize(const char *pcap_dev);
-int GetIfaceOffloading(const char *pcap_dev);
+int GetIfaceOffloading(const char *dev, int csum, int other);
 int GetIfaceRSSQueuesNum(const char *pcap_dev);
 #ifdef SIOCGIFFLAGS
 int GetIfaceFlags(const char *ifname);

--- a/src/util-ioctl.h
+++ b/src/util-ioctl.h
@@ -25,3 +25,12 @@ int GetIfaceMTU(const char *pcap_dev);
 int GetIfaceMaxPacketSize(const char *pcap_dev);
 int GetIfaceOffloading(const char *pcap_dev);
 int GetIfaceRSSQueuesNum(const char *pcap_dev);
+#ifdef SIOCGIFFLAGS
+int GetIfaceFlags(const char *ifname);
+#endif
+#ifdef SIOCSIFFLAGS
+int SetIfaceFlags(const char *ifname, int flags);
+#endif
+#ifdef SIOCGIFCAP
+int GetIfaceCaps(const char *ifname);
+#endif


### PR DESCRIPTION
Netmap fixes for IPS modes: redo config parsing so that IPS mode enables promisc mode for the 2nd interface as well.

Offloading detection improvements.

Small cleanups.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/452
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/457