### PR TITLE
eve: reduce flow_id to 51 bits

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -167,6 +167,9 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
     if (f == NULL)
         return;
     int64_t flow_id = FlowGetId(f);
+    /* reduce to 51 bits as Javascript and even JSON often seem to
+     * max out there. */
+    flow_id &= 0x7ffffffffffffLL;
     json_object_set_new(js, "flow_id", json_integer(flow_id));
 }
 


### PR DESCRIPTION
Evebox & ELK couldn't handle the large integers. It looks like (partly)
a javascript limitation that doesn't treat 64bit ints as real ints.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/481
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/486

https://redmine.openinfosecfoundation.org/issues/1870