### PR TITLE
Config option for disabling libhtp decompression

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2361,6 +2361,8 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
             SCLogWarning(SC_WARN_OUTDATED_LIBHTP, "can't set response-body-decompress-layer-limit "
                     "to %u, libhtp version too old", value);
 #endif
+        } else if (strcasecmp("response-body-decompress-enable", p->name) == 0) {
+            htp_config_set_response_decompression(cfg_prec->cfg, ConfValIsTrue(p->val));
         } else if (strcasecmp("path-convert-backslash-separators", p->name) == 0) {
             htp_config_set_backslash_convert_slashes(cfg_prec->cfg,
                                                      HTP_DECODER_URL_PATH,


### PR DESCRIPTION
Suricata has a config option to configure libhtp decompression layer limit, but no option to disable decompression altogether. 0 is interpreted as no limit, and negative values are not accepted, either.

This pull request adds such option.
