### PR TITLE
fix hex string overrun issues in dns - v1

### DIFF
--- a/src/app-layer-tls-handshake.c
+++ b/src/app-layer-tls-handshake.c
@@ -181,7 +181,7 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
             if (i == 0 && ssl_state->server_connp.cert0_fingerprint == NULL) {
                 int msg_len = cur_cert_length;
                 int hash_len = 20;
-                int out_len = 60;
+                int out_len = hash_len * 3 + 1;
                 char out[out_len];
                 unsigned char *hash;
                 hash = ComputeSHA1((unsigned char *) input, (int) msg_len);

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -181,7 +181,8 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs, DNSTransaction *tx, 
                 /* turn fp raw buffer into a nice :-separate hex string */
                 uint16_t fp_len = (entry->data_len - 2);
                 uint8_t *dptr = ptr+2;
-                uint32_t output_len = fp_len * 2 + 1; // create c-string, so add space for 0.
+                /* c-string for ':' separated hex and trailing \0. */
+                uint32_t output_len = fp_len * 3 + 1;
                 char hexstring[output_len], *p = hexstring;
                 memset(hexstring, 0x00, output_len);
 


### PR DESCRIPTION
2 fixes where the buffer being written to was not large enough.

- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/290
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/295

/cc @regit 