### PR TITLE
Fixes v1

### DIFF
--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -387,6 +387,15 @@ void *ParseAFPConfig(const char *iface)
 
 finalize:
 
+    /* if the number of threads is not 1, we need to first check if fanout
+     * functions on this system. */
+    if (aconf->threads != 1) {
+        if (AFPIsFanoutSupported() == 0) {
+            aconf->threads = 1;
+        }
+    }
+
+    /* try to automagically set the proper number of threads */
     if (aconf->threads == 0) {
         int rss_queues;
         aconf->threads = (int)UtilCpuGetNumProcessorsOnline();

--- a/src/runmode-netmap.c
+++ b/src/runmode-netmap.c
@@ -255,10 +255,12 @@ static void *ParseNetmapConfig(const char *iface_name)
     ParseNetmapSettings(&aconf->in, aconf->iface_name, if_root, if_default);
 
     /* if we have a copy iface, parse that as well */
-    if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
-        if (strlen(out_iface) > 0) {
-            if_root = ConfFindDeviceConfig(netmap_node, out_iface);
-            ParseNetmapSettings(&aconf->out, out_iface, if_root, if_default);
+    if (netmap_node != NULL) {
+        if (ConfGetChildValueWithDefault(if_root, if_default, "copy-iface", &out_iface) == 1) {
+            if (strlen(out_iface) > 0) {
+                if_root = ConfFindDeviceConfig(netmap_node, out_iface);
+                ParseNetmapSettings(&aconf->out, out_iface, if_root, if_default);
+            }
         }
     }
 

--- a/src/source-af-packet.h
+++ b/src/source-af-packet.h
@@ -147,4 +147,6 @@ TmEcode AFPPeersListCheck();
 void AFPPeersListClean();
 int AFPGetLinkType(const char *ifname);
 
+int AFPIsFanoutSupported(void);
+
 #endif /* __SOURCE_AFP_H__ */


### PR DESCRIPTION
Small coverity fix.

AF_PACKET work around for CentOS6 (and others) not starting up because of missing FANOUT support. With this patch:
<pre>
[20669] 21/6/2016 -- 16:49:21 - (runmode-af-packet.c:296) <Config> (ParseAFPConfig) -- Using flow cluster mode for AF_PACKET (iface eth0)
[20669] 21/6/2016 -- 16:49:21 - (runmode-af-packet.c:300) <Config> (ParseAFPConfig) -- Using defrag kernel functionality for AF_PACKET (iface eth0)
[20669] 21/6/2016 -- 16:49:21 - (source-af-packet.c:1831) <Perf> (AFPIsFanoutSupported) -- fanout not supported by kernel: Protocol not available
[20669] 21/6/2016 -- 16:49:21 - (util-ioctl.c:336) <Perf> (GetIfaceOffloadingLinux) -- NIC offloading on eth0: SG: unset, GRO: unset, LRO: unset, TSO: unset, GSO: unset
[20669] 21/6/2016 -- 16:49:21 - (runmode-af-packet.c:463) <Config> (ParseAFPConfig) -- eth0: enabling zero copy mode by using data release call
[20669] 21/6/2016 -- 16:49:21 - (util-runmodes.c:288) <Info> (RunModeSetLiveCaptureWorkersForDevice) -- Going to use 1 thread(s)
[20669] 21/6/2016 -- 16:49:21 - (flow-manager.c:720) <Config> (FlowManagerThreadSpawn) -- using 1 flow manager threads
[20669] 21/6/2016 -- 16:49:21 - (flow-manager.c:884) <Config> (FlowRecyclerThreadSpawn) -- using 1 flow recycler threads
[20669] 21/6/2016 -- 16:49:21 - (tm-threads.c:2168) <Notice> (TmThreadWaitOnThreadInit) -- all 1 packet processing threads, 4 management threads initialized, engine started.
[20684] 21/6/2016 -- 16:49:21 - (source-af-packet.c:1592) <Perf> (AFPComputeRingParams) -- AF_PACKET RX Ring params: block_size=32768 block_nr=103 frame_size=1600 frame_nr=2060
[20684] 21/6/2016 -- 16:49:21 - (source-af-packet.c:476) <Info> (AFPPeersListReachedInc) -- All AFP capture threads are running.
</pre>