### PR TITLE
rule-reload: remember pending USR2 signals

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -303,7 +303,11 @@ static void SignalHandlerSigterm(/*@unused@*/ int sig)
  */
 static void SignalHandlerSigusr2(int sig)
 {
-    sigusr2_count = 1;
+    if (sigusr2_count < 16) {
+        sigusr2_count++;
+    } else {
+        SCLogWarning(SC_ERR_LIVE_RULE_SWAP, "Too many USR2 signals pending, ignoring new ones!");
+    }
 }
 
 /**


### PR DESCRIPTION
We did ignore additional USR2 signals while a rule-reload was running.
This changes the counter to be incremented with every additional USR2
signal so we don't ignore them anymore but it's still limited to prevent
huge overload or even overflow.

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/29
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/29

This solves https://redmine.openinfosecfoundation.org/issues/1277