### PR TITLE
[preview] disable offloading v1

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -427,10 +427,15 @@ finalize:
     switch (ltype) {
         case LINKTYPE_ETHERNET:
             /* af-packet can handle csum offloading */
-            if (GetIfaceOffloading(iface, 0, 1) == 1) {
-                SCLogWarning(SC_ERR_AFP_CREATE,
-                    "Using AF_PACKET with offloading activated leads to capture problems");
+            if (LiveGetOffload() == 0) {
+                if (GetIfaceOffloading(iface, 0, 1) == 1) {
+                    SCLogWarning(SC_ERR_AFP_CREATE,
+                            "Using AF_PACKET with offloading activated leads to capture problems");
+                }
+            } else {
+                DisableIfaceOffloading(iface, 0, 1);
             }
+            break;
         case -1:
         default:
             break;

--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -294,7 +294,11 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
     }
 
     /* netmap needs all offloading to be disabled */
-    (void)GetIfaceOffloading(ifname, 1, 1);
+    if (LiveGetOffload() == 0) {
+        (void)GetIfaceOffloading(ifname, 1, 1);
+    } else {
+        DisableIfaceOffloading(ifname, 1, 1);
+    }
 
     /* not found, create new record */
     pdev = SCMalloc(sizeof(*pdev));

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -395,6 +395,12 @@ TmEcode ReceivePcapThreadInit(ThreadVars *tv, void *initdata, void **data)
 
     SCLogInfo("using interface %s", (char *)pcapconfig->iface);
 
+    if (LiveGetOffload() == 0) {
+        (void)GetIfaceOffloading((char *)pcapconfig->iface, 1, 1);
+    } else {
+        DisableIfaceOffloading((char *)pcapconfig->iface, 1, 1);
+    }
+
     ptv->checksum_mode = pcapconfig->checksum_mode;
     if (ptv->checksum_mode == CHECKSUM_VALIDATION_AUTO) {
         SCLogInfo("Running in 'auto' checksum mode. Detection of interface state will require "

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -39,6 +39,23 @@ static int live_devices_stats = 1;
 static int LiveSafeDeviceName(const char *devname,
                               char *newdevname, size_t destlen);
 
+static int g_live_devices_disable_offloading = 1;
+
+void LiveSetOffloadDisable(void)
+{
+    g_live_devices_disable_offloading = 1;
+}
+
+void LiveSetOffloadWarn(void)
+{
+    g_live_devices_disable_offloading = 0;
+}
+
+int LiveGetOffload(void)
+{
+    return g_live_devices_disable_offloading;
+}
+
 /**
  *  \brief Add a pcap device for monitoring
  *

--- a/src/util-device.h
+++ b/src/util-device.h
@@ -34,6 +34,9 @@ typedef struct LiveDevice_ {
     TAILQ_ENTRY(LiveDevice_) next;
 } LiveDevice;
 
+void LiveSetOffloadDisable(void);
+void LiveSetOffloadWarn(void);
+int LiveGetOffload(void);
 
 int LiveRegisterDevice(const char *dev);
 int LiveGetDeviceCount(void);

--- a/src/util-ioctl.c
+++ b/src/util-ioctl.c
@@ -292,6 +292,33 @@ static int GetEthtoolValue(const char *dev, int cmd, uint32_t *value)
     return 0;
 }
 
+static int SetEthtoolValue(const char *dev, int cmd, uint32_t value)
+{
+    struct ifreq ifr;
+    int fd;
+    struct ethtool_value ethv;
+
+    fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd == -1) {
+        return -1;
+    }
+    (void)strlcpy(ifr.ifr_name, dev, sizeof(ifr.ifr_name));
+
+    ethv.cmd = cmd;
+    ethv.data = value;
+    ifr.ifr_data = (void *) &ethv;
+    if (ioctl(fd, SIOCETHTOOL, (char *)&ifr) < 0) {
+        SCLogWarning(SC_ERR_SYSCALL,
+                  "Failure when trying to get feature via ioctl for '%s': %s (%d)",
+                  dev, strerror(errno), errno);
+        close(fd);
+        return -1;
+    }
+
+    close(fd);
+    return 0;
+}
+
 static int GetIfaceOffloadingLinux(const char *dev, int csum, int other)
 {
     int ret = 0;
@@ -368,6 +395,62 @@ static int GetIfaceOffloadingLinux(const char *dev, int csum, int other)
                     dev, sg, gro, lro, tso, gso, dev);
             ret = 1;
         }
+    }
+    return ret;
+}
+
+static int DisableIfaceOffloadingLinux(const char *dev, int csum, int other)
+{
+    int ret = 0;
+    uint32_t value = 0;
+
+    if (csum) {
+#ifdef ETHTOOL_GRXCSUM
+        if (GetEthtoolValue(dev, ETHTOOL_GRXCSUM, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling rxcsum offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_SRXCSUM, 0);
+        }
+#endif
+#ifdef ETHTOOL_GTXCSUM
+        if (GetEthtoolValue(dev, ETHTOOL_GTXCSUM, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling txcsum offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_STXCSUM, 0);
+        }
+#endif
+    }
+    if (other) {
+#ifdef ETHTOOL_GGRO
+        if (GetEthtoolValue(dev, ETHTOOL_GGRO, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling gro offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_SGRO, 0);
+        }
+#endif
+#ifdef ETHTOOL_GTSO
+        if (GetEthtoolValue(dev, ETHTOOL_GTSO, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling tso offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_STSO, 0);
+        }
+#endif
+#ifdef ETHTOOL_GGSO
+        if (GetEthtoolValue(dev, ETHTOOL_GGSO, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling gso offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_SGSO, 0);
+        }
+#endif
+#ifdef ETHTOOL_GSG
+        if (GetEthtoolValue(dev, ETHTOOL_GSG, &value) == 0 && value != 0) {
+            SCLogInfo("%s: disabling sg offloading", dev);
+            SetEthtoolValue(dev, ETHTOOL_SSG, 0);
+        }
+#endif
+#ifdef ETHTOOL_GFLAGS
+        if (GetEthtoolValue(dev, ETHTOOL_GFLAGS, &value) == 0) {
+            if (value & ETH_FLAG_LRO) {
+                SCLogInfo("%s: disabling lro offloading", dev);
+                SetEthtoolValue(dev, ETHTOOL_SSG, value & ~ETH_FLAG_LRO);
+            }
+        }
+#endif
     }
     return ret;
 }
@@ -472,7 +555,9 @@ int GetIfaceOffloading(const char *dev, int csum, int other)
 
 int DisableIfaceOffloading(const char *dev, int csum, int other)
 {
-#if defined SIOCSIFCAP
+#if defined HAVE_LINUX_ETHTOOL_H && defined SIOCETHTOOL
+    return DisableIfaceOffloadingLinux(dev, csum, other);
+#elif defined SIOCSIFCAP
     return DisableIfaceOffloadingBSD(dev);
 #else
     return 0;

--- a/src/util-ioctl.h
+++ b/src/util-ioctl.h
@@ -34,3 +34,4 @@ int SetIfaceFlags(const char *ifname, int flags);
 #ifdef SIOCGIFCAP
 int GetIfaceCaps(const char *ifname);
 #endif
+int DisableIfaceOffloading(const char *dev, int csum, int other);


### PR DESCRIPTION
First stab at disabling offloading through ioctl commands instead of just warning on the settings. Implemented for FreeBSD (ifcaps) and Linux (ethtool).

TODO:
- testing
- make configurable

cc: @regit @gureedo 

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/459
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/464
