### PR TITLE
util-threshold-config: parse suppress rules with spaces in ip list

### DIFF
--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -73,7 +73,7 @@ typedef enum ThresholdRuleType {
  *  suppress gen_id 1, sig_id 2000328
  *  suppress gen_id 1, sig_id 2000328, track by_src, ip fe80::/10
 */
-#define DETECT_SUPPRESS_REGEX "^,\\s*track\\s*(by_dst|by_src|by_either)\\s*,\\s*ip\\s*([\\[\\],\\$\\da-zA-Z.:/_]+)*\\s*$"
+#define DETECT_SUPPRESS_REGEX "^,\\s*track\\s*(by_dst|by_src|by_either)\\s*,\\s*ip\\s*([\\[\\],\\$\\s\\da-zA-Z.:/_]+)*\\s*$"
 
 /* Default path for the threshold.config file */
 #if defined OS_WIN32 || defined __CYGWIN__


### PR DESCRIPTION
This modified regex allows spaces witihn the ip list for supress rules
like [10.0.0.1, 10.0.0.2].

This would also "fix" the issue from https://redmine.openinfosecfoundation.org/issues/1515

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/27
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/27