### PR TITLE
unified2: fix logging of tagged packets - v2

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2376,6 +2376,7 @@ static int PostConfLoadedSetup(SCInstance *suri)
     SCProtoNameInit();
 
     TagInitCtx();
+    PacketAlertTagInit();
     ThresholdInit();
     HostBitInitCtx();
     IPPairBitInitCtx();


### PR DESCRIPTION
The structure for creating the alert preceding each tagged packet
was not being initialized, preventing tagged packets from being
logged.

Note: Snort unified2 does not precede tagged packets with an
alert like is done here, so this just fixes what the code
intended to do, it does not make it Snort unified2
compatible.

Addresses issue:
https://redmine.openinfosecfoundation.org/issues/1854

Prscript output:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/285
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/290
