### PR TITLE
Issue 1854 - fix unified2 tag logging - v1

### DIFF
--- a/src/decode.h
+++ b/src/decode.h
@@ -85,6 +85,7 @@ enum PktSrcEnum {
 #include "decode-mpls.h"
 
 #include "detect-reference.h"
+#include "detect-tag.h"
 
 #include "app-layer-protos.h"
 
@@ -556,6 +557,9 @@ typedef struct Packet_
      * the packet to its owner's stack. If NULL, then allocated with malloc.
      */
     struct PktPool_ *pool;
+
+    /** Tag information if tagged. */
+    DetectTagDataEntry *tag;
 
 #ifdef PROFILING
     PktProfiling *profile;

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -29,32 +29,6 @@
 
 #include "util-profiling.h"
 
-/** tag signature we use for tag alerts */
-static Signature g_tag_signature;
-/** tag packet alert structure for tag alerts */
-static PacketAlert g_tag_pa;
-
-void PacketAlertTagInit(void)
-{
-    memset(&g_tag_signature, 0x00, sizeof(g_tag_signature));
-
-    g_tag_signature.id = TAG_SIG_ID;
-    g_tag_signature.gid = TAG_SIG_GEN;
-    g_tag_signature.num = TAG_SIG_ID;
-    g_tag_signature.rev = 1;
-    g_tag_signature.prio = 2;
-
-    memset(&g_tag_pa, 0x00, sizeof(g_tag_pa));
-
-    g_tag_pa.action = ACTION_ALERT;
-    g_tag_pa.s = &g_tag_signature;
-}
-
-PacketAlert *PacketAlertGetTag(void)
-{
-    return &g_tag_pa;
-}
-
 /**
  * \brief Handle a packet and check if needs a threshold logic
  *        Also apply rule action if necessary.

--- a/src/detect-engine-analyzer.c
+++ b/src/detect-engine-analyzer.c
@@ -35,6 +35,7 @@
 #include "detect-flow.h"
 #include "detect-flags.h"
 #include "util-print.h"
+#include "util-time.h"
 
 static int rule_warnings_only = 0;
 static FILE *rule_engine_analysis_FD = NULL;

--- a/src/detect-engine-tag.c
+++ b/src/detect-engine-tag.c
@@ -104,6 +104,7 @@ static DetectTagDataEntry *DetectTagDataCopy(DetectTagDataEntry *dtd)
     tde->flags = dtd->flags;
     tde->metric = dtd->metric;
     tde->count = dtd->count;
+    tde->event_id = dtd->event_id;
 
     tde->first_ts = dtd->first_ts;
     tde->last_ts = dtd->last_ts;
@@ -273,6 +274,10 @@ static void TagHandlePacketFlow(Flow *f, Packet *p)
             case DETECT_TAG_METRIC_BYTES:
                 iter->bytes += GET_PKT_LEN(p);
                 break;
+        }
+
+        if (p->tag == NULL) {
+            p->tag = iter;
         }
 
         /* If this packet triggered the rule with tag, we dont need

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -25,10 +25,6 @@
 #ifndef __DETECT_TAG_H__
 #define __DETECT_TAG_H__
 
-#include "suricata-common.h"
-#include "suricata.h"
-#include "util-time.h"
-
 /* Limit the number of times a session can be tagged by the
  * same rule without finishing older tags */
 #define DETECT_TAG_MATCH_LIMIT 10

--- a/src/detect-tag.h
+++ b/src/detect-tag.h
@@ -81,9 +81,8 @@ typedef struct DetectTagDataEntry_ {
     };
     uint32_t first_ts;                  /**< First time seen (for metric = seconds) */
     uint32_t last_ts;                   /**< Last time seen (to prune old sessions) */
-#if __WORDSIZE == 64
-    uint32_t pad1;
-#endif
+    uint32_t event_id;                  /**< Event ID of the event to initiate the tag (for unified2). */
+
     struct DetectTagDataEntry_ *next;   /**< Pointer to the next tag of this
                                          *   session/src_host/dst_host (if any from other rule) */
 } DetectTagDataEntry;

--- a/src/flow-worker.c
+++ b/src/flow-worker.c
@@ -46,6 +46,7 @@
 #include "detect-engine.h"
 
 #include "util-validate.h"
+#include "util-time.h"
 
 typedef DetectEngineThreadCtx *DetectEngineThreadCtxPtr;
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -49,6 +49,7 @@
 #include "util-classification-config.h"
 #include "util-syslog.h"
 #include "util-logopenfile.h"
+#include "util-time.h"
 
 #include "output.h"
 #include "output-json.h"
@@ -65,6 +66,7 @@
 #include "util-optimize.h"
 #include "util-buffer.h"
 #include "util-crypt.h"
+#include "util-time.h"
 
 #define MODULE_NAME "JsonAlertLog"
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -43,6 +43,7 @@
 
 #include "util-logopenfile.h"
 #include "util-crypt.h"
+#include "util-time.h"
 
 #include "output-json.h"
 #include "output-json-stats.h"

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -57,6 +57,7 @@
 #include "util-buffer.h"
 #include "util-logopenfile.h"
 #include "util-device.h"
+#include "util-time.h"
 
 
 #ifndef HAVE_LIBJANSSON

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -40,6 +40,7 @@
 #include "util-optimize.h"
 #include "util-checksum.h"
 #include "util-ioctl.h"
+#include "util-time.h"
 #include "tmqh-packetpool.h"
 
 #ifdef __SC_CUDA_SUPPORT__

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -41,6 +41,7 @@
 
 #include "util-unittest.h"
 #include "util-syslog.h"
+#include "util-time.h"
 
 #include "conf.h"
 

--- a/src/util-profiling-keywords.c
+++ b/src/util-profiling-keywords.c
@@ -36,6 +36,7 @@
 #include "util-byte.h"
 #include "util-profiling.h"
 #include "util-profiling-locks.h"
+#include "util-time.h"
 
 #ifdef PROFILING
 

--- a/src/util-profiling-rulegroups.c
+++ b/src/util-profiling-rulegroups.c
@@ -36,6 +36,7 @@
 #include "util-byte.h"
 #include "util-profiling.h"
 #include "util-profiling-locks.h"
+#include "util-time.h"
 
 #ifdef PROFILING
 

--- a/src/util-profiling-rules.c
+++ b/src/util-profiling-rules.c
@@ -35,6 +35,7 @@
 #include "util-byte.h"
 #include "util-profiling.h"
 #include "util-profiling-locks.h"
+#include "util-time.h"
 
 #ifdef PROFILING
 


### PR DESCRIPTION
Redmine issue: https://redmine.openinfosecfoundation.org/issues/1854

tag: fix unified tagging and make unified2 compliant

Logging of tagged packets in unified2 was not working as the tag alert structure was never being initialized. Instead of fixing that, making logging of tagged packets the same as in Snort, where there is no event type for tagged packets, but instead the event_id, and event_second field are used to reference the event structure that initiated the tag.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/283
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/288
