### PR TITLE
pcap: don't fail with --pcap with no device present -v1

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1167,7 +1167,9 @@ static int ParseCommandLinePcapLive(SCInstance *suri, const char *optarg)
 
     if (suri->run_mode == RUNMODE_UNKNOWN) {
         suri->run_mode = RUNMODE_PCAP_DEV;
-        LiveRegisterDevice(suri->pcap_dev);
+        if (optarg) {
+            LiveRegisterDevice(suri->pcap_dev);
+        }
     } else if (suri->run_mode == RUNMODE_PCAP_DEV) {
 #ifdef OS_WIN32
         SCLogError(SC_ERR_PCAP_MULTI_DEV_NO_SUPPORT, "pcap multi dev "


### PR DESCRIPTION
Issue: 1856.
https://redmine.openinfosecfoundation.org/issues/1856

A device with the name of "" (empty string) was being added
with LiveRegisterDevice which failed to initialize causing
Suricata to fail.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/282
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/287
