### PR TITLE
decode: add Cisco HDLC decoder - v3

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -137,5 +137,8 @@ alert pkthdr any any -> any any (msg:"SURICATA ERSPAN pkt too small"; decode-eve
 alert pkthdr any any -> any any (msg:"SURICATA ERSPAN unsupported version"; decode-event:erspan.unsupported_version; sid: 2200106; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA ERSPAN too many vlan layers"; decode-event:erspan.too_many_vlan_layers; sid: 2200107; rev:1;)
 
-# next sid is 2200110
+# CHDLC
+alert pkthdr any any -> any any (msg:"SURICATA CHDLC packet too small"; decode-event:chdlc.pkt_too_small; sid:2200110; rev:1;)
+
+# next sid is 2200111
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,6 +42,7 @@ conf-yaml-loader.c conf-yaml-loader.h \
 counters.c counters.h \
 data-queue.c data-queue.h \
 decode.c decode.h \
+decode-chdlc.h decode-chdlc.c \
 decode-erspan.c decode-erspan.h \
 decode-ethernet.c decode-ethernet.h \
 decode-events.c decode-events.h \

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -1,0 +1,70 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+/**
+ * \file
+ *
+ * \author Endace Technology Limited, Jason Ish <jason.ish@endace.com>
+ *
+ * Decoder for Cisco HDLC.
+ */
+
+#include "suricata-common.h"
+#include "decode-chdlc.h"
+#include "decode-ethernet.h"
+
+int DecodeCHDLC(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+    uint8_t *pkt, uint16_t len, PacketQueue *pq)
+{
+    if (unlikely(len < sizeof(CHDLCHdr))) {
+        ENGINE_SET_INVALID_EVENT(p, CHDLC_PKT_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    p->chdlch = (CHDLCHdr *)pkt;
+    if (unlikely(p->chdlch == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+
+    int offset = sizeof(CHDLCHdr);
+
+    /* Switch on the protocol field, which contains the same values as
+     * ethertypes in ethernet. */
+    switch (ntohs(p->chdlch->protocol)) {
+        case ETHERNET_TYPE_IP:
+            DecodeIPV4(tv, dtv, p, pkt + offset, len - offset, pq);
+            break;
+        case ETHERNET_TYPE_IPV6:
+            DecodeIPV6(tv, dtv, p, pkt + offset, len - offset, pq);
+            break;
+        default:
+            SCLogDebug("Unsupported CHDLC protocol: %d", p->chdlch->protocol);
+            break;
+    }
+
+    return TM_ECODE_OK;
+}
+
+/**
+ * @}
+ */

--- a/src/decode-chdlc.h
+++ b/src/decode-chdlc.h
@@ -1,0 +1,35 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Endace Technology Limited, Jason Ish <jason.ish@endace.com>
+ *
+ * Decoder for Cisco HDLC.
+ */
+
+#ifndef __DECODE_CHDLC_H__
+#define __DECODE_CHDLC_H__
+
+typedef struct CHDLCHdr_ {
+    uint8_t address;
+    uint8_t control;
+    uint16_t protocol;
+} __attribute__((__packed__)) CHDLCHdr;
+
+#endif /* ! __DECODE_CHDLC_H__ */

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -178,6 +178,9 @@ const struct DecodeEvents_ DEvents[] = {
     { "decoder.erspan.unsupported_version", ERSPAN_UNSUPPORTED_VERSION, },
     { "decoder.erspan.too_many_vlan_layers", ERSPAN_TOO_MANY_VLAN_LAYERS, },
 
+    /* CHDLC events */
+    { "decoder.chdlc.pkt_too_small", CHDLC_PKT_TOO_SMALL, },
+
     /* STREAM EVENTS */
     { "stream.3whs_ack_in_wrong_dir", STREAM_3WHS_ACK_IN_WRONG_DIR, },
     { "stream.3whs_async_wrong_seq", STREAM_3WHS_ASYNC_WRONG_SEQ, },

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -187,6 +187,9 @@ enum {
     ERSPAN_UNSUPPORTED_VERSION,
     ERSPAN_TOO_MANY_VLAN_LAYERS,
 
+    /* Cisco HDLC events. */
+    CHDLC_PKT_TOO_SMALL, /**< CHDLC packet smaller than minimum size. */
+
     /* END OF DECODE EVENTS ON SINGLE PACKET */
     DECODE_EVENT_PACKET_MAX,
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -66,6 +66,7 @@ enum PktSrcEnum {
 
 #include "action-globals.h"
 
+#include "decode-chdlc.h"
 #include "decode-erspan.h"
 #include "decode-ethernet.h"
 #include "decode-gre.h"
@@ -446,6 +447,7 @@ typedef struct Packet_
 
     /* header pointers */
     EthernetHdr *ethh;
+    CHDLCHdr *chdlch;
 
     /* Checksum for IP packets. */
     int32_t level3_comp_csum;
@@ -915,6 +917,8 @@ int DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, P
 int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeCHDLC(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *,
+    uint16_t, PacketQueue *);
 
 void AddressDebugPrint(Address *);
 
@@ -1030,6 +1034,7 @@ int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
 #define LINKTYPE_LINUX_SLL  113
 #define LINKTYPE_PPP        9
 #define LINKTYPE_RAW        DLT_RAW
+#define LINKTYPE_CHDLC      DLT_C_HDLC
 #define PPP_OVER_GRE        11
 #define VLAN_OVER_GRE       13
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -332,7 +332,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, void *initdata, void **data)
         case LINKTYPE_NULL:
             pcap_g.Decoder = DecodeNull;
             break;
-
+        case LINKTYPE_CHDLC:
+            pcap_g.Decoder = DecodeCHDLC;
+            break;
         default:
             SCLogError(SC_ERR_UNIMPLEMENTED, "datalink type %" PRId32 " not "
                       "(yet) supported in module PcapFile.\n", pcap_g.datalink);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -720,6 +720,9 @@ TmEcode DecodePcap(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
         case LINKTYPE_NULL:
             DecodeNull(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
+        case LINKTYPE_CHDLC:
+            DecodeCHDLC(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
+            break;
         default:
             SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodePcap", p->datalink);
             break;


### PR DESCRIPTION
Previous PR: #2151 

Changes from last PR:
- Add decoder rule.

Cisco HDLC decoder. Support added for PCAP, ERF and DAG.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1807

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/265
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/270
