### PR TITLE
decode: support Cisco Fabric Path / DCE - v1

### DIFF
--- a/src/decode-ethernet.c
+++ b/src/decode-ethernet.c
@@ -85,6 +85,12 @@ int DecodeEthernet(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
             DecodeMPLS(tv, dtv, p, pkt + ETHERNET_HEADER_LEN,
                        len - ETHERNET_HEADER_LEN, pq);
             break;
+        case ETHERNET_TYPE_DCE:
+            if (len > ETHERNET_DCE_HEADER_LEN) {
+                DecodeEthernet(tv, dtv, p, pkt + ETHERNET_DCE_HEADER_LEN,
+                    len - ETHERNET_DCE_HEADER_LEN, pq);
+            }
+            break;
         default:
             SCLogDebug("p %p pkt %p ether type %04x not supported", p,
                        pkt, ntohs(p->ethh->eth_type));

--- a/src/decode-ethernet.h
+++ b/src/decode-ethernet.h
@@ -26,6 +26,9 @@
 
 #define ETHERNET_HEADER_LEN           14
 
+/* Cisco Fabric Path / DCE header length. */
+#define ETHERNET_DCE_HEADER_LEN       ETHERNET_HEADER_LEN + 2
+
 /* Ethernet types -- taken from Snort and Libdnet */
 #define ETHERNET_TYPE_PUP             0x0200 /* PUP protocol */
 #define ETHERNET_TYPE_IP              0x0800
@@ -42,6 +45,8 @@
 #define ETHERNET_TYPE_LOOP            0x9000
 #define ETHERNET_TYPE_8021QINQ        0x9100
 #define ETHERNET_TYPE_ERSPAN          0x88BE
+#define ETHERNET_TYPE_DCE             0x8903 /* Data center ethernet,
+                                              * Cisco Fabric Path */
 
 typedef struct EthernetHdr_ {
     uint8_t eth_dst[6];


### PR DESCRIPTION
[dce-dns-request.zip](https://github.com/inliniac/suricata/files/428377/dce-dns-request.zip)

Cisco Fabric Path is ethernet wrapped in an ethernet like header
with 2 extra bytes.  The ethernet type is in the same location
so the ethernet decoder can be used with some validation
for the extra length.

This is just simple validation and decode. No extra counters or invalid events specific to fabric path.

I am not able to share the original pcap I received, but was able to create this one.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/286
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/291
