### PR TITLE
preview: directional logging - v2

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -226,7 +226,7 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction)
     if (direction & STREAM_TOCLIENT) {
         /* response side of the tx is done if we parsed a reply
          * or if we tagged this tx as 'reply lost'. */
-        return (dns_tx->replied|dns_tx->reply_lost) ? 1 : 0;
+        return (dns_tx->replied|dns_tx->reply_lost) ? 2 : 1;
     }
     else {
         /* tx is only created if we have a complete request,
@@ -253,11 +253,11 @@ int DNSGetTxLogged(void *alstate, void *tx, uint32_t logger)
 
 /** \brief get value for 'complete' status in DNS
  *
- *  For DNS we use a simple bool. 1 means done.
+ *  For DNS 1 means request done, 2 means reply done (or lost).
  */
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction)
 {
-    return 1;
+    return 2;
 }
 
 void DNSSetEvent(DNSState *s, uint8_t e)

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -274,7 +274,8 @@ static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uin
 
 }
 
-static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
+    const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 
@@ -292,6 +293,18 @@ static int JsonDnsLogger(ThreadVars *tv, void *thread_data, const Packet *p, Flo
 
         json_decref(js);
     }
+
+    SCReturnInt(TM_ECODE_OK);
+}
+
+static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
+    const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
+{
+    SCEnter();
+
+    LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
+    DNSTransaction *tx = txptr;
+    json_t *js;
 
     js = CreateJSONHeader((Packet *)p, 0, "dns");
     if (unlikely(js == NULL))
@@ -449,10 +462,21 @@ void TmModuleJsonDnsLogRegister (void)
     tmm_modules[TMM_JSONDNSLOG].cap_flags = 0;
     tmm_modules[TMM_JSONDNSLOG].flags = TM_FLAG_LOGAPI_TM;
 
-    OutputRegisterTxModule(MODULE_NAME, "dns-json-log", JsonDnsLogInitCtx,
-            ALPROTO_DNS, JsonDnsLogger);
-    OutputRegisterTxSubModule("eve-log", MODULE_NAME, "eve-log.dns", JsonDnsLogInitCtxSub,
-            ALPROTO_DNS, JsonDnsLogger);
+    /* Logger for requests. */
+    OutputRegisterTxModuleWithProgress(MODULE_NAME, "dns-json-log",
+        JsonDnsLogInitCtx, ALPROTO_DNS, JsonDnsLoggerToServer, 1, 1);
+
+    /* Logger for replies. */
+    OutputRegisterTxModuleWithProgress(MODULE_NAME, "dns-json-log",
+        JsonDnsLogInitCtx, ALPROTO_DNS, JsonDnsLoggerToClient, 2, 1);
+
+    /* Sub-logger for requests. */
+    OutputRegisterTxSubModuleWithProgress("eve-log", MODULE_NAME, "eve-log.dns",
+        JsonDnsLogInitCtxSub, ALPROTO_DNS, JsonDnsLoggerToServer, 1, 1);
+
+    /* Sub-logger for replies. */
+    OutputRegisterTxSubModuleWithProgress("eve-log", MODULE_NAME, "eve-log.dns",
+        JsonDnsLogInitCtxSub, ALPROTO_DNS, JsonDnsLoggerToClient, 2, 1);
 }
 
 #else

--- a/src/output.c
+++ b/src/output.c
@@ -31,8 +31,7 @@
 #include "util-debug.h"
 #include "output.h"
 
-static TAILQ_HEAD(, OutputModule_) output_modules =
-    TAILQ_HEAD_INITIALIZER(output_modules);
+OutputModuleList output_modules = TAILQ_HEAD_INITIALIZER(output_modules);
 
 /**
  * Registry of flags to be updated on file rotation notification.

--- a/src/output.h
+++ b/src/output.h
@@ -62,6 +62,9 @@ typedef struct OutputModule_ {
     TAILQ_ENTRY(OutputModule_) entries;
 } OutputModule;
 
+typedef TAILQ_HEAD(OutputModuleList_, OutputModule_) OutputModuleList;
+extern OutputModuleList output_modules;
+
 void OutputRegisterModule(const char *, const char *, OutputCtx *(*)(ConfNode *));
 
 void OutputRegisterPacketModule(const char *name, const char *conf_name,

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -718,6 +718,96 @@ static void SetupOutput(const char *name, OutputModule *module, OutputCtx *outpu
     }
 }
 
+static void RunModeInitializeEveOutput(ConfNode *conf, OutputCtx *parent_ctx) {
+    ConfNode *types = ConfNodeLookupChild(conf, "types");
+    SCLogDebug("types %p", types);
+    if (types != NULL) {
+        ConfNode *type = NULL;
+        TAILQ_FOREACH(type, &types->head, next) {
+            SCLogConfig("enabling 'eve-log' module '%s'", type->val);
+
+            int sub_count = 0;
+            char subname[256];
+            snprintf(subname, sizeof(subname), "eve-log.%s", type->val);
+
+            /* Now setup all registers logger of this name. */
+            OutputModule *sub_module;
+            TAILQ_FOREACH(sub_module, &output_modules, entries) {
+                if (strcmp(subname, sub_module->conf_name) == 0) {
+                    sub_count++;
+
+                    if (sub_module->parent_name == NULL ||
+                        strcmp(sub_module->parent_name, "eve-log") != 0) {
+                        FatalError(SC_ERR_INVALID_ARGUMENT,
+                            "bad parent for %s", subname);
+                    }
+                    if (sub_module->InitSubFunc == NULL) {
+                        FatalError(SC_ERR_INVALID_ARGUMENT,
+                            "bad sub-module for %s", subname);
+                    }
+                    ConfNode *sub_output_config =
+                        ConfNodeLookupChild(type, type->val);
+                    // sub_output_config may be NULL if no config
+
+                    /* pass on parent output_ctx */
+                    OutputCtx *sub_output_ctx =
+                        sub_module->InitSubFunc(sub_output_config,
+                            parent_ctx);
+                    if (sub_output_ctx == NULL) {
+                        continue;
+                    }
+
+                    AddOutputToFreeList(sub_module, sub_output_ctx);
+                    SetupOutput(sub_module->name, sub_module,
+                        sub_output_ctx);
+                }
+            }
+
+            /* Error is no registered loggers with this name
+             * were found .*/
+            if (!sub_count) {
+                FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                    "No output module named %s", subname);
+                continue;
+            }
+        }
+    }
+}
+
+static void RunModeInitializeLuaOutput(ConfNode *conf, OutputCtx *parent_ctx)
+{
+    OutputModule *lua_module = OutputGetModuleByConfName("lua");
+    BUG_ON(lua_module == NULL);
+
+    ConfNode *scripts = ConfNodeLookupChild(conf, "scripts");
+    BUG_ON(scripts == NULL); //TODO
+
+    OutputModule *m;
+    TAILQ_FOREACH(m, &parent_ctx->submodules, entries) {
+        SCLogDebug("m %p %s:%s", m, m->name, m->conf_name);
+
+        ConfNode *script = NULL;
+        TAILQ_FOREACH(script, &scripts->head, next) {
+            SCLogDebug("script %s", script->val);
+            if (strcmp(script->val, m->conf_name) == 0) {
+                break;
+            }
+        }
+        BUG_ON(script == NULL);
+
+        /* pass on parent output_ctx */
+        OutputCtx *sub_output_ctx =
+            m->InitSubFunc(script, parent_ctx);
+        if (sub_output_ctx == NULL) {
+            SCLogInfo("sub_output_ctx NULL, skipping");
+            continue;
+        }
+
+        AddOutputToFreeList(m, sub_output_ctx);
+        SetupOutput(m->name, m, sub_output_ctx);
+    }
+}
+
 /**
  * Initialize the output modules.
  */
@@ -787,112 +877,51 @@ void RunModeInitializeOutputs(void)
             tls_log_enabled = 1;
         }
 
-        OutputModule *module = OutputGetModuleByConfName(output->val);
-        if (module == NULL) {
+        OutputModule *module;
+        int count = 0;
+        TAILQ_FOREACH(module, &output_modules, entries) {
+            if (strcmp(module->conf_name, output->val) != 0) {
+                continue;
+            }
+
+            count++;
+
+            OutputCtx *output_ctx = NULL;
+            if (module->InitFunc != NULL) {
+                output_ctx = module->InitFunc(output_config);
+                if (output_ctx == NULL) {
+                    FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
+                        "output module setup failed");
+                    continue;
+                }
+            } else if (module->InitSubFunc != NULL) {
+                SCLogInfo("skipping submodule");
+                continue;
+            }
+
+            // TODO if module == parent, find it's children
+            if (strcmp(output->val, "eve-log") == 0) {
+                RunModeInitializeEveOutput(output_config, output_ctx);
+
+                /* add 'eve-log' to free list as it's the owner of the
+                 * main output ctx from which the sub-modules share the
+                 * LogFileCtx */
+                AddOutputToFreeList(module, output_ctx);
+            } else if (strcmp(output->val, "lua") == 0) {
+                SCLogDebug("handle lua");
+                if (output_ctx == NULL)
+                    continue;
+                RunModeInitializeLuaOutput(output_config, output_ctx);
+                AddOutputToFreeList(module, output_ctx);
+            } else {
+                AddOutputToFreeList(module, output_ctx);
+                SetupOutput(module->name, module, output_ctx);
+            }
+        }
+        if (count == 0) {
             FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
                 "No output module named %s", output->val);
             continue;
-        }
-
-        OutputCtx *output_ctx = NULL;
-        if (module->InitFunc != NULL) {
-            output_ctx = module->InitFunc(output_config);
-            if (output_ctx == NULL) {
-                FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT, "output module setup failed");
-                continue;
-            }
-        } else if (module->InitSubFunc != NULL) {
-            SCLogInfo("skipping submodule");
-            continue;
-        }
-
-        // TODO if module == parent, find it's children
-        if (strcmp(output->val, "eve-log") == 0) {
-            ConfNode *types = ConfNodeLookupChild(output_config, "types");
-            SCLogDebug("types %p", types);
-            if (types != NULL) {
-                ConfNode *type = NULL;
-                TAILQ_FOREACH(type, &types->head, next) {
-                    SCLogConfig("enabling 'eve-log' module '%s'", type->val);
-
-                    char subname[256];
-                    snprintf(subname, sizeof(subname), "%s.%s", output->val, type->val);
-
-                    OutputModule *sub_module = OutputGetModuleByConfName(subname);
-                    if (sub_module == NULL) {
-                        FatalErrorOnInit(SC_ERR_INVALID_ARGUMENT,
-                                "No output module named %s", subname);
-                        continue;
-                    }
-                    if (sub_module->parent_name == NULL ||
-                            strcmp(sub_module->parent_name,output->val) != 0) {
-                        FatalError(SC_ERR_INVALID_ARGUMENT,
-                                "bad parent for %s", subname);
-                    }
-                    if (sub_module->InitSubFunc == NULL) {
-                        FatalError(SC_ERR_INVALID_ARGUMENT,
-                                "bad sub-module for %s", subname);
-                    }
-                    ConfNode *sub_output_config = ConfNodeLookupChild(type, type->val);
-                    // sub_output_config may be NULL if no config
-
-                    /* pass on parent output_ctx */
-                    OutputCtx *sub_output_ctx =
-                        sub_module->InitSubFunc(sub_output_config, output_ctx);
-                    if (sub_output_ctx == NULL) {
-                        continue;
-                    }
-
-                    AddOutputToFreeList(sub_module, sub_output_ctx);
-                    SetupOutput(sub_module->name, sub_module, sub_output_ctx);
-                }
-            }
-            /* add 'eve-log' to free list as it's the owner of the
-             * main output ctx from which the sub-modules share the
-             * LogFileCtx */
-            AddOutputToFreeList(module, output_ctx);
-
-        } else if (strcmp(output->val, "lua") == 0) {
-            SCLogDebug("handle lua");
-
-            if (output_ctx == NULL)
-                continue;
-
-            OutputModule *lua_module = OutputGetModuleByConfName(output->val);
-            BUG_ON(lua_module == NULL);
-            AddOutputToFreeList(lua_module, output_ctx);
-
-            ConfNode *scripts = ConfNodeLookupChild(output_config, "scripts");
-            BUG_ON(scripts == NULL); //TODO
-
-            OutputModule *m;
-            TAILQ_FOREACH(m, &output_ctx->submodules, entries) {
-                SCLogDebug("m %p %s:%s", m, m->name, m->conf_name);
-
-                ConfNode *script = NULL;
-                TAILQ_FOREACH(script, &scripts->head, next) {
-                    SCLogDebug("script %s", script->val);
-                    if (strcmp(script->val, m->conf_name) == 0) {
-                        break;
-                    }
-                }
-                BUG_ON(script == NULL);
-
-                /* pass on parent output_ctx */
-                OutputCtx *sub_output_ctx =
-                    m->InitSubFunc(script, output_ctx);
-                if (sub_output_ctx == NULL) {
-                    SCLogInfo("sub_output_ctx NULL, skipping");
-                    continue;
-                }
-
-                AddOutputToFreeList(m, sub_output_ctx);
-                SetupOutput(m->name, m, sub_output_ctx);
-            }
-
-        } else {
-            AddOutputToFreeList(module, output_ctx);
-            SetupOutput(module->name, module, output_ctx);
         }
     }
 


### PR DESCRIPTION
Replaces PR #2170 with a PR that applies directly to master.

Take a different approach to per directional logging than the previous PRs did (#1992). Instead of touching the core tx logging logic, allow a logger name to be registered multiple times, where the TS and TC logging functions can be registered separately.

For DNS the result is that requests are logged before the response, and requests will be timestamped with the request timestamp, not the response timestamp.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/271
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/276
