### PR TITLE
stream: fix depth reached detection

### DIFF
--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -157,7 +157,9 @@ enum
 #define STREAMTCP_STREAM_FLAG_KEEPALIVE         0x0004
 /** Stream has reached it's reassembly depth, all further packets are ignored */
 #define STREAMTCP_STREAM_FLAG_DEPTH_REACHED     0x0008
-// vacancy
+/** Stream has reached it's reassembly depth, but part current segment fit in
+ * depth and will be inspected */
+#define STREAMTCP_STREAM_FLAG_DEPTH_PARTIALLY_REACHED     0x0010
 /** Stream supports TIMESTAMP -- used to set ssn STREAMTCP_FLAG_TIMESTAMP
  *  flag. */
 #define STREAMTCP_STREAM_FLAG_TIMESTAMP         0x0020


### PR DESCRIPTION
When a segment only partially fit in streaming depth, the stream
depth reached flag was not set resulting in a continuous
inspection of the rest of the session.

I've seen this issue when working on shunting where I had continuous stream instead of having them shunt.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/184
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/180