### PR TITLE
app-layer-parser: fix segfault

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -819,8 +819,9 @@ int AppLayerParserGetStateProgressCompletionStatus(AppProto alproto,
 {
     SCEnter();
     int r = 0;
-    r = alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
-                StateGetProgressCompletionStatus(direction);
+    r = (likely(alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].StateGetProgressCompletionStatus != NULL)) ?
+            alp_ctx.ctxs[FLOW_PROTO_DEFAULT][alproto].
+                StateGetProgressCompletionStatus(direction) : 0;
     SCReturnInt(r);
 }
 


### PR DESCRIPTION
app-layer-parser: fix segfault that had occured when a protocol's eve logger
is enabled, but its app layer parser is disabled.

- PR decanio: https://buildbot.openinfosecfoundation.org/builders/decanio/builds/23
- PR decanio-pcap: https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/23
