### PR TITLE
support "tag in eve logging - v3

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -175,6 +175,23 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
     json_object_set_new(js, "alert", ajs);
 }
 
+static void AlertJsonPacket(const Packet *p, json_t *js)
+{
+    unsigned long len = GET_PKT_LEN(p) * 2;
+    uint8_t encoded_packet[len];
+    Base64Encode((unsigned char*) GET_PKT_DATA(p), GET_PKT_LEN(p),
+        encoded_packet, &len);
+    json_object_set_new(js, "packet", json_string((char *)encoded_packet));
+
+    /* Create packet info. */
+    json_t *packetinfo_js = json_object();
+    if (unlikely(packetinfo_js == NULL)) {
+        return;
+    }
+    json_object_set_new(packetinfo_js, "linktype", json_integer(p->datalink));
+    json_object_set_new(js, "packet_info", packetinfo_js);
+}
+
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     MemBuffer *payload = aft->payload_buffer;
@@ -183,7 +200,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
     int i;
 
-    if (p->alerts.cnt == 0)
+    if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
         return TM_ECODE_OK;
 
     json_t *js = CreateJSONHeader((Packet *)p, 0, "alert");
@@ -325,10 +342,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
         /* base64-encoded full packet */
         if (json_output_ctx->flags & LOG_JSON_PACKET) {
-            unsigned long len = GET_PKT_LEN(p) * 2;
-            uint8_t encoded_packet[len];
-            Base64Encode((unsigned char*) GET_PKT_DATA(p), GET_PKT_LEN(p), encoded_packet, &len);
-            json_object_set_new(js, "packet", json_string((char *)encoded_packet));
+            AlertJsonPacket(p, js);
         }
 
         HttpXFFCfg *xff_cfg = json_output_ctx->xff_cfg;
@@ -367,6 +381,16 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     }
     json_object_clear(js);
     json_decref(js);
+
+    if (p->flags & PKT_HAS_TAG) {
+        MemBufferReset(aft->json_buffer);
+        json_t *packetjs = CreateJSONHeader((Packet *)p, 0, "packet");
+        if (unlikely(packetjs != NULL)) {
+            AlertJsonPacket(p, packetjs);
+            OutputJSONBuffer(packetjs, aft->file_ctx, &aft->json_buffer);
+            json_decref(packetjs);
+        }
+    }
 
     return TM_ECODE_OK;
 }
@@ -457,7 +481,10 @@ static int JsonAlertLogger(ThreadVars *tv, void *thread_data, const Packet *p)
 
 static int JsonAlertLogCondition(ThreadVars *tv, const Packet *p)
 {
-    return (p->alerts.cnt ? TRUE : FALSE);
+    if (p->alerts.cnt || (p->flags & PKT_HAS_TAG)) {
+        return TRUE;
+    }
+    return FALSE;
 }
 
 #define OUTPUT_BUFFER_SIZE 65535

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,6 +164,10 @@ outputs:
             ssh: yes                 # enable dumping of ssh fields
             smtp: yes                # enable dumping of smtp fields
 
+            # Enable the logging of tagged packets for rules using the
+            # "tag" keyword.
+            tagged-packets: yes
+
             # HTTP X-Forwarded-For support by adding an extra field or overwriting
             # the source or destination IP address (depending on flow direction)
             # with the one reported in the X-Forwarded-For HTTP header. This is


### PR DESCRIPTION
Previous PR:
https://github.com/inliniac/suricata/pull/2196

Changes from last PR:
- Check value for NULL.
- Making logging of tagged packets optional (on in default config)
- Add packet_info object to hold linktype.
- Add packet_info to alert events that include the packet.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/292
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/297
