### PR TITLE
privs: add capability CAP_SYS_NICE - v1

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -76,16 +76,18 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
         case RUNMODE_AFP_DEV:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
                     CAP_NET_RAW,            /* needed for pcap live mode */
+                    CAP_SYS_NICE,
                     -1);
             break;
         case RUNMODE_PFRING:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
-                    CAP_NET_ADMIN, CAP_NET_RAW,
+                    CAP_NET_ADMIN, CAP_NET_RAW, CAP_SYS_NICE,
                     -1);
             break;
         case RUNMODE_NFQ:
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
                     CAP_NET_ADMIN,          /* needed for nfqueue inline mode */
+                    CAP_SYS_NICE,
                     -1);
             break;
     }


### PR DESCRIPTION
Allows the setting of thread priorities after dropping privileges.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1808

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/258
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/263
