### PR TITLE
rule-parsing: reject unescaped double quote within content section

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -186,6 +186,9 @@ int DetectContentDataParse(const char *keyword, const char *contentstr,
                     }
                     escape = 0;
                     converted = 1;
+                } else if (str[i] == '"') {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid unescaped double quote within content section");
+                    goto error;
                 } else {
                     str[x] = str[i];
                     x++;


### PR DESCRIPTION
A double quote within the first and last double quote is an indication for a wrong rule, like the later one in https://redmine.openinfosecfoundation.org/issues/312 

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/31
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/31