### PR TITLE
util-runmode: pass initdata to runmode workers for nfqueue

### DIFF
--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -629,7 +629,7 @@ int RunModeSetIPSWorker(ConfigIPSParserFunc ConfigParser,
             exit(EXIT_FAILURE);
         }
 
-        TmSlotSetFuncAppend(tv, tm_module, NULL);
+        TmSlotSetFuncAppend(tv, tm_module, (void *) ConfigParser(i));
 
         tm_module = TmModuleGetByName("RespondReject");
         if (tm_module == NULL) {


### PR DESCRIPTION
The VerdictNFQ was missing the initdata which results in a segfault
within CaptureStatsSetup. This commit adds the passing of the initdata.

This fixes https://redmine.openinfosecfoundation.org/issues/1589

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/28
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/28