### PR TITLE
lua smtp: fix SMTPGetMimeField arg checking

### DIFF
--- a/src/util-lua-smtp.c
+++ b/src/util-lua-smtp.c
@@ -112,6 +112,9 @@ static int SMTPGetMimeField(lua_State *luastate)
         return LuaCallbackError(luastate, "Error: no flow found");
     }
     const char *name = LuaGetStringArgument(luastate, 1);
+    if (name == NULL)
+        return LuaCallbackError(luastate, "1st argument missing, empty or wrong type");
+
     /* lock check */
     if(lock_hint == LUA_FLOW_NOT_LOCKED_BY_PARENT) {
         FLOWLOCK_RDLOCK(flow);


### PR DESCRIPTION
Properly check argument before passing it on: CID 1363385: (NULL_RETURNS)

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/465
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/470