### PR TITLE
Ruleset stats v17

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -342,6 +342,7 @@ util-decode-asn1.c util-decode-asn1.h \
 util-decode-der.c util-decode-der.h \
 util-decode-der-get.c util-decode-der-get.h \
 util-decode-mime.c util-decode-mime.h \
+util-detect.c util-detect.h \
 util-device.c util-device.h \
 util-enum.c util-enum.h \
 util-error.c util-error.h \

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -298,9 +298,9 @@ static int AlertFastLogTest01()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"FastLog test\"; content:\"GET\"; "
-            "Classtype:unknown; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"FastLog test\"; content:\"GET\"; " "Classtype:unknown; sid:1;)",
+                               NULL);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -343,9 +343,9 @@ static int AlertFastLogTest02()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"FastLog test\"; content:\"GET\"; "
-            "Classtype:unknown; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"FastLog test\"; content:\"GET\"; " "Classtype:unknown; sid:1;)",
+                               NULL);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -3331,9 +3331,9 @@ static int AppLayerProtoDetectTest16(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                                   "(msg:\"Test content option\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any " "(msg:\"Test content option\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -3424,9 +3424,9 @@ static int AppLayerProtoDetectTest17(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert http any !80 -> any any "
-                                   "(msg:\"http over non standar port\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any !80 -> any any " "(msg:\"http over non standar port\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -3519,9 +3519,9 @@ static int AppLayerProtoDetectTest18(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert ftp any any -> any any "
-                                   "(msg:\"Test content option\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ftp any any -> any any " "(msg:\"Test content option\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -3610,9 +3610,9 @@ static int AppLayerProtoDetectTest19(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert http any !80 -> any any "
-                                   "(msg:\"http over non standar port\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any !80 -> any any " "(msg:\"http over non standar port\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -3712,9 +3712,9 @@ static int AppLayerProtoDetectTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                                   "(msg:\"Test content option\"; "
-                                   "content:\"one\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any " "(msg:\"Test content option\"; " "content:\"one\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1880,7 +1880,7 @@ static int ModbusParserTest03(void) {
                                       "(msg:\"Modbus Data mismatch\"; "
                                       "app-layer-event: "
                                       "modbus.value_mismatch; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2047,7 +2047,7 @@ static int ModbusParserTest05(void) {
                                       "(msg:\"Modbus invalid Protocol version\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_protocol_id; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2133,7 +2133,7 @@ static int ModbusParserTest06(void) {
                                       "(msg:\"Modbus unsolicited response\"; "
                                       "app-layer-event: "
                                       "modbus.unsolicited_response; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2219,7 +2219,7 @@ static int ModbusParserTest07(void) {
                                       "(msg:\"Modbus invalid Length\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_length; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2306,7 +2306,7 @@ static int ModbusParserTest08(void) {
                                       "(msg:\"Modbus Exception code invalid\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_exception_code; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2595,7 +2595,7 @@ static int ModbusParserTest11(void) {
                                       "(msg:\"Modbus invalid Length\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_length; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2682,7 +2682,7 @@ static int ModbusParserTest12(void) {
                                       "(msg:\"Modbus invalid Length\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_length; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -2899,7 +2899,7 @@ static int ModbusParserTest15(void) {
                                       "(msg:\"Modbus invalid Length\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_length; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -3008,7 +3008,7 @@ static int ModbusParserTest16(void) {
                                       "(msg:\"Modbus invalid Length\"; "
                                       "app-layer-event: "
                                       "modbus.invalid_length; "
-                                      "sid:1;)");
+                                      "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 

--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -4191,7 +4191,7 @@ static int SMTPParserTest12(void)
     s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any "
                                    "(msg:\"SMTP event handling\"; "
                                    "app-layer-event: smtp.invalid_reply; "
-                                   "sid:1;)");
+                                   "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 
@@ -4332,7 +4332,7 @@ static int SMTPParserTest13(void)
                               "(msg:\"SMTP event handling\"; "
                               "app-layer-event: "
                               "smtp.invalid_pipelined_sequence; "
-                              "sid:1;)");
+                              "sid:1;)", NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-ack.c
+++ b/src/detect-ack.c
@@ -176,38 +176,32 @@ static int DetectAckSigTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     /* These three are crammed in here as there is no Parse */
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing ack\";ack:foo;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing ack\";ack:foo;sid:1;)", NULL) != NULL)
     {
         printf("invalid ack accepted: ");
         goto cleanup_engine;
     }
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing ack\";ack:9999999999;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing ack\";ack:9999999999;sid:1;)", NULL) != NULL)
     {
         printf("overflowing ack accepted: ");
         goto cleanup_engine;
     }
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing ack\";ack:-100;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing ack\";ack:-100;sid:1;)", NULL) != NULL)
     {
         printf("negative ack accepted: ");
         goto cleanup_engine;
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing ack\";ack:41;sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing ack\";ack:41;sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto cleanup_engine;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert tcp any any -> any any "
-                                     "(msg:\"Testing ack\";ack:42;sid:2;)");
+                                     "alert tcp any any -> any any " "(msg:\"Testing ack\";ack:42;sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto cleanup_engine;
     }

--- a/src/detect-app-layer-event.c
+++ b/src/detect-app-layer-event.c
@@ -533,7 +533,7 @@ int DetectAppLayerEventTest03(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(app-layer-event: applayer_mismatch_protocol_both_directions; "
-                               "sid:1;)");
+                               "sid:1;)", NULL);
     FAIL_IF(de_ctx->sig_list == NULL);
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
@@ -620,7 +620,7 @@ int DetectAppLayerEventTest04(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(app-layer-event: applayer_detect_protocol_only_one_direction; "
-                               "sid:1;)");
+                               "sid:1;)", NULL);
     FAIL_IF(de_ctx->sig_list == NULL);
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
@@ -719,7 +719,7 @@ int DetectAppLayerEventTest05(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(app-layer-event: applayer_mismatch_protocol_both_directions; "
-                               "sid:1;)");
+                               "sid:1;)", NULL);
     FAIL_IF (de_ctx->sig_list == NULL);
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);

--- a/src/detect-app-layer-protocol.c
+++ b/src/detect-app-layer-protocol.c
@@ -202,8 +202,9 @@ int DetectAppLayerProtocolTest03(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(app-layer-protocol:http; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(app-layer-protocol:http; sid:1;)",
+                NULL);
     if (s->alproto != ALPROTO_HTTP) {
         printf("signature alproto should be http\n");
         goto end;
@@ -233,8 +234,9 @@ int DetectAppLayerProtocolTest04(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(app-layer-protocol:!http; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(app-layer-protocol:!http; sid:1;)",
+                NULL);
     if (s->alproto != ALPROTO_UNKNOWN) {
         printf("signature alproto should be unknown\n");
         goto end;
@@ -271,8 +273,9 @@ int DetectAppLayerProtocolTest05(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(app-layer-protocol:!http; app-layer-protocol:!smtp; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(app-layer-protocol:!http; app-layer-protocol:!smtp; sid:1;)",
+                NULL);
     if (s->alproto != ALPROTO_UNKNOWN) {
         printf("signature alproto should be unknown\n");
         goto end;
@@ -296,8 +299,9 @@ int DetectAppLayerProtocolTest06(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert http any any -> any any "
-                "(app-layer-protocol:smtp; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert http any any -> any any " "(app-layer-protocol:smtp; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("if (s != NULL)\n");
         goto end;
@@ -321,8 +325,9 @@ int DetectAppLayerProtocolTest07(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert http any any -> any any "
-                "(app-layer-protocol:!smtp; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert http any any -> any any " "(app-layer-protocol:!smtp; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("if (s != NULL)\n");
         goto end;
@@ -346,8 +351,9 @@ int DetectAppLayerProtocolTest08(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(app-layer-protocol:!smtp; app-layer-protocol:http; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(app-layer-protocol:!smtp; app-layer-protocol:http; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("if (s != NULL)\n");
         goto end;
@@ -371,8 +377,9 @@ int DetectAppLayerProtocolTest09(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(app-layer-protocol:http; app-layer-protocol:!smtp; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(app-layer-protocol:http; app-layer-protocol:!smtp; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("if (s != NULL)\n");
         goto end;

--- a/src/detect-base64-data.c
+++ b/src/detect-base64-data.c
@@ -100,8 +100,8 @@ static int DetectBase64DataSetupTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert smtp any any -> any any (msg:\"DetectBase64DataSetupTest\"; "
-        "base64_decode; base64_data; content:\"content\"; sid:1; rev:1;)");
+                               "alert smtp any any -> any any (msg:\"DetectBase64DataSetupTest\"; " "base64_decode; base64_data; content:\"content\"; sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("SigInit failed: ");
         goto end;
@@ -145,14 +145,8 @@ static int DetectBase64DataSetupTest02(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert smtp any any -> any any ( "
-        "msg:\"DetectBase64DataSetupTest\"; "
-        "file_data; "
-        "content:\"SGV\"; "
-        "base64_decode: bytes 16; "
-        "base64_data; "
-        "content:\"content\"; "
-        "sid:1; rev:1;)");
+                               "alert smtp any any -> any any ( " "msg:\"DetectBase64DataSetupTest\"; " "file_data; " "content:\"SGV\"; " "base64_decode: bytes 16; " "base64_data; " "content:\"content\"; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("SigInit failed: ");
         goto end;
@@ -202,14 +196,8 @@ static int DetectBase64DataSetupTest03(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert smtp any any -> any any ( "
-        "msg:\"DetectBase64DataSetupTest\"; "
-        "base64_decode: bytes 16; "
-        "base64_data; "
-        "content:\"content\"; "
-        "file_data; "
-        "content:\"SGV\"; "
-        "sid:1; rev:1;)");
+                               "alert smtp any any -> any any ( " "msg:\"DetectBase64DataSetupTest\"; " "base64_decode: bytes 16; " "base64_data; " "content:\"content\"; " "file_data; " "content:\"SGV\"; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         printf("SigInit should have failed: ");
         goto end;
@@ -241,7 +229,8 @@ static int DetectBase64DataSetupTest04(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any (msg:\"some b64thing\"; flow:established,from_server; file_data; content:\"sometext\"; fast_pattern; base64_decode:relative; base64_data; content:\"foobar\"; nocase; tag:session,120,seconds; sid:1111111; rev:1;)");
+                               "alert tcp any any -> any any (msg:\"some b64thing\"; flow:established,from_server; file_data; content:\"sometext\"; fast_pattern; base64_decode:relative; base64_data; content:\"foobar\"; nocase; tag:session,120,seconds; sid:1111111; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("SigInit failed: ");
         goto end;

--- a/src/detect-base64-decode.c
+++ b/src/detect-base64-decode.c
@@ -433,10 +433,8 @@ static int DetectBase64DecodeTestSetup(void)
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any ("
-        "msg:\"DetectBase64DecodeTestSetup\"; "
-        "base64_decode; content:\"content\"; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (" "msg:\"DetectBase64DecodeTestSetup\"; " "base64_decode; content:\"content\"; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -474,11 +472,8 @@ static int DetectBase64DecodeHttpHeaderTestSetup(void)
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any ("
-        "msg:\"DetectBase64DecodeTestSetup\"; "
-        "content:\"Authorization: basic \"; http_header; "
-        "base64_decode; content:\"content\"; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (" "msg:\"DetectBase64DecodeTestSetup\"; " "content:\"Authorization: basic \"; http_header; " "base64_decode; content:\"content\"; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -527,9 +522,8 @@ static int DetectBase64DecodeTestDecode(void)
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any (msg:\"base64 test\"; "
-        "base64_decode; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (msg:\"base64 test\"; " "base64_decode; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -584,9 +578,8 @@ static int DetectBase64DecodeTestDecodeWithOffset(void)
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any (msg:\"base64 test\"; "
-        "base64_decode: offset 8; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (msg:\"base64 test\"; " "base64_decode: offset 8; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -643,9 +636,8 @@ static int DetectBase64DecodeTestDecodeLargeOffset(void)
 
     /* Offset is out of range. */
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any (msg:\"base64 test\"; "
-        "base64_decode: bytes 16, offset 32; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (msg:\"base64 test\"; " "base64_decode: bytes 16, offset 32; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -700,10 +692,8 @@ static int DetectBase64DecodeTestDecodeRelative(void)
     }
 
     de_ctx->sig_list = SigInit(de_ctx,
-        "alert tcp any any -> any any (msg:\"base64 test\"; "
-        "content:\"aaaaaaaa\"; "
-        "base64_decode: relative; "
-        "sid:1; rev:1;)");
+                               "alert tcp any any -> any any (msg:\"base64 test\"; " "content:\"aaaaaaaa\"; " "base64_decode: relative; " "sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-byte-extract.c
+++ b/src/detect-byte-extract.c
@@ -1507,11 +1507,9 @@ int DetectByteExtractTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,2,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,2,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1584,11 +1582,9 @@ int DetectByteExtractTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; pcre:/asf/; "
-                                   "byte_extract:4,0,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; pcre:/asf/; " "byte_extract:4,0,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1672,11 +1668,9 @@ int DetectByteExtractTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; byte_jump:1,13; "
-                                   "byte_extract:4,0,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; byte_jump:1,13; " "byte_extract:4,0,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1760,11 +1754,9 @@ int DetectByteExtractTest37(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; uricontent:\"two\"; "
-                                   "byte_extract:4,0,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; uricontent:\"two\"; " "byte_extract:4,0,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1861,11 +1853,9 @@ int DetectByteExtractTest38(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; uricontent:\"two\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; uricontent:\"two\"; " "byte_extract:4,0,two,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1961,11 +1951,9 @@ int DetectByteExtractTest39(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; content:\"two\"; http_uri; "
-                                   "byte_extract:4,0,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; content:\"two\"; http_uri; " "byte_extract:4,0,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2062,11 +2050,9 @@ int DetectByteExtractTest40(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; content:\"two\"; http_uri; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; content:\"two\"; http_uri; " "byte_extract:4,0,two,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2161,12 +2147,9 @@ int DetectByteExtractTest41(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2263,14 +2246,9 @@ int DetectByteExtractTest42(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "uricontent: \"three\"; "
-                                   "byte_extract:4,0,four,string,hex,relative; "
-                                   "byte_extract:4,0,five,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "uricontent: \"three\"; " "byte_extract:4,0,four,string,hex,relative; " "byte_extract:4,0,five,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2413,12 +2391,9 @@ int DetectByteExtractTest43(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "content: \"three\"; offset:two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "content: \"three\"; offset:two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2512,14 +2487,9 @@ int DetectByteExtractTest44(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "content: \"four\"; offset:two; "
-                                   "content: \"five\"; offset:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "content: \"four\"; offset:two; " "content: \"five\"; offset:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2634,12 +2604,9 @@ int DetectByteExtractTest45(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "content: \"three\"; depth:two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "content: \"three\"; depth:two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2734,14 +2701,9 @@ int DetectByteExtractTest46(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "content: \"four\"; depth:two; "
-                                   "content: \"five\"; depth:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "content: \"four\"; depth:two; " "content: \"five\"; depth:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2856,12 +2818,9 @@ int DetectByteExtractTest47(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "content: \"three\"; distance:two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "content: \"three\"; distance:two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -2957,14 +2916,9 @@ int DetectByteExtractTest48(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "content: \"four\"; distance:two; "
-                                   "content: \"five\"; distance:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "content: \"four\"; distance:two; " "content: \"five\"; distance:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3084,12 +3038,9 @@ int DetectByteExtractTest49(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "content: \"three\"; within:two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "content: \"three\"; within:two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3186,14 +3137,9 @@ int DetectByteExtractTest50(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "content: \"four\"; within:two; "
-                                   "content: \"five\"; within:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "content: \"four\"; within:two; " "content: \"five\"; within:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3316,12 +3262,9 @@ int DetectByteExtractTest51(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_test: 2,=,10, two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_test: 2,=,10, two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3414,14 +3357,9 @@ int DetectByteExtractTest52(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_test: 2,=,two,three; "
-                                   "byte_test: 3,=,10,three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_test: 2,=,two,three; " "byte_test: 3,=,10,three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3535,12 +3473,9 @@ int DetectByteExtractTest53(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_jump: 2,two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_jump: 2,two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3632,14 +3567,9 @@ int DetectByteExtractTest54(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_jump: 2,two; "
-                                   "byte_jump: 3,three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_jump: 2,two; " "byte_jump: 3,three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -3750,15 +3680,9 @@ int DetectByteExtractTest55(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing byte_extract\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_extract:4,0,four,string,hex; "
-                                   "byte_extract:4,0,five,string,hex; "
-                                   "content: \"four\"; within:two; distance:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing byte_extract\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_extract:4,0,four,string,hex; " "byte_extract:4,0,five,string,hex; " "content: \"four\"; within:two; distance:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3864,16 +3788,9 @@ int DetectByteExtractTest56(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "uricontent:\"urione\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_extract:4,0,four,string,hex; "
-                                   "byte_extract:4,0,five,string,hex; "
-                                   "content: \"four\"; within:two; distance:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "uricontent:\"urione\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_extract:4,0,four,string,hex; " "byte_extract:4,0,five,string,hex; " "content: \"four\"; within:two; distance:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4014,16 +3931,9 @@ int DetectByteExtractTest57(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "uricontent: \"urione\"; "
-                                   "byte_extract:4,0,two,string,hex,relative; "
-                                   "byte_extract:4,0,three,string,hex,relative; "
-                                   "byte_extract:4,0,four,string,hex,relative; "
-                                   "byte_extract:4,0,five,string,hex,relative; "
-                                   "uricontent: \"four\"; within:two; distance:three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "uricontent: \"urione\"; " "byte_extract:4,0,two,string,hex,relative; " "byte_extract:4,0,three,string,hex,relative; " "byte_extract:4,0,four,string,hex,relative; " "byte_extract:4,0,five,string,hex,relative; " "uricontent: \"four\"; within:two; distance:three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4178,15 +4088,9 @@ int DetectByteExtractTest58(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_jump: 2,two; "
-                                   "byte_jump: 3,three; "
-                                   "isdataat: three; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_jump: 2,two; " "byte_jump: 3,three; " "isdataat: three; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4311,15 +4215,9 @@ int DetectByteExtractTest59(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex; "
-                                   "byte_extract:4,0,three,string,hex; "
-                                   "byte_jump: 2,two; "
-                                   "byte_jump: 3,three; "
-                                   "isdataat: three,relative; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex; " "byte_extract:4,0,three,string,hex; " "byte_jump: 2,two; " "byte_jump: 3,three; " "isdataat: three,relative; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4444,14 +4342,9 @@ int DetectByteExtractTest60(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex,relative; "
-                                   "uricontent: \"three\"; "
-                                   "byte_extract:4,0,four,string,hex,relative; "
-                                   "isdataat: two; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex,relative; " "uricontent: \"three\"; " "byte_extract:4,0,four,string,hex,relative; " "isdataat: two; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4587,14 +4480,9 @@ int DetectByteExtractTest61(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "byte_extract:4,0,two,string,hex,relative; "
-                                   "uricontent: \"three\"; "
-                                   "byte_extract:4,0,four,string,hex,relative; "
-                                   "isdataat: four, relative; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "byte_extract:4,0,two,string,hex,relative; " "uricontent: \"three\"; " "byte_extract:4,0,four,string,hex,relative; " "isdataat: four, relative; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4729,9 +4617,9 @@ static int DetectByteExtractTest62(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(file_data; byte_extract:4,2,two,relative,string,hex; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(file_data; byte_extract:4,2,two,relative,string,hex; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-bytejump.c
+++ b/src/detect-bytejump.c
@@ -946,13 +946,9 @@ int DetectBytejumpTestParse10(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                               "dce_stub_data; "
-                               "content:\"one\"; distance:0; "
-                               "byte_jump:4,0,align,multiplier 2, "
-                               "post_offset -16,relative,dce; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_jump:4,0,align,multiplier 2, " "post_offset -16,relative,dce; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -973,13 +969,9 @@ int DetectBytejumpTestParse10(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "byte_jump:4,0,align,multiplier 2, "
-                      "post_offset -16,relative,dce; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_jump:4,0,align,multiplier 2, " "post_offset -16,relative,dce; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1000,13 +992,9 @@ int DetectBytejumpTestParse10(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "byte_jump:4,0,align,multiplier 2, "
-                      "post_offset -16,relative; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_jump:4,0,align,multiplier 2, " "post_offset -16,relative; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1049,78 +1037,57 @@ int DetectBytejumpTestParse11(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,string,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,string,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_sub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,big,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_sub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,big,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,little,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,little,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,string,hex,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,string,hex,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,string,dec,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,string,dec,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,string,oct,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,string,oct,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytejump_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "dce_stub_data; "
-                "content:\"one\"; byte_jump:4,0,align,multiplier 2, "
-                "post_offset -16,from_beginning,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; byte_jump:4,0,align,multiplier 2, " "post_offset -16,from_beginning,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
@@ -1149,9 +1116,9 @@ static int DetectBytejumpTestParse12(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; byte_jump:4,0,align,multiplier 2, "
-                               "post_offset -16,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(file_data; byte_jump:4,0,align,multiplier 2, " "post_offset -16,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-bytetest.c
+++ b/src/detect-bytetest.c
@@ -1100,12 +1100,9 @@ int DetectBytetestTestParse20(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytetest_body\"; "
-                               "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                               "dce_stub_data; "
-                               "content:\"one\"; distance:0; "
-                               "byte_test:1,=,1,6,relative,dce; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_test:1,=,1,6,relative,dce; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1127,12 +1124,9 @@ int DetectBytetestTestParse20(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytetest_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "byte_test:1,=,1,6,relative,dce; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_test:1,=,1,6,relative,dce; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1154,12 +1148,9 @@ int DetectBytetestTestParse20(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytetest_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "byte_test:1,=,1,6,relative; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "byte_test:1,=,1,6,relative; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1203,100 +1194,89 @@ int DetectBytetestTestParse21(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,string,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,string,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,big,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,big,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,little,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,little,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,hex,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,hex,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,dec,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,dec,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,oct,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,oct,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,string,hex,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,string,hex,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,big,string,hex,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,big,string,hex,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,big,string,oct,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,big,string,oct,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,little,string,hex,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,little,string,hex,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
     }
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing bytetest_body\"; "
-                "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                "content:\"one\"; byte_test:1,=,1,6,big,string,dec,dce; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing bytetest_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "content:\"one\"; byte_test:1,=,1,6,big,string,dec,dce; sid:1;)",
+                NULL);
     if (s != NULL) {
         result = 0;
         goto end;
@@ -1325,8 +1305,9 @@ static int DetectBytetestTestParse22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; byte_test:1,=,1,6,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(file_data; byte_test:1,=,1,6,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -165,9 +165,9 @@ int DetectClasstypeTest01()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Classtype test\"; "
-                               "Classtype:not_available; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Classtype test\"; " "Classtype:not_available; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -196,8 +196,9 @@ int DetectClasstypeTest02()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:bad-unknown; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:bad-unknown; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         printf("first sig failed to parse: ");
         result = 0;
@@ -206,13 +207,15 @@ int DetectClasstypeTest02()
     de_ctx->sig_list = last = sig;
     result = (sig != NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:not-there; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:not-there; sid:1;)",
+                  NULL);
     last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:Bad-UnkNown; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:Bad-UnkNown; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         printf("second sig failed to parse: ");
         result = 0;
@@ -222,8 +225,9 @@ int DetectClasstypeTest02()
     last = sig;
     result &= (sig != NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:nothing-wrong; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:nothing-wrong; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         result = 0;
         goto end;
@@ -232,8 +236,9 @@ int DetectClasstypeTest02()
     last = sig;
     result &= (sig != NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:attempted_dos; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:attempted_dos; sid:1;)",
+                  NULL);
     last->next = sig;
     result &= (sig == NULL);
 
@@ -262,8 +267,9 @@ int DetectClasstypeTest03()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:bad-unknown; priority:1; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:bad-unknown; priority:1; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         result = 0;
         goto end;
@@ -272,9 +278,9 @@ int DetectClasstypeTest03()
     result = (sig != NULL);
     result &= (sig->prio == 1);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Classtype test\"; Classtype:unKnoWn; "
-                  "priority:3; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Classtype test\"; Classtype:unKnoWn; " "priority:3; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         result = 0;
         goto end;
@@ -284,8 +290,9 @@ int DetectClasstypeTest03()
     result &= (sig != NULL);
     result &= (sig->prio == 3);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"Classtype test\"; "
-                  "Classtype:nothing-wrong; priority:1; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (msg:\"Classtype test\"; " "Classtype:nothing-wrong; priority:1; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         result = 0;
         goto end;

--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -696,7 +696,7 @@ int DetectContentLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pktsize, ch
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig);
+    de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -1110,7 +1110,7 @@ int DetectContentParseTest17(void)
     if (de_ctx == NULL)
         goto end;
 
-    de_ctx->sig_list = SigInit(de_ctx, sigstr);
+    de_ctx->sig_list = SigInit(de_ctx, sigstr, NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1173,11 +1173,9 @@ int DetectContentParseTest19(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing dce iface, stub_data with content\"; "
-                               "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                               "dce_stub_data; "
-                               "content:\"one\"; distance:0; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing dce iface, stub_data with content\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf ("failed dce iface, stub_data with content ");
         result = 0;
@@ -1202,11 +1200,9 @@ int DetectContentParseTest19(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing dce iface, stub_data with contents & distance, within\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; content:\"two\"; within:10; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing dce iface, stub_data with contents & distance, within\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; content:\"two\"; within:10; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         printf("failed dce iface, stub_data with content & distance, within");
         result = 0;
@@ -1304,12 +1300,9 @@ int DetectContentParseTest19(void)
     }
     result &= (data->distance == 2);
 */
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing dce iface, stub with contents, distance, within\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "content:\"two\"; within:10; distance:2; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing dce iface, stub with contents, distance, within\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "content:\"two\"; within:10; distance:2; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1424,9 +1417,9 @@ int DetectContentParseTest19(void)
     }
     result &= (data->offset == 10 && data->depth == 13);
 */
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing content\"; "
-                      "content:\"one\"; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing content\"; " "content:\"one\"; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         printf ("failed testing content");
         result = 0;
@@ -1461,8 +1454,8 @@ int DetectContentParseTest20(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1490,8 +1483,8 @@ int DetectContentParseTest21(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1519,8 +1512,8 @@ int DetectContentParseTest22(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"boo; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"boo; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1548,8 +1541,8 @@ int DetectContentParseTest23(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:boo\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:boo\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1579,8 +1572,8 @@ int DetectContentParseTest24(void)
 
     de_ctx->flags |= DE_QUIET;
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert udp any any -> any any "
-                                   "(msg:\"test\"; content:    !\"boo\"; sid:238012;)");
+                                   "alert udp any any -> any any " "(msg:\"test\"; content:    !\"boo\"; sid:238012;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL: ");
         result = 0;
@@ -1618,8 +1611,8 @@ int DetectContentParseTest25(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1647,8 +1640,8 @@ int DetectContentParseTest26(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1676,8 +1669,8 @@ int DetectContentParseTest27(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1705,8 +1698,8 @@ int DetectContentParseTest28(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1734,8 +1727,8 @@ int DetectContentParseTest29(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"aast|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"aast|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1763,8 +1756,8 @@ int DetectContentParseTest30(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"aast|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"aast|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1792,8 +1785,8 @@ int DetectContentParseTest31(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"aast|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"aast|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1821,8 +1814,8 @@ int DetectContentParseTest32(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af|asdf\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af|asdf\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1850,8 +1843,8 @@ int DetectContentParseTest33(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1879,8 +1872,8 @@ int DetectContentParseTest34(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af|af|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af|af|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1908,8 +1901,8 @@ int DetectContentParseTest35(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"|af|af|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"|af|af|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1937,8 +1930,8 @@ static int DetectContentParseTest36(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1977,8 +1970,8 @@ static int DetectContentParseTest37(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; content:\"def\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; content:\"def\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2017,8 +2010,8 @@ static int DetectContentParseTest38(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; content:\"def\"; within:8; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; content:\"def\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2060,7 +2053,7 @@ static int SigTestPositiveTestContent(char *rule, uint8_t *buf)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, rule);
+    de_ctx->sig_list = SigInit(de_ctx, rule, NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2101,8 +2094,8 @@ static int DetectContentParseTest39(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; within:8; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2141,8 +2134,8 @@ static int DetectContentParseTest40(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; distance:3; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; distance:3; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2326,7 +2319,7 @@ static int SigTestNegativeTestContent(char *rule, uint8_t *buf)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, rule);
+    de_ctx->sig_list = SigInit(de_ctx, rule, NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -1544,8 +1544,9 @@ int DetectCsumICMPV6Test01(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert ip any any -> any any "
-                                   "(icmpv6-csum:valid; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any " "(icmpv6-csum:valid; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("SigInit failed\n");
         goto end;

--- a/src/detect-dce-iface.c
+++ b/src/detect-dce-iface.c
@@ -883,10 +883,9 @@ static int DetectDceIfaceTestParse12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx,"alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5,=0,any_frag; "
-                                   "sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5,=0,any_frag; " "sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
@@ -1391,10 +1390,9 @@ static int DetectDceIfaceTestParse14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5,=0; "
-                                   "sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5,=0; " "sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
@@ -1594,17 +1592,15 @@ static int DetectDceIfaceTestParse15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"DCERPC\"; "
-                              "dce_iface:57674cd0-5200-11ce-a897-08002b2e9c6d; "
-                              "sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_iface:57674cd0-5200-11ce-a897-08002b2e9c6d; " "sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"DCERPC\"; "
-                              "dce_iface:342cfd40-3c6c-11ce-a893-08002b2e9c6d; "
-                              "sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_iface:342cfd40-3c6c-11ce-a893-08002b2e9c6d; " "sid:2;)",
+                              NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-dce-opnum.c
+++ b/src/detect-dce-opnum.c
@@ -1151,10 +1151,8 @@ static int DetectDceOpnumTestParse08(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_opnum:9; "
-                                   "sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_opnum:9; " "sid:1;)",
+                                   NULL);
     if (s == NULL)
         goto end;
 
@@ -1690,10 +1688,8 @@ static int DetectDceOpnumTestParse09(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_opnum:9; "
-                                   "sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_opnum:9; " "sid:1;)",
+                                   NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -1362,16 +1362,19 @@ static int DetectDceStubDataTestParse04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 02|\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 02|\"; sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 75|\"; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 75|\"; sid:2;)",
+                              NULL);
     if (s == NULL)
         goto end;
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 18|\"; sid:3;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"DCERPC\"; dce_stub_data; content:\"|00 18|\"; sid:3;)",
+                              NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-dce-stub-data.c
+++ b/src/detect-dce-stub-data.c
@@ -611,10 +611,8 @@ static int DetectDceStubDataTestParse02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_stub_data; content:\"|42 42 42 42|\";"
-                                   "sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_stub_data; content:\"|42 42 42 42|\";" "sid:1;)",
+                                   NULL);
     if (s == NULL)
         goto end;
 
@@ -1166,10 +1164,8 @@ static int DetectDceStubDataTestParse03(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_stub_data; content:\"|42 42 42 42|\";"
-                                   "sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_stub_data; content:\"|42 42 42 42|\";" "sid:1;)",
+                                   NULL);
     if (s == NULL)
         goto end;
 
@@ -1668,24 +1664,18 @@ static int DetectDceStubDataTestParse05(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_stub_data; content:\"|00 02|\"; "
-                                   "sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_stub_data; content:\"|00 02|\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL)
         goto end;
     s = de_ctx->sig_list->next = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_stub_data; content:\"|00 75|\"; "
-                                   "sid:2;)");
+                                         "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_stub_data; content:\"|00 75|\"; " "sid:2;)",
+                                         NULL);
     if (s == NULL)
         goto end;
     s = de_ctx->sig_list->next->next = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"DCERPC\"; "
-                                   "dce_stub_data; content:\"|00 18|\"; "
-                                   "sid:3;)");
+                                               "alert tcp any any -> any any " "(msg:\"DCERPC\"; " "dce_stub_data; content:\"|00 18|\"; " "sid:3;)",
+                                               NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-detection-filter.c
+++ b/src/detect-detection-filter.c
@@ -409,7 +409,9 @@ static int DetectDetectionFilterTestSig1(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: track by_dst, count 4, seconds 60; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"detection_filter Test\"; detection_filter: track by_dst, count 4, seconds 60; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -484,7 +486,9 @@ static int DetectDetectionFilterTestSig2(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 4, seconds 60; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 4, seconds 60; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -557,7 +561,9 @@ static int DetectDetectionFilterTestSig3(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 2, seconds 60; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (msg:\"detection_filter Test 2\"; detection_filter: track by_dst, count 2, seconds 60; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-distance.c
+++ b/src/detect-distance.c
@@ -190,7 +190,9 @@ static int DetectDistanceTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (content:\"|AA BB|\"; content:\"|CC DD EE FF 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE|\"; distance: 4; within: 19; sid:1; rev:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (content:\"|AA BB|\"; content:\"|CC DD EE FF 00 11 22 33 44 55 66 77 88 99 AA BB CC DD EE|\"; distance: 4; within: 19; sid:1; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -140,9 +140,9 @@ static int DetectDnsQueryTest01(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -272,15 +272,15 @@ static int DetectDnsQueryTest02(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google.com\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.com\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google.net\"; nocase; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.net\"; nocase; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -424,9 +424,9 @@ static int DetectDnsQueryTest03(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "content:\"google\"; nocase; dns_query; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "content:\"google\"; nocase; dns_query; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -530,9 +530,9 @@ static int DetectDnsQueryTest04(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -694,15 +694,15 @@ static int DetectDnsQueryTest05(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google.com\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.com\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google.net\"; nocase; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.net\"; nocase; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -863,17 +863,15 @@ static int DetectDnsQueryTest06(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                              "(msg:\"Test dns_query option\"; "
-                              "dns_query; content:\"google\"; nocase; "
-                              "pcre:\"/google\\.com$/i\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google\"; nocase; " "pcre:\"/google\\.com$/i\"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                                      "(msg:\"Test dns_query option\"; "
-                                      "dns_query; content:\"google\"; nocase; "
-                                      "pcre:\"/^\\.[a-z]{2,3}$/iR\"; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google\"; nocase; " "pcre:\"/^\\.[a-z]{2,3}$/iR\"; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1009,21 +1007,21 @@ static int DetectDnsQueryTest07(void)
     de_ctx->mpm_matcher = DEFAULT_MPM;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                                   "(msg:\"Test dns_query option\"; "
-                                   "dns_query; content:\"google.com\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.com\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                                   "(msg:\"Test dns_query option\"; "
-                                   "dns_query; content:\"google.net\"; nocase; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test dns_query option\"; " "dns_query; content:\"google.net\"; nocase; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
-                                   "(msg:\"Test Z flag event\"; "
-                                   "app-layer-event:dns.z_flag_set; sid:3;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert dns any any -> any any " "(msg:\"Test Z flag event\"; " "app-layer-event:dns.z_flag_set; sid:3;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-dsize.c
+++ b/src/detect-dsize.c
@@ -742,14 +742,16 @@ int DetectDsizeIcmpv6Test01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-            "(msg:\"ICMP Large ICMP Packet\"; dsize:>8; sid:1; rev:4;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any " "(msg:\"ICMP Large ICMP Packet\"; dsize:>8; sid:1; rev:4;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx, "alert icmp any any -> any any "
-            "(msg:\"ICMP Large ICMP Packet\"; dsize:>800; sid:2; rev:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any " "(msg:\"ICMP Large ICMP Packet\"; dsize:>800; sid:2; rev:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-engine-dcepayload.c
+++ b/src/detect-engine-dcepayload.c
@@ -6526,11 +6526,11 @@ int DcePayloadTest15(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -6642,11 +6642,11 @@ int DcePayloadTest16(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -6758,11 +6758,11 @@ int DcePayloadTest17(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -6874,11 +6874,11 @@ int DcePayloadTest18(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -6990,11 +6990,11 @@ int DcePayloadTest19(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -7106,11 +7106,11 @@ int DcePayloadTest20(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
-    s->next = SigInit(de_ctx, sig2);
+    s->next = SigInit(de_ctx, sig2, NULL);
     if (s->next == NULL)
         goto end;
 
@@ -7214,7 +7214,7 @@ int DcePayloadTest21(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
@@ -7315,7 +7315,7 @@ int DcePayloadTest22(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
@@ -7417,7 +7417,7 @@ int DcePayloadTest23(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
@@ -7477,13 +7477,9 @@ int DcePayloadParseTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; content:\"two\"; "
-                                   "content:\"three\"; within:10; "
-                                   "content:\"four\"; distance:4; "
-                                   "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; content:\"two\"; " "content:\"three\"; within:10; " "content:\"four\"; distance:4; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -7598,15 +7594,9 @@ int DcePayloadParseTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "pkt_data; "
-                                   "content:\"one\"; "
-                                   "content:\"two\"; "
-                                   "content:\"three\"; within:5; "
-                                   "content:\"four\"; distance:10; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "pkt_data; " "content:\"one\"; " "content:\"two\"; " "content:\"three\"; within:5; " "content:\"four\"; distance:10; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -7725,14 +7715,9 @@ int DcePayloadParseTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "content:\"three\"; within:5; "
-                                   "content:\"four\"; distance:10; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "content:\"three\"; within:5; " "content:\"four\"; distance:10; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -7851,15 +7836,9 @@ int DcePayloadParseTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "pkt_data; "
-                                   "content:\"three\";"
-                                   "content:\"four\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "pkt_data; " "content:\"three\";" "content:\"four\";" "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -7979,16 +7958,9 @@ int DcePayloadParseTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "pkt_data; "
-                                   "pcre:/boom/; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "content:\"three\";"
-                                   "content:\"four\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "pkt_data; " "pcre:/boom/; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "content:\"three\";" "content:\"four\";" "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8121,16 +8093,9 @@ int DcePayloadParseTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "pkt_data; "
-                                   "byte_jump:2,5; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "content:\"three\";"
-                                   "content:\"four\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "pkt_data; " "byte_jump:2,5; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "content:\"three\";" "content:\"four\";" "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8268,16 +8233,9 @@ int DcePayloadParseTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "byte_jump:2,5,relative; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "pkt_data; "
-                                   "content:\"three\";"
-                                   "content:\"four\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "byte_jump:2,5,relative; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "pkt_data; " "content:\"three\";" "content:\"four\";" "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8415,16 +8373,9 @@ int DcePayloadParseTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "byte_jump:2,5,relative; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "pkt_data; "
-                                   "content:\"three\";"
-                                   "content:\"four\"; within:4; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "byte_jump:2,5,relative; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "pkt_data; " "content:\"three\";" "content:\"four\"; within:4; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8562,16 +8513,9 @@ int DcePayloadParseTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_stub_data; "
-                                   "pcre:/boom/R; "
-                                   "content:\"one\"; distance:10; within:5; "
-                                   "content:\"two\"; within:5;"
-                                   "pkt_data; "
-                                   "content:\"three\";"
-                                   "content:\"four\"; distance:5;"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_stub_data; " "pcre:/boom/R; " "content:\"one\"; distance:10; within:5; " "content:\"two\"; within:5;" "pkt_data; " "content:\"three\";" "content:\"four\"; distance:5;" "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8705,16 +8649,9 @@ int DcePayloadParseTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "pcre:/boom/R; "
-                                   "byte_jump:1,2,relative,align,dce; "
-                                   "content:\"one\"; within:4; distance:8; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "pcre:/boom/R; " "byte_jump:1,2,relative,align,dce; " "content:\"one\"; within:4; distance:8; " "pkt_data; " "content:\"two\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8828,14 +8765,9 @@ int DcePayloadParseTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "byte_test:1,=,0,0,relative,dce; "
-                                   "pkt_data; "
-                                   "content:\"one\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "byte_test:1,=,0,0,relative,dce; " "pkt_data; " "content:\"one\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8915,15 +8847,9 @@ int DcePayloadParseTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "isdataat:10,relative; "
-                                   "content:\"one\"; within:4; distance:8; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "isdataat:10,relative; " "content:\"one\"; within:4; distance:8; " "pkt_data; " "content:\"two\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9020,15 +8946,9 @@ int DcePayloadParseTest37(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "byte_jump:1,2,relative,align,dce; "
-                                   "byte_test:1,=,2,0,relative,dce; "
-                                   "pkt_data; "
-                                   "content:\"one\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "byte_jump:1,2,relative,align,dce; " "byte_test:1,=,2,0,relative,dce; " "pkt_data; " "content:\"one\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9128,16 +9048,9 @@ int DcePayloadParseTest38(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "pcre:/boom/R; "
-                                   "byte_jump:1,2,relative,align,dce; "
-                                   "byte_test:1,=,2,0,relative,dce; "
-                                   "pkt_data; "
-                                   "content:\"one\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "pcre:/boom/R; " "byte_jump:1,2,relative,align,dce; " "byte_test:1,=,2,0,relative,dce; " "pkt_data; " "content:\"one\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9247,13 +9160,9 @@ int DcePayloadParseTest39(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "content:\"two\"; within:4; distance:8; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "content:\"two\"; within:4; distance:8; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9333,16 +9242,9 @@ int DcePayloadParseTest40(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "content:\"one\"; within:10; "
-                                   "content:\"two\"; distance:20; within:30; "
-                                   "byte_test:1,=,2,0,relative,dce; "
-                                   "pkt_data; "
-                                   "content:\"three\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "content:\"one\"; within:10; " "content:\"two\"; distance:20; within:30; " "byte_test:1,=,2,0,relative,dce; " "pkt_data; " "content:\"three\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9463,16 +9365,9 @@ int DcePayloadParseTest41(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "content:\"one\"; within:10; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "byte_test:1,=,2,0,relative,dce; "
-                                   "content:\"three\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "content:\"one\"; within:10; " "pkt_data; " "content:\"two\"; " "byte_test:1,=,2,0,relative,dce; " "content:\"three\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9633,7 +9528,7 @@ int DcePayloadTest42(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
@@ -9735,7 +9630,7 @@ int DcePayloadTest43(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     s = de_ctx->sig_list;
     if (s == NULL)
         goto end;
@@ -9796,16 +9691,9 @@ int DcePayloadParseTest44(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "content:\"one\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "isdataat:10,relative; "
-                                   "content:\"one\"; within:4; distance:8; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "dce_opnum:10; dce_stub_data; " "isdataat:10,relative; " "content:\"one\"; within:4; distance:8; " "pkt_data; " "content:\"two\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9923,15 +9811,9 @@ int DcePayloadParseTest45(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "content:\"one\"; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "byte_jump:1,2,relative,align,dce; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "content:\"one\"; " "dce_opnum:10; dce_stub_data; " "byte_jump:1,2,relative,align,dce; " "pkt_data; " "content:\"two\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -10035,15 +9917,9 @@ int DcePayloadParseTest46(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Testing bytejump_body\"; "
-                                   "dce_iface:12345678-1234-1234-1234-123456789012; "
-                                   "content:\"one\"; "
-                                   "dce_opnum:10; dce_stub_data; "
-                                   "byte_test:1,=,2,0,relative,dce; "
-                                   "pkt_data; "
-                                   "content:\"two\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:12345678-1234-1234-1234-123456789012; " "content:\"one\"; " "dce_opnum:10; dce_stub_data; " "byte_test:1,=,2,0,relative,dce; " "pkt_data; " "content:\"two\"; " "sid:1;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;

--- a/src/detect-engine-filedata-smtp.c
+++ b/src/detect-engine-filedata-smtp.c
@@ -423,9 +423,9 @@ static int DetectEngineSMTPFiledataTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert smtp any any -> any any "
-                              "(msg:\"file_data smtp test\"; "
-                              "file_data; content:\"message\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert smtp any any -> any any " "(msg:\"file_data smtp test\"; " "file_data; content:\"message\"; sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-engine-filedata-smtp.c
+++ b/src/detect-engine-filedata-smtp.c
@@ -362,9 +362,9 @@ static int DetectEngineSMTPFiledataTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert smtp any any -> any any "
-                               "(msg:\"file_data smtp test\"; "
-                               "file_data; content:\"message\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert smtp any any -> any any " "(msg:\"file_data smtp test\"; " "file_data; content:\"message\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -494,9 +494,9 @@ static int DetectEngineSMTPFiledataTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert smtp any any -> any any "
-                               "(msg:\"file_data smtp test\"; "
-                               "file_data; content:\"evil\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert smtp any any -> any any " "(msg:\"file_data smtp test\"; " "file_data; content:\"evil\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-engine-hcbd.c
+++ b/src/detect-engine-hcbd.c
@@ -363,7 +363,7 @@ static int RunTest (struct TestSteps *steps, const char *sig, const char *yaml)
     f.alproto = ALPROTO_HTTP;
 
     SCLogDebug("sig %s", sig);
-    DetectEngineAppendSig(de_ctx, (char *)sig);
+    DetectEngineAppendSig(de_ctx, (char *)sig, NULL);
 
     de_ctx->flags |= DE_QUIET;
 

--- a/src/detect-engine-hcd.c
+++ b/src/detect-engine-hcd.c
@@ -239,10 +239,9 @@ static int DetectEngineHttpCookieTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CONNECT\"; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CONNECT\"; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -337,10 +336,9 @@ static int DetectEngineHttpCookieTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; depth:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; depth:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -435,10 +433,9 @@ static int DetectEngineHttpCookieTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"ECT\"; depth:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"ECT\"; depth:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -533,10 +530,9 @@ static int DetectEngineHttpCookieTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"ECT\"; depth:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"ECT\"; depth:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -631,10 +627,9 @@ static int DetectEngineHttpCookieTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"CON\"; depth:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"CON\"; depth:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -729,10 +724,9 @@ static int DetectEngineHttpCookieTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"ECT\"; offset:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"ECT\"; offset:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -827,10 +821,9 @@ static int DetectEngineHttpCookieTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"CO\"; offset:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"CO\"; offset:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -925,10 +918,9 @@ static int DetectEngineHttpCookieTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"ECT\"; offset:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"ECT\"; offset:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1023,10 +1015,9 @@ static int DetectEngineHttpCookieTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CON\"; offset:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CON\"; offset:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1121,11 +1112,9 @@ static int DetectEngineHttpCookieTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:\"EC\"; within:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:\"EC\"; within:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1220,11 +1209,9 @@ static int DetectEngineHttpCookieTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:!\"EC\"; within:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:!\"EC\"; within:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1319,11 +1306,9 @@ static int DetectEngineHttpCookieTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:\"EC\"; within:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:\"EC\"; within:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1418,11 +1403,9 @@ static int DetectEngineHttpCookieTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:!\"EC\"; within:4; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:!\"EC\"; within:4; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1517,11 +1500,9 @@ static int DetectEngineHttpCookieTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:\"EC\"; distance:2; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:\"EC\"; distance:2; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1616,11 +1597,9 @@ static int DetectEngineHttpCookieTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:!\"EC\"; distance:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:!\"EC\"; distance:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1715,11 +1694,9 @@ static int DetectEngineHttpCookieTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:\"EC\"; distance:3; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:\"EC\"; distance:3; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1814,11 +1791,9 @@ static int DetectEngineHttpCookieTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_cookie; "
-                               "content:!\"EC\"; distance:2; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_cookie; " "content:!\"EC\"; distance:2; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hhd.c
+++ b/src/detect-engine-hhd.c
@@ -374,10 +374,9 @@ static int DetectEngineHttpHeaderTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -470,10 +469,9 @@ static int DetectEngineHttpHeaderTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; depth:15; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; depth:15; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -566,10 +564,9 @@ static int DetectEngineHttpHeaderTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"one\"; depth:5; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"one\"; depth:5; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -662,10 +659,9 @@ static int DetectEngineHttpHeaderTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; depth:5; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; depth:5; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -758,10 +754,9 @@ static int DetectEngineHttpHeaderTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"one\"; depth:15; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"one\"; depth:15; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -854,10 +849,9 @@ static int DetectEngineHttpHeaderTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; offset:10; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; offset:10; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -950,10 +944,9 @@ static int DetectEngineHttpHeaderTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"one\"; offset:15; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"one\"; offset:15; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1046,10 +1039,9 @@ static int DetectEngineHttpHeaderTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; offset:15; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; offset:15; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1142,10 +1134,9 @@ static int DetectEngineHttpHeaderTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"one\"; offset:10; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"one\"; offset:10; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1238,10 +1229,9 @@ static int DetectEngineHttpHeaderTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:\"three\"; http_header; within:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:\"three\"; http_header; within:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1334,10 +1324,9 @@ static int DetectEngineHttpHeaderTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:!\"three\"; http_header; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:!\"three\"; http_header; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1430,10 +1419,9 @@ static int DetectEngineHttpHeaderTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:!\"three\"; http_header; within:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:!\"three\"; http_header; within:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1526,10 +1514,9 @@ static int DetectEngineHttpHeaderTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:\"three\"; http_header; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:\"three\"; http_header; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1622,10 +1609,9 @@ static int DetectEngineHttpHeaderTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:\"five\"; http_header; distance:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:\"five\"; http_header; distance:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1718,10 +1704,9 @@ static int DetectEngineHttpHeaderTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:!\"five\"; http_header; distance:15; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:!\"five\"; http_header; distance:15; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1814,10 +1799,9 @@ static int DetectEngineHttpHeaderTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:!\"five\"; http_header; distance:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:!\"five\"; http_header; distance:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1910,10 +1894,9 @@ static int DetectEngineHttpHeaderTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:\"five\"; http_header; distance:15; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:\"five\"; http_header; distance:15; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2003,10 +1986,9 @@ static int DetectEngineHttpHeaderTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; content:\"five\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; content:\"five\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2078,10 +2060,9 @@ static int DetectEngineHttpHeaderTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"one\"; http_header; fast_pattern; content:\"five\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"one\"; http_header; fast_pattern; content:\"five\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2163,11 +2144,9 @@ static int DetectEngineHttpHeaderTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:!\"dummy\"; http_header; within:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:!\"dummy\"; http_header; within:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2287,11 +2266,9 @@ static int DetectEngineHttpHeaderTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:!\"dummy\"; within:7; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:!\"dummy\"; within:7; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2411,11 +2388,9 @@ static int DetectEngineHttpHeaderTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:!\"dummy\"; distance:3; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:!\"dummy\"; distance:3; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2535,11 +2510,9 @@ static int DetectEngineHttpHeaderTest23(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:!\"dummy\"; distance:13; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:!\"dummy\"; distance:13; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2659,11 +2632,9 @@ static int DetectEngineHttpHeaderTest24(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:\"dummy\"; within:15; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:\"dummy\"; within:15; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2783,11 +2754,9 @@ static int DetectEngineHttpHeaderTest25(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:\"dummy\"; within:10; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:\"dummy\"; within:10; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2907,11 +2876,9 @@ static int DetectEngineHttpHeaderTest26(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:\"dummy\"; distance:8; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:\"dummy\"; distance:8; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3031,11 +2998,9 @@ static int DetectEngineHttpHeaderTest27(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "pcre:/body1/H; "
-                               "content:\"dummy\"; distance:14; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "pcre:/body1/H; " "content:\"dummy\"; distance:14; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3160,10 +3125,9 @@ static int DetectEngineHttpHeaderTest28(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Content-Length: 6\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Content-Length: 6\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3289,10 +3253,9 @@ static int DetectEngineHttpHeaderTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Content-Length: 7\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Content-Length: 7\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3451,10 +3414,9 @@ static int DetectEngineHttpHeaderTest30(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"dummycookieset\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"dummycookieset\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3571,12 +3533,9 @@ static int DetectEngineHttpHeaderTest31(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(content:\"Accept|3a|\"; http_header; "
-                               "content:!\"Cookie|3a|\"; http_header; "
-                               "content:\"Crazy6|3a|\"; http_header; "
-                               "content:\"SixZix|3a|\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(content:\"Accept|3a|\"; http_header; " "content:!\"Cookie|3a|\"; http_header; " "content:\"Crazy6|3a|\"; http_header; " "content:\"SixZix|3a|\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3677,9 +3636,9 @@ static int DetectEngineHttpHeaderTest32(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(content:\"Dummy\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(content:\"Dummy\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3788,9 +3747,9 @@ static int DetectEngineHttpHeaderTest33(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(content:\"Dummy\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(content:\"Dummy\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hhhd.c
+++ b/src/detect-engine-hhhd.c
@@ -204,10 +204,9 @@ static int DetectEngineHttpHHTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"connect\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"connect\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -302,10 +301,9 @@ static int DetectEngineHttpHHTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"co\"; depth:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"co\"; depth:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -400,10 +398,9 @@ static int DetectEngineHttpHHTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:!\"ect\"; depth:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:!\"ect\"; depth:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -498,10 +495,9 @@ static int DetectEngineHttpHHTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"ect\"; depth:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"ect\"; depth:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -596,10 +592,9 @@ static int DetectEngineHttpHHTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"con\"; depth:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"con\"; depth:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -694,10 +689,9 @@ static int DetectEngineHttpHHTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"ect\"; offset:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"ect\"; offset:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -792,10 +786,9 @@ static int DetectEngineHttpHHTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"co\"; offset:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"co\"; offset:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -890,10 +883,9 @@ static int DetectEngineHttpHHTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"ect\"; offset:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"ect\"; offset:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -988,10 +980,9 @@ static int DetectEngineHttpHHTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"con\"; offset:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"con\"; offset:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1086,11 +1077,9 @@ static int DetectEngineHttpHHTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:\"ec\"; within:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:\"ec\"; within:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1185,11 +1174,9 @@ static int DetectEngineHttpHHTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:!\"ec\"; within:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:!\"ec\"; within:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1284,11 +1271,9 @@ static int DetectEngineHttpHHTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:\"ec\"; within:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:\"ec\"; within:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1383,11 +1368,9 @@ static int DetectEngineHttpHHTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:!\"ec\"; within:4; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:!\"ec\"; within:4; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1482,11 +1465,9 @@ static int DetectEngineHttpHHTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:\"ec\"; distance:2; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:\"ec\"; distance:2; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1581,11 +1562,9 @@ static int DetectEngineHttpHHTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:!\"ec\"; distance:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:!\"ec\"; distance:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1680,11 +1659,9 @@ static int DetectEngineHttpHHTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:\"ec\"; distance:3; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:\"ec\"; distance:3; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1779,11 +1756,9 @@ static int DetectEngineHttpHHTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"co\"; http_host;  "
-                               "content:!\"ec\"; distance:2; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"co\"; http_host;  " "content:!\"ec\"; distance:2; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1874,10 +1849,9 @@ static int DetectEngineHttpHHTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"kaboom\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1968,10 +1942,9 @@ static int DetectEngineHttpHHTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"kaboom\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2062,10 +2035,9 @@ static int DetectEngineHttpHHTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"8080\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"8080\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2155,10 +2127,9 @@ static int DetectEngineHttpHHTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"kaboom\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2248,10 +2219,9 @@ static int DetectEngineHttpHHTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"kaboom\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2341,10 +2311,9 @@ static int DetectEngineHttpHHTest23(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"8080\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"8080\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2435,10 +2404,9 @@ static int DetectEngineHttpHHTest24(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"kaboom\"; http_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"kaboom\"; http_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2529,10 +2497,9 @@ static int DetectEngineHttpHHTest25(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_host header test\"; "
-                               "content:\"rabbit\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_host header test\"; " "content:\"rabbit\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hmd.c
+++ b/src/detect-engine-hmd.c
@@ -195,10 +195,9 @@ static int DetectEngineHttpMethodTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"GET\"; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"GET\"; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -292,10 +291,9 @@ static int DetectEngineHttpMethodTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; depth:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; depth:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -389,10 +387,9 @@ static int DetectEngineHttpMethodTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"ECT\"; depth:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"ECT\"; depth:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -486,10 +483,9 @@ static int DetectEngineHttpMethodTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"ECT\"; depth:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"ECT\"; depth:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -583,10 +579,9 @@ static int DetectEngineHttpMethodTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"CON\"; depth:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"CON\"; depth:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -680,10 +675,9 @@ static int DetectEngineHttpMethodTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"ECT\"; offset:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"ECT\"; offset:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -777,10 +771,9 @@ static int DetectEngineHttpMethodTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"CO\"; offset:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"CO\"; offset:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -874,10 +867,9 @@ static int DetectEngineHttpMethodTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"ECT\"; offset:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"ECT\"; offset:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -971,10 +963,9 @@ static int DetectEngineHttpMethodTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CON\"; offset:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CON\"; offset:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1068,11 +1059,9 @@ static int DetectEngineHttpMethodTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:\"EC\"; within:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:\"EC\"; within:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1166,11 +1155,9 @@ static int DetectEngineHttpMethodTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:!\"EC\"; within:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:!\"EC\"; within:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1264,11 +1251,9 @@ static int DetectEngineHttpMethodTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:\"EC\"; within:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:\"EC\"; within:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1362,11 +1347,9 @@ static int DetectEngineHttpMethodTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:!\"EC\"; within:4; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:!\"EC\"; within:4; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1460,11 +1443,9 @@ static int DetectEngineHttpMethodTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:\"EC\"; distance:2; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:\"EC\"; distance:2; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1558,11 +1539,9 @@ static int DetectEngineHttpMethodTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:!\"EC\"; distance:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:!\"EC\"; distance:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1656,11 +1635,9 @@ static int DetectEngineHttpMethodTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:\"EC\"; distance:3; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:\"EC\"; distance:3; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1754,11 +1731,9 @@ static int DetectEngineHttpMethodTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"CO\"; http_method; "
-                               "content:!\"EC\"; distance:2; http_method; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"CO\"; http_method; " "content:!\"EC\"; distance:2; http_method; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hrhd.c
+++ b/src/detect-engine-hrhd.c
@@ -246,10 +246,9 @@ static int DetectEngineHttpRawHeaderTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -342,10 +341,9 @@ static int DetectEngineHttpRawHeaderTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; depth:15; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; depth:15; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -438,10 +436,9 @@ static int DetectEngineHttpRawHeaderTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"one\"; depth:5; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"one\"; depth:5; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -534,10 +531,9 @@ static int DetectEngineHttpRawHeaderTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; depth:5; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; depth:5; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -630,10 +626,9 @@ static int DetectEngineHttpRawHeaderTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"one\"; depth:15; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"one\"; depth:15; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -726,10 +721,9 @@ static int DetectEngineHttpRawHeaderTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; offset:10; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; offset:10; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -822,10 +816,9 @@ static int DetectEngineHttpRawHeaderTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"one\"; offset:15; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"one\"; offset:15; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -918,10 +911,9 @@ static int DetectEngineHttpRawHeaderTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; offset:15; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; offset:15; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1014,10 +1006,9 @@ static int DetectEngineHttpRawHeaderTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"one\"; offset:10; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"one\"; offset:10; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1110,10 +1101,9 @@ static int DetectEngineHttpRawHeaderTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:\"three\"; http_raw_header; within:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:\"three\"; http_raw_header; within:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1206,10 +1196,9 @@ static int DetectEngineHttpRawHeaderTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:!\"three\"; http_raw_header; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:!\"three\"; http_raw_header; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1302,10 +1291,9 @@ static int DetectEngineHttpRawHeaderTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:!\"three\"; http_raw_header; within:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:!\"three\"; http_raw_header; within:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1398,10 +1386,9 @@ static int DetectEngineHttpRawHeaderTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:\"three\"; http_raw_header; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:\"three\"; http_raw_header; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1494,10 +1481,9 @@ static int DetectEngineHttpRawHeaderTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; distance:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; distance:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1590,10 +1576,9 @@ static int DetectEngineHttpRawHeaderTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:!\"five\"; http_raw_header; distance:15; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:!\"five\"; http_raw_header; distance:15; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1686,10 +1671,9 @@ static int DetectEngineHttpRawHeaderTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:!\"five\"; http_raw_header; distance:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:!\"five\"; http_raw_header; distance:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1782,10 +1766,9 @@ static int DetectEngineHttpRawHeaderTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; distance:15; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; distance:15; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1875,10 +1858,9 @@ static int DetectEngineHttpRawHeaderTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; content:\"five\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1950,10 +1932,9 @@ static int DetectEngineHttpRawHeaderTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; fast_pattern; content:\"five\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"one\"; http_raw_header; fast_pattern; content:\"five\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2035,11 +2016,9 @@ static int DetectEngineHttpRawHeaderTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:!\"dummy\"; http_raw_header; within:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:!\"dummy\"; http_raw_header; within:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2159,11 +2138,9 @@ static int DetectEngineHttpRawHeaderTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:!\"dummy\"; within:7; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:!\"dummy\"; within:7; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2283,11 +2260,9 @@ static int DetectEngineHttpRawHeaderTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:!\"dummy\"; distance:3; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:!\"dummy\"; distance:3; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2407,11 +2382,9 @@ static int DetectEngineHttpRawHeaderTest23(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:!\"dummy\"; distance:13; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:!\"dummy\"; distance:13; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2531,11 +2504,9 @@ static int DetectEngineHttpRawHeaderTest24(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:\"dummy\"; within:15; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:\"dummy\"; within:15; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2655,11 +2626,9 @@ static int DetectEngineHttpRawHeaderTest25(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:\"dummy\"; within:10; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:\"dummy\"; within:10; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2779,11 +2748,9 @@ static int DetectEngineHttpRawHeaderTest26(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:\"dummy\"; distance:8; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:\"dummy\"; distance:8; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2901,11 +2868,9 @@ static int DetectEngineHttpRawHeaderTest27(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; flow:to_server; "
-                               "pcre:/body1/D; "
-                               "content:\"dummy\"; distance:14; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; flow:to_server; " "pcre:/body1/D; " "content:\"dummy\"; distance:14; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3030,10 +2995,9 @@ static int DetectEngineHttpRawHeaderTest28(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_client; "
-                               "content:\"Content-Length: 6\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_client; " "content:\"Content-Length: 6\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3159,10 +3123,9 @@ static int DetectEngineHttpRawHeaderTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_client; "
-                               "content:\"Content-Length: 7\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_client; " "content:\"Content-Length: 7\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3315,10 +3278,9 @@ static int DetectEngineHttpRawHeaderTest31(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(flow:to_server; "
-                               "content:\"Dummy\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; " "content:\"Dummy\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3427,10 +3389,9 @@ static int DetectEngineHttpRawHeaderTest32(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(flow:to_server; "
-                               "content:\"Dummy\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; " "content:\"Dummy\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hrhhd.c
+++ b/src/detect-engine-hrhhd.c
@@ -232,10 +232,9 @@ static int DetectEngineHttpHRHTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"CONNECT\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"CONNECT\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -330,10 +329,9 @@ static int DetectEngineHttpHRHTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"CO\"; depth:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"CO\"; depth:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -428,10 +426,9 @@ static int DetectEngineHttpHRHTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:!\"ECT\"; depth:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:!\"ECT\"; depth:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -526,10 +523,9 @@ static int DetectEngineHttpHRHTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"ECT\"; depth:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"ECT\"; depth:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -624,10 +620,9 @@ static int DetectEngineHttpHRHTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"CON\"; depth:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"CON\"; depth:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -722,10 +717,9 @@ static int DetectEngineHttpHRHTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"ECT\"; offset:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"ECT\"; offset:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -820,10 +814,9 @@ static int DetectEngineHttpHRHTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"CO\"; offset:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"CO\"; offset:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -918,10 +911,9 @@ static int DetectEngineHttpHRHTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:!\"ECT\"; offset:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:!\"ECT\"; offset:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1016,10 +1008,9 @@ static int DetectEngineHttpHRHTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host header test\"; "
-                               "content:\"CON\"; offset:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host header test\"; " "content:\"CON\"; offset:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1114,11 +1105,9 @@ static int DetectEngineHttpHRHTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:\"EC\"; within:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:\"EC\"; within:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1213,11 +1202,9 @@ static int DetectEngineHttpHRHTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:!\"EC\"; within:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:!\"EC\"; within:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1312,11 +1299,9 @@ static int DetectEngineHttpHRHTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:\"EC\"; within:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:\"EC\"; within:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1411,11 +1396,9 @@ static int DetectEngineHttpHRHTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:!\"EC\"; within:4; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:!\"EC\"; within:4; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1510,11 +1493,9 @@ static int DetectEngineHttpHRHTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:\"EC\"; distance:2; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:\"EC\"; distance:2; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1609,11 +1590,9 @@ static int DetectEngineHttpHRHTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:!\"EC\"; distance:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:!\"EC\"; distance:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1708,11 +1687,9 @@ static int DetectEngineHttpHRHTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:\"EC\"; distance:3; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:\"EC\"; distance:3; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1807,11 +1784,9 @@ static int DetectEngineHttpHRHTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"CO\"; http_raw_host;  "
-                               "content:!\"EC\"; distance:2; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"CO\"; http_raw_host;  " "content:!\"EC\"; distance:2; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1902,10 +1877,9 @@ static int DetectEngineHttpHRHTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"kaboom\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"kaboom\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1996,10 +1970,9 @@ static int DetectEngineHttpHRHTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"kaboom\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"kaboom\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2090,10 +2063,9 @@ static int DetectEngineHttpHRHTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"8080\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"8080\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2183,10 +2155,9 @@ static int DetectEngineHttpHRHTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"kaboom\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"kaboom\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2276,10 +2247,9 @@ static int DetectEngineHttpHRHTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"kaboom\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"kaboom\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2369,10 +2339,9 @@ static int DetectEngineHttpHRHTest23(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"8080\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"8080\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2463,10 +2432,9 @@ static int DetectEngineHttpHRHTest24(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"kaboom\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"kaboom\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2557,10 +2525,9 @@ static int DetectEngineHttpHRHTest25(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_raw_host header test\"; "
-                               "content:\"rabbit\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_raw_host header test\"; " "content:\"rabbit\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hrl.c
+++ b/src/detect-engine-hrl.c
@@ -151,9 +151,9 @@ static int UriTestSig01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -273,9 +273,9 @@ static int UriTestSig02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/one/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/one/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -395,9 +395,9 @@ static int UriTestSig03(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/blah/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/blah/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -517,9 +517,9 @@ static int UriTestSig04(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -639,9 +639,9 @@ static int UriTestSig05(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>4; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>4; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -761,9 +761,9 @@ static int UriTestSig06(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/(oneself)+/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/(oneself)+/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -883,9 +883,9 @@ static int UriTestSig07(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen \"; "
-                                   "pcre:/(one){2,}(self)?/U; urilen:3<>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen \"; " "pcre:/(one){2,}(self)?/U; urilen:3<>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1005,9 +1005,9 @@ static int UriTestSig08(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen\"; "
-                                   "pcre:/(blabla){2,}(self)?/U; urilen:3<>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen\"; " "pcre:/(blabla){2,}(self)?/U; urilen:3<>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1127,9 +1127,9 @@ static int UriTestSig09(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen \"; "
-                                   "pcre:/(one){2,}(self)?/U; urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen \"; " "pcre:/(one){2,}(self)?/U; urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1249,9 +1249,9 @@ static int UriTestSig10(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent with urilen option\"; "
-                                   "uricontent:\"one\"; urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent with urilen option\"; " "uricontent:\"one\"; urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1371,10 +1371,9 @@ static int UriTestSig11(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test content, uricontent, pcre /U and urilen options\"; "
-                                   "content:\"one\"; uricontent:\"one\"; pcre:/(one){2,}(self)?/U;"
-                                   "urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test content, uricontent, pcre /U and urilen options\"; " "content:\"one\"; uricontent:\"one\"; pcre:/(one){2,}(self)?/U;" "urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1494,10 +1493,9 @@ static int UriTestSig12(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U, uricontent and urilen option\"; "
-                                   "uricontent:\"one\"; "
-                                   "pcre:/(one)+self/U; urilen:>2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U, uricontent and urilen option\"; " "uricontent:\"one\"; " "pcre:/(one)+self/U; urilen:>2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1617,9 +1615,9 @@ static int UriTestSig13(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>2; uricontent:\"one\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>2; uricontent:\"one\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1740,9 +1738,9 @@ static int UriTestSig14(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; pcre:/one(self)?/U;sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; pcre:/one(self)?/U;sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1863,9 +1861,9 @@ static int UriTestSig15(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; pcre:/^\\/one(self)?$/U;sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; pcre:/^\\/one(self)?$/U;sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1986,7 +1984,9 @@ static int UriTestSig16(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any any (msg:\"ET TROJAN Downadup/Conficker A or B Worm reporting\"; flow:to_server,established; uricontent:\"/search?q=\"; pcre:\"/^\\/search\\?q=[0-9]{1,3}(&aq=7(\\?[0-9a-f]{8})?)?/U\"; pcre:\"/\\x0d\\x0aHost\\: \\d+\\.\\d+\\.\\d+\\.\\d+\\x0d\\x0a/\"; sid:2009024; rev:9;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any any (msg:\"ET TROJAN Downadup/Conficker A or B Worm reporting\"; flow:to_server,established; uricontent:\"/search?q=\"; pcre:\"/^\\/search\\?q=[0-9]{1,3}(&aq=7(\\?[0-9a-f]{8})?)?/U\"; pcre:\"/\\x0d\\x0aHost\\: \\d+\\.\\d+\\.\\d+\\.\\d+\\x0d\\x0a/\"; sid:2009024; rev:9;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2105,11 +2105,9 @@ static int UriTestSig17(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"this\"; uricontent:\"is\"; within:6; "
-                               "uricontent:\"big\"; within:8; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"this\"; uricontent:\"is\"; within:6; " "uricontent:\"big\"; within:8; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2200,11 +2198,9 @@ static int UriTestSig18(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"this\"; uricontent:\"is\"; within:9; "
-                               "uricontent:\"big\"; within:12; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"this\"; uricontent:\"is\"; within:9; " "uricontent:\"big\"; within:12; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2295,12 +2291,9 @@ static int UriTestSig19(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"now\"; uricontent:\"this\"; "
-                               "uricontent:\"is\"; within:12; "
-                               "uricontent:\"big\"; within:8; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"now\"; uricontent:\"this\"; " "uricontent:\"is\"; within:12; " "uricontent:\"big\"; within:8; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2391,11 +2384,9 @@ static int UriTestSig20(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"thus\"; offset:8; "
-                               "uricontent:\"is\"; within:6; "
-                               "uricontent:\"big\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"thus\"; offset:8; " "uricontent:\"is\"; within:6; " "uricontent:\"big\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2486,10 +2477,9 @@ static int UriTestSig21(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix\"; uricontent:\"this\"; within:6; "
-                               "uricontent:!\"and\"; distance:0; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix\"; uricontent:\"this\"; within:6; " "uricontent:!\"and\"; distance:0; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2581,9 +2571,9 @@ static int UriTestSig22(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "pcre:/super/U; uricontent:\"nova\"; within:7; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "pcre:/super/U; uricontent:\"nova\"; within:7; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2674,9 +2664,9 @@ static int UriTestSig23(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:!\"fix_this_now\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:!\"fix_this_now\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2767,9 +2757,9 @@ static int UriTestSig24(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"we_need_to\"; uricontent:!\"fix_this_now\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"we_need_to\"; uricontent:!\"fix_this_now\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2860,9 +2850,9 @@ static int UriTestSig25(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "pcre:/normalized/U; uricontent:\"normalized uri\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "pcre:/normalized/U; uricontent:\"normalized uri\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2953,9 +2943,9 @@ static int UriTestSig26(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix_this\"; isdataat:4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix_this\"; isdataat:4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3046,9 +3036,9 @@ static int UriTestSig27(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix_this\"; isdataat:!10,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix_this\"; isdataat:!10,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3172,10 +3162,8 @@ static int UriTestSig28(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"ring\"; distance:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"ring\"; distance:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3264,10 +3252,8 @@ static int UriTestSig29(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"ring\"; distance:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"ring\"; distance:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3356,10 +3342,8 @@ static int UriTestSig30(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"_b5ig\"; offset:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"_b5ig\"; offset:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3448,10 +3432,8 @@ static int UriTestSig31(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"his\"; depth:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"his\"; depth:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3540,10 +3522,8 @@ static int UriTestSig32(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"g_st\"; within:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"g_st\"; within:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3631,9 +3611,9 @@ static int UriTestSig33(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:15; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:15; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3721,9 +3701,9 @@ static int UriTestSig34(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:15, norm; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:15, norm; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3811,9 +3791,9 @@ static int UriTestSig35(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:16; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:16; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3901,9 +3881,9 @@ static int UriTestSig36(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:16, norm; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:16, norm; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3991,9 +3971,9 @@ static int UriTestSig37(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:17, raw; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:17, raw; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -4081,9 +4061,9 @@ static int UriTestSig38(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:18, raw; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:18, raw; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-engine-hrud.c
+++ b/src/detect-engine-hrud.c
@@ -215,10 +215,9 @@ static int DetectEngineHttpRawUriTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"../c/./d\"; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"../c/./d\"; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -339,10 +338,9 @@ static int DetectEngineHttpRawUriTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"/c/./d\"; http_raw_uri; offset:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"/c/./d\"; http_raw_uri; offset:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -449,10 +447,9 @@ static int DetectEngineHttpRawUriTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"/a/b\"; http_raw_uri; offset:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"/a/b\"; http_raw_uri; offset:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -577,10 +574,9 @@ static int DetectEngineHttpRawUriTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:!\"/a/b\"; http_raw_uri; offset:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:!\"/a/b\"; http_raw_uri; offset:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -704,10 +700,9 @@ static int DetectEngineHttpRawUriTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"a/b\"; http_raw_uri; depth:10; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"a/b\"; http_raw_uri; depth:10; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -831,10 +826,9 @@ static int DetectEngineHttpRawUriTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:!\"/a/b\"; http_raw_uri; depth:25; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:!\"/a/b\"; http_raw_uri; depth:25; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -958,10 +952,9 @@ static int DetectEngineHttpRawUriTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:!\"/c/./d\"; http_raw_uri; depth:12; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:!\"/c/./d\"; http_raw_uri; depth:12; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1085,10 +1078,9 @@ static int DetectEngineHttpRawUriTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:!\"/c/./d\"; http_raw_uri; depth:18; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:!\"/c/./d\"; http_raw_uri; depth:18; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1212,11 +1204,9 @@ static int DetectEngineHttpRawUriTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"/a\"; http_raw_uri; "
-                               "content:\"./c/.\"; http_raw_uri; within:9; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"/a\"; http_raw_uri; " "content:\"./c/.\"; http_raw_uri; within:9; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1340,11 +1330,9 @@ static int DetectEngineHttpRawUriTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"/a\"; http_raw_uri; "
-                               "content:!\"boom\"; http_raw_uri; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"/a\"; http_raw_uri; " "content:!\"boom\"; http_raw_uri; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1468,11 +1456,9 @@ static int DetectEngineHttpRawUriTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:\"boom\"; http_raw_uri; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:\"boom\"; http_raw_uri; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1596,11 +1582,9 @@ static int DetectEngineHttpRawUriTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:!\"/b/..\"; http_raw_uri; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:!\"/b/..\"; http_raw_uri; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1724,11 +1708,9 @@ static int DetectEngineHttpRawUriTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:\"/c/.\"; http_raw_uri; distance:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:\"/c/.\"; http_raw_uri; distance:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1852,11 +1834,9 @@ static int DetectEngineHttpRawUriTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:!\"b/..\"; http_raw_uri; distance:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:!\"b/..\"; http_raw_uri; distance:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1980,11 +1960,9 @@ static int DetectEngineHttpRawUriTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:\"/c/\"; http_raw_uri; distance:7; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:\"/c/\"; http_raw_uri; distance:7; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2108,11 +2086,9 @@ static int DetectEngineHttpRawUriTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"./a\"; http_raw_uri; "
-                               "content:!\"/c/\"; http_raw_uri; distance:4; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"./a\"; http_raw_uri; " "content:!\"/c/\"; http_raw_uri; distance:4; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2218,11 +2194,9 @@ static int DetectEngineHttpRawUriTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"body1\"; http_raw_uri; "
-                               "content:\"bambu\"; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"body1\"; http_raw_uri; " "content:\"bambu\"; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2290,11 +2264,9 @@ static int DetectEngineHttpRawUriTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"body1\"; http_raw_uri; "
-                               "content:\"bambu\"; http_raw_uri; fast_pattern; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"body1\"; http_raw_uri; " "content:\"bambu\"; http_raw_uri; fast_pattern; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2362,11 +2334,9 @@ static int DetectEngineHttpRawUriTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"bambu\"; http_raw_uri; "
-                               "content:\"is\"; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"bambu\"; http_raw_uri; " "content:\"is\"; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2434,11 +2404,9 @@ static int DetectEngineHttpRawUriTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "content:\"bambu\"; http_raw_uri; "
-                               "content:\"is\"; http_raw_uri; fast_pattern; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "content:\"bambu\"; http_raw_uri; " "content:\"is\"; http_raw_uri; fast_pattern; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2524,11 +2492,9 @@ static int DetectEngineHttpRawUriTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:!\"/c/\"; http_raw_uri; within:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:!\"/c/\"; http_raw_uri; within:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2652,11 +2618,9 @@ static int DetectEngineHttpRawUriTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:!\"/c/\"; within:5; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:!\"/c/\"; within:5; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2780,11 +2744,9 @@ static int DetectEngineHttpRawUriTest23(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:!\"/c/\"; distance:3; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:!\"/c/\"; distance:3; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2908,11 +2870,9 @@ static int DetectEngineHttpRawUriTest24(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:!\"/c/\"; distance:10; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:!\"/c/\"; distance:10; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3036,11 +2996,9 @@ static int DetectEngineHttpRawUriTest25(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:\"/c/\"; within:10; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:\"/c/\"; within:10; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3164,11 +3122,9 @@ static int DetectEngineHttpRawUriTest26(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:\"/c/\"; within:5; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:\"/c/\"; within:5; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3292,11 +3248,9 @@ static int DetectEngineHttpRawUriTest27(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:\"/c/\"; distance:5; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:\"/c/\"; distance:5; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3420,11 +3374,9 @@ static int DetectEngineHttpRawUriTest28(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http raw uri test\"; "
-                               "pcre:/\\.\\/a/I; "
-                               "content:\"/c/\"; distance:10; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http raw uri test\"; " "pcre:/\\.\\/a/I; " "content:\"/c/\"; distance:10; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3535,10 +3487,9 @@ static int DetectEngineHttpRawUriTest29(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative raw uri contents\"; "
-                               "content:\"/c/\"; http_raw_uri; "
-                               "isdataat:4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative raw uri contents\"; " "content:\"/c/\"; http_raw_uri; " "isdataat:4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3629,9 +3580,9 @@ static int DetectEngineHttpRawUriTest30(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative raw uri contents\"; "
-                               "uricontent:\"/c/\"; isdataat:!10,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative raw uri contents\"; " "uricontent:\"/c/\"; isdataat:!10,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -370,7 +370,7 @@ static int RunTest(struct TestSteps *steps, const char *sig, const char *yaml)
     f.alproto = ALPROTO_HTTP;
 
     SCLogDebug("sig %s", sig);
-    DetectEngineAppendSig(de_ctx, (char *)sig);
+    DetectEngineAppendSig(de_ctx, (char *)sig, NULL);
 
     de_ctx->flags |= DE_QUIET;
 
@@ -3656,15 +3656,9 @@ static int DetectEngineHttpServerBodyFileDataTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if (!(DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-                               "(msg:\"match on 1st\"; "
-                               "file_data; content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; byte_test:4,=,1234,-8,relative,string;"
-                               "sid:1;)")))
+    if (!(DetectEngineAppendSig(de_ctx, "alert http any any -> any any " "(msg:\"match on 1st\"; " "file_data; content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; byte_test:4,=,1234,-8,relative,string;" "sid:1;)", NULL)))
         goto end;
-    if (!(DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-                               "(msg:\"match on 2nd\"; "
-                               "file_data; content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; byte_test:4,=,5678,-8,relative,string;"
-                               "sid:2;)")))
+    if (!(DetectEngineAppendSig(de_ctx, "alert http any any -> any any " "(msg:\"match on 2nd\"; " "file_data; content:\"XYZ\"; content:\"_klm_\"; distance:0; content:\"abcd\"; distance:4; byte_test:4,=,5678,-8,relative,string;" "sid:2;)", NULL)))
         goto end;
 
     SigGroupBuild(de_ctx);

--- a/src/detect-engine-hsbd.c
+++ b/src/detect-engine-hsbd.c
@@ -498,10 +498,9 @@ static int DetectEngineHttpServerBodyTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"message\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"message\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -620,10 +619,9 @@ static int DetectEngineHttpServerBodyTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"ABC\"; http_server_body; offset:4; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"ABC\"; http_server_body; offset:4; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -742,10 +740,9 @@ static int DetectEngineHttpServerBodyTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"ABC\"; http_server_body; offset:14; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"ABC\"; http_server_body; offset:14; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -880,10 +877,9 @@ static int DetectEngineHttpServerBodyTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:!\"abc\"; http_server_body; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:!\"abc\"; http_server_body; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1008,10 +1004,9 @@ static int DetectEngineHttpServerBodyTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"abc\"; http_server_body; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"abc\"; http_server_body; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1136,10 +1131,9 @@ static int DetectEngineHttpServerBodyTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:!\"def\"; http_server_body; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:!\"def\"; http_server_body; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1264,10 +1258,9 @@ static int DetectEngineHttpServerBodyTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:!\"def\"; http_server_body; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:!\"def\"; http_server_body; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1392,10 +1385,9 @@ static int DetectEngineHttpServerBodyTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:!\"abc\"; http_server_body; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:!\"abc\"; http_server_body; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1520,11 +1512,9 @@ static int DetectEngineHttpServerBodyTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"abc\"; http_server_body; depth:3; "
-                               "content:\"def\"; http_server_body; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"abc\"; http_server_body; depth:3; " "content:\"def\"; http_server_body; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1649,11 +1639,9 @@ static int DetectEngineHttpServerBodyTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"abc\"; http_server_body; depth:3; "
-                               "content:!\"xyz\"; http_server_body; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"abc\"; http_server_body; depth:3; " "content:!\"xyz\"; http_server_body; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1778,11 +1766,9 @@ static int DetectEngineHttpServerBodyTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"abc\"; http_server_body; depth:3; "
-                               "content:\"xyz\"; http_server_body; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"abc\"; http_server_body; depth:3; " "content:\"xyz\"; http_server_body; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1907,11 +1893,9 @@ static int DetectEngineHttpServerBodyTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"ab\"; http_server_body; depth:2; "
-                               "content:\"ef\"; http_server_body; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"ab\"; http_server_body; depth:2; " "content:\"ef\"; http_server_body; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2036,11 +2020,9 @@ static int DetectEngineHttpServerBodyTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"ab\"; http_server_body; depth:3; "
-                               "content:!\"yz\"; http_server_body; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"ab\"; http_server_body; depth:3; " "content:!\"yz\"; http_server_body; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2165,11 +2147,9 @@ static int DetectEngineHttpServerBodyTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "pcre:/ab/Q; "
-                               "content:\"ef\"; http_server_body; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "pcre:/ab/Q; " "content:\"ef\"; http_server_body; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2294,11 +2274,9 @@ static int DetectEngineHttpServerBodyTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "pcre:/abc/Q; "
-                               "content:!\"xyz\"; http_server_body; distance:0; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "pcre:/abc/Q; " "content:!\"xyz\"; http_server_body; distance:0; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2449,10 +2427,9 @@ libhtp:\n\
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"890\"; within:3; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"890\"; within:3; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2625,10 +2602,9 @@ libhtp:\n\
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"890\"; depth:3; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"890\"; depth:3; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2785,10 +2761,9 @@ static int DetectEngineHttpServerBodyTest18(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"file\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"file\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2915,10 +2890,9 @@ static int DetectEngineHttpServerBodyTest19(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"file\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"file\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3045,10 +3019,9 @@ static int DetectEngineHttpServerBodyTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"file\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"file\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3176,10 +3149,9 @@ static int DetectEngineHttpServerBodyTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"file\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"file\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3309,10 +3281,9 @@ static int DetectEngineHttpServerBodyTest22(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"file\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"file\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3430,11 +3401,9 @@ static int DetectEngineHttpServerBodyFileDataTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "file_data; pcre:/ab/; "
-                               "content:\"ef\"; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "file_data; pcre:/ab/; " "content:\"ef\"; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3559,11 +3528,9 @@ static int DetectEngineHttpServerBodyFileDataTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "file_data; pcre:/abc/; "
-                               "content:!\"xyz\"; distance:0; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "file_data; pcre:/abc/; " "content:!\"xyz\"; distance:0; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hscd.c
+++ b/src/detect-engine-hscd.c
@@ -211,10 +211,9 @@ static int DetectEngineHttpStatCodeTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"200\"; http_stat_code; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"200\"; http_stat_code; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -333,10 +332,9 @@ static int DetectEngineHttpStatCodeTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"123\"; http_stat_code; offset:4; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"123\"; http_stat_code; offset:4; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -455,10 +453,9 @@ static int DetectEngineHttpStatCodeTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"789\"; http_stat_code; offset:5; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"789\"; http_stat_code; offset:5; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -593,10 +590,9 @@ static int DetectEngineHttpStatCodeTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:!\"200\"; http_stat_code; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:!\"200\"; http_stat_code; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -721,10 +717,9 @@ static int DetectEngineHttpStatCodeTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"200\"; http_stat_code; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"200\"; http_stat_code; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -849,10 +844,9 @@ static int DetectEngineHttpStatCodeTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:!\"123\"; http_stat_code; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:!\"123\"; http_stat_code; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -977,10 +971,9 @@ static int DetectEngineHttpStatCodeTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:!\"123\"; http_stat_code; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:!\"123\"; http_stat_code; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1105,10 +1098,9 @@ static int DetectEngineHttpStatCodeTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:!\"200\"; http_stat_code; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:!\"200\"; http_stat_code; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1233,11 +1225,9 @@ static int DetectEngineHttpStatCodeTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"200\"; http_stat_code; depth:3; "
-                               "content:\"123\"; http_stat_code; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"200\"; http_stat_code; depth:3; " "content:\"123\"; http_stat_code; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1362,11 +1352,9 @@ static int DetectEngineHttpStatCodeTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"200\"; http_stat_code; depth:3; "
-                               "content:!\"124\"; http_stat_code; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"200\"; http_stat_code; depth:3; " "content:!\"124\"; http_stat_code; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1491,11 +1479,9 @@ static int DetectEngineHttpStatCodeTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"200\"; http_stat_code; depth:3; "
-                               "content:\"124\"; http_stat_code; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"200\"; http_stat_code; depth:3; " "content:\"124\"; http_stat_code; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1620,11 +1606,9 @@ static int DetectEngineHttpStatCodeTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"20\"; http_stat_code; depth:2; "
-                               "content:\"23\"; http_stat_code; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"20\"; http_stat_code; depth:2; " "content:\"23\"; http_stat_code; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1749,11 +1733,9 @@ static int DetectEngineHttpStatCodeTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "content:\"20\"; http_stat_code; depth:3; "
-                               "content:!\"25\"; http_stat_code; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "content:\"20\"; http_stat_code; depth:3; " "content:!\"25\"; http_stat_code; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1878,11 +1860,9 @@ static int DetectEngineHttpStatCodeTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "pcre:/20/S; "
-                               "content:\"23\"; http_stat_code; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "pcre:/20/S; " "content:\"23\"; http_stat_code; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2007,11 +1987,9 @@ static int DetectEngineHttpStatCodeTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat code test\"; "
-                               "pcre:/200/S; "
-                               "content:!\"124\"; http_stat_code; distance:0; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat code test\"; " "pcre:/200/S; " "content:!\"124\"; http_stat_code; distance:0; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hsmd.c
+++ b/src/detect-engine-hsmd.c
@@ -211,10 +211,9 @@ static int DetectEngineHttpStatMsgTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"message\"; http_stat_msg; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"message\"; http_stat_msg; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -333,10 +332,9 @@ static int DetectEngineHttpStatMsgTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"ABC\"; http_stat_msg; offset:4; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"ABC\"; http_stat_msg; offset:4; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -455,10 +453,9 @@ static int DetectEngineHttpStatMsgTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"ABC\"; http_stat_msg; offset:14; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"ABC\"; http_stat_msg; offset:14; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -593,10 +590,9 @@ static int DetectEngineHttpStatMsgTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:!\"abc\"; http_stat_msg; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:!\"abc\"; http_stat_msg; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -721,10 +717,9 @@ static int DetectEngineHttpStatMsgTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"abc\"; http_stat_msg; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"abc\"; http_stat_msg; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -849,10 +844,9 @@ static int DetectEngineHttpStatMsgTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:!\"def\"; http_stat_msg; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:!\"def\"; http_stat_msg; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -977,10 +971,9 @@ static int DetectEngineHttpStatMsgTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:!\"def\"; http_stat_msg; offset:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:!\"def\"; http_stat_msg; offset:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1105,10 +1098,9 @@ static int DetectEngineHttpStatMsgTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:!\"abc\"; http_stat_msg; depth:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:!\"abc\"; http_stat_msg; depth:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1233,11 +1225,9 @@ static int DetectEngineHttpStatMsgTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"abc\"; http_stat_msg; depth:3; "
-                               "content:\"def\"; http_stat_msg; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"abc\"; http_stat_msg; depth:3; " "content:\"def\"; http_stat_msg; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1362,11 +1352,9 @@ static int DetectEngineHttpStatMsgTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"abc\"; http_stat_msg; depth:3; "
-                               "content:!\"xyz\"; http_stat_msg; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"abc\"; http_stat_msg; depth:3; " "content:!\"xyz\"; http_stat_msg; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1491,11 +1479,9 @@ static int DetectEngineHttpStatMsgTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"abc\"; http_stat_msg; depth:3; "
-                               "content:\"xyz\"; http_stat_msg; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"abc\"; http_stat_msg; depth:3; " "content:\"xyz\"; http_stat_msg; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1620,11 +1606,9 @@ static int DetectEngineHttpStatMsgTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"ab\"; http_stat_msg; depth:2; "
-                               "content:\"ef\"; http_stat_msg; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"ab\"; http_stat_msg; depth:2; " "content:\"ef\"; http_stat_msg; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1749,11 +1733,9 @@ static int DetectEngineHttpStatMsgTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "content:\"ab\"; http_stat_msg; depth:3; "
-                               "content:!\"yz\"; http_stat_msg; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "content:\"ab\"; http_stat_msg; depth:3; " "content:!\"yz\"; http_stat_msg; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1878,11 +1860,9 @@ static int DetectEngineHttpStatMsgTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "pcre:/ab/Y; "
-                               "content:\"ef\"; http_stat_msg; distance:2; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "pcre:/ab/Y; " "content:\"ef\"; http_stat_msg; distance:2; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2007,11 +1987,9 @@ static int DetectEngineHttpStatMsgTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http stat msg test\"; "
-                               "pcre:/abc/Y; "
-                               "content:!\"xyz\"; http_stat_msg; distance:0; within:3; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http stat msg test\"; " "pcre:/abc/Y; " "content:!\"xyz\"; http_stat_msg; distance:0; within:3; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-hua.c
+++ b/src/detect-engine-hua.c
@@ -206,10 +206,9 @@ static int DetectEngineHttpUATest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CONNECT\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CONNECT\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -304,10 +303,9 @@ static int DetectEngineHttpUATest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CO\"; depth:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CO\"; depth:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -402,10 +400,9 @@ static int DetectEngineHttpUATest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_user_agent test\"; "
-                               "content:!\"ECT\"; depth:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_user_agent test\"; " "content:!\"ECT\"; depth:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -500,10 +497,9 @@ static int DetectEngineHttpUATest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"ECT\"; depth:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"ECT\"; depth:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -598,10 +594,9 @@ static int DetectEngineHttpUATest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:!\"CON\"; depth:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:!\"CON\"; depth:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -696,10 +691,9 @@ static int DetectEngineHttpUATest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"ECT\"; offset:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"ECT\"; offset:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -794,10 +788,9 @@ static int DetectEngineHttpUATest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:!\"CO\"; offset:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:!\"CO\"; offset:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -892,10 +885,9 @@ static int DetectEngineHttpUATest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:!\"ECT\"; offset:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:!\"ECT\"; offset:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -990,10 +982,9 @@ static int DetectEngineHttpUATest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CON\"; offset:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CON\"; offset:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1088,11 +1079,9 @@ static int DetectEngineHttpUATest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_user_agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:\"EC\"; within:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_user_agent test\"; " "content:\"CO\"; http_user_agent; " "content:\"EC\"; within:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1187,11 +1176,9 @@ static int DetectEngineHttpUATest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:!\"EC\"; within:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CO\"; http_user_agent; " "content:!\"EC\"; within:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1286,11 +1273,9 @@ static int DetectEngineHttpUATest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_user_agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:\"EC\"; within:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_user_agent test\"; " "content:\"CO\"; http_user_agent; " "content:\"EC\"; within:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1385,11 +1370,9 @@ static int DetectEngineHttpUATest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:!\"EC\"; within:4; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CO\"; http_user_agent; " "content:!\"EC\"; within:4; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1484,11 +1467,9 @@ static int DetectEngineHttpUATest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_user_agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:\"EC\"; distance:2; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_user_agent test\"; " "content:\"CO\"; http_user_agent; " "content:\"EC\"; distance:2; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1583,11 +1564,9 @@ static int DetectEngineHttpUATest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:!\"EC\"; distance:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CO\"; http_user_agent; " "content:!\"EC\"; distance:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1682,11 +1661,9 @@ static int DetectEngineHttpUATest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:\"EC\"; distance:3; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"CO\"; http_user_agent; " "content:\"EC\"; distance:3; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1781,11 +1758,9 @@ static int DetectEngineHttpUATest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http_user_agent test\"; "
-                               "content:\"CO\"; http_user_agent; "
-                               "content:!\"EC\"; distance:2; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http_user_agent test\"; " "content:\"CO\"; http_user_agent; " "content:!\"EC\"; distance:2; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1568,7 +1568,9 @@ static int IPOnlyTestSig01(void)
 
     de_ctx.flags |= DE_QUIET;
 
-    Signature *s = SigInit(&de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-01 sig is IPOnly \"; sid:400001; rev:1;)");
+    Signature *s = SigInit(&de_ctx,
+                           "alert tcp any any -> any any (msg:\"SigTest40-01 sig is IPOnly \"; sid:400001; rev:1;)",
+                           NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1597,7 +1599,9 @@ static int IPOnlyTestSig02 (void)
 
     de_ctx.flags |= DE_QUIET;
 
-    Signature *s = SigInit(&de_ctx,"alert tcp any any -> any 80 (msg:\"SigTest40-02 sig is not IPOnly \"; sid:400001; rev:1;)");
+    Signature *s = SigInit(&de_ctx,
+                           "alert tcp any any -> any 80 (msg:\"SigTest40-02 sig is not IPOnly \"; sid:400001; rev:1;)",
+                           NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1629,7 +1633,9 @@ static int IPOnlyTestSig03 (void)
     de_ctx->flags |= DE_QUIET;
 
     /* combination of pcre and content */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pcre and content) \"; content:\"php\"; pcre:\"/require(_once)?/i\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pcre and content) \"; content:\"php\"; pcre:\"/require(_once)?/i\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1641,7 +1647,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* content */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (content) \"; content:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (content) \"; content:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1653,7 +1661,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* uricontent */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (uricontent) \"; uricontent:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (uricontent) \"; uricontent:\"match something\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1665,7 +1675,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* pcre */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pcre) \"; pcre:\"/e?idps rule[sz]/i\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pcre) \"; pcre:\"/e?idps rule[sz]/i\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1677,7 +1689,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* flow */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flow) \"; flow:to_server; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flow) \"; flow:to_server; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1689,7 +1703,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* dsize */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (dsize) \"; dsize:100; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (dsize) \"; dsize:100; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1701,7 +1717,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* flowbits */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowbits) \"; flowbits:unset; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowbits) \"; flowbits:unset; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1713,7 +1731,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* flowvar */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowvar) \"; pcre:\"/(?<flow_var>.*)/i\"; flowvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (flowvar) \"; pcre:\"/(?<flow_var>.*)/i\"; flowvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1725,7 +1745,9 @@ static int IPOnlyTestSig03 (void)
     SigFree(s);
 
     /* pktvar */
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pktvar) \"; pcre:\"/(?<pkt_var>.*)/i\"; pktvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:\"SigTest40-03 sig is not IPOnly (pktvar) \"; pcre:\"/(?<pkt_var>.*)/i\"; pktvar:var,\"str\"; classtype:misc-activity; sid:400001; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2127,8 +2149,8 @@ static int IPOnlyTestSig13(void)
     de_ctx.flags |= DE_QUIET;
 
     Signature *s = SigInit(&de_ctx,
-                           "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; "
-                           "flowbits:set,myflow1; sid:1; rev:1;)");
+                           "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; " "flowbits:set,myflow1; sid:1; rev:1;)",
+                           NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2152,8 +2174,8 @@ static int IPOnlyTestSig14(void)
     de_ctx.flags |= DE_QUIET;
 
     Signature *s = SigInit(&de_ctx,
-                           "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; "
-                           "flowbits:set,myflow1; flowbits:isset,myflow2; sid:1; rev:1;)");
+                           "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; " "flowbits:set,myflow1; flowbits:isset,myflow2; sid:1; rev:1;)",
+                           NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -999,55 +999,45 @@ static int DetectEngineInspectModbusTest08(void)
 
     /* readInputsRegistersReq, Starting Address = 0x08, Quantity of Registers = 0x60 */
     /* Read access address from 9 to 104 */
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address <9;  sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address <9;  sid:1;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 9;  sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 9;  sid:2;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 5<>9;  sid:3;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 5<>9;  sid:3;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address <10;  sid:4;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address <10;  sid:4;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 5<>10;  sid:5;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 5<>10;  sid:5;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address >103;  sid:6;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address >103;  sid:6;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 103<>110;  sid:7;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 103<>110;  sid:7;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 104;  sid:8;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 104;  sid:8;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address >104;  sid:9;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address >104;  sid:9;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus access\"; "
-                                      "modbus: access read input, "
-                                      "address 104<>110;  sid:10;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus access\"; " "modbus: access read input, " "address 104<>110;  sid:10;)",
+                              NULL);
 
     if (s == NULL)
         goto end;
@@ -1184,55 +1174,45 @@ static int DetectEngineInspectModbusTest09(void)
     /* Write access register address 15 = 0x1234 (4660)     */
     /* Write access register address 16 = 0x5678 (22136)    */
     /* Write access register address 17 = 0x9ABC (39612)    */
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 15, value <4660;  sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 15, value <4660;  sid:1;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 16, value <22137;  sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 16, value <22137;  sid:2;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 17, value 39612;  sid:3;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 17, value 39612;  sid:3;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 15, value 4661;  sid:4;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 15, value 4661;  sid:4;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 16, value 20000<>22136;  sid:5;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 16, value 20000<>22136;  sid:5;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 17, value 30000<>39613;  sid:6;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 17, value 30000<>39613;  sid:6;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 15, value 4659<>5000;  sid:7;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 15, value 4659<>5000;  sid:7;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 16, value 22136<>30000;  sid:8;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 16, value 22136<>30000;  sid:8;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 17, value >39611;  sid:9;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 17, value >39611;  sid:9;)",
+                              NULL);
 
-    s = DetectEngineAppendSig(de_ctx, "alert modbus any any -> any any "
-                                      "(msg:\"Testing modbus write access\"; "
-                                      "modbus: access write holding, "
-                                      "address 15, value >4660;  sid:10;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert modbus any any -> any any " "(msg:\"Testing modbus write access\"; " "modbus: access write holding, " "address 15, value >4660;  sid:10;)",
+                              NULL);
 
     if (s == NULL)
         goto end;

--- a/src/detect-engine-modbus.c
+++ b/src/detect-engine-modbus.c
@@ -370,9 +370,9 @@ static int DetectEngineInspectModbusTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                            "(msg:\"Testing modbus code function\"; "
-                                            "modbus: function 23; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus code function\"; " "modbus: function 23; sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -460,9 +460,9 @@ static int DetectEngineInspectModbusTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                           "(msg:\"Testing modbus function and subfunction\"; "
-                                           "modbus: function 8, subfunction 4;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus function and subfunction\"; " "modbus: function 8, subfunction 4;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -549,9 +549,9 @@ static int DetectEngineInspectModbusTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                           "(msg:\"Testing modbus category function\"; "
-                                           "modbus: function reserved;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus category function\"; " "modbus: function reserved;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -639,9 +639,9 @@ static int DetectEngineInspectModbusTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus category function\"; "
-                                       "modbus: function !assigned;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus category function\"; " "modbus: function !assigned;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -728,9 +728,9 @@ static int DetectEngineInspectModbusTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                           "(msg:\"Testing modbus access type\"; "
-                                           "modbus: access read;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus access type\"; " "modbus: access read;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -818,9 +818,9 @@ static int DetectEngineInspectModbusTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                           "(msg:\"Testing modbus access type\"; "
-                                           "modbus: access read input;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus access type\"; " "modbus: access read input;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
@@ -908,9 +908,9 @@ static int DetectEngineInspectModbusTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                           "(msg:\"Testing modbus address access\"; "
-                                           "modbus: access read, address 30870;  sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert modbus any any -> any any " "(msg:\"Testing modbus address access\"; " "modbus: access read, address 30870;  sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;

--- a/src/detect-engine-payload.c
+++ b/src/detect-engine-payload.c
@@ -573,7 +573,7 @@ static int PayloadTestSig13(void)
         de_ctx->flags |= DE_QUIET;
         de_ctx->mpm_matcher = mpm_type;
 
-        de_ctx->sig_list = SigInit(de_ctx, sig);
+        de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
         if (de_ctx->sig_list == NULL) {
             printf("signature == NULL: ");
             goto end;

--- a/src/detect-engine-proto.c
+++ b/src/detect-engine-proto.c
@@ -205,7 +205,7 @@ static int DetectProtoInitTest(DetectEngineCtx **de_ctx, Signature **sig,
 
     (*de_ctx)->flags |= DE_QUIET;
 
-    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr);
+    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr, NULL);
     if ((*de_ctx)->sig_list == NULL) {
         goto end;
     }
@@ -515,20 +515,23 @@ static int DetectProtoTestSig01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert udp any any -> any any "
-            "(msg:\"Not tcp\"; flow:to_server; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert udp any any -> any any " "(msg:\"Not tcp\"; flow:to_server; sid:1;)",
+                                   NULL);
 
     if (s == NULL)
         goto end;
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any "
-            "(msg:\"IP\"; flow:to_server; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any " "(msg:\"IP\"; flow:to_server; sid:2;)",
+                          NULL);
 
     if (s == NULL)
         goto end;
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any "
-            "(msg:\"TCP\"; flow:to_server; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any " "(msg:\"TCP\"; flow:to_server; sid:3;)",
+                          NULL);
 
     if (s == NULL)
         goto end;
@@ -580,15 +583,17 @@ static int DetectProtoTestSig02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp-pkt any any -> any any "
-            "(msg:\"tcp-pkt\"; content:\"blah\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp-pkt any any -> any any " "(msg:\"tcp-pkt\"; content:\"blah\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("tcp-pkt sig parsing failed: ");
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp-stream any any -> any any "
-            "(msg:\"tcp-stream\"; content:\"blah\"; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp-stream any any -> any any " "(msg:\"tcp-stream\"; content:\"blah\"; sid:2;)",
+                          NULL);
     if (s == NULL) {
         printf("tcp-pkt sig parsing failed: ");
         goto end;

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -1193,11 +1193,15 @@ static int SigGroupHeadTest10(void)
     if (de_ctx == NULL)
         return 0;
 
-    s = DetectEngineAppendSig(de_ctx, "alert icmp 192.168.0.0/16 any -> any any (icode:>1; itype:11; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert icmp 192.168.0.0/16 any -> any any (icode:>1; itype:11; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert icmp any any -> 192.168.0.0/16 any (icode:1; itype:5; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert icmp any any -> 192.168.0.0/16 any (icode:1; itype:5; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1239,11 +1243,15 @@ static int SigGroupHeadTest11(void)
     if (de_ctx == NULL || p == NULL)
         return 0;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any 1024: -> any 1024: (content:\"abc\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any 1024: -> any 1024: (content:\"abc\"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"def\"; http_client_body; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"def\"; http_client_body; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -831,45 +831,45 @@ static int SigGroupHeadTest06(void)
     if (de_ctx == NULL)
         return 0;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:0;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:1;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:2;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:2;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:3;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:3;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:4;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:4;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
@@ -915,45 +915,45 @@ static int SigGroupHeadTest07(void)
     if (de_ctx == NULL)
         return 0;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:0;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:1;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:2;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:2;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:3;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:3;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:4;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:4;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
@@ -1007,45 +1007,45 @@ static int SigGroupHeadTest08(void)
     if (de_ctx == NULL)
         return 0;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:0;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:1;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:2;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:2;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:3;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:3;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:4;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:4;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
@@ -1101,45 +1101,45 @@ static int SigGroupHeadTest09(void)
     if (de_ctx == NULL)
         return 0;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:0;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:1;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:2;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:2;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:3;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:3;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = prev_sig->next;
 
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:4;)");
+    prev_sig->next = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(msg:\"SigGroupHead tests\"; content:\"test1\"; " "content:\"test2\"; content:\"test3\"; sid:4;)",
+                             NULL);
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -806,7 +806,7 @@ void SCSigSignatureOrderingModuleCleanup(DetectEngineCtx *de_ctx)
 /**********Unittests**********/
 
 DetectEngineCtx *DetectEngineCtxInit(void);
-Signature *SigInit(DetectEngineCtx *, char *);
+Signature *SigInit(DetectEngineCtx *, char *, char *);
 void SigFree(Signature *);
 void DetectEngineCtxFree(DetectEngineCtx *);
 
@@ -855,56 +855,72 @@ static int SCSigOrderingTest02(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; flowvar:http_host,\"www.oisf.net\"; rev:4; priority:1; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; flowvar:http_host,\"www.oisf.net\"; rev:4; priority:1; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -912,42 +928,54 @@ static int SCSigOrderingTest02(void)
     prevsig = sig;
 
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; flowbits:set,TEST.one; flowbits:noalert; sid:9;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; flowbits:set,TEST.one; flowbits:noalert; sid:9;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:10;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:10;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:11;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:11;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:12;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:12;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; pktvar:http_host,\"www.oisf.net\"; priority:2; flowbits:isnotset,TEST.two; sid:13;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; pktvar:http_host,\"www.oisf.net\"; priority:2; flowbits:isnotset,TEST.two; sid:13;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowbits:set,TEST.two; sid:14;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowbits:set,TEST.two; sid:14;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1023,56 +1051,72 @@ static int SCSigOrderingTest03(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; flowbits:unset,TEST.one; rev:4; priority:2; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; flowbits:unset,TEST.one; rev:4; priority:2; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; flowbits:isset,TEST.one; rev:4; priority:1; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; flowbits:isset,TEST.one; rev:4; priority:1; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; priority:2; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; priority:2; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; flowbits:isnotset,TEST.one; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; flowbits:isnotset,TEST.one; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; flowbits:unset,TEST.one; rev:4; priority:3; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; flowbits:unset,TEST.one; rev:4; priority:3; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; flowbits:toggle,TEST.one; rev:4; priority:1; pktvar:http_host,\"www.oisf.net\"; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/220[- ]/\"; flowbits:toggle,TEST.one; rev:4; priority:1; pktvar:http_host,\"www.oisf.net\"; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1080,42 +1124,54 @@ static int SCSigOrderingTest03(void)
     prevsig = sig;
 
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; flowbits:set,TEST.one; flowbits:noalert; pktvar:http_host,\"www.oisf.net\"; sid:9;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; flowbits:set,TEST.one; flowbits:noalert; pktvar:http_host,\"www.oisf.net\"; sid:9;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:10;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:10;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:11;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:11;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:12;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:12;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; flowbits:isnotset,TEST.one; sid:13;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; flowbits:isnotset,TEST.one; sid:13;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; flowbits:set,TEST.one; sid:14;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; flowbits:set,TEST.one; sid:14;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1186,63 +1242,81 @@ static int SCSigOrderingTest04(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; rev:4; priority:3; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; rev:4; priority:3; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; priority:3; flowvar:http_host,\"www.oisf.net\"; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<flow_http_host>.*)\\r\\n/m\"; rev:4; priority:3; flowvar:http_host,\"www.oisf.net\"; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; pktvar:http_host,\"www.oisf.net\"; rev:4; priority:1; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; pktvar:http_host,\"www.oisf.net\"; rev:4; priority:1; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; flowvar:http_host,\"www.oisf.net\"; pktvar:http_host,\"www.oisf.net\"; priority:1; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; flowvar:http_host,\"www.oisf.net\"; pktvar:http_host,\"www.oisf.net\"; priority:1; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowvar:http_host,\"www.oisf.net\"; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowvar:http_host,\"www.oisf.net\"; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowvar:http_host,\"www.oisf.net\"; sid:9;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; flowvar:http_host,\"www.oisf.net\"; sid:9;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1307,55 +1381,71 @@ static int SCSigOrderingTest05(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; rev:4; priority:3; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; content:\"220\"; offset:10; rev:4; priority:3; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; pktvar:http_host,\"www.oisf.net\"; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; pcre:\"/^User-Agent: (?P<pkt_http_host>.*)\\r\\n/m\"; rev:4; priority:3; pktvar:http_host,\"www.oisf.net\"; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:3; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; pktvar:http_host,\"www.oisf.net\"; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; pktvar:http_host,\"www.oisf.net\"; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; pktvar:http_host,\"www.oisf.net\"; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; pktvar:http_host,\"www.oisf.net\"; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1418,56 +1508,72 @@ static int SCSigOrderingTest06(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; rev:4; priority:2; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; rev:4; priority:2; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1528,56 +1634,72 @@ static int SCSigOrderingTest07(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1; rev:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1; rev:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; sid:2; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; sid:2; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; sid:3; rev:4; priority:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; sid:3; rev:4; priority:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; sid:4; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; sid:4; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:5; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:5; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:6; rev:4; priority:1;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:6; rev:4; priority:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:7; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:7; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; sid:8; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; sid:8; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1648,56 +1770,72 @@ static int SCSigOrderingTest08(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1; rev:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1; rev:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; sid:2; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; sid:2; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; sid:3; rev:4; priority:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; sid:3; rev:4; priority:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; sid:4; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; sid:4; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:5; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:5; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "reject tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:6; rev:4; priority:1;)");
+    sig = SigInit(de_ctx,
+                  "reject tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:6; rev:4; priority:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:7; rev:4;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; sid:7; rev:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; sid:8; rev:4; priority:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; sid:8; rev:4; priority:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1775,56 +1913,72 @@ static int SCSigOrderingTest09(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; priority:2; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; priority:2; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1899,56 +2053,72 @@ static int SCSigOrderingTest10(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; rev:4; priority:2; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; rev:4; priority:2; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:10; depth:4; rev:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:10; depth:4; rev:4; priority:2; sid:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)");
+    sig = SigInit(de_ctx,
+                  "pass tcp any !21:902 -> any any (msg:\"Testing sigordering pass\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:5;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering drop\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:1; sid:6;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "drop tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)");
+    sig = SigInit(de_ctx,
+                  "drop tcp any !21:902 -> any any (msg:\"Testing sigordering reject\"; content:\"220\"; offset:11; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:7;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering alert\"; content:\"220\"; offset:12; depth:4; pcre:\"/220[- ]/\"; rev:4; priority:2; sid:8;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2012,21 +2182,27 @@ static int SCSigOrderingTest11(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering set\"; flowbits:isnotset,myflow1; rev:4; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering set\"; flowbits:isnotset,myflow1; rev:4; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig = sig;
     de_ctx->sig_list = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering toggle\"; flowbits:toggle,myflow2; rev:4; sid:2;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering toggle\"; flowbits:toggle,myflow2; rev:4; sid:2;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
     prevsig->next = sig;
     prevsig = sig;
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"Testing sigordering unset\"; flowbits:isset, myflow1; flowbits:unset,myflow2; rev:4; priority:3; sid:3;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"Testing sigordering unset\"; flowbits:isset, myflow1; flowbits:unset,myflow2; rev:4; priority:3; sid:3;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -806,7 +806,7 @@ void SCSigSignatureOrderingModuleCleanup(DetectEngineCtx *de_ctx)
 /**********Unittests**********/
 
 DetectEngineCtx *DetectEngineCtxInit(void);
-Signature *SigInit(DetectEngineCtx *, char *, char *);
+Signature *SigInit(DetectEngineCtx *, char *, char **);
 void SigFree(Signature *);
 void DetectEngineCtxFree(DetectEngineCtx *);
 

--- a/src/detect-engine-sigorder.c
+++ b/src/detect-engine-sigorder.c
@@ -2314,15 +2314,21 @@ static int SCSigOrderingTest13(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flowbits:isset,bit1; flowbits:set,bit2; flowbits:set,bit3; sid:6;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp any any -> any any (flowbits:isset,bit1; flowbits:set,bit2; flowbits:set,bit3; sid:6;)",
+                                NULL);
     if (sig == NULL) {
         goto end;
     }
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flowbits:set,bit1; flowbits:set,bit2; sid:7;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp any any -> any any (flowbits:set,bit1; flowbits:set,bit2; sid:7;)",
+                                NULL);
     if (sig == NULL) {
         goto end;
     }
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flowbits:isset,bit1; flowbits:isset,bit2; flowbits:isset,bit3; sid:5;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp any any -> any any (flowbits:isset,bit1; flowbits:isset,bit2; flowbits:isset,bit3; sid:5;)",
+                                NULL);
     if (sig == NULL) {
         goto end;
     }

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -1582,12 +1582,16 @@ static int DeStateSigTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"/\"; http_uri; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"body\"; nocase; http_client_body; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"/\"; http_uri; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"body\"; nocase; http_client_body; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -1774,7 +1778,9 @@ static int DeStateSigTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"POST\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)");
+    Signature *s = DetectEngineAppendSig(de_ctx,
+                                         "alert http any any -> any any (content:\"POST\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)",
+                                         NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1901,7 +1907,9 @@ static int DeStateSigTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)");
+    Signature *s = DetectEngineAppendSig(de_ctx,
+                                         "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)",
+                                         NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2028,7 +2036,9 @@ static int DeStateSigTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filename:\"nomatch\"; sid:1; rev:1;)");
+    Signature *s = DetectEngineAppendSig(de_ctx,
+                                         "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filename:\"nomatch\"; sid:1; rev:1;)",
+                                         NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2155,7 +2165,9 @@ static int DeStateSigTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"POST\"; http_method; content:\"upload.cgi\"; http_uri; filename:\"nomatch\"; filestore; sid:1; rev:1;)");
+    Signature *s = DetectEngineAppendSig(de_ctx,
+                                         "alert http any any -> any any (content:\"POST\"; http_method; content:\"upload.cgi\"; http_uri; filename:\"nomatch\"; filestore; sid:1; rev:1;)",
+                                         NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2284,7 +2296,9 @@ static int DeStateSigTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)");
+    Signature *s = DetectEngineAppendSig(de_ctx,
+                                         "alert http any any -> any any (content:\"GET\"; http_method; content:\"upload.cgi\"; http_uri; filestore; sid:1; rev:1;)",
+                                         NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-engine-state.c
+++ b/src/detect-engine-state.c
@@ -1433,7 +1433,9 @@ static int DeStateSigTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy\"; http_cookie; sid:1; rev:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy\"; http_cookie; sid:1; rev:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-engine-uri.c
+++ b/src/detect-engine-uri.c
@@ -216,9 +216,9 @@ static int UriTestSig01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -338,9 +338,9 @@ static int UriTestSig02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/one/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/one/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -460,9 +460,9 @@ static int UriTestSig03(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/blah/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/blah/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -582,9 +582,9 @@ static int UriTestSig04(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -704,9 +704,9 @@ static int UriTestSig05(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>4; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>4; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -826,9 +826,9 @@ static int UriTestSig06(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option\"; "
-                                   "pcre:/(oneself)+/U; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option\"; " "pcre:/(oneself)+/U; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -948,9 +948,9 @@ static int UriTestSig07(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen \"; "
-                                   "pcre:/(one){2,}(self)?/U; urilen:3<>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen \"; " "pcre:/(one){2,}(self)?/U; urilen:3<>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1070,9 +1070,9 @@ static int UriTestSig08(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen\"; "
-                                   "pcre:/(blabla){2,}(self)?/U; urilen:3<>20; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen\"; " "pcre:/(blabla){2,}(self)?/U; urilen:3<>20; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1192,9 +1192,9 @@ static int UriTestSig09(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U option with urilen \"; "
-                                   "pcre:/(one){2,}(self)?/U; urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U option with urilen \"; " "pcre:/(one){2,}(self)?/U; urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1314,9 +1314,9 @@ static int UriTestSig10(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent with urilen option\"; "
-                                   "uricontent:\"one\"; urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent with urilen option\"; " "uricontent:\"one\"; urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1436,10 +1436,9 @@ static int UriTestSig11(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test content, uricontent, pcre /U and urilen options\"; "
-                                   "content:\"one\"; uricontent:\"one\"; pcre:/(one){2,}(self)?/U;"
-                                   "urilen:<2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test content, uricontent, pcre /U and urilen options\"; " "content:\"one\"; uricontent:\"one\"; pcre:/(one){2,}(self)?/U;" "urilen:<2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1559,10 +1558,9 @@ static int UriTestSig12(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test pcre /U, uricontent and urilen option\"; "
-                                   "uricontent:\"one\"; "
-                                   "pcre:/(one)+self/U; urilen:>2; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test pcre /U, uricontent and urilen option\"; " "uricontent:\"one\"; " "pcre:/(one)+self/U; urilen:>2; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1682,9 +1680,9 @@ static int UriTestSig13(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test urilen option\"; "
-                                   "urilen:>2; uricontent:\"one\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test urilen option\"; " "urilen:>2; uricontent:\"one\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1805,9 +1803,9 @@ static int UriTestSig14(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; pcre:/one(self)?/U;sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; pcre:/one(self)?/U;sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1928,9 +1926,9 @@ static int UriTestSig15(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                                   "(msg:\"Test uricontent option\"; "
-                                   "uricontent:\"one\"; pcre:/^\\/one(self)?$/U;sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Test uricontent option\"; " "uricontent:\"one\"; pcre:/^\\/one(self)?$/U;sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2051,7 +2049,9 @@ static int UriTestSig16(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any any (msg:\"ET TROJAN Downadup/Conficker A or B Worm reporting\"; flow:to_server,established; uricontent:\"/search?q=\"; pcre:\"/^\\/search\\?q=[0-9]{1,3}(&aq=7(\\?[0-9a-f]{8})?)?/U\"; pcre:\"/\\x0d\\x0aHost\\: \\d+\\.\\d+\\.\\d+\\.\\d+\\x0d\\x0a/\"; sid:2009024; rev:9;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any any (msg:\"ET TROJAN Downadup/Conficker A or B Worm reporting\"; flow:to_server,established; uricontent:\"/search?q=\"; pcre:\"/^\\/search\\?q=[0-9]{1,3}(&aq=7(\\?[0-9a-f]{8})?)?/U\"; pcre:\"/\\x0d\\x0aHost\\: \\d+\\.\\d+\\.\\d+\\.\\d+\\x0d\\x0a/\"; sid:2009024; rev:9;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2170,11 +2170,9 @@ static int UriTestSig17(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"this\"; uricontent:\"is\"; within:6; "
-                               "uricontent:\"big\"; within:8; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"this\"; uricontent:\"is\"; within:6; " "uricontent:\"big\"; within:8; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2265,11 +2263,9 @@ static int UriTestSig18(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"this\"; uricontent:\"is\"; within:9; "
-                               "uricontent:\"big\"; within:12; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"this\"; uricontent:\"is\"; within:9; " "uricontent:\"big\"; within:12; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2360,12 +2356,9 @@ static int UriTestSig19(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"now\"; uricontent:\"this\"; "
-                               "uricontent:\"is\"; within:12; "
-                               "uricontent:\"big\"; within:8; "
-                               "uricontent:\"string\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"now\"; uricontent:\"this\"; " "uricontent:\"is\"; within:12; " "uricontent:\"big\"; within:8; " "uricontent:\"string\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2456,11 +2449,9 @@ static int UriTestSig20(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"thus\"; offset:8; "
-                               "uricontent:\"is\"; within:6; "
-                               "uricontent:\"big\"; within:8; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"thus\"; offset:8; " "uricontent:\"is\"; within:6; " "uricontent:\"big\"; within:8; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2551,10 +2542,9 @@ static int UriTestSig21(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix\"; uricontent:\"this\"; within:6; "
-                               "uricontent:!\"and\"; distance:0; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix\"; uricontent:\"this\"; within:6; " "uricontent:!\"and\"; distance:0; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2646,9 +2636,9 @@ static int UriTestSig22(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "pcre:/super/U; uricontent:\"nova\"; within:7; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "pcre:/super/U; uricontent:\"nova\"; within:7; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2739,9 +2729,9 @@ static int UriTestSig23(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:!\"fix_this_now\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:!\"fix_this_now\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2832,9 +2822,9 @@ static int UriTestSig24(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"we_need_to\"; uricontent:!\"fix_this_now\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"we_need_to\"; uricontent:!\"fix_this_now\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -2925,9 +2915,9 @@ static int UriTestSig25(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "pcre:/normalized/U; uricontent:\"normalized uri\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "pcre:/normalized/U; uricontent:\"normalized uri\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3018,9 +3008,9 @@ static int UriTestSig26(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix_this\"; isdataat:4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix_this\"; isdataat:4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3111,9 +3101,9 @@ static int UriTestSig27(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "uricontent:\"fix_this\"; isdataat:!10,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "uricontent:\"fix_this\"; isdataat:!10,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3237,10 +3227,8 @@ static int UriTestSig28(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"ring\"; distance:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"ring\"; distance:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3329,10 +3317,8 @@ static int UriTestSig29(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"ring\"; distance:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"ring\"; distance:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3421,10 +3407,8 @@ static int UriTestSig30(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"_b5ig\"; offset:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"_b5ig\"; offset:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3513,10 +3497,8 @@ static int UriTestSig31(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"his\"; depth:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"his\"; depth:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3605,10 +3587,8 @@ static int UriTestSig32(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any (msg:\"dummy\"; "
-                               "uricontent:\"this\"; "
-                               "byte_extract:1,2,one,string,dec,relative; "
-                               "uricontent:\"g_st\"; within:one; sid:1;)");
+                               "alert tcp any any -> any any (msg:\"dummy\"; " "uricontent:\"this\"; " "byte_extract:1,2,one,string,dec,relative; " "uricontent:\"g_st\"; within:one; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3696,9 +3676,9 @@ static int UriTestSig33(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:15; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:15; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3786,9 +3766,9 @@ static int UriTestSig34(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:15, norm; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:15, norm; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3876,9 +3856,9 @@ static int UriTestSig35(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:16; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:16; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -3966,9 +3946,9 @@ static int UriTestSig36(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:16, norm; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:16, norm; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -4056,9 +4036,9 @@ static int UriTestSig37(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:17, raw; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:17, raw; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -4146,9 +4126,9 @@ static int UriTestSig38(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"test multiple relative uricontents\"; "
-                               "urilen:18, raw; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"test multiple relative uricontents\"; " "urilen:18, raw; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -820,6 +820,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
         goto error;
 
     memset(de_ctx,0,sizeof(DetectEngineCtx));
+    memset(&de_ctx->sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (minimal) {
         de_ctx->minimal = 1;

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -492,7 +492,6 @@ void DetectEngineRegisterAppInspectionEngine(uint8_t ipproto,
 enum DetectEngineSyncState {
     IDLE,   /**< ready to start a reload */
     RELOAD, /**< command main thread to do the reload */
-    DONE,   /**< main thread telling us reload is done */
 };
 
 
@@ -530,21 +529,20 @@ int DetectEngineReloadIsStart(void)
 }
 
 /* main thread sets done when it's done */
-void DetectEngineReloadSetDone(void)
+void DetectEngineReloadSetIdle(void)
 {
     SCMutexLock(&detect_sync.m);
-    detect_sync.state = DONE;
+    detect_sync.state = IDLE;
     SCMutexUnlock(&detect_sync.m);
 }
 
 /* caller loops this until it returns 1 */
-int DetectEngineReloadIsDone(void)
+int DetectEngineReloadIsIdle(void)
 {
     int r = 0;
     SCMutexLock(&detect_sync.m);
-    if (detect_sync.state == DONE) {
+    if (detect_sync.state == IDLE) {
         r = 1;
-        detect_sync.state = IDLE;
     }
     SCMutexUnlock(&detect_sync.m);
     return r;

--- a/src/detect-engine.h
+++ b/src/detect-engine.h
@@ -83,8 +83,8 @@ int DetectEngineMultiTenantSetup(void);
 
 int DetectEngineReloadStart(void);
 int DetectEngineReloadIsStart(void);
-void DetectEngineReloadSetDone(void);
-int DetectEngineReloadIsDone(void);
+void DetectEngineReloadSetIdle(void);
+int DetectEngineReloadIsIdle(void);
 
 int DetectEngineLoadTenantBlocking(uint32_t tenant_id, const char *yaml);
 int DetectEngineReloadTenantBlocking(uint32_t tenant_id, const char *yaml, int reload_cnt);

--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -391,9 +391,9 @@ int DetectFastPatternTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; tcpv4-csum:valid; fast_pattern; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; tcpv4-csum:valid; fast_pattern; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -431,10 +431,9 @@ int DetectFastPatternTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern; "
-                               "content:\"boo\"; fast_pattern; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern; " "content:\"boo\"; fast_pattern; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -460,9 +459,9 @@ int DetectFastPatternTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -500,9 +499,9 @@ int DetectFastPatternTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:boo; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:boo; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -536,11 +535,9 @@ int DetectFastPatternTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; fast_pattern; "
-                               "content:\"strings_str4\"; content:\"strings_string5\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; fast_pattern; " "content:\"strings_str4\"; content:\"strings_string5\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -588,11 +585,9 @@ int DetectFastPatternTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; fast_pattern; "
-                               "content:\"strings_str4\"; content:\"strings_string5\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; fast_pattern; " "content:\"strings_str4\"; content:\"strings_string5\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -639,11 +634,9 @@ int DetectFastPatternTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; fast_pattern; "
-                               "content:\"strings_str4\"; content:\"strings_string5\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; fast_pattern; " "content:\"strings_str4\"; content:\"strings_string5\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -692,11 +685,9 @@ int DetectFastPatternTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; fast_pattern; "
-                               "content:\"strings_str4\"; content:\"strings_string5\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; fast_pattern; " "content:\"strings_str4\"; content:\"strings_string5\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -746,11 +737,9 @@ int DetectFastPatternTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; "
-                               "content:\"strings4_imp\"; fast_pattern; "
-                               "content:\"strings_string5\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; " "content:\"strings4_imp\"; fast_pattern; " "content:\"strings_string5\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -800,11 +789,9 @@ int DetectFastPatternTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; "
-                               "content:\"strings4_imp\"; fast_pattern; "
-                               "content:\"strings_string5\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; " "content:\"strings4_imp\"; fast_pattern; " "content:\"strings_string5\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -856,11 +843,9 @@ int DetectFastPatternTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; "
-                               "content:\"strings4_imp\"; fast_pattern; "
-                               "content:\"strings_string5\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; " "content:\"strings4_imp\"; fast_pattern; " "content:\"strings_string5\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -908,11 +893,9 @@ int DetectFastPatternTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; "
-                               "content:\"strings4_imp\"; "
-                               "content:\"strings_string5\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; " "content:\"strings4_imp\"; " "content:\"strings_string5\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -963,11 +946,9 @@ int DetectFastPatternTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"string1\"; "
-                               "content:\"string2\"; content:\"strings3\"; "
-                               "content:\"strings4_imp\"; "
-                               "content:\"strings_string5\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"string1\"; " "content:\"string2\"; content:\"strings3\"; " "content:\"strings4_imp\"; " "content:\"strings_string5\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1021,13 +1002,15 @@ int DetectFastPatternTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"fast_pattern test\"; content:\"strings_string5\"; content:\"knight\"; fast_pattern; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"fast_pattern test\"; content:\"strings_string5\"; content:\"knight\"; fast_pattern; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
-    de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                                     "(msg:\"test different content\"; content:\"Dummy is our name\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any " "(msg:\"test different content\"; content:\"Dummy is our name\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL)
         goto end;
 
@@ -1071,9 +1054,9 @@ int DetectFastPatternTest15(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1112,9 +1095,9 @@ int DetectFastPatternTest16(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1150,8 +1133,9 @@ int DetectFastPatternTest17(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1186,8 +1170,9 @@ int DetectFastPatternTest18(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1221,8 +1206,9 @@ int DetectFastPatternTest19(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:only; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:only; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1243,8 +1229,9 @@ int DetectFastPatternTest20(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; distance:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; distance:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1265,8 +1252,9 @@ int DetectFastPatternTest21(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:only; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:only; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1287,8 +1275,9 @@ int DetectFastPatternTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; within:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; within:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1309,8 +1298,9 @@ int DetectFastPatternTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:only; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:only; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1331,8 +1321,9 @@ int DetectFastPatternTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; offset:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; offset:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1353,8 +1344,9 @@ int DetectFastPatternTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:only; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:only; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1375,8 +1367,9 @@ int DetectFastPatternTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; depth:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; depth:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1397,8 +1390,9 @@ int DetectFastPatternTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1419,8 +1413,9 @@ int DetectFastPatternTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; content:\"two\"; distance:30; content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; content:\"two\"; distance:30; content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1450,8 +1445,9 @@ int DetectFastPatternTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; within:30; content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; within:30; content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1480,8 +1476,9 @@ int DetectFastPatternTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; offset:30; content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; offset:30; content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1510,8 +1507,9 @@ int DetectFastPatternTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; depth:30; content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; depth:30; content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1540,8 +1538,9 @@ int DetectFastPatternTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; content:\"two\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; content:\"two\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1571,8 +1570,9 @@ int DetectFastPatternTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; fast_pattern; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; fast_pattern; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1593,8 +1593,9 @@ int DetectFastPatternTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; fast_pattern; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; fast_pattern; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1615,8 +1616,9 @@ int DetectFastPatternTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; fast_pattern; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; fast_pattern; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1637,8 +1639,9 @@ int DetectFastPatternTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; fast_pattern; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; fast_pattern; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1659,8 +1662,9 @@ int DetectFastPatternTest37(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; content:\"oneonetwo\"; fast_pattern:3,4; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; content:\"oneonetwo\"; fast_pattern:3,4; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1689,8 +1693,9 @@ int DetectFastPatternTest38(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1719,8 +1724,9 @@ int DetectFastPatternTest39(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1749,8 +1755,9 @@ int DetectFastPatternTest40(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1779,8 +1786,9 @@ int DetectFastPatternTest41(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"twotwotwo\"; fast_pattern:3,4; content:\"three\"; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -1809,8 +1817,9 @@ int DetectFastPatternTest42(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; distance:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; distance:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1839,8 +1848,9 @@ int DetectFastPatternTest43(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; within:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; within:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1869,8 +1879,9 @@ int DetectFastPatternTest44(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; offset:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; offset:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1899,8 +1910,9 @@ int DetectFastPatternTest45(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; depth:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; depth:10; content:\"threethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->ctx;
@@ -1929,8 +1941,9 @@ int DetectFastPatternTest46(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:65977,4; content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:65977,4; content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1951,8 +1964,9 @@ int DetectFastPatternTest47(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"twooneone\"; fast_pattern:3,65977; content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"twooneone\"; fast_pattern:3,65977; content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1973,8 +1987,9 @@ int DetectFastPatternTest48(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; fast_pattern:65534,4; content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; fast_pattern:65534,4; content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -1995,8 +2010,9 @@ int DetectFastPatternTest49(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *cd = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_PMATCH]->prev->ctx;
@@ -2026,8 +2042,9 @@ int DetectFastPatternTest50(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; distance:10; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; distance:10; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2048,8 +2065,9 @@ int DetectFastPatternTest51(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; within:10; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; within:10; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2070,8 +2088,9 @@ int DetectFastPatternTest52(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; offset:10; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; offset:10; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2092,8 +2111,9 @@ int DetectFastPatternTest53(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; depth:10; content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; depth:10; content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2123,9 +2143,9 @@ int DetectFastPatternTest54(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"/one/\"; fast_pattern:only; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"/one/\"; fast_pattern:only; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2164,9 +2184,9 @@ int DetectFastPatternTest55(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"oneoneone\"; fast_pattern:3,4; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"oneoneone\"; fast_pattern:3,4; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2202,8 +2222,9 @@ int DetectFastPatternTest56(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2238,8 +2259,9 @@ int DetectFastPatternTest57(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"oneoneone\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"oneoneone\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2273,8 +2295,9 @@ int DetectFastPatternTest58(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2295,8 +2318,9 @@ int DetectFastPatternTest59(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; distance:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; distance:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2317,8 +2341,9 @@ int DetectFastPatternTest60(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2339,8 +2364,9 @@ int DetectFastPatternTest61(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; within:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; within:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2361,8 +2387,9 @@ int DetectFastPatternTest62(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2383,8 +2410,9 @@ int DetectFastPatternTest63(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; offset:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; offset:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2405,8 +2433,9 @@ int DetectFastPatternTest64(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:only; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2427,8 +2456,9 @@ int DetectFastPatternTest65(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; depth:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; depth:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2449,8 +2479,9 @@ int DetectFastPatternTest66(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2471,8 +2502,9 @@ int DetectFastPatternTest67(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent: \"one\"; uricontent:\"two\"; distance:30; uricontent:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent: \"one\"; uricontent:\"two\"; distance:30; uricontent:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2502,8 +2534,9 @@ int DetectFastPatternTest68(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; within:30; uricontent:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; within:30; uricontent:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2532,8 +2565,9 @@ int DetectFastPatternTest69(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; offset:30; uricontent:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; offset:30; uricontent:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2562,8 +2596,9 @@ int DetectFastPatternTest70(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; depth:30; uricontent:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; depth:30; uricontent:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2592,8 +2627,9 @@ int DetectFastPatternTest71(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:!\"one\"; fast_pattern; uricontent:\"two\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:!\"one\"; fast_pattern; uricontent:\"two\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2623,8 +2659,9 @@ int DetectFastPatternTest72(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2645,8 +2682,9 @@ int DetectFastPatternTest73(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2667,8 +2705,9 @@ int DetectFastPatternTest74(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2689,8 +2728,9 @@ int DetectFastPatternTest75(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; uricontent:!\"one\"; fast_pattern; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -2711,8 +2751,9 @@ int DetectFastPatternTest76(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2741,8 +2782,9 @@ int DetectFastPatternTest77(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2771,8 +2813,9 @@ int DetectFastPatternTest78(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2801,8 +2844,9 @@ int DetectFastPatternTest79(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2831,8 +2875,9 @@ int DetectFastPatternTest80(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -2861,8 +2906,9 @@ int DetectFastPatternTest81(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; distance:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; distance:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2891,8 +2937,9 @@ int DetectFastPatternTest82(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; within:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; within:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2921,8 +2968,9 @@ int DetectFastPatternTest83(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; offset:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; offset:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2951,8 +2999,9 @@ int DetectFastPatternTest84(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; depth:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; depth:10; uricontent:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -2984,8 +3033,9 @@ int DetectFastPatternTest85(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:65977,4; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:65977,4; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3006,8 +3056,9 @@ int DetectFastPatternTest86(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,65977; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"oneonetwo\"; fast_pattern:3,65977; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3028,8 +3079,9 @@ int DetectFastPatternTest87(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:65534,4; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; fast_pattern:65534,4; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3050,8 +3102,9 @@ int DetectFastPatternTest88(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3081,8 +3134,9 @@ int DetectFastPatternTest89(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; distance:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; distance:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3103,8 +3157,9 @@ int DetectFastPatternTest90(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; within:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; within:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3125,8 +3180,9 @@ int DetectFastPatternTest91(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; offset:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; offset:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3147,8 +3203,9 @@ int DetectFastPatternTest92(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; depth:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:!\"oneonetwo\"; fast_pattern:3,4; depth:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3174,8 +3231,9 @@ int DetectFastPatternTest93(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3209,9 +3267,9 @@ int DetectFastPatternTest94(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_uri; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_uri; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3250,9 +3308,9 @@ int DetectFastPatternTest95(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_uri; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_uri; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3288,8 +3346,9 @@ int DetectFastPatternTest96(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3324,8 +3383,9 @@ int DetectFastPatternTest97(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3359,8 +3419,9 @@ int DetectFastPatternTest98(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3381,8 +3442,9 @@ int DetectFastPatternTest99(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; distance:10; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; distance:10; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3403,8 +3465,9 @@ int DetectFastPatternTest100(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3425,8 +3488,9 @@ int DetectFastPatternTest101(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; within:10; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; within:10; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3447,8 +3511,9 @@ int DetectFastPatternTest102(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3469,8 +3534,9 @@ int DetectFastPatternTest103(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; offset:10; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; offset:10; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3491,8 +3557,9 @@ int DetectFastPatternTest104(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:only; http_uri; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3513,8 +3580,9 @@ int DetectFastPatternTest105(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; depth:10; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; depth:10; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3535,8 +3603,9 @@ int DetectFastPatternTest106(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"two\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"two\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3557,8 +3626,9 @@ int DetectFastPatternTest107(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent: \"one\"; uricontent:\"two\"; distance:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent: \"one\"; uricontent:\"two\"; distance:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3588,8 +3658,9 @@ int DetectFastPatternTest108(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; within:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; within:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -3618,8 +3689,9 @@ int DetectFastPatternTest109(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; offset:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; offset:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -3648,8 +3720,9 @@ int DetectFastPatternTest110(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; depth:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; depth:30; content:\"two\"; fast_pattern:only; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -3678,8 +3751,9 @@ int DetectFastPatternTest111(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_uri; uricontent:\"two\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_uri; uricontent:\"two\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3709,8 +3783,9 @@ int DetectFastPatternTest112(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3731,8 +3806,9 @@ int DetectFastPatternTest113(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3753,8 +3829,9 @@ int DetectFastPatternTest114(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3775,8 +3852,9 @@ int DetectFastPatternTest115(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"two\"; content:!\"one\"; fast_pattern; http_uri; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -3797,8 +3875,9 @@ int DetectFastPatternTest116(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3827,8 +3906,9 @@ int DetectFastPatternTest117(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3857,8 +3937,9 @@ int DetectFastPatternTest118(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3887,8 +3968,9 @@ int DetectFastPatternTest119(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3917,8 +3999,9 @@ int DetectFastPatternTest120(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -3947,8 +4030,9 @@ int DetectFastPatternTest121(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -3977,8 +4061,9 @@ int DetectFastPatternTest122(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -4007,8 +4092,9 @@ int DetectFastPatternTest123(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -4037,8 +4123,9 @@ int DetectFastPatternTest124(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; uricontent:\"two\"; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; uricontent:\"two\"; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->ctx;
@@ -4070,8 +4157,9 @@ int DetectFastPatternTest125(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:65977,4; http_uri; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:65977,4; http_uri; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4092,8 +4180,9 @@ int DetectFastPatternTest126(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,65977; http_uri; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"oneonetwo\"; fast_pattern:3,65977; http_uri; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4114,8 +4203,9 @@ int DetectFastPatternTest127(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:\"two\"; fast_pattern:65534,4; http_uri; uricontent:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:\"two\"; fast_pattern:65534,4; http_uri; uricontent:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4136,8 +4226,9 @@ int DetectFastPatternTest128(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -4167,8 +4258,9 @@ int DetectFastPatternTest129(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; distance:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; distance:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4189,8 +4281,9 @@ int DetectFastPatternTest130(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; within:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; within:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4211,8 +4304,9 @@ int DetectFastPatternTest131(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; http_uri; offset:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"twooneone\"; fast_pattern:3,4; http_uri; offset:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4233,8 +4327,9 @@ int DetectFastPatternTest132(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; depth:10; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; depth:10; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4255,8 +4350,9 @@ int DetectFastPatternTest133(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; content:!\"oneonetwo\"; fast_pattern:3,4; http_uri; uricontent:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_UMATCH]->prev->ctx;
@@ -4291,8 +4387,9 @@ int DetectFastPatternTest134(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -4326,9 +4423,9 @@ int DetectFastPatternTest135(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_client_body; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_client_body; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -4363,9 +4460,9 @@ int DetectFastPatternTest136(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_client_body; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_client_body; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -4396,8 +4493,9 @@ int DetectFastPatternTest137(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -4430,8 +4528,9 @@ int DetectFastPatternTest138(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -4463,8 +4562,9 @@ int DetectFastPatternTest139(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4485,8 +4585,9 @@ int DetectFastPatternTest140(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; distance:10; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; distance:10; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4507,8 +4608,9 @@ int DetectFastPatternTest141(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4529,8 +4631,9 @@ int DetectFastPatternTest142(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; within:10; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; within:10; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4551,8 +4654,9 @@ int DetectFastPatternTest143(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4573,8 +4677,9 @@ int DetectFastPatternTest144(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; offset:10; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; offset:10; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4595,8 +4700,9 @@ int DetectFastPatternTest145(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:only; http_client_body; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4617,8 +4723,9 @@ int DetectFastPatternTest146(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; depth:10; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; depth:10; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4639,8 +4746,9 @@ int DetectFastPatternTest147(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"two\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"two\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4661,8 +4769,9 @@ int DetectFastPatternTest148(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; http_client_body; content:\"two\"; http_client_body; distance:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; http_client_body; content:\"two\"; http_client_body; distance:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -4692,8 +4801,9 @@ int DetectFastPatternTest149(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; within:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; within:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -4722,8 +4832,9 @@ int DetectFastPatternTest150(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; offset:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; offset:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -4752,8 +4863,9 @@ int DetectFastPatternTest151(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; depth:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; depth:30; content:\"two\"; fast_pattern:only; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -4782,8 +4894,9 @@ int DetectFastPatternTest152(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_client_body; content:\"two\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_client_body; content:\"two\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -4813,8 +4926,9 @@ int DetectFastPatternTest153(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4835,8 +4949,9 @@ int DetectFastPatternTest154(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4857,8 +4972,9 @@ int DetectFastPatternTest155(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4879,8 +4995,9 @@ int DetectFastPatternTest156(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_client_body; content:!\"one\"; fast_pattern; http_client_body; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -4901,8 +5018,9 @@ int DetectFastPatternTest157(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -4931,8 +5049,9 @@ int DetectFastPatternTest158(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -4961,8 +5080,9 @@ int DetectFastPatternTest159(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -4991,8 +5111,9 @@ int DetectFastPatternTest160(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -5021,8 +5142,9 @@ int DetectFastPatternTest161(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -5051,8 +5173,9 @@ int DetectFastPatternTest162(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -5081,8 +5204,9 @@ int DetectFastPatternTest163(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -5111,8 +5235,9 @@ int DetectFastPatternTest164(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -5141,8 +5266,9 @@ int DetectFastPatternTest165(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; http_client_body; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->ctx;
@@ -5174,8 +5300,9 @@ int DetectFastPatternTest166(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:65977,4; http_client_body; content:\"three\"; http_client_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:65977,4; http_client_body; content:\"three\"; http_client_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5196,8 +5323,9 @@ int DetectFastPatternTest167(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_client_body; content:\"oneonetwo\"; fast_pattern:3,65977; http_client_body; content:\"three\"; distance:10; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_client_body; content:\"oneonetwo\"; fast_pattern:3,65977; http_client_body; content:\"three\"; distance:10; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5218,8 +5346,9 @@ int DetectFastPatternTest168(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:65534,4; http_client_body; content:\"three\"; http_client_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:\"two\"; fast_pattern:65534,4; http_client_body; content:\"three\"; http_client_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5240,8 +5369,9 @@ int DetectFastPatternTest169(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -5271,8 +5401,9 @@ int DetectFastPatternTest170(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; distance:10; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; distance:10; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5293,8 +5424,9 @@ int DetectFastPatternTest171(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; within:10; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; within:10; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5315,8 +5447,9 @@ int DetectFastPatternTest172(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"twooneone\"; fast_pattern:3,4; http_client_body; offset:10; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"twooneone\"; fast_pattern:3,4; http_client_body; offset:10; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5337,8 +5470,9 @@ int DetectFastPatternTest173(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; depth:10; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; depth:10; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5359,8 +5493,9 @@ int DetectFastPatternTest174(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; content:!\"oneonetwo\"; fast_pattern:3,4; http_client_body; content:\"three\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH]->prev->ctx;
@@ -5395,8 +5530,9 @@ int DetectFastPatternTest175(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; distance:20; fast_pattern; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; distance:20; fast_pattern; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5417,8 +5553,9 @@ int DetectFastPatternTest176(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; within:20; fast_pattern; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; within:20; fast_pattern; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5439,8 +5576,9 @@ int DetectFastPatternTest177(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; offset:20; fast_pattern; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; offset:20; fast_pattern; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5461,8 +5599,9 @@ int DetectFastPatternTest178(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; content:!\"one\"; depth:20; fast_pattern; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; content:!\"one\"; depth:20; fast_pattern; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5487,10 +5626,9 @@ int DetectFastPatternTest179(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_header; "
-                               "content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_header; " "content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -5524,9 +5662,9 @@ int DetectFastPatternTest180(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_header; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_header; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -5561,9 +5699,9 @@ int DetectFastPatternTest181(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_header; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_header; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -5594,8 +5732,9 @@ int DetectFastPatternTest182(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -5628,8 +5767,9 @@ int DetectFastPatternTest183(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -5661,8 +5801,9 @@ int DetectFastPatternTest184(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5683,8 +5824,9 @@ int DetectFastPatternTest185(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; distance:10; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; distance:10; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5705,8 +5847,9 @@ int DetectFastPatternTest186(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5727,8 +5870,9 @@ int DetectFastPatternTest187(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; within:10; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; within:10; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5749,8 +5893,9 @@ int DetectFastPatternTest188(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5771,8 +5916,9 @@ int DetectFastPatternTest189(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; offset:10; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; offset:10; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5793,8 +5939,9 @@ int DetectFastPatternTest190(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:only; http_header; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5815,8 +5962,9 @@ int DetectFastPatternTest191(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; depth:10; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; depth:10; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5837,8 +5985,9 @@ int DetectFastPatternTest192(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"two\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"two\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -5859,8 +6008,9 @@ int DetectFastPatternTest193(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; http_header; content:\"two\"; http_header; distance:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; http_header; content:\"two\"; http_header; distance:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -5890,8 +6040,9 @@ int DetectFastPatternTest194(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; within:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; within:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -5920,8 +6071,9 @@ int DetectFastPatternTest195(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; offset:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; offset:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -5950,8 +6102,9 @@ int DetectFastPatternTest196(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; depth:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; depth:30; content:\"two\"; fast_pattern:only; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -5980,8 +6133,9 @@ int DetectFastPatternTest197(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_header; content:\"two\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_header; content:\"two\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6011,8 +6165,9 @@ int DetectFastPatternTest198(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6033,8 +6188,9 @@ int DetectFastPatternTest199(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6055,8 +6211,9 @@ int DetectFastPatternTest200(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6077,8 +6234,9 @@ int DetectFastPatternTest201(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_header; content:!\"one\"; fast_pattern; http_header; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6099,8 +6257,9 @@ int DetectFastPatternTest202(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6129,8 +6288,9 @@ int DetectFastPatternTest203(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6159,8 +6319,9 @@ int DetectFastPatternTest204(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6189,8 +6350,9 @@ int DetectFastPatternTest205(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6219,8 +6381,9 @@ int DetectFastPatternTest206(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6249,8 +6412,9 @@ int DetectFastPatternTest207(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -6279,8 +6443,9 @@ int DetectFastPatternTest208(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -6309,8 +6474,9 @@ int DetectFastPatternTest209(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -6339,8 +6505,9 @@ int DetectFastPatternTest210(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; http_header; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; http_header; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->ctx;
@@ -6372,8 +6539,9 @@ int DetectFastPatternTest211(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:65977,4; http_header; content:\"three\"; http_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:65977,4; http_header; content:\"three\"; http_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6394,8 +6562,9 @@ int DetectFastPatternTest212(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_header; content:\"oneonetwo\"; fast_pattern:3,65977; http_header; content:\"three\"; distance:10; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_header; content:\"oneonetwo\"; fast_pattern:3,65977; http_header; content:\"three\"; distance:10; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6416,8 +6585,9 @@ int DetectFastPatternTest213(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:\"two\"; fast_pattern:65534,4; http_header; content:\"three\"; http_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:\"two\"; fast_pattern:65534,4; http_header; content:\"three\"; http_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6438,8 +6608,9 @@ int DetectFastPatternTest214(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6469,8 +6640,9 @@ int DetectFastPatternTest215(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; distance:10; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; distance:10; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6491,8 +6663,9 @@ int DetectFastPatternTest216(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; within:10; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; within:10; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6513,8 +6686,9 @@ int DetectFastPatternTest217(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; offset:10; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; offset:10; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6535,8 +6709,9 @@ int DetectFastPatternTest218(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; depth:10; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; depth:10; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6557,8 +6732,9 @@ int DetectFastPatternTest219(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_header; content:\"three\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHDMATCH]->prev->ctx;
@@ -6593,10 +6769,9 @@ int DetectFastPatternTest220(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; "
-                               "content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; " "content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -6630,9 +6805,9 @@ int DetectFastPatternTest221(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"/one/\"; fast_pattern:only; http_raw_header; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"/one/\"; fast_pattern:only; http_raw_header; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -6667,9 +6842,9 @@ int DetectFastPatternTest222(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"oneoneone\"; fast_pattern:3,4; http_raw_header; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"oneoneone\"; fast_pattern:3,4; http_raw_header; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -6700,8 +6875,9 @@ int DetectFastPatternTest223(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -6734,8 +6910,9 @@ int DetectFastPatternTest224(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"oneoneone\"; fast_pattern:3,4; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"oneoneone\"; fast_pattern:3,4; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -6767,8 +6944,9 @@ int DetectFastPatternTest225(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6789,8 +6967,9 @@ int DetectFastPatternTest226(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; distance:10; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; distance:10; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6811,8 +6990,9 @@ int DetectFastPatternTest227(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6833,8 +7013,9 @@ int DetectFastPatternTest228(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; within:10; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; within:10; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6855,8 +7036,9 @@ int DetectFastPatternTest229(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6877,8 +7059,9 @@ int DetectFastPatternTest230(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; offset:10; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; offset:10; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6899,8 +7082,9 @@ int DetectFastPatternTest231(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:only; http_raw_header; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6921,8 +7105,9 @@ int DetectFastPatternTest232(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; depth:10; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; depth:10; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6943,8 +7128,9 @@ int DetectFastPatternTest233(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"two\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"two\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -6965,8 +7151,9 @@ int DetectFastPatternTest234(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content: \"one\"; http_raw_header; content:\"two\"; http_raw_header; distance:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content: \"one\"; http_raw_header; content:\"two\"; http_raw_header; distance:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -6996,8 +7183,9 @@ int DetectFastPatternTest235(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; within:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; within:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7026,8 +7214,9 @@ int DetectFastPatternTest236(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; offset:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; offset:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7056,8 +7245,9 @@ int DetectFastPatternTest237(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; depth:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; depth:30; content:\"two\"; fast_pattern:only; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7086,8 +7276,9 @@ int DetectFastPatternTest238(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:!\"one\"; fast_pattern; http_raw_header; content:\"two\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:!\"one\"; fast_pattern; http_raw_header; content:\"two\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7117,8 +7308,9 @@ int DetectFastPatternTest239(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7139,8 +7331,9 @@ int DetectFastPatternTest240(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7161,8 +7354,9 @@ int DetectFastPatternTest241(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7183,8 +7377,9 @@ int DetectFastPatternTest242(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"two\"; http_raw_header; content:!\"one\"; fast_pattern; http_raw_header; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7205,8 +7400,9 @@ int DetectFastPatternTest243(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7235,8 +7431,9 @@ int DetectFastPatternTest244(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7265,8 +7462,9 @@ int DetectFastPatternTest245(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7295,8 +7493,9 @@ int DetectFastPatternTest246(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7325,8 +7524,9 @@ int DetectFastPatternTest247(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7355,8 +7555,9 @@ int DetectFastPatternTest248(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7385,8 +7586,9 @@ int DetectFastPatternTest249(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7415,8 +7617,9 @@ int DetectFastPatternTest250(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7445,8 +7648,9 @@ int DetectFastPatternTest251(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; http_raw_header; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->ctx;
@@ -7478,8 +7682,9 @@ int DetectFastPatternTest252(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:65977,4; http_raw_header; content:\"three\"; http_raw_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:65977,4; http_raw_header; content:\"three\"; http_raw_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7500,8 +7705,9 @@ int DetectFastPatternTest253(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\";  http_raw_header; content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_header; content:\"three\"; distance:10; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\";  http_raw_header; content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_header; content:\"three\"; distance:10; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7522,8 +7728,9 @@ int DetectFastPatternTest254(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:65534,4; http_raw_header; content:\"three\"; http_raw_header; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:\"two\"; fast_pattern:65534,4; http_raw_header; content:\"three\"; http_raw_header; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7544,8 +7751,9 @@ int DetectFastPatternTest255(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7575,8 +7783,9 @@ int DetectFastPatternTest256(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; distance:10; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; distance:10; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7597,8 +7806,9 @@ int DetectFastPatternTest257(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; within:10; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; within:10; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7619,8 +7829,9 @@ int DetectFastPatternTest258(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; offset:10; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; offset:10; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7641,8 +7852,9 @@ int DetectFastPatternTest259(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; depth:10; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; depth:10; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7663,8 +7875,9 @@ int DetectFastPatternTest260(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_header; content:\"three\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHDMATCH]->prev->ctx;
@@ -7699,10 +7912,9 @@ int DetectFastPatternTest261(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_method; "
-                               "content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_method; " "content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -7736,9 +7948,9 @@ int DetectFastPatternTest262(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_method; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_method; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -7773,9 +7985,9 @@ int DetectFastPatternTest263(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_method; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_method; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -7806,8 +8018,9 @@ int DetectFastPatternTest264(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -7840,8 +8053,9 @@ int DetectFastPatternTest265(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -7873,8 +8087,9 @@ int DetectFastPatternTest266(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7895,8 +8110,9 @@ int DetectFastPatternTest267(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; distance:10; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; distance:10; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7917,8 +8133,9 @@ int DetectFastPatternTest268(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7939,8 +8156,9 @@ int DetectFastPatternTest269(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; within:10; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; within:10; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7961,8 +8179,9 @@ int DetectFastPatternTest270(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -7983,8 +8202,9 @@ int DetectFastPatternTest271(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; offset:10; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; offset:10; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8005,8 +8225,9 @@ int DetectFastPatternTest272(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:only; http_method; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8027,8 +8248,9 @@ int DetectFastPatternTest273(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; depth:10; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; depth:10; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8049,8 +8271,9 @@ int DetectFastPatternTest274(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"two\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"two\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8071,8 +8294,9 @@ int DetectFastPatternTest275(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; http_method; content:\"two\"; http_method; distance:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; http_method; content:\"two\"; http_method; distance:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -8102,8 +8326,9 @@ int DetectFastPatternTest276(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; within:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; within:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8132,8 +8357,9 @@ int DetectFastPatternTest277(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; offset:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; offset:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8162,8 +8388,9 @@ int DetectFastPatternTest278(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; depth:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; depth:30; content:\"two\"; fast_pattern:only; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8192,8 +8419,9 @@ int DetectFastPatternTest279(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_method; content:\"two\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_method; content:\"two\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8223,8 +8451,9 @@ int DetectFastPatternTest280(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8245,8 +8474,9 @@ int DetectFastPatternTest281(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8267,8 +8497,9 @@ int DetectFastPatternTest282(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8289,8 +8520,9 @@ int DetectFastPatternTest283(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_method; content:!\"one\"; fast_pattern; http_method; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8311,8 +8543,9 @@ int DetectFastPatternTest284(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8341,8 +8574,9 @@ int DetectFastPatternTest285(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8371,8 +8605,9 @@ int DetectFastPatternTest286(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8401,8 +8636,9 @@ int DetectFastPatternTest287(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8431,8 +8667,9 @@ int DetectFastPatternTest288(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8461,8 +8698,9 @@ int DetectFastPatternTest289(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8491,8 +8729,9 @@ int DetectFastPatternTest290(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8521,8 +8760,9 @@ int DetectFastPatternTest291(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8551,8 +8791,9 @@ int DetectFastPatternTest292(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; http_method; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; http_method; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->ctx;
@@ -8584,8 +8825,9 @@ int DetectFastPatternTest293(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:65977,4; http_method; content:\"three\"; http_method; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:65977,4; http_method; content:\"three\"; http_method; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8606,8 +8848,9 @@ int DetectFastPatternTest294(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_method; content:\"oneonetwo\"; fast_pattern:3,65977; http_method; content:\"three\"; distance:10; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_method; content:\"oneonetwo\"; fast_pattern:3,65977; http_method; content:\"three\"; distance:10; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8628,8 +8871,9 @@ int DetectFastPatternTest295(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:\"two\"; fast_pattern:65534,4; http_method; content:\"three\"; http_method; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:\"two\"; fast_pattern:65534,4; http_method; content:\"three\"; http_method; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8650,8 +8894,9 @@ int DetectFastPatternTest296(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8681,8 +8926,9 @@ int DetectFastPatternTest297(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; distance:10; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; distance:10; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8703,8 +8949,9 @@ int DetectFastPatternTest298(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; within:10; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; within:10; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8725,8 +8972,9 @@ int DetectFastPatternTest299(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; offset:10; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; offset:10; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8747,8 +8995,9 @@ int DetectFastPatternTest300(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; depth:10; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; depth:10; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -8769,8 +9018,9 @@ int DetectFastPatternTest301(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_method; content:!\"oneonetwo\"; fast_pattern:3,4; http_method; content:\"three\"; http_method; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HMDMATCH]->prev->ctx;
@@ -8805,10 +9055,9 @@ int DetectFastPatternTest302(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; "
-                               "content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; " "content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -8842,9 +9091,9 @@ int DetectFastPatternTest303(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_cookie; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_cookie; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -8879,9 +9128,9 @@ int DetectFastPatternTest304(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_cookie; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_cookie; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -8912,8 +9161,9 @@ int DetectFastPatternTest305(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -8946,8 +9196,9 @@ int DetectFastPatternTest306(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -8979,8 +9230,9 @@ int DetectFastPatternTest307(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9001,8 +9253,9 @@ int DetectFastPatternTest308(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; distance:10; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; distance:10; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9023,8 +9276,9 @@ int DetectFastPatternTest309(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9045,8 +9299,9 @@ int DetectFastPatternTest310(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; within:10; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; within:10; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9067,8 +9322,9 @@ int DetectFastPatternTest311(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9089,8 +9345,9 @@ int DetectFastPatternTest312(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; offset:10; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; offset:10; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9111,8 +9368,9 @@ int DetectFastPatternTest313(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:only; http_cookie; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9133,8 +9391,9 @@ int DetectFastPatternTest314(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; depth:10; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; depth:10; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9155,8 +9414,9 @@ int DetectFastPatternTest315(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"two\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"two\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9177,8 +9437,9 @@ int DetectFastPatternTest316(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; http_cookie; content:\"two\"; http_cookie; distance:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; http_cookie; content:\"two\"; http_cookie; distance:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -9208,8 +9469,9 @@ int DetectFastPatternTest317(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; within:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; within:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9238,8 +9500,9 @@ int DetectFastPatternTest318(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; offset:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; offset:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9268,8 +9531,9 @@ int DetectFastPatternTest319(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; depth:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; depth:30; content:\"two\"; fast_pattern:only; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9298,8 +9562,9 @@ int DetectFastPatternTest320(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_cookie; content:\"two\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_cookie; content:\"two\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9329,8 +9594,9 @@ int DetectFastPatternTest321(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9351,8 +9617,9 @@ int DetectFastPatternTest322(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9373,8 +9640,9 @@ int DetectFastPatternTest323(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9395,8 +9663,9 @@ int DetectFastPatternTest324(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_cookie; content:!\"one\"; fast_pattern; http_cookie; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9417,8 +9686,9 @@ int DetectFastPatternTest325(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9447,8 +9717,9 @@ int DetectFastPatternTest326(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9477,8 +9748,9 @@ int DetectFastPatternTest327(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9507,8 +9779,9 @@ int DetectFastPatternTest328(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9537,8 +9810,9 @@ int DetectFastPatternTest329(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9567,8 +9841,9 @@ int DetectFastPatternTest330(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; distance:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9597,8 +9872,9 @@ int DetectFastPatternTest331(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; within:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9627,8 +9903,9 @@ int DetectFastPatternTest332(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; offset:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9657,8 +9934,9 @@ int DetectFastPatternTest333(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; http_cookie; depth:10; content:\"oneonethree\"; fast_pattern:3,4; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->ctx;
@@ -9690,8 +9968,9 @@ int DetectFastPatternTest334(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:65977,4; http_cookie; content:\"three\"; http_cookie; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:65977,4; http_cookie; content:\"three\"; http_cookie; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9712,8 +9991,9 @@ int DetectFastPatternTest335(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_cookie; content:\"oneonetwo\"; fast_pattern:3,65977; http_cookie; content:\"three\"; distance:10; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_cookie; content:\"oneonetwo\"; fast_pattern:3,65977; http_cookie; content:\"three\"; distance:10; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9734,8 +10014,9 @@ int DetectFastPatternTest336(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:65534,4; http_cookie; content:\"three\"; http_cookie; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:\"two\"; fast_pattern:65534,4; http_cookie; content:\"three\"; http_cookie; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9756,8 +10037,9 @@ int DetectFastPatternTest337(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9787,8 +10069,9 @@ int DetectFastPatternTest338(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; distance:10; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; distance:10; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9809,8 +10092,9 @@ int DetectFastPatternTest339(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; within:10; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; within:10; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9831,8 +10115,9 @@ int DetectFastPatternTest340(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; offset:10; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; offset:10; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9853,8 +10138,9 @@ int DetectFastPatternTest341(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; depth:10; content:\"three2\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; depth:10; content:\"three2\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -9875,8 +10161,9 @@ int DetectFastPatternTest342(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_cookie; content:!\"oneonetwo\"; fast_pattern:3,4; http_cookie; content:\"three\"; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HCDMATCH]->prev->ctx;
@@ -9911,10 +10198,9 @@ int DetectFastPatternTest343(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -9948,9 +10234,9 @@ int DetectFastPatternTest344(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"/one/\"; fast_pattern:only; http_raw_uri; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"/one/\"; fast_pattern:only; http_raw_uri; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -9985,9 +10271,9 @@ int DetectFastPatternTest345(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_uri; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_uri; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -10018,8 +10304,9 @@ int DetectFastPatternTest346(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -10052,8 +10339,9 @@ int DetectFastPatternTest347(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -10085,9 +10373,9 @@ int DetectFastPatternTest348(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:only; http_raw_uri; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10108,9 +10396,9 @@ int DetectFastPatternTest349(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; distance:10; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10131,9 +10419,9 @@ int DetectFastPatternTest350(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:only; http_raw_uri; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10154,9 +10442,9 @@ int DetectFastPatternTest351(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; within:10; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10177,9 +10465,9 @@ int DetectFastPatternTest352(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:only; http_raw_uri; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10200,9 +10488,9 @@ int DetectFastPatternTest353(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; offset:10; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10223,9 +10511,9 @@ int DetectFastPatternTest354(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:only; http_raw_uri; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10246,9 +10534,9 @@ int DetectFastPatternTest355(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; depth:10; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10269,9 +10557,9 @@ int DetectFastPatternTest356(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"two\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"two\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10292,10 +10580,9 @@ int DetectFastPatternTest357(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content: \"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content: \"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; distance:30; " "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -10325,10 +10612,9 @@ int DetectFastPatternTest358(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; within:30; " "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10357,10 +10643,9 @@ int DetectFastPatternTest359(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; offset:30; " "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10389,10 +10674,9 @@ int DetectFastPatternTest360(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; depth:30; " "content:\"two\"; fast_pattern:only; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10421,9 +10705,9 @@ int DetectFastPatternTest361(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_raw_uri; " "content:\"two\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10453,9 +10737,9 @@ int DetectFastPatternTest362(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_uri; "
-                               "content:!\"one\"; fast_pattern; http_raw_uri; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_uri; " "content:!\"one\"; fast_pattern; http_raw_uri; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10476,9 +10760,9 @@ int DetectFastPatternTest363(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_uri; "
-                               "content:!\"one\"; fast_pattern; http_raw_uri; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_uri; " "content:!\"one\"; fast_pattern; http_raw_uri; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10499,9 +10783,9 @@ int DetectFastPatternTest364(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_uri; "
-                               "content:!\"one\"; fast_pattern; http_raw_uri; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_uri; " "content:!\"one\"; fast_pattern; http_raw_uri; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10522,9 +10806,9 @@ int DetectFastPatternTest365(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_uri; "
-                               "content:!\"one\"; fast_pattern; http_raw_uri; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_uri; " "content:!\"one\"; fast_pattern; http_raw_uri; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10545,10 +10829,9 @@ int DetectFastPatternTest366(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10577,10 +10860,9 @@ int DetectFastPatternTest367(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10609,10 +10891,9 @@ int DetectFastPatternTest368(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10641,10 +10922,9 @@ int DetectFastPatternTest369(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10673,10 +10953,9 @@ int DetectFastPatternTest370(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10705,10 +10984,9 @@ int DetectFastPatternTest371(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10737,10 +11015,9 @@ int DetectFastPatternTest372(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10769,10 +11046,9 @@ int DetectFastPatternTest373(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10801,10 +11077,9 @@ int DetectFastPatternTest374(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->ctx;
@@ -10836,10 +11111,9 @@ int DetectFastPatternTest375(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:65977,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:65977,4; http_raw_uri; " "content:\"three\"; http_raw_uri; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10860,10 +11134,9 @@ int DetectFastPatternTest376(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_raw_uri; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_uri; "
-                               "content:\"three\"; distance:10; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_raw_uri; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_uri; " "content:\"three\"; distance:10; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10884,10 +11157,9 @@ int DetectFastPatternTest377(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; fast_pattern:65534,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; fast_pattern:65534,4; http_raw_uri; " "content:\"three\"; http_raw_uri; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10908,10 +11180,9 @@ int DetectFastPatternTest378(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -10941,10 +11212,9 @@ int DetectFastPatternTest379(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; distance:10; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; distance:10; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10965,10 +11235,9 @@ int DetectFastPatternTest380(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; within:10; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; within:10; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -10989,10 +11258,9 @@ int DetectFastPatternTest381(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; offset:10; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; offset:10; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11013,10 +11281,9 @@ int DetectFastPatternTest382(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; depth:10; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; depth:10; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11037,10 +11304,9 @@ int DetectFastPatternTest383(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_uri; " "content:\"three\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRUDMATCH]->prev->ctx;
@@ -11075,10 +11341,9 @@ int DetectFastPatternTest384(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11112,9 +11377,9 @@ int DetectFastPatternTest385(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_stat_msg; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_stat_msg; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -11149,9 +11414,9 @@ int DetectFastPatternTest386(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_msg; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_msg; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -11182,8 +11447,9 @@ int DetectFastPatternTest387(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -11218,8 +11484,9 @@ int DetectFastPatternTest388(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -11254,9 +11521,9 @@ int DetectFastPatternTest389(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:only; http_stat_msg; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11277,9 +11544,9 @@ int DetectFastPatternTest390(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; distance:10; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11300,9 +11567,9 @@ int DetectFastPatternTest391(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:only; http_stat_msg; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11323,9 +11590,9 @@ int DetectFastPatternTest392(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; within:10; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11346,9 +11613,9 @@ int DetectFastPatternTest393(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:only; http_stat_msg; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11369,9 +11636,9 @@ int DetectFastPatternTest394(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; offset:10; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11392,9 +11659,9 @@ int DetectFastPatternTest395(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:only; http_stat_msg; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11415,9 +11682,9 @@ int DetectFastPatternTest396(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; depth:10; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11438,9 +11705,9 @@ int DetectFastPatternTest397(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"two\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"two\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11461,10 +11728,9 @@ int DetectFastPatternTest398(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; distance:30; " "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -11494,10 +11760,9 @@ int DetectFastPatternTest399(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; within:30; " "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11526,10 +11791,9 @@ int DetectFastPatternTest400(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; offset:30; " "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11558,10 +11822,9 @@ int DetectFastPatternTest401(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; depth:30; " "content:\"two\"; fast_pattern:only; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11590,9 +11853,9 @@ int DetectFastPatternTest402(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_stat_msg; " "content:\"two\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11622,9 +11885,9 @@ int DetectFastPatternTest403(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_msg; "
-                               "content:!\"one\"; fast_pattern; http_stat_msg; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_msg; " "content:!\"one\"; fast_pattern; http_stat_msg; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11645,9 +11908,9 @@ int DetectFastPatternTest404(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_msg; "
-                               "content:!\"one\"; fast_pattern; http_stat_msg; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_msg; " "content:!\"one\"; fast_pattern; http_stat_msg; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11668,9 +11931,9 @@ int DetectFastPatternTest405(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_msg; "
-                               "content:!\"one\"; fast_pattern; http_stat_msg; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_msg; " "content:!\"one\"; fast_pattern; http_stat_msg; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11691,9 +11954,9 @@ int DetectFastPatternTest406(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_msg; "
-                               "content:!\"one\"; fast_pattern; http_stat_msg; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_msg; " "content:!\"one\"; fast_pattern; http_stat_msg; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -11714,10 +11977,9 @@ int DetectFastPatternTest407(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11746,10 +12008,9 @@ int DetectFastPatternTest408(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11778,10 +12039,9 @@ int DetectFastPatternTest409(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11810,10 +12070,9 @@ int DetectFastPatternTest410(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11842,10 +12101,9 @@ int DetectFastPatternTest411(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -11874,10 +12132,9 @@ int DetectFastPatternTest412(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11906,10 +12163,9 @@ int DetectFastPatternTest413(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11938,10 +12194,9 @@ int DetectFastPatternTest414(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -11970,10 +12225,9 @@ int DetectFastPatternTest415(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; http_stat_msg; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; http_stat_msg; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->ctx;
@@ -12005,10 +12259,9 @@ int DetectFastPatternTest416(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:65977,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:65977,4; http_stat_msg; " "content:\"three\"; http_stat_msg; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12029,10 +12282,9 @@ int DetectFastPatternTest417(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_stat_msg; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_stat_msg; "
-                               "content:\"three\"; distance:10; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_stat_msg; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_stat_msg; " "content:\"three\"; distance:10; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12053,10 +12305,9 @@ int DetectFastPatternTest418(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:\"two\"; fast_pattern:65534,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:\"two\"; fast_pattern:65534,4; http_stat_msg; " "content:\"three\"; http_stat_msg; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12077,10 +12328,9 @@ int DetectFastPatternTest419(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -12110,10 +12360,9 @@ int DetectFastPatternTest420(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; distance:10; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; distance:10; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12134,10 +12383,9 @@ int DetectFastPatternTest421(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; within:10; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; within:10; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12158,10 +12406,9 @@ int DetectFastPatternTest422(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; offset:10; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; offset:10; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12182,10 +12429,9 @@ int DetectFastPatternTest423(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; depth:10; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; depth:10; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12206,10 +12452,9 @@ int DetectFastPatternTest424(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_msg; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; "
-                               "content:\"three\"; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_msg; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_msg; " "content:\"three\"; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSMDMATCH]->prev->ctx;
@@ -12244,10 +12489,9 @@ int DetectFastPatternTest425(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -12281,9 +12525,9 @@ int DetectFastPatternTest426(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_stat_code; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_stat_code; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -12318,9 +12562,9 @@ int DetectFastPatternTest427(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_code; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_code; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -12351,8 +12595,9 @@ int DetectFastPatternTest428(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -12388,8 +12633,9 @@ int DetectFastPatternTest429(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -12424,9 +12670,9 @@ int DetectFastPatternTest430(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:only; http_stat_code; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12447,9 +12693,9 @@ int DetectFastPatternTest431(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; distance:10; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12470,9 +12716,9 @@ int DetectFastPatternTest432(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:only; http_stat_code; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12493,9 +12739,9 @@ int DetectFastPatternTest433(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; within:10; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12516,9 +12762,9 @@ int DetectFastPatternTest434(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:only; http_stat_code; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12539,9 +12785,9 @@ int DetectFastPatternTest435(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; offset:10; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12562,9 +12808,9 @@ int DetectFastPatternTest436(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:only; http_stat_code; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12585,9 +12831,9 @@ int DetectFastPatternTest437(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; depth:10; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12608,9 +12854,9 @@ int DetectFastPatternTest438(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"two\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"two\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12631,10 +12877,9 @@ int DetectFastPatternTest439(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_stat_code; " "content:\"two\"; http_stat_code; distance:30; " "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -12664,10 +12909,9 @@ int DetectFastPatternTest440(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; within:30; " "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -12696,10 +12940,9 @@ int DetectFastPatternTest441(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; offset:30; " "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -12728,10 +12971,9 @@ int DetectFastPatternTest442(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; depth:30; " "content:\"two\"; fast_pattern:only; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -12760,9 +13002,9 @@ int DetectFastPatternTest443(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_stat_code; "
-                               "content:\"two\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_stat_code; " "content:\"two\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -12792,9 +13034,9 @@ int DetectFastPatternTest444(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_code; "
-                               "content:!\"one\"; fast_pattern; http_stat_code; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_code; " "content:!\"one\"; fast_pattern; http_stat_code; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12815,9 +13057,9 @@ int DetectFastPatternTest445(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_code; "
-                               "content:!\"one\"; fast_pattern; http_stat_code; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_code; " "content:!\"one\"; fast_pattern; http_stat_code; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12838,9 +13080,9 @@ int DetectFastPatternTest446(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_code; "
-                               "content:!\"one\"; fast_pattern; http_stat_code; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_code; " "content:!\"one\"; fast_pattern; http_stat_code; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12861,9 +13103,9 @@ int DetectFastPatternTest447(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_stat_code; "
-                               "content:!\"one\"; fast_pattern; http_stat_code; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_stat_code; " "content:!\"one\"; fast_pattern; http_stat_code; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -12884,10 +13126,9 @@ int DetectFastPatternTest448(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -12916,10 +13157,9 @@ int DetectFastPatternTest449(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -12948,10 +13188,9 @@ int DetectFastPatternTest450(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -12980,10 +13219,9 @@ int DetectFastPatternTest451(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -13012,10 +13250,9 @@ int DetectFastPatternTest452(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -13044,10 +13281,9 @@ int DetectFastPatternTest453(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -13076,10 +13312,9 @@ int DetectFastPatternTest454(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -13108,10 +13343,9 @@ int DetectFastPatternTest455(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -13140,10 +13374,9 @@ int DetectFastPatternTest456(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; http_stat_code; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; http_stat_code; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->ctx;
@@ -13175,10 +13408,9 @@ int DetectFastPatternTest457(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:65977,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:65977,4; http_stat_code; " "content:\"three\"; http_stat_code; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13199,10 +13431,9 @@ int DetectFastPatternTest458(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_stat_code; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_stat_code; "
-                               "content:\"three\"; distance:10; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_stat_code; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_stat_code; " "content:\"three\"; distance:10; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13223,10 +13454,9 @@ int DetectFastPatternTest459(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:\"two\"; fast_pattern:65534,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:\"two\"; fast_pattern:65534,4; http_stat_code; " "content:\"three\"; http_stat_code; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13247,10 +13477,9 @@ int DetectFastPatternTest460(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -13280,10 +13509,9 @@ int DetectFastPatternTest461(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; distance:10; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; distance:10; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13304,10 +13532,9 @@ int DetectFastPatternTest462(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; within:10; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; within:10; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13328,10 +13555,9 @@ int DetectFastPatternTest463(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; offset:10; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; offset:10; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13352,10 +13578,9 @@ int DetectFastPatternTest464(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; depth:10; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; depth:10; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13376,10 +13601,9 @@ int DetectFastPatternTest465(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_stat_code; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; "
-                               "content:\"three\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_stat_code; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_stat_code; " "content:\"three\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HSCDMATCH]->prev->ctx;
@@ -13414,10 +13638,9 @@ int DetectFastPatternTest466(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13452,9 +13675,9 @@ int DetectFastPatternTest467(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_server_body; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_server_body; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13489,9 +13712,9 @@ int DetectFastPatternTest468(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_server_body; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_server_body; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13522,8 +13745,9 @@ int DetectFastPatternTest469(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13558,8 +13782,9 @@ int DetectFastPatternTest470(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13594,9 +13819,9 @@ int DetectFastPatternTest471(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:only; http_server_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13617,9 +13842,9 @@ int DetectFastPatternTest472(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; distance:10; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13640,9 +13865,9 @@ int DetectFastPatternTest473(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:only; http_server_body; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13663,9 +13888,9 @@ int DetectFastPatternTest474(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; within:10; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13686,9 +13911,9 @@ int DetectFastPatternTest475(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:only; http_server_body; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13709,9 +13934,9 @@ int DetectFastPatternTest476(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; offset:10; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13732,9 +13957,9 @@ int DetectFastPatternTest477(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:only; http_server_body; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13755,9 +13980,9 @@ int DetectFastPatternTest478(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; depth:10; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13778,9 +14003,9 @@ int DetectFastPatternTest479(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"two\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"two\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13801,10 +14026,9 @@ int DetectFastPatternTest480(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_server_body; " "content:\"two\"; http_server_body; distance:30; " "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13834,10 +14058,9 @@ int DetectFastPatternTest481(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; within:30; " "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13867,10 +14090,9 @@ int DetectFastPatternTest482(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; offset:30; " "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13900,10 +14122,9 @@ int DetectFastPatternTest483(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; depth:30; " "content:\"two\"; fast_pattern:only; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13933,9 +14154,9 @@ int DetectFastPatternTest484(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_server_body; "
-                               "content:\"two\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_server_body; " "content:\"two\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -13966,9 +14187,9 @@ int DetectFastPatternTest485(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_server_body; "
-                               "content:!\"one\"; fast_pattern; http_server_body; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_server_body; " "content:!\"one\"; fast_pattern; http_server_body; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -13989,9 +14210,9 @@ int DetectFastPatternTest486(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_server_body; "
-                               "content:!\"one\"; fast_pattern; http_server_body; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_server_body; " "content:!\"one\"; fast_pattern; http_server_body; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14012,9 +14233,9 @@ int DetectFastPatternTest487(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_server_body; "
-                               "content:!\"one\"; fast_pattern; http_server_body; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_server_body; " "content:!\"one\"; fast_pattern; http_server_body; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14035,9 +14256,9 @@ int DetectFastPatternTest488(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_server_body; "
-                               "content:!\"one\"; fast_pattern; http_server_body; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_server_body; " "content:!\"one\"; fast_pattern; http_server_body; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14058,10 +14279,9 @@ int DetectFastPatternTest489(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14091,10 +14311,9 @@ int DetectFastPatternTest490(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14124,10 +14343,9 @@ int DetectFastPatternTest491(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14157,10 +14375,9 @@ int DetectFastPatternTest492(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14190,10 +14407,9 @@ int DetectFastPatternTest493(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14223,10 +14439,9 @@ int DetectFastPatternTest494(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14256,10 +14471,9 @@ int DetectFastPatternTest495(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14289,10 +14503,9 @@ int DetectFastPatternTest496(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14322,10 +14535,9 @@ int DetectFastPatternTest497(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; http_server_body; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; http_server_body; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14358,10 +14570,9 @@ int DetectFastPatternTest498(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:65977,4; http_server_body; "
-                               "content:\"three\"; http_server_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:65977,4; http_server_body; " "content:\"three\"; http_server_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14382,10 +14593,9 @@ int DetectFastPatternTest499(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_server_body; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_server_body; "
-                               "content:\"three\"; distance:10; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_server_body; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_server_body; " "content:\"three\"; distance:10; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14406,10 +14616,9 @@ int DetectFastPatternTest500(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; fast_pattern:65534,4; http_server_body; "
-                               "content:\"three\"; http_server_body; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; fast_pattern:65534,4; http_server_body; " "content:\"three\"; http_server_body; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14430,10 +14639,9 @@ int DetectFastPatternTest501(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14464,10 +14672,9 @@ int DetectFastPatternTest502(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; distance:10; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; distance:10; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14488,10 +14695,9 @@ int DetectFastPatternTest503(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; within:10; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; within:10; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14512,10 +14718,9 @@ int DetectFastPatternTest504(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; offset:10; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; offset:10; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14536,10 +14741,9 @@ int DetectFastPatternTest505(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; depth:10; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; depth:10; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14560,10 +14764,9 @@ int DetectFastPatternTest506(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; "
-                               "content:\"three\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_server_body; " "content:\"three\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14599,10 +14802,9 @@ int DetectFastPatternTest507(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14637,9 +14839,9 @@ int DetectFastPatternTest508(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; fast_pattern:only; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; fast_pattern:only; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14674,9 +14876,9 @@ int DetectFastPatternTest509(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"oneoneone\"; fast_pattern:3,4; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"oneoneone\"; fast_pattern:3,4; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14707,8 +14909,9 @@ int DetectFastPatternTest510(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14743,8 +14946,9 @@ int DetectFastPatternTest511(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"oneoneone\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"oneoneone\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -14779,9 +14983,9 @@ int DetectFastPatternTest512(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:only; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:only; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14802,9 +15006,9 @@ int DetectFastPatternTest513(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; distance:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; distance:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14825,9 +15029,9 @@ int DetectFastPatternTest514(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:only; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:only; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14848,9 +15052,9 @@ int DetectFastPatternTest515(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; within:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; within:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14871,9 +15075,9 @@ int DetectFastPatternTest516(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:only;  offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:only;  offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14894,9 +15098,9 @@ int DetectFastPatternTest517(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; offset:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; offset:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14917,9 +15121,9 @@ int DetectFastPatternTest518(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:only; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:only; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14940,9 +15144,9 @@ int DetectFastPatternTest519(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; depth:10; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; depth:10; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14963,9 +15167,9 @@ int DetectFastPatternTest520(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -14986,10 +15190,9 @@ int DetectFastPatternTest521(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\" one\"; "
-                               "content:\"two\"; distance:30; "
-                               "content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\" one\"; " "content:\"two\"; distance:30; " "content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15019,10 +15222,9 @@ int DetectFastPatternTest522(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; within:30; "
-                               "content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; within:30; " "content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15052,10 +15254,9 @@ int DetectFastPatternTest523(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; offset:30; "
-                               "content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; offset:30; " "content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15085,10 +15286,9 @@ int DetectFastPatternTest524(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; depth:30; "
-                               "content:\"two\"; fast_pattern:only; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; depth:30; " "content:\"two\"; fast_pattern:only; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15118,9 +15318,9 @@ int DetectFastPatternTest525(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:!\"one\"; fast_pattern; "
-                               "content:\"two\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:!\"one\"; fast_pattern; " "content:\"two\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15151,9 +15351,9 @@ int DetectFastPatternTest526(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"two\"; "
-                               "content:!\"one\"; fast_pattern; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"two\"; " "content:!\"one\"; fast_pattern; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15174,9 +15374,9 @@ int DetectFastPatternTest527(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"two\"; "
-                               "content:!\"one\"; fast_pattern; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"two\"; " "content:!\"one\"; fast_pattern; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15197,9 +15397,9 @@ int DetectFastPatternTest528(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"two\"; "
-                               "content:!\"one\"; fast_pattern; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"two\"; " "content:!\"one\"; fast_pattern; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15220,9 +15420,9 @@ int DetectFastPatternTest529(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"two\"; "
-                               "content:!\"one\"; fast_pattern; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"two\"; " "content:!\"one\"; fast_pattern; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15243,10 +15443,9 @@ int DetectFastPatternTest530(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4;  "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,4;  " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15276,10 +15475,9 @@ int DetectFastPatternTest531(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15309,10 +15507,9 @@ int DetectFastPatternTest532(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15342,10 +15539,9 @@ int DetectFastPatternTest533(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15375,10 +15571,9 @@ int DetectFastPatternTest534(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15408,10 +15603,9 @@ int DetectFastPatternTest535(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15441,10 +15635,9 @@ int DetectFastPatternTest536(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15474,10 +15667,9 @@ int DetectFastPatternTest537(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15507,10 +15699,9 @@ int DetectFastPatternTest538(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15543,10 +15734,9 @@ int DetectFastPatternTest539(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:65977,4; "
-                               "content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:65977,4; " "content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15567,10 +15757,9 @@ int DetectFastPatternTest540(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; "
-                               "content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"oneonetwo\"; fast_pattern:3,65977; " "content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15591,10 +15780,9 @@ int DetectFastPatternTest541(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:\"two\"; fast_pattern:65534,4; "
-                               "content:\"three\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:\"two\"; fast_pattern:65534,4; " "content:\"three\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15615,10 +15803,9 @@ int DetectFastPatternTest542(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15649,10 +15836,9 @@ int DetectFastPatternTest543(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; distance:10; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; distance:10; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15673,10 +15859,9 @@ int DetectFastPatternTest544(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; within:10; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; within:10; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15697,10 +15882,9 @@ int DetectFastPatternTest545(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; offset:10; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; offset:10; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15721,10 +15905,9 @@ int DetectFastPatternTest546(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; depth:10; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; depth:10; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15745,10 +15928,9 @@ int DetectFastPatternTest547(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(file_data; content:\"one\"; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; "
-                               "content:\"three\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(file_data; content:\"one\"; " "content:!\"oneonetwo\"; fast_pattern:3,4; " "content:\"three\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15784,10 +15966,9 @@ int DetectFastPatternTest548(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -15822,9 +16003,9 @@ int DetectFastPatternTest549(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_user_agent; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_user_agent; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15859,9 +16040,9 @@ int DetectFastPatternTest550(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_user_agent; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_user_agent; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15892,8 +16073,9 @@ int DetectFastPatternTest551(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15928,8 +16110,9 @@ int DetectFastPatternTest552(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -15964,9 +16147,9 @@ int DetectFastPatternTest553(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:only; http_user_agent; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -15987,9 +16170,9 @@ int DetectFastPatternTest554(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; distance:10; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16010,9 +16193,9 @@ int DetectFastPatternTest555(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:only; http_user_agent; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16033,9 +16216,9 @@ int DetectFastPatternTest556(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; within:10; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16056,9 +16239,9 @@ int DetectFastPatternTest557(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:only; http_user_agent; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16079,9 +16262,9 @@ int DetectFastPatternTest558(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; offset:10; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16102,9 +16285,9 @@ int DetectFastPatternTest559(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:only; http_user_agent; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16125,9 +16308,9 @@ int DetectFastPatternTest560(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; depth:10; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16148,9 +16331,9 @@ int DetectFastPatternTest561(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"two\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"two\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16171,10 +16354,9 @@ int DetectFastPatternTest562(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_user_agent; " "content:\"two\"; http_user_agent; distance:30; " "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -16204,10 +16386,9 @@ int DetectFastPatternTest563(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; within:30; " "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16236,10 +16417,9 @@ int DetectFastPatternTest564(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; offset:30; " "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16268,10 +16448,9 @@ int DetectFastPatternTest565(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; depth:30; " "content:\"two\"; fast_pattern:only; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16300,9 +16479,9 @@ int DetectFastPatternTest566(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_user_agent; "
-                               "content:\"two\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_user_agent; " "content:\"two\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16332,9 +16511,9 @@ int DetectFastPatternTest567(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_user_agent; "
-                               "content:!\"one\"; fast_pattern; http_user_agent; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_user_agent; " "content:!\"one\"; fast_pattern; http_user_agent; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16355,9 +16534,9 @@ int DetectFastPatternTest568(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_user_agent; "
-                               "content:!\"one\"; fast_pattern; http_user_agent; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_user_agent; " "content:!\"one\"; fast_pattern; http_user_agent; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16378,9 +16557,9 @@ int DetectFastPatternTest569(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_user_agent; "
-                               "content:!\"one\"; fast_pattern; http_user_agent; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_user_agent; " "content:!\"one\"; fast_pattern; http_user_agent; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16401,9 +16580,9 @@ int DetectFastPatternTest570(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_user_agent; "
-                               "content:!\"one\"; fast_pattern; http_user_agent; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_user_agent; " "content:!\"one\"; fast_pattern; http_user_agent; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16424,10 +16603,9 @@ int DetectFastPatternTest571(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16456,10 +16634,9 @@ int DetectFastPatternTest572(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16488,10 +16665,9 @@ int DetectFastPatternTest573(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16520,10 +16696,9 @@ int DetectFastPatternTest574(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16552,10 +16727,9 @@ int DetectFastPatternTest575(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16584,10 +16758,9 @@ int DetectFastPatternTest576(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16616,10 +16789,9 @@ int DetectFastPatternTest577(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16648,10 +16820,9 @@ int DetectFastPatternTest578(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16680,10 +16851,9 @@ int DetectFastPatternTest579(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; http_user_agent; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; http_user_agent; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->ctx;
@@ -16715,10 +16885,9 @@ int DetectFastPatternTest580(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:65977,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:65977,4; http_user_agent; " "content:\"three\"; http_user_agent; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16739,10 +16908,9 @@ int DetectFastPatternTest581(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_user_agent; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_user_agent; "
-                               "content:\"three\"; distance:10; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_user_agent; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_user_agent; " "content:\"three\"; distance:10; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16763,10 +16931,9 @@ int DetectFastPatternTest582(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; fast_pattern:65534,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; fast_pattern:65534,4; http_user_agent; " "content:\"three\"; http_user_agent; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16787,10 +16954,9 @@ int DetectFastPatternTest583(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16820,10 +16986,9 @@ int DetectFastPatternTest584(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; distance:10; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; distance:10; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16844,10 +17009,9 @@ int DetectFastPatternTest585(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; within:10; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; within:10; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16868,10 +17032,9 @@ int DetectFastPatternTest586(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; offset:10; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; offset:10; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16892,10 +17055,9 @@ int DetectFastPatternTest587(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; depth:10; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; depth:10; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -16916,10 +17078,9 @@ int DetectFastPatternTest588(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; "
-                               "content:\"three\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_user_agent; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_user_agent; " "content:\"three\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HUADMATCH]->prev->ctx;
@@ -16954,10 +17115,9 @@ int DetectFastPatternTest589(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -16991,9 +17151,9 @@ int DetectFastPatternTest590(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_host;  "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_host;  " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17028,9 +17188,9 @@ int DetectFastPatternTest591(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_host; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17061,8 +17221,9 @@ int DetectFastPatternTest592(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17097,8 +17258,9 @@ int DetectFastPatternTest593(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17133,9 +17295,9 @@ int DetectFastPatternTest594(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:only; http_host; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:only; http_host; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17156,9 +17318,9 @@ int DetectFastPatternTest595(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; distance:10; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17179,9 +17341,9 @@ int DetectFastPatternTest596(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:only; http_host; within:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:only; http_host; within:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17202,9 +17364,9 @@ int DetectFastPatternTest597(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; within:10; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17225,9 +17387,9 @@ int DetectFastPatternTest598(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:only; http_host; offset:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:only; http_host; offset:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17248,9 +17410,9 @@ int DetectFastPatternTest599(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; offset:10; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17271,9 +17433,9 @@ int DetectFastPatternTest600(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:only; http_host; depth:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:only; http_host; depth:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17294,9 +17456,9 @@ int DetectFastPatternTest601(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; depth:10; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17317,9 +17479,9 @@ int DetectFastPatternTest602(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"two\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"two\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17340,10 +17502,9 @@ int DetectFastPatternTest603(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_host; "
-                               "content:\"two\"; http_host; distance:30; "
-                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_host; " "content:\"two\"; http_host; distance:30; " "content:\"two\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -17373,10 +17534,9 @@ int DetectFastPatternTest604(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; within:30; "
-                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; within:30; " "content:\"two\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17405,10 +17565,9 @@ int DetectFastPatternTest605(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; offset:30; "
-                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; offset:30; " "content:\"two\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17437,10 +17596,9 @@ int DetectFastPatternTest606(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; depth:30; "
-                               "content:\"two\"; fast_pattern:only; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; depth:30; " "content:\"two\"; fast_pattern:only; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17469,9 +17627,9 @@ int DetectFastPatternTest607(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_host; "
-                               "content:\"two\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_host; " "content:\"two\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17501,9 +17659,9 @@ int DetectFastPatternTest608(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; "
-                               "content:!\"one\"; fast_pattern; http_host; distance:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_host; " "content:!\"one\"; fast_pattern; http_host; distance:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17524,9 +17682,9 @@ int DetectFastPatternTest609(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; "
-                               "content:!\"one\"; fast_pattern; http_host; within:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_host; " "content:!\"one\"; fast_pattern; http_host; within:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17547,9 +17705,9 @@ int DetectFastPatternTest610(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; "
-                               "content:!\"one\"; fast_pattern; http_host; offset:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_host; " "content:!\"one\"; fast_pattern; http_host; offset:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17570,9 +17728,9 @@ int DetectFastPatternTest611(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_host; "
-                               "content:!\"one\"; fast_pattern; http_host; depth:20; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_host; " "content:!\"one\"; fast_pattern; http_host; depth:20; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17593,10 +17751,9 @@ int DetectFastPatternTest612(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17625,10 +17782,9 @@ int DetectFastPatternTest613(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; distance:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; distance:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17657,10 +17813,9 @@ int DetectFastPatternTest614(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; within:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; within:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17689,10 +17844,9 @@ int DetectFastPatternTest615(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; offset:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; offset:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17721,10 +17875,9 @@ int DetectFastPatternTest616(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; depth:30; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; depth:30; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17753,10 +17906,9 @@ int DetectFastPatternTest617(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; distance:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; distance:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17785,10 +17937,9 @@ int DetectFastPatternTest618(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; within:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; within:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17817,10 +17968,9 @@ int DetectFastPatternTest619(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; offset:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; offset:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17849,10 +17999,9 @@ int DetectFastPatternTest620(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; http_host; depth:10; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; http_host; depth:10; " "content:\"oneonethree\"; fast_pattern:3,4; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->ctx;
@@ -17884,10 +18033,9 @@ int DetectFastPatternTest621(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:65977,4; http_host; "
-                               "content:\"three\"; http_host; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:65977,4; http_host; " "content:\"three\"; http_host; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17908,10 +18056,9 @@ int DetectFastPatternTest622(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_host; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_host; "
-                               "content:\"three\"; distance:10; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_host; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_host; " "content:\"three\"; distance:10; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17932,10 +18079,9 @@ int DetectFastPatternTest623(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; fast_pattern:65534,4; http_host; "
-                               "content:\"three\"; http_host; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; fast_pattern:65534,4; http_host; " "content:\"three\"; http_host; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -17956,10 +18102,9 @@ int DetectFastPatternTest624(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -17989,10 +18134,9 @@ int DetectFastPatternTest625(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; distance:10; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; distance:10; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18013,10 +18157,9 @@ int DetectFastPatternTest626(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; within:10; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; within:10; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18037,10 +18180,9 @@ int DetectFastPatternTest627(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; offset:10; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; offset:10; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18061,10 +18203,9 @@ int DetectFastPatternTest628(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; depth:10; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; depth:10; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18085,10 +18226,9 @@ int DetectFastPatternTest629(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; "
-                               "content:\"three\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_host; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_host; " "content:\"three\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HHHDMATCH]->prev->ctx;
@@ -18123,10 +18263,9 @@ int DetectFastPatternTest630(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18161,9 +18300,9 @@ int DetectFastPatternTest631(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_raw_host; nocase; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_raw_host; nocase; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -18200,9 +18339,9 @@ int DetectFastPatternTest632(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "msg:\"Testing fast_pattern\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_host; nocase; " "msg:\"Testing fast_pattern\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -18235,8 +18374,9 @@ int DetectFastPatternTest633(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -18272,8 +18412,9 @@ int DetectFastPatternTest634(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"oneoneone\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -18309,9 +18450,9 @@ int DetectFastPatternTest635(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; distance:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; distance:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18332,9 +18473,9 @@ int DetectFastPatternTest636(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; distance:10; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; distance:10; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18355,9 +18496,9 @@ int DetectFastPatternTest637(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; within:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; within:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18378,9 +18519,9 @@ int DetectFastPatternTest638(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; within:10; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; within:10; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18401,9 +18542,9 @@ int DetectFastPatternTest639(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; offset:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; offset:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18424,9 +18565,9 @@ int DetectFastPatternTest640(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; offset:10; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; offset:10; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18447,9 +18588,9 @@ int DetectFastPatternTest641(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; depth:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; depth:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18470,9 +18611,9 @@ int DetectFastPatternTest642(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; depth:10; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; depth:10; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18493,9 +18634,9 @@ int DetectFastPatternTest643(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18516,10 +18657,9 @@ int DetectFastPatternTest644(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\" one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; distance:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\" one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; distance:30; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -18550,10 +18690,9 @@ int DetectFastPatternTest645(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; within:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; within:30; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -18583,10 +18722,9 @@ int DetectFastPatternTest646(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; offset:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; offset:30; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -18616,10 +18754,9 @@ int DetectFastPatternTest647(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; depth:30; nocase; "
-                               "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; depth:30; nocase; " "content:\"two\"; fast_pattern:only; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -18649,9 +18786,9 @@ int DetectFastPatternTest648(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:!\"one\"; fast_pattern; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:!\"one\"; fast_pattern; http_raw_host; nocase; " "content:\"two\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18682,9 +18819,9 @@ int DetectFastPatternTest649(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_raw_host; distance:20; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_host; nocase; " "content:!\"one\"; fast_pattern; http_raw_host; distance:20; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18705,9 +18842,9 @@ int DetectFastPatternTest650(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_raw_host; within:20; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_host; nocase; " "content:!\"one\"; fast_pattern; http_raw_host; within:20; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18728,9 +18865,9 @@ int DetectFastPatternTest651(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_raw_host; offset:20; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_host; nocase; " "content:!\"one\"; fast_pattern; http_raw_host; offset:20; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18751,9 +18888,9 @@ int DetectFastPatternTest652(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_raw_host; nocase; "
-                               "content:!\"one\"; fast_pattern; http_raw_host; depth:20; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_raw_host; nocase; " "content:!\"one\"; fast_pattern; http_raw_host; depth:20; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -18774,10 +18911,9 @@ int DetectFastPatternTest653(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18807,10 +18943,9 @@ int DetectFastPatternTest654(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; distance:30; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; distance:30; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18840,10 +18975,9 @@ int DetectFastPatternTest655(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; within:30; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; within:30; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18873,10 +19007,9 @@ int DetectFastPatternTest656(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; offset:30; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; offset:30; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18906,10 +19039,9 @@ int DetectFastPatternTest657(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; depth:30; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; depth:30; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -18939,10 +19071,9 @@ int DetectFastPatternTest658(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; distance:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; distance:10; nocase; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -18972,10 +19103,9 @@ int DetectFastPatternTest659(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; within:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; within:10; nocase; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -19005,10 +19135,9 @@ int DetectFastPatternTest660(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; offset:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; offset:10; nocase; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -19038,10 +19167,9 @@ int DetectFastPatternTest661(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; http_raw_host; depth:10; nocase; "
-                               "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; http_raw_host; depth:10; nocase; " "content:\"oneonethree\"; fast_pattern:3,4; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->ctx;
@@ -19074,10 +19202,9 @@ int DetectFastPatternTest662(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:65977,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; distance:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:65977,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; distance:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19098,10 +19225,9 @@ int DetectFastPatternTest663(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\";  http_raw_host; nocase; "
-                               "content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_host; nocase; "
-                               "content:\"three\"; distance:10; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\";  http_raw_host; nocase; " "content:\"oneonetwo\"; fast_pattern:3,65977; http_raw_host; nocase; " "content:\"three\"; distance:10; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19122,10 +19248,9 @@ int DetectFastPatternTest664(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:\"two\"; fast_pattern:65534,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; distance:10; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:\"two\"; fast_pattern:65534,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; distance:10; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19146,10 +19271,9 @@ int DetectFastPatternTest665(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -19180,10 +19304,9 @@ int DetectFastPatternTest666(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; distance:10; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; distance:10; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19204,10 +19327,9 @@ int DetectFastPatternTest667(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; within:10; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; within:10; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19228,10 +19350,9 @@ int DetectFastPatternTest668(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; offset:10; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; offset:10; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19252,10 +19373,9 @@ int DetectFastPatternTest669(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; depth:10; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; depth:10; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
@@ -19276,10 +19396,9 @@ int DetectFastPatternTest670(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; "
-                               "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; "
-                               "content:\"three\"; http_raw_host; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_host; nocase; " "content:!\"oneonetwo\"; fast_pattern:3,4; http_raw_host; nocase; " "content:\"three\"; http_raw_host; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     DetectContentData *ud = (DetectContentData *)de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_HRHHDMATCH]->prev->ctx;
@@ -19342,7 +19461,7 @@ int DetectFastPatternTest671(void)
     de_ctx->flags |= DE_QUIET;
 
     i = 0;
-    s[i] = SigInit(de_ctx, sigs[i]);
+    s[i] = SigInit(de_ctx, sigs[i], NULL);
     de_ctx->sig_list = sig = s[i];
     if (sig == NULL) {
         printf("SigInit(de_ctx, sig1) failure\n");
@@ -19350,7 +19469,7 @@ int DetectFastPatternTest671(void)
     }
     i++;
     for ( ; i < no_of_sigs; i++) {
-        s[i] = SigInit(de_ctx, sigs[i]);
+        s[i] = SigInit(de_ctx, sigs[i], NULL);
         sig->next = s[i];
         sig = sig->next;
         if (sig == NULL) {

--- a/src/detect-file-data.c
+++ b/src/detect-file-data.c
@@ -113,8 +113,8 @@ static int DetectFiledataParseTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert smtp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)");
+                               "alert smtp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -150,8 +150,8 @@ static int DetectFiledataParseTest02(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -187,8 +187,8 @@ static int DetectFiledataParseTest03(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any 25 "
-                               "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)");
+                               "alert tcp any any -> any 25 " "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -227,8 +227,8 @@ static int DetectFiledataParseTest04(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert smtp any any -> any any "
-                               "(msg:\"test\"; flow:to_client,established; file_data; content:\"abc\"; sid:1;)");
+                               "alert smtp any any -> any any " "(msg:\"test\"; flow:to_client,established; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 1;
     }
@@ -255,8 +255,8 @@ static int DetectFiledataParseTest05(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert http any any -> any any "
-                               "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)");
+                               "alert http any any -> any any " "(msg:\"test\"; flow:to_server,established; file_data; content:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 1;
     }

--- a/src/detect-filesize.c
+++ b/src/detect-filesize.c
@@ -437,7 +437,7 @@ static int DetectFilesizeInitTest(DetectEngineCtx **de_ctx, Signature **sig,
 
     (*de_ctx)->flags |= DE_QUIET;
 
-    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr);
+    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr, NULL);
     if ((*de_ctx)->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -1027,7 +1027,7 @@ static int DetectFlowSigTest01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig1);
+    de_ctx->sig_list = SigInit(de_ctx, sig1, NULL);
     if (de_ctx->sig_list == NULL) {
         printf("signature == NULL: ");
         goto end;

--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -366,7 +366,9 @@ static int FlowBitsTestSig01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Noalert\"; flowbits:noalert,wrongusage; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Noalert\"; flowbits:noalert,wrongusage; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL) {
         goto end;
@@ -442,31 +444,41 @@ static int FlowBitsTestSig02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"isset rule need an option\"; flowbits:isset; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"isset rule need an option\"; flowbits:isset; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL) {
         error_count++;
     }
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"isnotset rule need an option\"; flowbits:isnotset; content:\"GET \"; sid:2;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"isnotset rule need an option\"; flowbits:isnotset; content:\"GET \"; sid:2;)",
+                                   NULL);
 
     if (s == NULL) {
         error_count++;
     }
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"set rule need an option\"; flowbits:set; content:\"GET \"; sid:3;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"set rule need an option\"; flowbits:set; content:\"GET \"; sid:3;)",
+                                   NULL);
 
     if (s == NULL) {
         error_count++;
     }
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"unset rule need an option\"; flowbits:unset; content:\"GET \"; sid:4;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"unset rule need an option\"; flowbits:unset; content:\"GET \"; sid:4;)",
+                                   NULL);
 
     if (s == NULL) {
         error_count++;
     }
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"toggle rule need an option\"; flowbits:toggle; content:\"GET \"; sid:5;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"toggle rule need an option\"; flowbits:toggle; content:\"GET \"; sid:5;)",
+                                   NULL);
 
     if (s == NULL) {
         error_count++;
@@ -563,7 +575,9 @@ static int FlowBitsTestSig03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Unknown cmd\"; flowbits:wrongcmd; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Unknown cmd\"; flowbits:wrongcmd; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL) {
         goto end;
@@ -642,7 +656,9 @@ static int FlowBitsTestSig04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"isset option\"; flowbits:isset,fbt; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"isset option\"; flowbits:isset,fbt; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     idx = VariableNameGetIdx(de_ctx, "fbt", VAR_TYPE_FLOW_BIT);
 
@@ -723,7 +739,9 @@ static int FlowBitsTestSig05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Noalert\"; flowbits:noalert; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Noalert\"; flowbits:noalert; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL || ((s->flags & SIG_FLAG_NOALERT) != SIG_FLAG_NOALERT)) {
         goto end;
@@ -814,7 +832,9 @@ static int FlowBitsTestSig06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow; sid:10;)",
+                                   NULL);
 
     if (s == NULL) {
         goto end;
@@ -916,12 +936,16 @@ static int FlowBitsTestSig07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow2; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow2; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Flowbit unset\"; flowbits:unset,myflow2; sid:11;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"Flowbit unset\"; flowbits:unset,myflow2; sid:11;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1023,13 +1047,17 @@ static int FlowBitsTestSig08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow2; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"Flowbit set\"; flowbits:set,myflow2; sid:10;)",
+                                   NULL);
 
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next  = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Flowbit unset\"; flowbits:toggle,myflow2; sid:11;)");
+    s = s->next  = SigInit(de_ctx,
+                           "alert ip any any -> any any (msg:\"Flowbit unset\"; flowbits:toggle,myflow2; sid:11;)",
+                           NULL);
 
     if (s == NULL) {
         goto end;

--- a/src/detect-fragoffset.c
+++ b/src/detect-fragoffset.c
@@ -325,12 +325,16 @@ int DetectFragOffsetMatchTest01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert ip any any -> any any (fragoffset:546; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (fragoffset:546; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx, "alert ip any any -> any any (fragoffset:5000; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (fragoffset:5000; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-ftpbounce.c
+++ b/src/detect-ftpbounce.c
@@ -321,8 +321,9 @@ static int DetectFtpbounceTestALMatch02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
-                                   "(msg:\"Ftp Bounce\"; ftpbounce; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Ftp Bounce\"; ftpbounce; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -462,8 +463,9 @@ static int DetectFtpbounceTestALMatch03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any "
-                                   "(msg:\"Ftp Bounce\"; ftpbounce; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any " "(msg:\"Ftp Bounce\"; ftpbounce; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-geoip.c
+++ b/src/detect-geoip.c
@@ -382,7 +382,7 @@ static int GeoipParseTest(char *rule, int ncountries, char **countries, uint32_t
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, rule);
+    de_ctx->sig_list = SigInit(de_ctx, rule, NULL);
 
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
@@ -503,7 +503,7 @@ static int GeoipMatchTest(char *rule, char *srcip, char *dstip)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, rule);
+    de_ctx->sig_list = SigInit(de_ctx, rule, NULL);
 
     if (de_ctx->sig_list == NULL) {
         goto end;

--- a/src/detect-gid.c
+++ b/src/detect-gid.c
@@ -126,7 +126,9 @@ static int GidTestParse01 (void)
     if (de_ctx == NULL)
         goto end;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)",
+                              NULL);
     if (s == NULL || s->gid != 1)
         goto end;
 
@@ -151,7 +153,7 @@ static int GidTestParse02 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:a;)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:1; gid:a;)", NULL) != NULL)
         goto end;
 
     result = 1;
@@ -175,8 +177,7 @@ static int GidTestParse03 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx,
-            "alert tcp any any -> any any (content:\"ABC\"; gid:\";)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"ABC\"; gid:\";)", NULL) != NULL)
         goto end;
 
     result = 1;

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -678,13 +678,15 @@ static int HostBitsTestSig02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:isset,abc,src; content:\"GET \"; sid:1;)");
+                              "alert ip any any -> any any (hostbits:isset,abc,src; content:\"GET \"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:isnotset,abc,dst; content:\"GET \"; sid:2;)");
+                              "alert ip any any -> any any (hostbits:isnotset,abc,dst; content:\"GET \"; sid:2;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
@@ -696,13 +698,15 @@ static int HostBitsTestSig02(void)
     }
 */
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:unset,abc,src; content:\"GET \"; sid:4;)");
+                              "alert ip any any -> any any (hostbits:unset,abc,src; content:\"GET \"; sid:4;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:toggle,abc,dst; content:\"GET \"; sid:5;)");
+                              "alert ip any any -> any any (hostbits:toggle,abc,dst; content:\"GET \"; sid:5;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
@@ -1353,22 +1357,26 @@ static int HostBitsTestSig08(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:set,myflow2; sid:10;)");
+                              "alert ip any any -> any any (hostbits:set,myflow2; sid:10;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:toggle,myflow2; sid:11;)");
+                              "alert ip any any -> any any (hostbits:toggle,myflow2; sid:11;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:toggle,myflow2; sid:12;)");
+                              "alert ip any any -> any any (hostbits:toggle,myflow2; sid:12;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (hostbits:isset,myflow2; sid:13;)");
+                              "alert ip any any -> any any (hostbits:isset,myflow2; sid:13;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-hostbits.c
+++ b/src/detect-hostbits.c
@@ -617,7 +617,9 @@ static int HostBitsTestSig01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (hostbits:set,abc; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (hostbits:set,abc; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL) {
         printf("bad sig: ");
@@ -846,7 +848,9 @@ static int HostBitsTestSig04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"isset option\"; hostbits:isset,fbt; content:\"GET \"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"isset option\"; hostbits:isset,fbt; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     idx = VariableNameGetIdx(de_ctx, "fbt", VAR_TYPE_HOST_BIT);
 
@@ -934,7 +938,8 @@ static int HostBitsTestSig05(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-        "alert ip any any -> any any (hostbits:noalert; content:\"GET \"; sid:1;)");
+                                   "alert ip any any -> any any (hostbits:noalert; content:\"GET \"; sid:1;)",
+                                   NULL);
 
     if (s == NULL || ((s->flags & SIG_FLAG_NOALERT) != SIG_FLAG_NOALERT)) {
         goto end;
@@ -1240,14 +1245,16 @@ static int HostBitsTestSig07(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-            "alert ip any any -> any any (hostbits:set,myflow2; sid:10;)");
+                                   "alert ip any any -> any any (hostbits:set,myflow2; sid:10;)",
+                                   NULL);
 
     if (s == NULL) {
         goto end;
     }
 
     s = s->next  = SigInit(de_ctx,
-            "alert ip any any -> any any (hostbits:isset,myflow2; sid:11;)");
+                           "alert ip any any -> any any (hostbits:isset,myflow2; sid:11;)",
+                           NULL);
 
     if (s == NULL) {
         goto end;

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -1254,12 +1254,16 @@ static int DetectHttpClientBodyTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"one\"; http_client_body; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"one\"; http_client_body; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; content:\"two\"; http_client_body; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; content:\"two\"; http_client_body; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -1473,12 +1477,16 @@ static int DetectHttpClientBodyTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"one\"; http_client_body; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; content:\"one\"; http_client_body; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; content:\"two\"; http_client_body; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; content:\"two\"; http_client_body; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;

--- a/src/detect-http-client-body.c
+++ b/src/detect-http-client-body.c
@@ -150,9 +150,9 @@ static int DetectHttpClientBodyTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_client_body\"; "
-                               "content:\"one\"; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_client_body\"; " "content:\"one\"; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -187,9 +187,9 @@ static int DetectHttpClientBodyTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_client_body\"; "
-                               "content:\"one\"; http_client_body:; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_client_body\"; " "content:\"one\"; http_client_body:; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -215,9 +215,9 @@ static int DetectHttpClientBodyTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_client_body\"; "
-                               "http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_client_body\"; " "http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -243,9 +243,9 @@ static int DetectHttpClientBodyTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_client_body\"; "
-                               "content:\"one\"; rawbytes; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_client_body\"; " "content:\"one\"; rawbytes; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -271,9 +271,9 @@ static int DetectHttpClientBodyTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_client_body\"; "
-                               "content:\"one\"; http_client_body; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_client_body\"; " "content:\"one\"; http_client_body; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -335,10 +335,9 @@ static int DetectHttpClientBodyTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"message\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"message\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -446,10 +445,9 @@ static int DetectHttpClientBodyTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"message\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"message\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -573,10 +571,9 @@ static int DetectHttpClientBodyTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"message\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"message\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -703,10 +700,9 @@ static int DetectHttpClientBodyTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"body1This\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"body1This\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -833,10 +829,9 @@ static int DetectHttpClientBodyTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"body1This\"; http_client_body; nocase;"
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"body1This\"; http_client_body; nocase;" "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -954,10 +949,9 @@ static int DetectHttpClientBodyTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:!\"message1\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:!\"message1\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1056,10 +1050,9 @@ static int DetectHttpClientBodyTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:!\"message\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:!\"message\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1158,10 +1151,9 @@ static int DetectHttpClientBodyTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_client_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_client_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1704,9 +1696,9 @@ int DetectHttpClientBodyTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_client_body; "
-                               "content:\"three\"; distance:10; http_client_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; http_client_body; " "content:\"three\"; distance:10; http_client_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1759,9 +1751,9 @@ int DetectHttpClientBodyTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_client_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; pcre:/two/; " "content:\"three\"; distance:10; http_client_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1813,9 +1805,9 @@ int DetectHttpClientBodyTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_client_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; pcre:/two/; " "content:\"three\"; distance:10; within:15; http_client_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1867,10 +1859,9 @@ int DetectHttpClientBodyTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_client_body; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; pcre:/two/; " "content:\"three\"; distance:10; http_client_body; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1923,10 +1914,9 @@ int DetectHttpClientBodyTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; offset:10; http_client_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_client_body; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; offset:10; http_client_body; pcre:/two/; " "content:\"three\"; distance:10; http_client_body; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1980,10 +1970,9 @@ int DetectHttpClientBodyTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; offset:10; http_client_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_client_body; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; offset:10; http_client_body; pcre:/two/; " "content:\"three\"; distance:10; http_client_body; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2006,10 +1995,9 @@ int DetectHttpClientBodyTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; pcre:/two/; "
-                               "content:\"three\"; http_client_body; depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; pcre:/two/; " "content:\"three\"; http_client_body; depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2062,9 +2050,9 @@ int DetectHttpClientBodyTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; "
-                               "content:\"two\"; distance:0; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; " "content:\"two\"; distance:0; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2106,9 +2094,9 @@ int DetectHttpClientBodyTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; "
-                               "content:\"two\"; within:5; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; " "content:\"two\"; within:5; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2150,8 +2138,9 @@ int DetectHttpClientBodyTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2174,8 +2163,9 @@ int DetectHttpClientBodyTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_client_body; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_client_body; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list != NULL\n");
         goto end;
@@ -2198,8 +2188,9 @@ int DetectHttpClientBodyTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2222,9 +2213,9 @@ int DetectHttpClientBodyTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/P; "
-                               "content:\"two\"; within:5; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/P; " "content:\"two\"; within:5; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2273,9 +2264,9 @@ int DetectHttpClientBodyTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_client_body; "
-                               "pcre:/one/PR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_client_body; " "pcre:/one/PR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2324,9 +2315,9 @@ int DetectHttpClientBodyTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/P; "
-                               "content:\"two\"; distance:5; http_client_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/P; " "content:\"two\"; distance:5; http_client_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-http-cookie.c
+++ b/src/detect-http-cookie.c
@@ -137,8 +137,9 @@ int DetectHttpCookieTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; http_cookie;sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; http_cookie;sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -161,9 +162,9 @@ int DetectHttpCookieTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; content:\"me\"; "
-                               "http_cookie:woo; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; content:\"me\"; " "http_cookie:woo; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -186,11 +187,9 @@ int DetectHttpCookieTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; content:\"one\"; "
-                               "http_cookie; content:\"two\"; http_cookie; "
-                               "content:\"two\"; http_cookie; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; content:\"one\"; " "http_cookie; content:\"two\"; http_cookie; " "content:\"two\"; http_cookie; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -232,9 +231,9 @@ int DetectHttpCookieTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; content:\"one\"; "
-                               "fast_pattern; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; content:\"one\"; " "fast_pattern; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -257,9 +256,9 @@ int DetectHttpCookieTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; content:\"one\"; "
-                               "rawbytes; http_cookie; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; content:\"one\"; " "rawbytes; http_cookie; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -282,9 +281,9 @@ int DetectHttpCookieTest06(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_cookie\"; content:\"one\"; "
-                               "http_cookie; uricontent:\"abc\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_cookie\"; content:\"one\"; " "http_cookie; uricontent:\"abc\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -354,15 +353,16 @@ static int DetectHttpCookieSigTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:\"me\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:\"me\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                      "cookie\"; content:\"go\"; http_cookie; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "cookie\"; content:\"go\"; http_cookie; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -460,9 +460,9 @@ static int DetectHttpCookieSigTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:\"me\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:\"me\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -553,9 +553,9 @@ static int DetectHttpCookieSigTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:\"boo\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:\"boo\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -647,9 +647,9 @@ static int DetectHttpCookieSigTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:!\"boo\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:!\"boo\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -741,9 +741,9 @@ static int DetectHttpCookieSigTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:\"dummy\"; nocase; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:\"dummy\"; nocase; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -835,9 +835,9 @@ static int DetectHttpCookieSigTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:\"dummy\"; "
-                                   "http_cookie; nocase; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:\"dummy\"; " "http_cookie; nocase; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -928,9 +928,9 @@ static int DetectHttpCookieSigTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; content:!\"dummy\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; content:!\"dummy\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1038,9 +1038,9 @@ static int DetectHttpCookieSigTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                                   "(flow:to_client; content:\"response_user_agent\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any " "(flow:to_client; content:\"response_user_agent\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1169,15 +1169,15 @@ static int DetectHttpCookieSigTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                                   "(flow:to_server; content:\"request_user_agent\"; "
-                                   "http_cookie; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any " "(flow:to_server; content:\"request_user_agent\"; " "http_cookie; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
-    s = de_ctx->sig_list->next = SigInit(de_ctx,"alert http any any -> any any "
-                                         "(flow:to_client; content:\"response_user_agent\"; "
-                                         "http_cookie; sid:2;)");
+    s = de_ctx->sig_list->next = SigInit(de_ctx,
+                                         "alert http any any -> any any " "(flow:to_client; content:\"response_user_agent\"; " "http_cookie; sid:2;)",
+                                         NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-http-header.c
+++ b/src/detect-http-header.c
@@ -145,9 +145,9 @@ static int DetectHttpHeaderTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; "
-                               "content:\"one\"; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; " "content:\"one\"; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -187,9 +187,9 @@ static int DetectHttpHeaderTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; "
-                               "content:\"one\"; http_header:; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; " "content:\"one\"; http_header:; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
     else
@@ -217,9 +217,9 @@ static int DetectHttpHeaderTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; "
-                               "http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; " "http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
     else
@@ -247,9 +247,9 @@ static int DetectHttpHeaderTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; "
-                               "content:\"one\"; rawbytes; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; " "content:\"one\"; rawbytes; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
     else
@@ -277,9 +277,9 @@ static int DetectHttpHeaderTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; "
-                               "content:\"one\"; nocase; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; " "content:\"one\"; nocase; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
     else
@@ -342,10 +342,9 @@ static int DetectHttpHeaderTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Content-Type: text/html\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Content-Type: text/html\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -451,10 +450,9 @@ static int DetectHttpHeaderTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Mozilla\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Mozilla\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -578,10 +576,9 @@ static int DetectHttpHeaderTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Gecko/20091221 Firefox/3.5.7\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Gecko/20091221 Firefox/3.5.7\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -707,10 +704,9 @@ static int DetectHttpHeaderTest09(void)
     de_ctx->flags |= DE_QUIET;
     de_ctx->mpm_matcher = DEFAULT_MPM;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Firefox/3.5.7|0D 0A|Content\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Firefox/3.5.7|0D 0A|Content\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -835,10 +831,9 @@ static int DetectHttpHeaderTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"firefox/3.5.7|0D 0A|content\"; nocase; http_header;"
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"firefox/3.5.7|0D 0A|content\"; nocase; http_header;" "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -955,10 +950,9 @@ static int DetectHttpHeaderTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"lalalalala\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"lalalalala\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1056,10 +1050,9 @@ static int DetectHttpHeaderTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:!\"User-Agent: Mozilla/5.0 \"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:!\"User-Agent: Mozilla/5.0 \"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1158,10 +1151,9 @@ static int DetectHttpHeaderTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; "
-                               "content:\"Host: www.openinfosecfoundation.org\"; http_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; " "content:\"Host: www.openinfosecfoundation.org\"; http_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1219,9 +1211,9 @@ int DetectHttpHeaderTest20(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; "
-                               "content:\"two\"; distance:0; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; " "content:\"two\"; distance:0; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1263,9 +1255,9 @@ int DetectHttpHeaderTest21(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; "
-                               "content:\"two\"; within:5; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; " "content:\"two\"; within:5; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1307,8 +1299,9 @@ int DetectHttpHeaderTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1331,8 +1324,9 @@ int DetectHttpHeaderTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_header; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_header; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1355,8 +1349,9 @@ int DetectHttpHeaderTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1379,9 +1374,9 @@ int DetectHttpHeaderTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/H; "
-                               "content:\"two\"; within:5; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/H; " "content:\"two\"; within:5; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1430,9 +1425,9 @@ int DetectHttpHeaderTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_header; "
-                               "pcre:/one/HR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_header; " "pcre:/one/HR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1481,9 +1476,9 @@ int DetectHttpHeaderTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/H; "
-                               "content:\"two\"; distance:5; http_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/H; " "content:\"two\"; distance:5; http_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1566,9 +1561,9 @@ static int DetectHttpHeaderTest28(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(app-layer-event:http.host_header_ambiguous; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(app-layer-event:http.host_header_ambiguous; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1653,9 +1648,9 @@ static int DetectHttpHeaderTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(app-layer-event:http.host_header_ambiguous; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(app-layer-event:http.host_header_ambiguous; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1740,9 +1735,9 @@ static int DetectHttpHeaderTest30(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(app-layer-event:http.host_header_ambiguous; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(app-layer-event:http.host_header_ambiguous; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -1225,12 +1225,16 @@ static int DetectHttpHHTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"body one\"; http_host; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"body one\"; http_host; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"body two\"; http_host; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"body two\"; http_host; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;

--- a/src/detect-http-hh.c
+++ b/src/detect-http-hh.c
@@ -144,9 +144,9 @@ static int DetectHttpHHTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_host\"; " "content:\"one\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -175,9 +175,9 @@ static int DetectHttpHHTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_host\"; " "content:\"one\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -203,9 +203,9 @@ static int DetectHttpHHTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_host\"; "
-                               "http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_host\"; " "http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -231,9 +231,9 @@ static int DetectHttpHHTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; rawbytes; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_host\"; " "content:\"one\"; rawbytes; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -258,9 +258,9 @@ static int DetectHttpHHTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_host\"; "
-                               "content:\"one\"; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_host\"; " "content:\"one\"; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -320,10 +320,9 @@ static int DetectHttpHHTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -427,10 +426,9 @@ static int DetectHttpHHTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -550,10 +548,9 @@ static int DetectHttpHHTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -680,10 +677,9 @@ static int DetectHttpHHTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"body1this\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"body1this\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -810,10 +806,9 @@ static int DetectHttpHHTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"body1this\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"body1this\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -930,10 +925,9 @@ static int DetectHttpHHTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:!\"message\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1029,10 +1023,9 @@ static int DetectHttpHHTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:!\"message\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1129,10 +1122,9 @@ static int DetectHttpHHTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1400,9 +1392,9 @@ int DetectHttpHHTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_host; "
-                               "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; content:\"two\"; http_host; " "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1455,9 +1447,9 @@ int DetectHttpHHTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; pcre:/two/; " "content:\"three\"; distance:10; http_host; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1509,9 +1501,9 @@ int DetectHttpHHTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_host; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; pcre:/two/; " "content:\"three\"; distance:10; within:15; http_host; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1563,10 +1555,9 @@ int DetectHttpHHTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; pcre:/two/; " "content:\"three\"; distance:10; http_host; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1619,10 +1610,9 @@ int DetectHttpHHTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_host; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_host; pcre:/two/; " "content:\"three\"; distance:10; http_host; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1676,10 +1666,9 @@ int DetectHttpHHTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_host; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_host; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_host; pcre:/two/; " "content:\"three\"; distance:10; http_host; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1702,10 +1691,9 @@ int DetectHttpHHTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; pcre:/two/; "
-                               "content:\"three\"; http_host; depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; pcre:/two/; " "content:\"three\"; http_host; depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1758,9 +1746,9 @@ int DetectHttpHHTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; distance:0; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; distance:0; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1802,9 +1790,9 @@ int DetectHttpHHTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; "
-                               "content:\"two\"; within:5; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; " "content:\"two\"; within:5; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1846,8 +1834,9 @@ int DetectHttpHHTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1870,8 +1859,9 @@ int DetectHttpHHTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_host; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_host; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list != NULL\n");
         goto end;
@@ -1894,8 +1884,9 @@ int DetectHttpHHTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1918,9 +1909,9 @@ int DetectHttpHHTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/W; "
-                               "content:\"two\"; within:5; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/W; " "content:\"two\"; within:5; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1969,9 +1960,9 @@ int DetectHttpHHTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"two\"; http_host; "
-                               "pcre:/one/WR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"two\"; http_host; " "pcre:/one/WR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2020,9 +2011,9 @@ int DetectHttpHHTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/W; "
-                               "content:\"two\"; distance:5; http_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/W; " "content:\"two\"; distance:5; http_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-http-hrh.c
+++ b/src/detect-http-hrh.c
@@ -144,9 +144,9 @@ static int DetectHttpHRHTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_host\"; "
-                               "content:\"one\"; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_host\"; " "content:\"one\"; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -175,9 +175,9 @@ static int DetectHttpHRHTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_host\"; "
-                               "content:\"one\"; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_host\"; " "content:\"one\"; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -203,9 +203,9 @@ static int DetectHttpHRHTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_host\"; "
-                               "http_raw_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_host\"; " "http_raw_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -231,9 +231,9 @@ static int DetectHttpHRHTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_host\"; "
-                               "content:\"one\"; rawbytes; http_raw_host; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_host\"; " "content:\"one\"; rawbytes; http_raw_host; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -258,9 +258,9 @@ static int DetectHttpHRHTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_host\"; "
-                               "content:\"one\"; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_host\"; " "content:\"one\"; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -320,10 +320,9 @@ static int DetectHttpHRHTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -427,10 +426,9 @@ static int DetectHttpHRHTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -550,10 +548,9 @@ static int DetectHttpHRHTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"message\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"message\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -680,10 +677,9 @@ static int DetectHttpHRHTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"body1This\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"body1This\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -810,10 +806,9 @@ static int DetectHttpHRHTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"bodY1This\"; http_raw_host; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"bodY1This\"; http_raw_host; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -929,10 +924,9 @@ static int DetectHttpHRHTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:!\"message\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1028,10 +1022,9 @@ static int DetectHttpHRHTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:!\"message\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:!\"message\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1128,10 +1121,9 @@ static int DetectHttpHRHTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_raw_host;  "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_raw_host;  " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1396,9 +1388,9 @@ int DetectHttpHRHTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_raw_host;  "
-                               "content:\"three\"; distance:10; http_raw_host;  content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; content:\"two\"; http_raw_host;  " "content:\"three\"; distance:10; http_raw_host;  content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1451,9 +1443,9 @@ int DetectHttpHRHTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  pcre:/two/; "
-                               "content:\"three\"; distance:10; http_raw_host;  content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  pcre:/two/; " "content:\"three\"; distance:10; http_raw_host;  content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1505,9 +1497,9 @@ int DetectHttpHRHTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_raw_host;  content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  pcre:/two/; " "content:\"three\"; distance:10; within:15; http_raw_host;  content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1559,10 +1551,9 @@ int DetectHttpHRHTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  pcre:/two/; "
-                               "content:\"three\"; distance:10; http_raw_host;  "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  pcre:/two/; " "content:\"three\"; distance:10; http_raw_host;  " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1615,10 +1606,9 @@ int DetectHttpHRHTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_raw_host;  pcre:/two/; "
-                               "content:\"three\"; distance:10; http_raw_host;  within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_raw_host;  pcre:/two/; " "content:\"three\"; distance:10; http_raw_host;  within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1672,10 +1662,9 @@ int DetectHttpHRHTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_raw_host;  pcre:/two/; "
-                               "content:\"three\"; distance:10; http_raw_host;  within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_raw_host;  pcre:/two/; " "content:\"three\"; distance:10; http_raw_host;  within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1698,10 +1687,9 @@ int DetectHttpHRHTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host; nocase; pcre:/two/; "
-                               "content:\"three\"; http_raw_host;  depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host; nocase; pcre:/two/; " "content:\"three\"; http_raw_host;  depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1754,9 +1742,9 @@ int DetectHttpHRHTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  "
-                               "content:\"two\"; distance:0; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  " "content:\"two\"; distance:0; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1798,9 +1786,9 @@ int DetectHttpHRHTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  "
-                               "content:\"two\"; within:5; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  " "content:\"two\"; within:5; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1842,8 +1830,9 @@ int DetectHttpHRHTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1866,8 +1855,9 @@ int DetectHttpHRHTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_raw_host;  within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_raw_host;  within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list != NULL\n");
         goto end;
@@ -1890,8 +1880,9 @@ int DetectHttpHRHTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1914,9 +1905,9 @@ int DetectHttpHRHTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/Zi; "
-                               "content:\"two\"; within:5; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/Zi; " "content:\"two\"; within:5; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1965,9 +1956,9 @@ int DetectHttpHRHTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"two\"; http_raw_host;  "
-                               "pcre:/one/ZRi; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"two\"; http_raw_host;  " "pcre:/one/ZRi; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2016,9 +2007,9 @@ int DetectHttpHRHTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/Zi; "
-                               "content:\"two\"; distance:5; http_raw_host;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/Zi; " "content:\"two\"; distance:5; http_raw_host;  sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2117,10 +2108,9 @@ static int DetectHttpHRHTest37(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http host test\"; "
-                               "content:\"body1this\"; http_raw_host; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http host test\"; " "content:\"body1this\"; http_raw_host; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-http-hrh.c
+++ b/src/detect-http-hrh.c
@@ -1224,12 +1224,16 @@ static int DetectHttpHRHTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"Body one\"; http_raw_host;  sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"Body one\"; http_raw_host;  sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"Body two\"; http_raw_host;  sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"Body two\"; http_raw_host;  sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -122,7 +122,7 @@ void DetectHttpMethodFree(void *ptr)
  *  \retval 1 valid
  *  \retval 0 invalid
  */
-int DetectHttpMethodValidateRule(const Signature *s)
+int DetectHttpMethodValidateRule(const Signature *s, char **sigerror)
 {
     if (s->alproto != ALPROTO_HTTP)
         return 1;
@@ -135,16 +135,36 @@ int DetectHttpMethodValidateRule(const Signature *s)
             const DetectContentData *cd = (const DetectContentData *)sm->ctx;
             if (cd->content && cd->content_len) {
                 if (cd->content[cd->content_len-1] == 0x20) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with trailing space");
+                    *sigerror = SCStrdup("http_method pattern with trailing space");
+                    if (*sigerror == NULL) {
+                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                        return 0;
+                    }
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                     return 0;
                 } else if (cd->content[0] == 0x20) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with leading space");
+                    *sigerror = SCStrdup("http_method pattern with leading space");
+                    if (*sigerror == NULL) {
+                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                        return 0;
+                    }
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                     return 0;
                 } else if (cd->content[cd->content_len-1] == 0x09) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with trailing tab");
+                    *sigerror = SCStrdup("http_method pattern with trailing tab");
+                    if (*sigerror == NULL) {
+                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                        return 0;
+                    }
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                     return 0;
                 } else if (cd->content[0] == 0x09) {
-                    SCLogError(SC_ERR_INVALID_SIGNATURE, "http_method pattern with leading tab");
+                    *sigerror = SCStrdup("http_method pattern with leading tab");
+                    if (*sigerror == NULL) {
+                        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+                        return 0;
+                    }
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "%s", *sigerror);
                     return 0;
                 }
             }

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -300,13 +300,11 @@ static int DetectHttpMethodTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if (DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-                               "(content:\"one\"; http_method; nocase; sid:1;)") == NULL) {
+    if (DetectEngineAppendSig(de_ctx, "alert http any any -> any any " "(content:\"one\"; http_method; nocase; sid:1;)", NULL) == NULL) {
         printf("DetectEngineAppend == NULL: ");
         goto end;
     }
-    if (DetectEngineAppendSig(de_ctx, "alert http any any -> any any "
-                               "(content:\"one\"; nocase; http_method; sid:2;)") == NULL) {
+    if (DetectEngineAppendSig(de_ctx, "alert http any any -> any any " "(content:\"one\"; nocase; http_method; sid:2;)", NULL) == NULL) {
         printf("DetectEngineAppend == NULL: ");
         goto end;
     }

--- a/src/detect-http-method.c
+++ b/src/detect-http-method.c
@@ -168,10 +168,8 @@ int DetectHttpMethodTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "content:\"GET\"; "
-                               "http_method; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"GET\"; " "http_method; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -198,9 +196,8 @@ int DetectHttpMethodTest02(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "http_method; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "http_method; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -225,10 +222,8 @@ int DetectHttpMethodTest03(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "content:\"foobar\"; "
-                               "http_method:\"GET\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"foobar\"; " "http_method:\"GET\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -253,11 +248,8 @@ int DetectHttpMethodTest04(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "content:\"GET\"; "
-                               "fast_pattern; "
-                               "http_method; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"GET\"; " "fast_pattern; " "http_method; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -282,11 +274,8 @@ int DetectHttpMethodTest05(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "content:\"GET\"; "
-                               "rawbytes; "
-                               "http_method; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"GET\"; " "rawbytes; " "http_method; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -358,11 +347,8 @@ int DetectHttpMethodTest13(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "pcre:\"/HE/M\"; "
-                               "content:\"AD\"; "
-                               "within:2; http_method; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "pcre:\"/HE/M\"; " "content:\"AD\"; " "within:2; http_method; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -387,11 +373,8 @@ int DetectHttpMethodTest14(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "pcre:\"/HE/\"; "
-                               "content:\"AD\"; "
-                               "http_method; within:2; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "pcre:\"/HE/\"; " "content:\"AD\"; " "http_method; within:2; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -416,11 +399,8 @@ int DetectHttpMethodTest15(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_method\"; "
-                               "pcre:\"/HE/M\"; "
-                               "content:\"AD\"; "
-                               "http_method; within:2; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "pcre:\"/HE/M\"; " "content:\"AD\"; " "http_method; within:2; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -477,19 +457,15 @@ static int DetectHttpMethodSigTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"Testing http_method\"; "
-                                   "content:\"GET\"; "
-                                   "http_method; sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"GET\"; " "http_method; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     s = s->next = SigInit(de_ctx,
-                          "alert tcp any any -> any any "
-                          "(msg:\"Testing http_method\"; "
-                          "content:\"POST\"; "
-                          "http_method; sid:2;)");
+                          "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"POST\"; " "http_method; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -580,19 +556,15 @@ static int DetectHttpMethodSigTest02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"Testing http_method\"; "
-                                   "content:\"FOO\"; "
-                                   "http_method; sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"FOO\"; " "http_method; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     s = s->next = SigInit(de_ctx,
-                          "alert tcp any any -> any any "
-                          "(msg:\"Testing http_method\"; "
-                          "content:\"BAR\"; "
-                          "http_method; sid:2;)");
+                          "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"BAR\"; " "http_method; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -682,10 +654,8 @@ static int DetectHttpMethodSigTest03(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"Testing http_method\"; "
-                                   "content:\"GET\"; "
-                                   "http_method; sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "content:\"GET\"; " "http_method; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         SCLogDebug("Bad signature");
         goto end;
@@ -774,15 +744,15 @@ static int DetectHttpMethodSigTest04(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-            "alert tcp any any -> any any (msg:\"Testing http_method\"; "
-            "content:\"GET\"; http_method; sid:1;)");
+                                   "alert tcp any any -> any any (msg:\"Testing http_method\"; " "content:\"GET\"; http_method; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     s = s->next = SigInit(de_ctx,
-            "alert tcp any any -> any any (msg:\"Testing http_method\"; "
-            "content:!\"GET\"; http_method; sid:2;)");
+                          "alert tcp any any -> any any (msg:\"Testing http_method\"; " "content:!\"GET\"; http_method; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-http-raw-header.c
+++ b/src/detect-http-raw-header.c
@@ -144,9 +144,9 @@ static int DetectHttpRawHeaderTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; flow:to_server; " "content:\"one\"; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -186,9 +186,9 @@ static int DetectHttpRawHeaderTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; flow:to_server; "
-                               "content:\"one\"; http_raw_header:; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; flow:to_server; " "content:\"one\"; http_raw_header:; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
     else
@@ -216,9 +216,9 @@ static int DetectHttpRawHeaderTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; flow:to_server; "
-                               "http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; flow:to_server; " "http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
     else
@@ -246,9 +246,9 @@ static int DetectHttpRawHeaderTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; flow:to_server; "
-                               "content:\"one\"; rawbytes; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; flow:to_server; " "content:\"one\"; rawbytes; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
     else
@@ -276,9 +276,9 @@ static int DetectHttpRawHeaderTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_header\"; flow:to_server; "
-                               "content:\"one\"; nocase; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_header\"; flow:to_server; " "content:\"one\"; nocase; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
     else
@@ -341,10 +341,9 @@ static int DetectHttpRawHeaderTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"Content-Type: text/html\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"Content-Type: text/html\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -450,10 +449,9 @@ static int DetectHttpRawHeaderTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"Mozilla\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"Mozilla\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -577,10 +575,9 @@ static int DetectHttpRawHeaderTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"Gecko/20091221 Firefox/3.5.7\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"Gecko/20091221 Firefox/3.5.7\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -705,10 +702,9 @@ static int DetectHttpRawHeaderTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"Firefox/3.5.7|0D 0A|Content\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"Firefox/3.5.7|0D 0A|Content\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -833,10 +829,9 @@ static int DetectHttpRawHeaderTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"firefox/3.5.7|0D 0A|content\"; nocase; http_raw_header;"
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"firefox/3.5.7|0D 0A|content\"; nocase; http_raw_header;" "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -953,10 +948,9 @@ static int DetectHttpRawHeaderTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"lalalalala\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"lalalalala\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1054,10 +1048,9 @@ static int DetectHttpRawHeaderTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:!\"User-Agent: Mozilla/5.0 \"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:!\"User-Agent: Mozilla/5.0 \"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1156,10 +1149,9 @@ static int DetectHttpRawHeaderTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http header test\"; flow:to_server; "
-                               "content:\"Host: www.openinfosecfoundation.org\"; http_raw_header; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http header test\"; flow:to_server; " "content:\"Host: www.openinfosecfoundation.org\"; http_raw_header; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1218,9 +1210,9 @@ int DetectHttpRawHeaderTest20(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; "
-                               "content:\"two\"; distance:0; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; " "content:\"two\"; distance:0; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1262,9 +1254,9 @@ int DetectHttpRawHeaderTest21(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; "
-                               "content:\"two\"; within:5; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; " "content:\"two\"; within:5; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1306,8 +1298,9 @@ int DetectHttpRawHeaderTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; within:5; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; within:5; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1330,8 +1323,9 @@ int DetectHttpRawHeaderTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; http_raw_header; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; http_raw_header; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1354,8 +1348,9 @@ int DetectHttpRawHeaderTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1378,9 +1373,9 @@ int DetectHttpRawHeaderTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; pcre:/one/D; "
-                               "content:\"two\"; within:5; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; pcre:/one/D; " "content:\"two\"; within:5; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1429,9 +1424,9 @@ int DetectHttpRawHeaderTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; content:\"two\"; http_raw_header; "
-                               "pcre:/one/DR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; content:\"two\"; http_raw_header; " "pcre:/one/DR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1480,9 +1475,9 @@ int DetectHttpRawHeaderTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert http any any -> any any "
-                               "(flow:to_server; pcre:/one/D; "
-                               "content:\"two\"; distance:5; http_raw_header; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(flow:to_server; pcre:/one/D; " "content:\"two\"; distance:5; http_raw_header; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-http-raw-uri.c
+++ b/src/detect-http-raw-uri.c
@@ -116,8 +116,9 @@ int DetectHttpRawUriTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_uri\"; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -140,9 +141,9 @@ int DetectHttpRawUriTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_uri\"; content:\"one\"; "
-                               "http_raw_uri:wrong; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; content:\"one\"; " "http_raw_uri:wrong; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -165,12 +166,9 @@ int DetectHttpRawUriTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_uri\"; "
-                               "content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; http_raw_uri; "
-                               "content:\"three\"; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; " "content:\"one\"; http_raw_uri; " "content:\"two\"; http_raw_uri; " "content:\"three\"; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -212,10 +210,9 @@ int DetectHttpRawUriTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_uri\"; "
-                               "content:\"one\"; rawbytes; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; " "content:\"one\"; rawbytes; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -240,10 +237,9 @@ int DetectHttpRawUriTest05(void)
     if ((de_ctx = DetectEngineCtxInit()) == NULL)
         goto end;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                "(msg:\"Testing http_raw_uri\"; "
-                "content:\"we are testing http_raw_uri keyword\"; http_raw_uri; "
-                "sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; " "content:\"we are testing http_raw_uri keyword\"; http_raw_uri; " "sid:1;)",
+                NULL);
     if (s == NULL) {
         printf("sig failed to parse\n");
         goto end;
@@ -285,9 +281,9 @@ int DetectHttpRawUriTest12(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; distance:0; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; distance:0; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -332,9 +328,9 @@ int DetectHttpRawUriTest13(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; within:5; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; within:5; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -379,8 +375,9 @@ int DetectHttpRawUriTest14(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -403,8 +400,9 @@ int DetectHttpRawUriTest15(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -427,8 +425,9 @@ int DetectHttpRawUriTest16(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -451,9 +450,9 @@ int DetectHttpRawUriTest17(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; distance:0; http_raw_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; distance:0; http_raw_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -498,10 +497,9 @@ int DetectHttpRawUriTest18(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_raw_uri; "
-                               "content:\"two\"; within:5; http_raw_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_raw_uri; " "content:\"two\"; within:5; http_raw_uri; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -154,9 +154,9 @@ static int DetectHttpServerBodyTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_server_body\"; "
-                               "content:\"one\"; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_server_body\"; " "content:\"one\"; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -204,9 +204,9 @@ static int DetectHttpServerBodyTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_server_body\"; "
-                               "content:\"one\"; http_server_body:; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_server_body\"; " "content:\"one\"; http_server_body:; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -232,9 +232,9 @@ static int DetectHttpServerBodyTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_server_body\"; "
-                               "http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_server_body\"; " "http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -260,9 +260,9 @@ static int DetectHttpServerBodyTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_server_body\"; "
-                               "content:\"one\"; rawbytes; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_server_body\"; " "content:\"one\"; rawbytes; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -288,9 +288,9 @@ static int DetectHttpServerBodyTest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_server_body\"; "
-                               "content:\"one\"; http_server_body; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_server_body\"; " "content:\"one\"; http_server_body; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -356,10 +356,9 @@ static int DetectHttpServerBodyTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"message\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"message\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -479,10 +478,9 @@ static int DetectHttpServerBodyTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"message\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"message\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -616,10 +614,9 @@ static int DetectHttpServerBodyTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"message\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"message\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -763,10 +760,9 @@ static int DetectHttpServerBodyTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"message\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"message\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -918,10 +914,9 @@ static int DetectHttpServerBodyTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:\"MeSSaGE\"; http_server_body; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:\"MeSSaGE\"; http_server_body; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1069,10 +1064,9 @@ static int DetectHttpServerBodyTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:!\"MaSSaGE\"; http_server_body; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:!\"MaSSaGE\"; http_server_body; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1212,10 +1206,9 @@ static int DetectHttpServerBodyTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "content:!\"MeSSaGE\"; http_server_body; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "content:!\"MeSSaGE\"; http_server_body; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1343,10 +1336,9 @@ static int DetectHttpServerBodyTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "content:\"longbufferabcdefghijklmnopqrstuvwxyz0123456789bufferend\"; http_server_body; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "content:\"longbufferabcdefghijklmnopqrstuvwxyz0123456789bufferend\"; http_server_body; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1740,9 +1732,9 @@ int DetectHttpServerBodyTest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_server_body; "
-                               "content:\"three\"; distance:10; http_server_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; content:\"two\"; http_server_body; " "content:\"three\"; distance:10; http_server_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1795,9 +1787,9 @@ int DetectHttpServerBodyTest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_server_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; pcre:/two/; " "content:\"three\"; distance:10; http_server_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1849,9 +1841,9 @@ int DetectHttpServerBodyTest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_server_body; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; pcre:/two/; " "content:\"three\"; distance:10; within:15; http_server_body; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1903,10 +1895,9 @@ int DetectHttpServerBodyTest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_server_body; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; pcre:/two/; " "content:\"three\"; distance:10; http_server_body; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1959,10 +1950,9 @@ int DetectHttpServerBodyTest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; offset:10; http_server_body; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_server_body; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; offset:10; http_server_body; pcre:/two/; " "content:\"three\"; distance:10; http_server_body; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2016,10 +2006,9 @@ int DetectHttpServerBodyTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; offset:10; http_server_body; pcre:/two/; distance:10; "
-                               "content:\"three\"; distance:10; http_server_body; depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; offset:10; http_server_body; pcre:/two/; distance:10; " "content:\"three\"; distance:10; http_server_body; depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         printf("de_ctx->sig_list != NULL: ");
         goto end;
@@ -2042,10 +2031,9 @@ int DetectHttpServerBodyTest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; pcre:/two/; "
-                               "content:\"three\"; http_server_body; depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; pcre:/two/; " "content:\"three\"; http_server_body; depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2098,9 +2086,9 @@ int DetectHttpServerBodyTest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; distance:0; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; distance:0; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2142,9 +2130,9 @@ int DetectHttpServerBodyTest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; "
-                               "content:\"two\"; within:5; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; " "content:\"two\"; within:5; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2186,8 +2174,9 @@ int DetectHttpServerBodyTest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2210,8 +2199,9 @@ int DetectHttpServerBodyTest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_server_body; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_server_body; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2234,8 +2224,9 @@ int DetectHttpServerBodyTest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2258,9 +2249,9 @@ int DetectHttpServerBodyTest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/Q; "
-                               "content:\"two\"; within:5; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/Q; " "content:\"two\"; within:5; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2309,9 +2300,9 @@ int DetectHttpServerBodyTest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"two\"; http_server_body; "
-                               "pcre:/one/QR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"two\"; http_server_body; " "pcre:/one/QR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2360,9 +2351,9 @@ int DetectHttpServerBodyTest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(pcre:/one/Q; "
-                               "content:\"two\"; distance:5; http_server_body; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(pcre:/one/Q; " "content:\"two\"; distance:5; http_server_body; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2456,10 +2447,9 @@ static int DetectHttpServerBodyFileDataTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "file_data; content:\"message\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "file_data; content:\"message\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2579,10 +2569,9 @@ static int DetectHttpServerBodyFileDataTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "file_data; content:\"message\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "file_data; content:\"message\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2718,10 +2707,9 @@ static int DetectHttpServerBodyFileDataTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "file_data; content:\"message\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "file_data; content:\"message\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -2866,10 +2854,9 @@ static int DetectHttpServerBodyFileDataTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "file_data; content:\"message\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "file_data; content:\"message\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3021,10 +3008,9 @@ static int DetectHttpServerBodyFileDataTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http client body test\"; "
-                               "file_data; content:\"MeSSaGE\"; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http client body test\"; " "file_data; content:\"MeSSaGE\"; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3172,10 +3158,9 @@ static int DetectHttpServerBodyFileDataTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http file_data test\"; "
-                               "file_data; content:!\"MaSSaGE\"; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http file_data test\"; " "file_data; content:!\"MaSSaGE\"; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3315,10 +3300,9 @@ static int DetectHttpServerBodyFileDataTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http file_data test\"; "
-                               "file_data; content:!\"MeSSaGE\"; nocase; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http file_data test\"; " "file_data; content:!\"MeSSaGE\"; nocase; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -3446,10 +3430,9 @@ static int DetectHttpServerBodyFileDataTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http server body test\"; "
-                               "file_data; content:\"longbufferabcdefghijklmnopqrstuvwxyz0123456789bufferend\"; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http server body test\"; " "file_data; content:\"longbufferabcdefghijklmnopqrstuvwxyz0123456789bufferend\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 

--- a/src/detect-http-server-body.c
+++ b/src/detect-http-server-body.c
@@ -1456,12 +1456,16 @@ static int DetectHttpServerBodyTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; content:\"one\"; http_server_body; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; content:\"one\"; http_server_body; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; content:\"two\"; http_server_body; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; content:\"two\"; http_server_body; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -1624,12 +1628,16 @@ static int DetectHttpServerBodyTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; content:\"one\"; http_server_body; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; content:\"one\"; http_server_body; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; content:\"two\"; http_server_body; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; content:\"two\"; http_server_body; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -3550,12 +3558,16 @@ static int DetectHttpServerBodyFileDataTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"one\"; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"one\"; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"two\"; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"two\"; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -3706,12 +3718,16 @@ static int DetectHttpServerBodyFileDataTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"one\";  sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"one\";  sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"two\"; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (flow:established,to_client; file_data; content:\"two\"; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;

--- a/src/detect-http-stat-code.c
+++ b/src/detect-http-stat-code.c
@@ -126,24 +126,25 @@ int DetectHttpStatCodeTest01(void)
     }
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"Testing http_stat_code\"; http_stat_code; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_code\"; http_stat_code; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         printf("sid 1 parse failed to error out: ");
         goto end;
     }
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"Testing http_stat_code\"; content:\"|FF F1|\";"
-            " rawbytes; http_stat_code; sid:2;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_code\"; content:\"|FF F1|\";" " rawbytes; http_stat_code; sid:2;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         printf("sid 2 parse failed to error out: ");
         goto end;
     }
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-            "(msg:\"Testing http_stat_code\"; content:\"100\";"
-            "fast_pattern; http_stat_code; sid:3;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_code\"; content:\"100\";" "fast_pattern; http_stat_code; sid:3;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sid 3 parse failed: ");
         goto end;
@@ -175,11 +176,9 @@ int DetectHttpStatCodeTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_stat_code\"; content:\"one\"; "
-                               "http_stat_code; content:\"200\"; http_stat_code; "
-                               "content:\"two hundred\"; nocase; http_stat_code; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_code\"; content:\"one\"; " "http_stat_code; content:\"200\"; http_stat_code; " "content:\"two hundred\"; nocase; http_stat_code; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -259,8 +258,9 @@ static int DetectHttpStatCodeSigTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-            "\"HTTP status code\"; content:\"200\"; http_stat_code; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status code\"; content:\"200\"; http_stat_code; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -360,16 +360,16 @@ static int DetectHttpStatCodeSigTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status code\"; content:\"no\"; "
-                                   "http_stat_code; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status code\"; content:\"no\"; " "http_stat_code; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                        "Status code\"; content:\"100\";"
-                        "http_stat_code; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "Status code\"; content:\"100\";" "http_stat_code; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -476,16 +476,16 @@ static int DetectHttpStatCodeSigTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status code\"; content:\"FAIL\"; "
-                                   "http_stat_code; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status code\"; content:\"FAIL\"; " "http_stat_code; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                        "Status code nocase\"; content:\"fail\"; nocase; "
-                        "http_stat_code; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "Status code nocase\"; content:\"fail\"; nocase; " "http_stat_code; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -592,16 +592,16 @@ static int DetectHttpStatCodeSigTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status code\"; content:\"200\"; "
-                                   "http_stat_code; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status code\"; content:\"200\"; " "http_stat_code; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                        "Status code negation\"; content:!\"100\"; nocase; "
-                        "http_stat_code; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "Status code negation\"; content:!\"100\"; nocase; " "http_stat_code; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }

--- a/src/detect-http-stat-msg.c
+++ b/src/detect-http-stat-msg.c
@@ -124,20 +124,21 @@ int DetectHttpStatMsgTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_stat_msg\"; http_stat_msg;sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_msg\"; http_stat_msg;sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_stat_msg\"; content:\"|FF F1|\";"
-                                " rawbytes; http_stat_msg;sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_msg\"; content:\"|FF F1|\";" " rawbytes; http_stat_msg;sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         goto end;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_stat_msg\"; content:\"one\";"
-            "fast_pattern; http_stat_msg; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_msg\"; content:\"one\";" "fast_pattern; http_stat_msg; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     if (!(((DetectContentData *)de_ctx->sig_list->sm_lists[DETECT_SM_LIST_HSMDMATCH]->ctx)->flags &
@@ -167,11 +168,9 @@ int DetectHttpStatMsgTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_stat_msg\"; content:\"one\"; "
-                               "http_stat_msg; content:\"two\"; http_stat_msg; "
-                               "content:\"two\"; nocase; http_stat_msg; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_stat_msg\"; content:\"one\"; " "http_stat_msg; content:\"two\"; http_stat_msg; " "content:\"two\"; nocase; http_stat_msg; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -250,16 +249,16 @@ static int DetectHttpStatMsgSigTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status message\"; content:\"OK\"; "
-                                   "http_stat_msg; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status message\"; content:\"OK\"; " "http_stat_msg; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                      "Status message nocase\"; content:\"ok\"; nocase; "
-                      "http_stat_msg; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "Status message nocase\"; content:\"ok\"; nocase; " "http_stat_msg; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -365,9 +364,9 @@ static int DetectHttpStatMsgSigTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status message\"; content:\"no\"; "
-                                   "http_stat_msg; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status message\"; content:\"no\"; " "http_stat_msg; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -470,16 +469,16 @@ static int DetectHttpStatMsgSigTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP status message\"; content:\"ok\"; "
-                                   "nocase; http_stat_msg; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP status message\"; content:\"ok\"; " "nocase; http_stat_msg; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\"HTTP "
-                        "Status message nocase\"; content:!\"Not\"; "
-                        "http_stat_msg; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"HTTP " "Status message nocase\"; content:!\"Not\"; " "http_stat_msg; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -1225,12 +1225,16 @@ static int DetectHttpUATest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"Body one\"; http_user_agent; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"dummy1\"; http_cookie; content:\"Body one\"; http_user_agent; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"Body two\"; http_user_agent; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"dummy2\"; http_cookie; content:\"Body two\"; http_user_agent; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;

--- a/src/detect-http-ua.c
+++ b/src/detect-http-ua.c
@@ -145,9 +145,9 @@ static int DetectHttpUATest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_user_agent\"; "
-                               "content:\"one\"; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_user_agent\"; " "content:\"one\"; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 1;
     } else {
@@ -176,9 +176,9 @@ static int DetectHttpUATest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_user_agent\"; "
-                               "content:\"one\"; http_user_agent:; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_user_agent\"; " "content:\"one\"; http_user_agent:; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -204,9 +204,9 @@ static int DetectHttpUATest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_user_agent\"; "
-                               "http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_user_agent\"; " "http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -232,9 +232,9 @@ static int DetectHttpUATest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_user_agent\"; "
-                               "content:\"one\"; rawbytes; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_user_agent\"; " "content:\"one\"; rawbytes; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -259,9 +259,9 @@ static int DetectHttpUATest05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_user_agent\"; "
-                               "content:\"one\"; http_user_agent; nocase; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_user_agent\"; " "content:\"one\"; http_user_agent; nocase; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -321,10 +321,9 @@ static int DetectHttpUATest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"message\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"message\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -428,10 +427,9 @@ static int DetectHttpUATest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"message\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"message\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -551,10 +549,9 @@ static int DetectHttpUATest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"message\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"message\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -681,10 +678,9 @@ static int DetectHttpUATest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"body1This\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"body1This\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -811,10 +807,9 @@ static int DetectHttpUATest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"body1this\"; http_user_agent; nocase;"
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"body1this\"; http_user_agent; nocase;" "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -930,10 +925,9 @@ static int DetectHttpUATest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:!\"message\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:!\"message\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1029,10 +1023,9 @@ static int DetectHttpUATest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:!\"message\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:!\"message\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1129,10 +1122,9 @@ static int DetectHttpUATest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
-                               "(msg:\"http user agent test\"; "
-                               "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_user_agent; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert http any any -> any any " "(msg:\"http user agent test\"; " "content:\"abcdefghijklmnopqrstuvwxyz0123456789\"; http_user_agent; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
 
@@ -1404,9 +1396,9 @@ int DetectHttpUATest22(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; content:\"two\"; http_user_agent; "
-                               "content:\"three\"; distance:10; http_user_agent; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; content:\"two\"; http_user_agent; " "content:\"three\"; distance:10; http_user_agent; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1459,9 +1451,9 @@ int DetectHttpUATest23(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_user_agent; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; pcre:/two/; " "content:\"three\"; distance:10; http_user_agent; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1513,9 +1505,9 @@ int DetectHttpUATest24(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; distance:10; within:15; http_user_agent; content:\"four\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; pcre:/two/; " "content:\"three\"; distance:10; within:15; http_user_agent; content:\"four\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1567,10 +1559,9 @@ int DetectHttpUATest25(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_user_agent; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; pcre:/two/; " "content:\"three\"; distance:10; http_user_agent; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1623,10 +1614,9 @@ int DetectHttpUATest26(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_user_agent; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_user_agent; pcre:/two/; " "content:\"three\"; distance:10; http_user_agent; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1680,10 +1670,9 @@ int DetectHttpUATest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; offset:10; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; distance:10; http_user_agent; within:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; offset:10; http_user_agent; pcre:/two/; " "content:\"three\"; distance:10; http_user_agent; within:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1706,10 +1695,9 @@ int DetectHttpUATest28(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; pcre:/two/; "
-                               "content:\"three\"; http_user_agent; depth:10; "
-                               "content:\"four\"; distance:10; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; pcre:/two/; " "content:\"three\"; http_user_agent; depth:10; " "content:\"four\"; distance:10; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1762,9 +1750,9 @@ int DetectHttpUATest29(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; distance:0; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; distance:0; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1806,9 +1794,9 @@ int DetectHttpUATest30(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; "
-                               "content:\"two\"; within:5; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; " "content:\"two\"; within:5; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1850,8 +1838,9 @@ int DetectHttpUATest31(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1874,8 +1863,9 @@ int DetectHttpUATest32(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; http_user_agent; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; http_user_agent; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list != NULL\n");
         goto end;
@@ -1898,8 +1888,9 @@ int DetectHttpUATest33(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1922,9 +1913,9 @@ int DetectHttpUATest34(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/V; "
-                               "content:\"two\"; within:5; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/V; " "content:\"two\"; within:5; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -1973,9 +1964,9 @@ int DetectHttpUATest35(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"two\"; http_user_agent; "
-                               "pcre:/one/VR; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"two\"; http_user_agent; " "pcre:/one/VR; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -2024,9 +2015,9 @@ int DetectHttpUATest36(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(pcre:/one/V; "
-                               "content:\"two\"; distance:5; http_user_agent; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(pcre:/one/V; " "content:\"two\"; distance:5; http_user_agent; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-http-uri.c
+++ b/src/detect-http-uri.c
@@ -118,8 +118,9 @@ int DetectHttpUriTest01(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_uri\"; http_uri;sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_uri\"; http_uri;sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -142,9 +143,9 @@ int DetectHttpUriTest02(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_uri\"; content:\"one\"; "
-                               "http_cookie:wrong; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_uri\"; content:\"one\"; " "http_cookie:wrong; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -167,11 +168,9 @@ int DetectHttpUriTest03(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_uri\"; content:\"one\"; "
-                               "http_uri; content:\"two\"; http_uri; "
-                               "content:\"three\"; http_uri; "
-                               "sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_uri\"; content:\"one\"; " "http_uri; content:\"two\"; http_uri; " "content:\"three\"; http_uri; " "sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
@@ -213,9 +212,9 @@ int DetectHttpUriTest04(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing http_uri\"; content:\"one\"; "
-                               "rawbytes; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing http_uri\"; content:\"one\"; " "rawbytes; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         result = 1;
 
@@ -238,10 +237,9 @@ int DetectHttpUriTest05(void)
     if ((de_ctx = DetectEngineCtxInit()) == NULL)
         goto end;
 
-    s = SigInit(de_ctx, "alert tcp any any -> any any "
-                    "(msg:\"Testing http_uri\"; "
-                    "content:\"we are testing http_uri keyword\"; "
-                    "http_uri; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any " "(msg:\"Testing http_uri\"; " "content:\"we are testing http_uri keyword\"; " "http_uri; sid:1;)",
+                NULL);
     if (s == NULL) {
         printf("sig failed to parse\n");
         goto end;
@@ -278,9 +276,9 @@ int DetectHttpUriTest12(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_uri; "
-                               "content:\"two\"; distance:0; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_uri; " "content:\"two\"; distance:0; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -322,9 +320,9 @@ int DetectHttpUriTest13(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_uri; "
-                               "content:\"two\"; within:5; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_uri; " "content:\"two\"; within:5; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -366,8 +364,9 @@ int DetectHttpUriTest14(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; within:5; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -390,8 +389,9 @@ int DetectHttpUriTest15(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(content:\"one\"; http_uri; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; http_uri; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -425,8 +425,9 @@ int DetectHttpUriTest16(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                                "(content:\"one\"; within:5; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(content:\"one\"; within:5; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -449,9 +450,9 @@ int DetectHttpUriTest17(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; "
-                               "content:\"two\"; distance:0; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; " "content:\"two\"; distance:0; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;
@@ -493,9 +494,9 @@ int DetectHttpUriTest18(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                               "(uricontent:\"one\"; "
-                               "content:\"two\"; within:5; http_uri; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert icmp any any -> any any " "(uricontent:\"one\"; " "content:\"two\"; within:5; http_uri; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL\n");
         goto end;

--- a/src/detect-icmp-id.c
+++ b/src/detect-icmp-id.c
@@ -350,12 +350,16 @@ int DetectIcmpIdMatchTest01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any (icmp_id:21781; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any (icmp_id:21781; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx, "alert icmp any any -> any any (icmp_id:21782; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icmp_id:21782; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -435,7 +439,9 @@ int DetectIcmpIdMatchTest02 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any (icmp_id:0; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any (icmp_id:0; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-icmp-seq.c
+++ b/src/detect-icmp-seq.c
@@ -320,12 +320,16 @@ int DetectIcmpSeqMatchTest01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any (icmp_seq:2216; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any (icmp_seq:2216; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx, "alert icmp any any -> any any (icmp_seq:5000; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icmp_seq:5000; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-icode.c
+++ b/src/detect-icode.c
@@ -425,27 +425,37 @@ int DetectICodeMatchTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert icmp any any -> any any (icode:10; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any (icode:10; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (icode:<15; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icode:<15; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (icode:>20; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icode:>20; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (icode:8<>20; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icode:8<>20; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (icode:20<>8; sid:5;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (icode:20<>8; sid:5;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-ipproto.c
+++ b/src/detect-ipproto.c
@@ -9285,8 +9285,8 @@ static int DetectIPProtoTestSig2(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any (msg:\"Check ipproto usage\"; "
-                               "ip_proto:!103; sid:1;)");
+                               "alert ip any any -> any any (msg:\"Check ipproto usage\"; " "ip_proto:!103; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9370,8 +9370,8 @@ static int DetectIPProtoTestSig3(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any (msg:\"Check ipproto usage\"; "
-                               "ip_proto:103; sid:1;)");
+                               "alert ip any any -> any any (msg:\"Check ipproto usage\"; " "ip_proto:103; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;

--- a/src/detect-iprep.c
+++ b/src/detect-iprep.c
@@ -462,7 +462,9 @@ static int DetectIPRepTest01(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1;rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1;rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -524,7 +526,9 @@ static int DetectIPRepTest02(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:src,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:src,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -586,7 +590,9 @@ static int DetectIPRepTest03(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:dst,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:dst,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -649,7 +655,9 @@ static int DetectIPRepTest04(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:both,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:both,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -711,7 +719,9 @@ static int DetectIPRepTest05(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -773,7 +783,9 @@ static int DetectIPRepTest06(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -835,7 +847,9 @@ static int DetectIPRepTest07(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -898,7 +912,9 @@ static int DetectIPRepTest08(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"IPREP High value badhost\"; iprep:any,BadHosts,>,1; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -961,7 +977,9 @@ static int DetectIPRepTest09(void)
         goto end;
     }
 
-    sig = de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"test\"; iprep:src,BadHosts,>,9; sid:1; rev:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"test\"; iprep:src,BadHosts,>,9; sid:1; rev:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }

--- a/src/detect-isdataat.c
+++ b/src/detect-isdataat.c
@@ -474,12 +474,9 @@ int DetectIsdataatTestParse05(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                               "dce_stub_data; "
-                               "content:\"one\"; distance:0; "
-                               "isdataat:4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "isdataat:4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -497,12 +494,9 @@ int DetectIsdataatTestParse05(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "isdataat:4,relative; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "isdataat:4,relative; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -520,12 +514,9 @@ int DetectIsdataatTestParse05(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "content:\"one\"; distance:0; "
-                      "isdataat:4,relative,rawbytes; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "content:\"one\"; distance:0; " "isdataat:4,relative,rawbytes; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -543,9 +534,9 @@ int DetectIsdataatTestParse05(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "content:\"one\"; isdataat:4,relative,rawbytes; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; isdataat:4,relative,rawbytes; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -576,10 +567,9 @@ int DetectIsdataatTestParse06(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -620,10 +610,9 @@ int DetectIsdataatTestParse07(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "uricontent:\"one\"; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "uricontent:\"one\"; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -664,10 +653,9 @@ int DetectIsdataatTestParse08(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; http_uri; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; http_uri; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -708,10 +696,9 @@ int DetectIsdataatTestParse09(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; http_client_body; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; http_client_body; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -752,10 +739,9 @@ int DetectIsdataatTestParse10(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; http_header; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; http_header; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -796,10 +782,9 @@ int DetectIsdataatTestParse11(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "flow:to_server; content:\"one\"; http_raw_header; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "flow:to_server; content:\"one\"; http_raw_header; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -840,10 +825,9 @@ int DetectIsdataatTestParse12(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; http_method; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; http_method; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -884,10 +868,9 @@ int DetectIsdataatTestParse13(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "content:\"one\"; http_cookie; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; http_cookie; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -928,10 +911,9 @@ static int DetectIsdataatTestParse14(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing file_data and isdataat\"; "
-                               "file_data; content:\"one\"; "
-                               "isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing file_data and isdataat\"; " "file_data; content:\"one\"; " "isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -978,9 +960,9 @@ static int DetectIsdataatTestParse15(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing file_data and isdataat\"; "
-                               "file_data; isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing file_data and isdataat\"; " "file_data; isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse: ");
         goto end;
@@ -1028,9 +1010,9 @@ static int DetectIsdataatTestParse16(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing dns_query and isdataat\"; "
-                               "dns_query; isdataat:!4,relative; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing dns_query and isdataat\"; " "dns_query; isdataat:!4,relative; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse: ");
         goto end;

--- a/src/detect-itype.c
+++ b/src/detect-itype.c
@@ -425,27 +425,37 @@ int DetectITypeMatchTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert icmp any any -> any any (itype:10; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any (itype:10; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:<15; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (itype:<15; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:>20; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (itype:>20; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:8<>20; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (itype:8<>20; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert icmp any any -> any any (itype:20<>8; sid:5;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert icmp any any -> any any (itype:20<>8; sid:5;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-l3proto.c
+++ b/src/detect-l3proto.c
@@ -154,22 +154,30 @@ static int DetectL3protoTestSig1(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv4\"; l3_proto:ipv4; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"l3proto ipv4\"; l3_proto:ipv4; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv6\"; l3_proto:ipv6; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ipv6\"; l3_proto:ipv6; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ip4\"; l3_proto:ip4; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ip4\"; l3_proto:ip4; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ip6\"; l3_proto:ip6; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ip6\"; l3_proto:ip6; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -238,22 +246,30 @@ static int DetectL3protoTestSig2(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv4\"; l3_proto:ipv4; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"l3proto ipv4\"; l3_proto:ipv4; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv6\"; l3_proto:ipv6; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ipv6\"; l3_proto:ipv6; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ip4\"; l3_proto:ip4; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ip4\"; l3_proto:ip4; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ip6\"; l3_proto:ip6; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ip6\"; l3_proto:ip6; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -321,22 +337,30 @@ static int DetectL3protoTestSig3(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv4 and ip_proto udp\"; l3_proto:ipv4; ip_proto:17; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"l3proto ipv4 and ip_proto udp\"; l3_proto:ipv4; ip_proto:17; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv6 and ip_proto udp\"; l3_proto:ipv6; ip_proto:17; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ipv6 and ip_proto udp\"; l3_proto:ipv6; ip_proto:17; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ip4 and ip_proto tcp\"; l3_proto:ipv4; ip_proto:6; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ip4 and ip_proto tcp\"; l3_proto:ipv4; ip_proto:6; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"l3proto ipv6 and ip_proto tcp\"; l3_proto:ipv6; ip_proto:6; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"l3proto ipv6 and ip_proto tcp\"; l3_proto:ipv6; ip_proto:6; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-lua.c
+++ b/src/detect-lua.c
@@ -1275,7 +1275,7 @@ static int LuaMatchTest01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1437,7 +1437,7 @@ static int LuaMatchTest02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1573,7 +1573,7 @@ static int LuaMatchTest03(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1709,7 +1709,7 @@ static int LuaMatchTest04(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1857,7 +1857,7 @@ static int LuaMatchTest05(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2010,7 +2010,7 @@ static int LuaMatchTest06(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, sig);
+    s = DetectEngineAppendSig(de_ctx, sig, NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -434,9 +434,9 @@ static int DetectModbusTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus function\"; "
-                                       "modbus: function 1;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus function\"; " "modbus: function 1;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -478,9 +478,9 @@ static int DetectModbusTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus function and subfunction\"; "
-                                       "modbus: function 8, subfunction 4;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus function and subfunction\"; " "modbus: function 8, subfunction 4;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -523,9 +523,9 @@ static int DetectModbusTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.function\"; "
-                                       "modbus: function reserved;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.function\"; " "modbus: function reserved;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -569,9 +569,9 @@ static int DetectModbusTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus function\"; "
-                                       "modbus: function !assigned;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus function\"; " "modbus: function !assigned;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -613,9 +613,9 @@ static int DetectModbusTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.access\"; "
-                                       "modbus: access read;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.access\"; " "modbus: access read;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -659,9 +659,9 @@ static int DetectModbusTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.access\"; "
-                                       "modbus: access read discretes;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.access\"; " "modbus: access read discretes;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -705,9 +705,9 @@ static int DetectModbusTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.access\"; "
-                                       "modbus: access read, address 1000;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.access\"; " "modbus: access read, address 1000;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -755,9 +755,9 @@ static int DetectModbusTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.access\"; "
-                                       "modbus: access write coils, address >500;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.access\"; " "modbus: access write coils, address >500;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;
@@ -806,9 +806,9 @@ static int DetectModbusTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert modbus any any -> any any "
-                                       "(msg:\"Testing modbus.access\"; "
-                                       "modbus: access write holding, address 100, value 500<>1000;  sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert modbus any any -> any any " "(msg:\"Testing modbus.access\"; " "modbus: access write holding, address 100, value 500<>1000;  sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL)
         goto end;

--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -153,7 +153,9 @@ static int DetectMsgParseTest01(void)
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (msg:\"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)",
+                  NULL);
     if(sig == NULL)
         goto end;
 
@@ -180,7 +182,9 @@ static int DetectMsgParseTest02(void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"msg escape tests \\w\\x\\y\\'\\\"\\\\;\\:\"; flow:to_server,established; content:\"blah\"; uricontent:\"/blah/\"; sid: 100;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (msg:\"msg escape tests \\w\\x\\y\\'\\\"\\\\;\\:\"; flow:to_server,established; content:\"blah\"; uricontent:\"/blah/\"; sid: 100;)",
+                  NULL);
     if(sig == NULL)
         goto end;
 
@@ -210,7 +214,8 @@ static int DetectMsgParseTest03(void)
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg: \"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)");
+    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg: \"flow stateless to_server\"; flow:stateless,to_server; content:\"flowstatelesscheck\"; classtype:bad-unknown; sid: 40000002; rev: 1;)",
+                  NULL);
     if(sig == NULL)
         goto end;
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1629,7 +1629,7 @@ error:
  *
  * \retval Pointer to the Signature instance on success; NULL on failure.
  */
-Signature *SigInit(DetectEngineCtx *de_ctx, char *sigstr)
+Signature *SigInit(DetectEngineCtx *de_ctx, char *sigstr, char *sigerror)
 {
     SCEnter();
 
@@ -1904,7 +1904,7 @@ end:
  */
 Signature *DetectEngineAppendSig(DetectEngineCtx *de_ctx, char *sigstr)
 {
-    Signature *sig = SigInit(de_ctx, sigstr);
+    Signature *sig = SigInit(de_ctx, sigstr, NULL);
     if (sig == NULL) {
         return NULL;
     }
@@ -2070,7 +2070,9 @@ int SigParseTest01 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1;)",
+                  NULL);
     if (sig == NULL)
         result = 0;
 
@@ -2094,7 +2096,9 @@ int SigParseTest02 (void)
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    sig = SigInit(de_ctx, "alert tcp any !21:902 -> any any (msg:\"ET MALWARE Suspicious 220 Banner on Local Port\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:2003055; rev:4;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any !21:902 -> any any (msg:\"ET MALWARE Suspicious 220 Banner on Local Port\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:2003055; rev:4;)",
+                  NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2128,7 +2132,9 @@ int SigParseTest03 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp 1.2.3.4 any <- !1.2.3.4 any (msg:\"SigParseTest03\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp 1.2.3.4 any <- !1.2.3.4 any (msg:\"SigParseTest03\"; sid:1;)",
+                  NULL);
     if (sig != NULL) {
         result = 0;
         printf("expected NULL got sig ptr %p: ",sig);
@@ -2149,7 +2155,9 @@ int SigParseTest04 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp 1.2.3.4 1024: -> !1.2.3.4 1024: (msg:\"SigParseTest04\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp 1.2.3.4 1024: -> !1.2.3.4 1024: (msg:\"SigParseTest04\"; sid:1;)",
+                  NULL);
     if (sig == NULL)
         result = 0;
 
@@ -2169,7 +2177,9 @@ int SigParseTest05 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp 1.2.3.4 1024:65536 -> !1.2.3.4 any (msg:\"SigParseTest05\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp 1.2.3.4 1024:65536 -> !1.2.3.4 any (msg:\"SigParseTest05\"; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         result = 1;
     } else {
@@ -2192,7 +2202,9 @@ int SigParseTest06 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (flow:to_server; content:\"GET\"; nocase; http_method; uricontent:\"/uri/\"; nocase; content:\"Host|3A| abc\"; nocase; sid:1; rev:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (flow:to_server; content:\"GET\"; nocase; http_method; uricontent:\"/uri/\"; nocase; content:\"Host|3A| abc\"; nocase; sid:1; rev:1;)",
+                  NULL);
     if (sig != NULL) {
         result = 1;
     } else {
@@ -3210,7 +3222,9 @@ static int SigParseTestNegation01 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp !any any -> any any (msg:\"SigTest41-01 src address is !any \"; classtype:misc-activity; sid:410001; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp !any any -> any any (msg:\"SigTest41-01 src address is !any \"; classtype:misc-activity; sid:410001; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3236,7 +3250,9 @@ static int SigParseTestNegation02 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any !any -> any any (msg:\"SigTest41-02 src ip is !any \"; classtype:misc-activity; sid:410002; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any !any -> any any (msg:\"SigTest41-02 src ip is !any \"; classtype:misc-activity; sid:410002; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3262,7 +3278,9 @@ static int SigParseTestNegation03 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> any [80:!80] (msg:\"SigTest41-03 dst port [80:!80] \"; classtype:misc-activity; sid:410003; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any [80:!80] (msg:\"SigTest41-03 dst port [80:!80] \"; classtype:misc-activity; sid:410003; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3288,7 +3306,9 @@ static int SigParseTestNegation04 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> any [80,!80] (msg:\"SigTest41-03 dst port [80:!80] \"; classtype:misc-activity; sid:410003; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any [80,!80] (msg:\"SigTest41-03 dst port [80:!80] \"; classtype:misc-activity; sid:410003; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3314,7 +3334,9 @@ static int SigParseTestNegation05 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> [192.168.0.2,!192.168.0.2] any (msg:\"SigTest41-04 dst ip [192.168.0.2,!192.168.0.2] \"; classtype:misc-activity; sid:410004; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> [192.168.0.2,!192.168.0.2] any (msg:\"SigTest41-04 dst ip [192.168.0.2,!192.168.0.2] \"; classtype:misc-activity; sid:410004; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3340,7 +3362,9 @@ static int SigParseTestNegation06 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> any [100:1000,!1:20000] (msg:\"SigTest41-05 dst port [100:1000,!1:20000] \"; classtype:misc-activity; sid:410005; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any [100:1000,!1:20000] (msg:\"SigTest41-05 dst port [100:1000,!1:20000] \"; classtype:misc-activity; sid:410005; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3367,7 +3391,9 @@ static int SigParseTestNegation07 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> [192.168.0.2,!192.168.0.0/24] any (msg:\"SigTest41-06 dst ip [192.168.0.2,!192.168.0.0/24] \"; classtype:misc-activity; sid:410006; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> [192.168.0.2,!192.168.0.0/24] any (msg:\"SigTest41-06 dst ip [192.168.0.2,!192.168.0.0/24] \"; classtype:misc-activity; sid:410006; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;
@@ -3394,7 +3420,9 @@ static int SigParseTestNegation08 (void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tcp any any -> [192.168.0.0/16,!192.168.0.0/24] any (sid:410006; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> [192.168.0.0/16,!192.168.0.0/24] any (sid:410006; rev:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     }
@@ -3418,7 +3446,9 @@ int SigParseTestMpm01 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"mpm test\"; content:\"abcd\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (msg:\"mpm test\"; content:\"abcd\"; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         printf("sig failed to init: ");
         goto end;
@@ -3449,7 +3479,9 @@ int SigParseTestMpm02 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"mpm test\"; content:\"abcd\"; content:\"abcdef\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any (msg:\"mpm test\"; content:\"abcd\"; content:\"abcdef\"; sid:1;)",
+                  NULL);
     if (sig == NULL) {
         printf("sig failed to init: ");
         goto end;
@@ -3482,7 +3514,9 @@ static int SigParseTestAppLayerTLS01(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS01 \"; sid:410006; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS01 \"; sid:410006; rev:1;)",
+                NULL);
     if (s == NULL) {
         printf("parsing sig failed: ");
         goto end;
@@ -3517,7 +3551,9 @@ static int SigParseTestAppLayerTLS02(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS02 \"; tls.version:1.0; sid:410006; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS02 \"; tls.version:1.0; sid:410006; rev:1;)",
+                NULL);
     if (s == NULL) {
         printf("parsing sig failed: ");
         goto end;
@@ -3551,7 +3587,9 @@ static int SigParseTestAppLayerTLS03(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx,"alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS03 \"; tls.version:2.5; sid:410006; rev:1;)");
+    s = SigInit(de_ctx,
+                "alert tls any any -> any any (msg:\"SigParseTestAppLayerTLS03 \"; tls.version:2.5; sid:410006; rev:1;)",
+                NULL);
     if (s != NULL) {
         SigFree(s);
         goto end;

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1902,7 +1902,7 @@ end:
  * \retval Pointer to the head Signature in the detection engine ctx sig_list
  *         on success; NULL on failure.
  */
-Signature *DetectEngineAppendSig(DetectEngineCtx *de_ctx, char *sigstr)
+Signature *DetectEngineAppendSig(DetectEngineCtx *de_ctx, char *sigstr, char *sigerror)
 {
     Signature *sig = SigInit(de_ctx, sigstr, NULL);
     if (sig == NULL) {
@@ -2230,8 +2230,12 @@ int SigParseTest07(void)
     if (de_ctx == NULL)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)",
+                          NULL);
 
     result = (de_ctx->sig_list != NULL && de_ctx->sig_list->next == NULL);
 
@@ -2252,8 +2256,12 @@ int SigParseTest08(void)
     if (de_ctx == NULL)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:2;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:2;)",
+                          NULL);
 
     result = (de_ctx->sig_list != NULL && de_ctx->sig_list->next == NULL &&
               de_ctx->sig_list->rev == 2);
@@ -2275,11 +2283,21 @@ int SigParseTest09(void)
     if (de_ctx == NULL)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:2;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:6;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:4;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:2;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:2;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:6;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:4;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:2;)",
+                          NULL);
     result &= (de_ctx->sig_list != NULL && de_ctx->sig_list->id == 2 &&
                de_ctx->sig_list->rev == 2);
     if (result == 0)
@@ -2289,7 +2307,9 @@ int SigParseTest09(void)
     if (result == 0)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:1;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:1;)",
+                          NULL);
     result &= (de_ctx->sig_list != NULL && de_ctx->sig_list->id == 2 &&
                de_ctx->sig_list->rev == 2);
     if (result == 0)
@@ -2299,7 +2319,9 @@ int SigParseTest09(void)
     if (result == 0)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:4;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:4;)",
+                          NULL);
     result &= (de_ctx->sig_list != NULL && de_ctx->sig_list->id == 2 &&
                de_ctx->sig_list->rev == 4);
     if (result == 0)
@@ -2326,13 +2348,27 @@ int SigParseTest10(void)
     if (de_ctx == NULL)
         goto end;
 
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:3; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:4; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:5; rev:1;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:3; rev:2;)");
-    DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:2;)");
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:1; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:3; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:4; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:5; rev:1;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:3; rev:2;)",
+                          NULL);
+    DetectEngineAppendSig(de_ctx,
+                          "alert tcp any any -> any any (msg:\"boo\"; sid:2; rev:2;)",
+                          NULL);
 
     result &= ((de_ctx->sig_list->id == 2) &&
                (de_ctx->sig_list->next->id == 3) &&
@@ -2360,13 +2396,17 @@ int SigParseTest11(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\";) ");
+    s = DetectEngineAppendSig(de_ctx,
+                              "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\";) ",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 didn't parse: ");
         goto end;
     }
 
-    s = DetectEngineAppendSig(de_ctx, "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\"; sid:1;)            ");
+    s = DetectEngineAppendSig(de_ctx,
+                              "drop tcp any any -> any 80 (msg:\"Snort_Inline is blocking the http link\"; sid:1;)            ",
+                              NULL);
     if (s == NULL) {
         printf("sig 2 didn't parse: ");
         goto end;
@@ -2392,7 +2432,9 @@ static int SigParseTest12(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (file_data; content:\"abc\"; rawbytes; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (file_data; content:\"abc\"; rawbytes; sid:1;)",
+                              NULL);
     if (s != NULL) {
         printf("sig 1 should have given an error: ");
         goto end;
@@ -2418,7 +2460,9 @@ static int SigParseTest13(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"abc\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"abc\"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 invalidated: failure");
         goto end;
@@ -2455,7 +2499,9 @@ static int SigParseTest14(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"abc\"; dsize:>0; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"abc\"; dsize:>0; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 invalidated: failure");
         goto end;
@@ -2492,7 +2538,9 @@ static int SigParseTest15(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"abc\"; offset:5; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"abc\"; offset:5; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 invalidated: failure");
         goto end;
@@ -2529,7 +2577,9 @@ static int SigParseTest16(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"abc\"; depth:5; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"abc\"; depth:5; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 invalidated: failure");
         goto end;
@@ -2566,7 +2616,9 @@ static int SigParseTest17(void)
 
     Signature *s = NULL;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"abc\"; offset:1; depth:5; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"abc\"; offset:1; depth:5; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig 1 invalidated: failure");
         goto end;
@@ -2599,7 +2651,7 @@ static int SigParseTest18 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:99999999999999999999;)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:99999999999999999999;)", NULL) != NULL)
         goto end;
 
     result = 1;
@@ -2618,7 +2670,7 @@ static int SigParseTest19 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1; gid:99999999999999999999;)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1; gid:99999999999999999999;)", NULL) != NULL)
         goto end;
 
     result = 1;
@@ -2637,7 +2689,7 @@ static int SigParseTest20 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1; rev:99999999999999999999;)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> !1.2.3.4 any (msg:\"SigParseTest01\"; sid:1; rev:99999999999999999999;)", NULL) != NULL)
         goto end;
 
     result = 1;
@@ -2656,7 +2708,7 @@ static int SigParseTest21 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp [1.2.3.4, 1.2.3.5] any -> !1.2.3.4 any (sid:1;)") == NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp [1.2.3.4, 1.2.3.5] any -> !1.2.3.4 any (sid:1;)", NULL) == NULL)
         goto end;
 
     result = 1;
@@ -2675,7 +2727,7 @@ static int SigParseTest22 (void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx, "alert tcp [10.10.10.0/24, !10.10.10.247] any -> [10.10.10.0/24, !10.10.10.247] any (sid:1;)") == NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp [10.10.10.0/24, !10.10.10.247] any -> [10.10.10.0/24, !10.10.10.247] any (sid:1;)", NULL) == NULL)
         goto end;
 
     result = 1;
@@ -2695,7 +2747,9 @@ int SigParseBidirecTest06 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any - 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any - 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2715,7 +2769,9 @@ int SigParseBidirecTest07 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any <- 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any <- 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2735,7 +2791,9 @@ int SigParseBidirecTest08 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any < 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any < 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2755,7 +2813,9 @@ int SigParseBidirecTest09 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any > 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any > 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2775,7 +2835,9 @@ int SigParseBidirecTest10 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any -< 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any -< 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2795,7 +2857,9 @@ int SigParseBidirecTest11 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any >- 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any >- 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2815,7 +2879,9 @@ int SigParseBidirecTest12 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any >< 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any >< 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         result = 1;
 
@@ -2835,7 +2901,9 @@ int SigParseBidirecTest13 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any <> 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any <> 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig != NULL)
         result = 1;
 
@@ -2854,7 +2922,9 @@ int SigParseBidirecTest14 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any -> 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any -> 192.168.1.5 any (msg:\"SigParseBidirecTest05\"; sid:1;)",
+                                NULL);
     if (sig != NULL)
         result = 1;
 
@@ -2875,7 +2945,9 @@ int SigTestBidirec01 (void)
     if (de_ctx == NULL)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 1024:65535 -> !1.2.3.4 any (msg:\"SigTestBidirec01\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 1.2.3.4 1024:65535 -> !1.2.3.4 any (msg:\"SigTestBidirec01\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         goto end;
     if (sig->next != NULL)
@@ -2909,7 +2981,9 @@ int SigTestBidirec02 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 1024:65535 <> !1.2.3.4 any (msg:\"SigTestBidirec02\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 1.2.3.4 1024:65535 <> !1.2.3.4 any (msg:\"SigTestBidirec02\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         goto end;
     if (de_ctx->sig_list != sig)
@@ -3075,10 +3149,14 @@ int SigTestBidirec04 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any -> any any (msg:\"SigTestBidirec03 sid 1\"; sid:1;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any -> any any (msg:\"SigTestBidirec03 sid 1\"; sid:1;)",
+                                NULL);
     if (sig == NULL)
         goto end;
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any <> any any (msg:\"SigTestBidirec03 sid 2 bidirectional\"; sid:2;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any <> any any (msg:\"SigTestBidirec03 sid 2 bidirectional\"; sid:2;)",
+                                NULL);
     if (sig == NULL)
         goto end;
     if ( !(sig->init_flags & SIG_FLAG_INIT_BIDIREC))
@@ -3092,7 +3170,9 @@ int SigTestBidirec04 (void)
     if (de_ctx->signum != 3)
         goto end;
 
-    sig = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.1.1 any -> any any (msg:\"SigTestBidirec03 sid 3\"; sid:3;)");
+    sig = DetectEngineAppendSig(de_ctx,
+                                "alert tcp 192.168.1.1 any -> any any (msg:\"SigTestBidirec03 sid 3\"; sid:3;)",
+                                NULL);
     if (sig == NULL)
         goto end;
     if (sig->next == NULL)

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -51,7 +51,7 @@ void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
                                          SigMatch **, SigMatch **);
 void SigParsePrepare(void);
 void SigParseRegisterTests(void);
-Signature *DetectEngineAppendSig(DetectEngineCtx *, char *);
+Signature *DetectEngineAppendSig(DetectEngineCtx *, char *, char *);
 
 void SigMatchAppendSMToList(Signature *, SigMatch *, int);
 void SigMatchRemoveSMFromList(Signature *, SigMatch *, int);

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -43,7 +43,7 @@ enum {
 int SigParse(DetectEngineCtx *,Signature *, char *, uint8_t);
 Signature *SigAlloc(void);
 void SigFree(Signature *s);
-Signature *SigInit(DetectEngineCtx *,char *sigstr);
+Signature *SigInit(DetectEngineCtx *,char *sigstr, char *sigerror);
 Signature *SigInitReal(DetectEngineCtx *, char *);
 SigMatch *SigMatchGetLastSMFromLists(Signature *, int, ...);
 void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,

--- a/src/detect-parse.h
+++ b/src/detect-parse.h
@@ -43,7 +43,7 @@ enum {
 int SigParse(DetectEngineCtx *,Signature *, char *, uint8_t);
 Signature *SigAlloc(void);
 void SigFree(Signature *s);
-Signature *SigInit(DetectEngineCtx *,char *sigstr, char *sigerror);
+Signature *SigInit(DetectEngineCtx *,char *sigstr, char **sigerror);
 Signature *SigInitReal(DetectEngineCtx *, char *);
 SigMatch *SigMatchGetLastSMFromLists(Signature *, int, ...);
 void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
@@ -51,7 +51,7 @@ void SigMatchTransferSigMatchAcrossLists(SigMatch *sm,
                                          SigMatch **, SigMatch **);
 void SigParsePrepare(void);
 void SigParseRegisterTests(void);
-Signature *DetectEngineAppendSig(DetectEngineCtx *, char *, char *);
+Signature *DetectEngineAppendSig(DetectEngineCtx *, char *, char **);
 
 void SigMatchAppendSMToList(Signature *, SigMatch *, int);
 void SigMatchRemoveSMFromList(Signature *, SigMatch *, int);

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -1058,11 +1058,9 @@ int DetectPcreParseTest11(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Testing bytejump_body\"; "
-                               "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                               "dce_stub_data; "
-                               "pcre:/bamboo/R; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "pcre:/bamboo/R; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1080,11 +1078,9 @@ int DetectPcreParseTest11(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "pcre:/bamboo/R; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "pcre:/bamboo/R; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1102,11 +1098,9 @@ int DetectPcreParseTest11(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; "
-                      "dce_stub_data; "
-                      "pcre:/bamboo/RB; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "dce_iface:3919286a-b10c-11d0-9ba8-00c04fd92ef5; " "dce_stub_data; " "pcre:/bamboo/RB; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1124,9 +1118,9 @@ int DetectPcreParseTest11(void)
         goto end;
     }
 
-    s->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                      "(msg:\"Testing bytejump_body\"; "
-                      "content:\"one\"; pcre:/bamboo/; sid:1;)");
+    s->next = SigInit(de_ctx,
+                      "alert tcp any any -> any any " "(msg:\"Testing bytejump_body\"; " "content:\"one\"; pcre:/bamboo/; sid:1;)",
+                      NULL);
     if (s->next == NULL) {
         result = 0;
         goto end;
@@ -1161,8 +1155,9 @@ static int DetectPcreParseTest12(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; pcre:/abc/R; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(file_data; pcre:/abc/R; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1210,8 +1205,9 @@ static int DetectPcreParseTest13(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; content:\"abc\"; pcre:/def/R; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(file_data; content:\"abc\"; pcre:/def/R; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1259,8 +1255,9 @@ static int DetectPcreParseTest14(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; pcre:/def/; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(file_data; pcre:/def/; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -1304,10 +1301,8 @@ int DetectPcreParseTest15(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative http_method\"; "
-                               "content:\"GET\"; "
-                               "http_method; pcre:\"/abc/RM\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative http_method\"; " "content:\"GET\"; " "http_method; pcre:\"/abc/RM\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1335,10 +1330,8 @@ int DetectPcreParseTest16(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative http_cookie\"; "
-                               "content:\"test\"; "
-                               "http_cookie; pcre:\"/abc/RC\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative http_cookie\"; " "content:\"test\"; " "http_cookie; pcre:\"/abc/RC\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1365,10 +1358,8 @@ int DetectPcreParseTest17(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative http_raw_header\"; "
-                               "flow:to_server; content:\"test\"; "
-                               "http_raw_header; pcre:\"/abc/RD\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative http_raw_header\"; " "flow:to_server; content:\"test\"; " "http_raw_header; pcre:\"/abc/RD\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1395,10 +1386,8 @@ int DetectPcreParseTest18(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative http_header\"; "
-                               "content:\"test\"; "
-                               "http_header; pcre:\"/abc/RH\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative http_header\"; " "content:\"test\"; " "http_header; pcre:\"/abc/RH\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1425,10 +1414,8 @@ int DetectPcreParseTest19(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relativie http_client_body\"; "
-                               "content:\"test\"; "
-                               "http_client_body; pcre:\"/abc/RP\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relativie http_client_body\"; " "content:\"test\"; " "http_client_body; pcre:\"/abc/RP\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1455,10 +1442,8 @@ int DetectPcreParseTest20(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing http_raw_uri\"; "
-                               "content:\"test\"; "
-                               "http_raw_uri; pcre:\"/abc/RI\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing http_raw_uri\"; " "content:\"test\"; " "http_raw_uri; pcre:\"/abc/RI\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1485,10 +1470,8 @@ int DetectPcreParseTest21(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative uricontent\"; "
-                               "uricontent:\"test\"; "
-                               "pcre:\"/abc/RU\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative uricontent\"; " "uricontent:\"test\"; " "pcre:\"/abc/RU\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1515,10 +1498,8 @@ int DetectPcreParseTest22(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing pcre relative http_uri\"; "
-                               "content:\"test\"; "
-                               "http_uri; pcre:\"/abc/RU\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing pcre relative http_uri\"; " "content:\"test\"; " "http_uri; pcre:\"/abc/RU\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list != NULL) {
         result = 1;
@@ -1545,10 +1526,8 @@ int DetectPcreParseTest23(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing inconsistent pcre relative\"; "
-                               "content:\"GET\"; "
-                               "http_cookie; pcre:\"/abc/RM\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing inconsistent pcre relative\"; " "content:\"GET\"; " "http_cookie; pcre:\"/abc/RM\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -1575,9 +1554,8 @@ int DetectPcreParseTest24(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing inconsistent pcre modifiers\"; "
-                               "pcre:\"/abc/UI\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing inconsistent pcre modifiers\"; " "pcre:\"/abc/UI\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -1604,9 +1582,8 @@ int DetectPcreParseTest25(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"Testing inconsistent pcre modifiers\"; "
-                               "pcre:\"/abc/DH\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing inconsistent pcre modifiers\"; " "pcre:\"/abc/DH\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -1633,9 +1610,8 @@ static int DetectPcreParseTest26(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert http any any -> any any "
-                               "(msg:\"Testing inconsistent pcre modifiers\"; "
-                               "pcre:\"/abc/F\"; sid:1;)");
+                               "alert http any any -> any any " "(msg:\"Testing inconsistent pcre modifiers\"; " "pcre:\"/abc/F\"; sid:1;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -1661,9 +1637,9 @@ static int DetectPcreParseTest27(void)
         goto end;
 
     de_ctx->flags |= DE_QUIET;
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any 80 "
-            "(content:\"baduricontent\"; http_raw_uri; "
-            "pcre:\"/^[a-z]{5}\\.html/R\"; sid:2; rev:2;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any 80 " "(content:\"baduricontent\"; http_raw_uri; " "pcre:\"/^[a-z]{5}\\.html/R\"; sid:2; rev:2;)",
+                               NULL);
 
     if (de_ctx->sig_list == NULL) {
         result = 1;
@@ -1722,7 +1698,9 @@ static int DetectPcreTestSig01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; pcre:\"/^gEt/i\"; pcre:\"/\\/two\\//U; pcre:\"/GET \\/two\\//\"; pcre:\"/\\s+HTTP/R\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; pcre:\"/^gEt/i\"; pcre:\"/\\/two\\//U; pcre:\"/GET \\/two\\//\"; pcre:\"/\\s+HTTP/R\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1797,7 +1775,9 @@ static int DetectPcreTestSig02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; pcre:\"/two/O\"; sid:2;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; pcre:\"/two/O\"; sid:2;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1852,7 +1832,9 @@ static int DetectPcreTestSig03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"GET\"; pcre:!\"/two/\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"GET\"; pcre:!\"/two/\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1943,15 +1925,16 @@ static int DetectPcreModifPTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"Pcre modifier P\"; pcre:\"/DOCTYPE/P\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"Pcre modifier P\"; pcre:\"/DOCTYPE/P\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\""
-                          "Pcre modifier P (no match)\"; pcre:\"/blah/P\"; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"" "Pcre modifier P (no match)\"; pcre:\"/blah/P\"; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -2078,15 +2061,16 @@ static int DetectPcreModifPTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"Pcre modifier P\"; pcre:\"/DOC/P\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"Pcre modifier P\"; pcre:\"/DOC/P\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s->next = SigInit(de_ctx,"alert http any any -> any any (msg:\""
-                          "Pcre modifier P (no match)\"; pcre:\"/DOCTYPE/P\"; sid:2;)");
+    s->next = SigInit(de_ctx,
+                      "alert http any any -> any any (msg:\"" "Pcre modifier P (no match)\"; pcre:\"/DOCTYPE/P\"; sid:2;)",
+                      NULL);
     if (s->next == NULL) {
         goto end;
     }
@@ -2272,9 +2256,9 @@ static int DetectPcreTestSig09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; pcre:\"/dummy/C\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; pcre:\"/dummy/C\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2368,9 +2352,9 @@ static int DetectPcreTestSig10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP cookie\"; pcre:!\"/dummy/C\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP cookie\"; pcre:!\"/dummy/C\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2464,9 +2448,9 @@ static int DetectPcreTestSig11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP method\"; pcre:\"/POST/M\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP method\"; pcre:\"/POST/M\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2560,9 +2544,9 @@ static int DetectPcreTestSig12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP method\"; pcre:!\"/POST/M\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP method\"; pcre:!\"/POST/M\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2656,9 +2640,9 @@ static int DetectPcreTestSig13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP header\"; pcre:\"/User[-_]Agent[:]?\\sMozilla/H\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP header\"; pcre:\"/User[-_]Agent[:]?\\sMozilla/H\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2752,9 +2736,9 @@ static int DetectPcreTestSig14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"HTTP header\"; pcre:!\"/User-Agent[:]?\\s+Mozilla/H\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"HTTP header\"; pcre:!\"/User-Agent[:]?\\s+Mozilla/H\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2848,10 +2832,9 @@ static int DetectPcreTestSig15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"pcre relative HTTP cookie\"; content:\"dummy\";"
-                                   " http_cookie; pcre:\"/1234/RC\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"pcre relative HTTP cookie\"; content:\"dummy\";" " http_cookie; pcre:\"/1234/RC\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -2945,10 +2928,9 @@ static int DetectPcreTestSig16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\"pcre relative HTTP method\"; content:\"PO\";"
-                                   " http_method; pcre:\"/ST/RM\"; "
-                                   " sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\"pcre relative HTTP method\"; content:\"PO\";" " http_method; pcre:\"/ST/RM\"; " " sid:1;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-pcre.c
+++ b/src/detect-pcre.c
@@ -3180,12 +3180,16 @@ static int DetectPcreTxBodyChunksTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; pcre:\"/one/P\"; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; pcre:\"/one/P\"; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; pcre:\"/two/P\"; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; pcre:\"/two/P\"; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -3428,12 +3432,16 @@ static int DetectPcreTxBodyChunksTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; pcre:\"/one/P\"; sid:1; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"POST\"; http_method; content:\"Mozilla\"; http_header; content:\"dummy\"; http_cookie; pcre:\"/one/P\"; sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; pcre:\"/two/P\"; sid:2; rev:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any (content:\"GET\"; http_method; content:\"Firefox\"; http_header; content:\"dummy2\"; http_cookie; pcre:\"/two/P\"; sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -3649,7 +3657,9 @@ static int DetectPcreFlowvarCapture01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -3775,7 +3785,9 @@ static int DetectPcreFlowvarCapture02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; priority:1; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; priority:1; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -3788,7 +3800,9 @@ static int DetectPcreFlowvarCapture02(void)
     }
     DetectPcreData *pd1 = (DetectPcreData *)s->sm_lists[DETECT_SM_LIST_HHDMATCH]->next->ctx;
 
-    s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"Server: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; priority:3; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert http any any -> any any (content:\"Server: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; priority:3; sid:2;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -3921,7 +3935,9 @@ static int DetectPcreFlowvarCapture03(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; content:\"xyz\"; http_header; priority:1; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert http any any -> any any (content:\"User-Agent: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; content:\"xyz\"; http_header; priority:1; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -3934,7 +3950,9 @@ static int DetectPcreFlowvarCapture03(void)
     }
     DetectPcreData *pd1 = (DetectPcreData *)s->sm_lists[DETECT_SM_LIST_HHDMATCH]->next->ctx;
 
-    s = DetectEngineAppendSig(de_ctx, "alert http any any -> any any (content:\"Server: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; content:\"xyz\"; http_header; priority:3; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert http any any -> any any (content:\"Server: \"; http_header; pcre:\"/(?P<flow_ua>.*)\\r\\n/HR\"; content:\"xyz\"; http_header; priority:3; sid:2;)",
+                              NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto end;

--- a/src/detect-pkt-data.c
+++ b/src/detect-pkt-data.c
@@ -96,9 +96,9 @@ static int DetectPktDataTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(file_data; content:\"in file data\";"
-                               " pkt_data; content:\"in pkt data\";)");
+    Signature *sig = SigInit(de_ctx,
+                             "alert tcp any any -> any any " "(file_data; content:\"in file data\";" " pkt_data; content:\"in pkt data\";)",
+                             NULL);
     de_ctx->sig_list = sig;
     if (de_ctx->sig_list == NULL) {
         SCLogError(SC_ERR_INVALID_SIGNATURE,"could not load test signature");

--- a/src/detect-priority.c
+++ b/src/detect-priority.c
@@ -105,8 +105,9 @@ int DetectPriorityTest01()
         goto end;
     }
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(msg:\"Priority test\"; priority:2; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:2; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL)
         result = 1;
 
@@ -127,8 +128,9 @@ int DetectPriorityTest02()
         goto end;
     }
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:1; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:1; sid:1;)",
+                  NULL);
     de_ctx->sig_list = last = sig;
     if (sig == NULL) {
         result = 0;
@@ -137,38 +139,44 @@ int DetectPriorityTest02()
         result &= (sig->prio == 1);
     }
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:boo; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:boo; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:10boo; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:10boo; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:b10oo; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:b10oo; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:boo10; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:boo10; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; priority:-1; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; priority:-1; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     result &= (sig == NULL);
 
-    sig = SigInit(de_ctx, "alert tcp any any -> any any "
-                  "(msg:\"Priority test\"; sid:1;)");
+    sig = SigInit(de_ctx,
+                  "alert tcp any any -> any any " "(msg:\"Priority test\"; sid:1;)",
+                  NULL);
     if (last != NULL)
         last->next = sig;
     if (sig == NULL) {

--- a/src/detect-reference.c
+++ b/src/detect-reference.c
@@ -225,8 +225,9 @@ static int DetectReferenceParseTest01(void)
     FILE *fd = SCRConfGenerateValidDummyReferenceConfigFD01();
     SCRConfLoadReferenceConfigFile(de_ctx, fd);
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                                   "(msg:\"One reference\"; reference:one,001-2010; sid:2;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any " "(msg:\"One reference\"; reference:one,001-2010; sid:2;)",
+                                   NULL);
     if (s == NULL) {
         goto cleanup;
     }
@@ -271,10 +272,9 @@ static int DetectReferenceParseTest02(void)
     FILE *fd = SCRConfGenerateValidDummyReferenceConfigFD01();
     SCRConfLoadReferenceConfigFile(de_ctx, fd);
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                                   "(msg:\"Two references\"; "
-                                   "reference:one,openinfosecdoundation.txt; "
-                                   "reference:two,001-2010; sid:2;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any " "(msg:\"Two references\"; " "reference:one,openinfosecdoundation.txt; " "reference:two,001-2010; sid:2;)",
+                                   NULL);
     if (s == NULL) {
         printf("sig parse failed: ");
         goto cleanup;
@@ -325,9 +325,9 @@ static int DetectReferenceParseTest03(void)
     FILE *fd =SCRConfGenerateValidDummyReferenceConfigFD01();
     SCRConfLoadReferenceConfigFile(de_ctx, fd);
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert icmp any any -> any any "
-                                   "(msg:\"invalid ref\"; "
-                                   "reference:unknownkey,001-2010; sid:2;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert icmp any any -> any any " "(msg:\"invalid ref\"; " "reference:unknownkey,001-2010; sid:2;)",
+                                   NULL);
     if (s != NULL) {
         printf("sig parsed even though it's invalid: ");
         goto cleanup;

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -255,7 +255,7 @@ int DetectReplaceLongPatternMatchTest(uint8_t *raw_eth_pkt, uint16_t pktsize,
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig);
+    de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -585,8 +585,8 @@ static int DetectReplaceParseTest01(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; content:\"doh\"; replace:\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; content:\"doh\"; replace:\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -619,8 +619,8 @@ static int DetectReplaceParseTest02(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert http any any -> any any "
-                               "(msg:\"test\"; content:\"doh\"; replace:\"bon\"; sid:238012;)");
+                               "alert http any any -> any any " "(msg:\"test\"; content:\"doh\"; replace:\"bon\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -654,8 +654,8 @@ static int DetectReplaceParseTest03(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; content:\"doh\"; replace:\"don\"; http_header; sid:238012;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; content:\"doh\"; replace:\"don\"; http_header; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -688,8 +688,8 @@ static int DetectReplaceParseTest04(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; replace:\"don\"; sid:238012;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; replace:\"don\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -722,8 +722,8 @@ static int DetectReplaceParseTest05(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; replace:\"don\"; content:\"doh\"; sid:238012;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; replace:\"don\"; content:\"doh\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -756,8 +756,8 @@ static int DetectReplaceParseTest06(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; content:\"don\"; replace:\"donut\"; sid:238012;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; content:\"don\"; replace:\"donut\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -790,8 +790,8 @@ static int DetectReplaceParseTest07(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; content:\"don\"; replace:\"dou\"; content:\"jpg\"; http_header; sid:238012;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; content:\"don\"; replace:\"dou\"; content:\"jpg\"; http_header; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -509,27 +509,37 @@ static int DetectRpcTestSig01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, 3; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, 3; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, *; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, 2, *; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, 3; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, 3; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, *; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert udp any any -> any any (msg:\"RPC Get Port Call\"; rpc:100000, *, *; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert udp any any -> any any (msg:\"RPC Get XXX Call.. no match\"; rpc:123456, *, 3; sid:5;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert udp any any -> any any (msg:\"RPC Get XXX Call.. no match\"; rpc:123456, *, 3; sid:5;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-sameip.c
+++ b/src/detect-sameip.c
@@ -147,8 +147,8 @@ static int DetectSameipSigTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                                     "alert tcp any any -> any any "
-                                     "(msg:\"Testing sameip\"; sameip; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"Testing sameip\"; sameip; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-seq.c
+++ b/src/detect-seq.c
@@ -153,23 +153,17 @@ static int DetectSeqSigTest01(void)
         goto end;
 
     /* These three are crammed in here as there is no Parse */
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing seq\";seq:foo;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing seq\";seq:foo;sid:1;)", NULL) != NULL)
     {
         printf("invalid seq accepted: ");
         goto cleanup;
     }
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing seq\";seq:9999999999;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing seq\";seq:9999999999;sid:1;)", NULL) != NULL)
     {
         printf("overflowing seq accepted: ");
         goto cleanup;
     }
-    if (SigInit(de_ctx,
-                "alert tcp any any -> any any "
-                "(msg:\"Testing seq\";seq:-100;sid:1;)") != NULL)
+    if (SigInit(de_ctx, "alert tcp any any -> any any " "(msg:\"Testing seq\";seq:-100;sid:1;)", NULL) != NULL)
     {
         printf("negative seq accepted: ");
         goto cleanup;

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -99,7 +99,8 @@ static int SidTestParse01(void)
         goto end;
 
     s = DetectEngineAppendSig(de_ctx,
-        "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)");
+                              "alert tcp 1.2.3.4 any -> any any (sid:1; gid:1;)",
+                              NULL);
     if (s == NULL || s->id != 1)
         goto end;
 
@@ -119,8 +120,7 @@ static int SidTestParse02(void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx,
-            "alert tcp 1.2.3.4 any -> any any (sid:a; gid:1;)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp 1.2.3.4 any -> any any (sid:a; gid:1;)", NULL) != NULL)
         goto end;
 
     result = 1;
@@ -139,8 +139,7 @@ static int SidTestParse03(void)
     if (de_ctx == NULL)
         goto end;
 
-    if (DetectEngineAppendSig(de_ctx,
-            "alert tcp any any -> any any (content:\"ABC\"; sid:\";)") != NULL)
+    if (DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any (content:\"ABC\"; sid:\";)", NULL) != NULL)
         goto end;
 
     result = 1;

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -367,7 +367,9 @@ static int DetectSshVersionTestDetect01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:1.10; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:1.10; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -480,7 +482,9 @@ static int DetectSshVersionTestDetect02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:2_compat; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:2_compat; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -591,7 +595,9 @@ static int DetectSshVersionTestDetect03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:2_compat; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.protoversion:2_compat; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -339,7 +339,9 @@ static int DetectSshSoftwareVersionTestDetect01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:PuTTY_2.123; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:PuTTY_2.123; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -452,7 +454,9 @@ static int DetectSshSoftwareVersionTestDetect02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:PuTTY_2.123; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:PuTTY_2.123; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -564,7 +568,9 @@ static int DetectSshSoftwareVersionTestDetect03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:lalala-3.1.4; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ssh any any -> any any (msg:\"SSH\"; ssh.softwareversion:lalala-3.1.4; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-ssl-state.c
+++ b/src/detect-ssl-state.c
@@ -691,30 +691,27 @@ static int DetectSslStateTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"ssl state\"; ssl_state:client_hello; "
-                              "sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"ssl state\"; ssl_state:client_hello; " "sid:1;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello; "
-                              "sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"ssl state\"; " "ssl_state:client_hello | server_hello; " "sid:2;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello | "
-                              "client_keyx; sid:3;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"ssl state\"; " "ssl_state:client_hello | server_hello | " "client_keyx; sid:3;)",
+                              NULL);
     if (s == NULL)
         goto end;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                              "(msg:\"ssl state\"; "
-                              "ssl_state:client_hello | server_hello | "
-                              "client_keyx | server_keyx; sid:4;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(msg:\"ssl state\"; " "ssl_state:client_hello | server_hello | " "client_keyx | server_keyx; sid:4;)",
+                              NULL);
     if (s == NULL)
         goto end;
 

--- a/src/detect-ssl-version.c
+++ b/src/detect-ssl-version.c
@@ -424,7 +424,9 @@ static int DetectSslVersionTestDetect01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tls any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tls any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -549,7 +551,9 @@ static int DetectSslVersionTestDetect02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tls any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tls any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -683,7 +687,9 @@ static int DetectSslVersionTestDetect03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; content:\"|01 00 00 AD|\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:\"TLS\"; ssl_version:tls1.0; content:\"|01 00 00 AD|\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-template-buffer.c
+++ b/src/detect-template-buffer.c
@@ -103,20 +103,16 @@ static int DetectTemplateBufferTest(void)
 
     /* This rule should match. */
     s = DetectEngineAppendSig(de_ctx,
-        "alert tcp any any -> any any ("
-        "msg:\"TEMPLATE Test Rule\"; "
-        "template_buffer; content:\"World!\"; "
-        "sid:1; rev:1;)");
+                              "alert tcp any any -> any any (" "msg:\"TEMPLATE Test Rule\"; " "template_buffer; content:\"World!\"; " "sid:1; rev:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
 
     /* This rule should not match. */
     s = DetectEngineAppendSig(de_ctx,
-        "alert tcp any any -> any any ("
-        "msg:\"TEMPLATE Test Rule\"; "
-        "template_buffer; content:\"W0rld!\"; "
-        "sid:2; rev:1;)");
+                              "alert tcp any any -> any any (" "msg:\"TEMPLATE Test Rule\"; " "template_buffer; content:\"W0rld!\"; " "sid:2; rev:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-template.c
+++ b/src/detect-template.c
@@ -251,7 +251,9 @@ static int DetectTemplateSignatureTest01 (void) {
     if (de_ctx == NULL)
         goto end;
 
-    Signature *sig = DetectEngineAppendSig(de_ctx, "alert ip any any -> any any (template:1,10; sid:1; rev:1;)");
+    Signature *sig = DetectEngineAppendSig(de_ctx,
+                                           "alert ip any any -> any any (template:1,10; sid:1; rev:1;)",
+                                           NULL);
     if (sig == NULL) {
         printf("parsing signature failed: ");
         goto end;

--- a/src/detect-threshold.c
+++ b/src/detect-threshold.c
@@ -402,7 +402,9 @@ static int DetectThresholdTestSig1(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit\"; content:\"A\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold limit\"; content:\"A\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -506,7 +508,9 @@ static int DetectThresholdTestSig2(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold\"; threshold: type threshold, track by_dst, count 5, seconds 60; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold\"; threshold: type threshold, track by_dst, count 5, seconds 60; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -589,7 +593,9 @@ static int DetectThresholdTestSig3(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold limit\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -693,7 +699,9 @@ static int DetectThresholdTestSig4(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold both\"; threshold: type both, track by_dst, count 2, seconds 60; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold both\"; threshold: type both, track by_dst, count 2, seconds 60; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -766,12 +774,16 @@ static int DetectThresholdTestSig5(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1000\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any 80 (msg:\"Threshold limit sid 1000\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -845,12 +857,16 @@ static int DetectThresholdTestSig6Ticks(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any 80 (msg:\"Threshold limit sid 1\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit sid 1000\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any 80 (msg:\"Threshold limit sid 1000\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -937,7 +953,9 @@ static int DetectThresholdTestSig7(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type limit, track by_src, count 1, seconds 300; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type limit, track by_src, count 1, seconds 300; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1031,7 +1049,9 @@ static int DetectThresholdTestSig8(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type limit, track by_src, count 2, seconds 300; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type limit, track by_src, count 2, seconds 300; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1125,7 +1145,9 @@ static int DetectThresholdTestSig9(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type threshold, track by_src, count 3, seconds 100; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type threshold, track by_src, count 3, seconds 100; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1219,7 +1241,9 @@ static int DetectThresholdTestSig10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type threshold, track by_src, count 5, seconds 300; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type threshold, track by_src, count 5, seconds 300; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1313,7 +1337,9 @@ static int DetectThresholdTestSig11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type both, track by_src, count 3, seconds 300; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type both, track by_src, count 3, seconds 300; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1407,7 +1433,9 @@ static int DetectThresholdTestSig12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any 80 (threshold: type both, track by_src, count 5, seconds 300; sid:10;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 (threshold: type both, track by_src, count 5, seconds 300; sid:10;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -155,7 +155,7 @@ static int DetectTlsSniTest01(void)
 
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
                               "(msg:\"Test tls_sni option\"; "
-                              "tls_sni; content:\"google.com\"; sid:1;)");
+                              "tls_sni; content:\"google.com\"; sid:1;)", NULL);
     if (s == NULL) {
         goto end;
     }
@@ -268,7 +268,7 @@ static int DetectTlsSniTest02(void)
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
                               "(msg:\"Test tls_sni option\"; "
                               "tls_sni; content:\"google\"; nocase; "
-                              "pcre:\"/google\\.com$/i\"; sid:1;)");
+                              "pcre:\"/google\\.com$/i\"; sid:1;)", NULL);
     if (s == NULL) {
         goto end;
     }
@@ -276,7 +276,7 @@ static int DetectTlsSniTest02(void)
     s = DetectEngineAppendSig(de_ctx, "alert tls any any -> any any "
                               "(msg:\"Test tls_sni option\"; "
                               "tls_sni; content:\"google\"; nocase; "
-                              "pcre:\"/^\\.[a-z]{2,3}$/iR\"; sid:2;)");
+                              "pcre:\"/^\\.[a-z]{2,3}$/iR\"; sid:2;)", NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-tls-version.c
+++ b/src/detect-tls-version.c
@@ -337,7 +337,9 @@ static int DetectTlsVersionTestDetect01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tls any any -> any any (msg:\"TLS\"; tls.version:1.0; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tls any any -> any any (msg:\"TLS\"; tls.version:1.0; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -465,7 +467,9 @@ static int DetectTlsVersionTestDetect02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tls any any -> any any (msg:\"TLS\"; tls.version:1.0; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tls any any -> any any (msg:\"TLS\"; tls.version:1.0; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -603,7 +607,9 @@ static int DetectTlsVersionTestDetect03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"TLS\"; tls.version:1.0; content:\"|01 00 00 AD|\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:\"TLS\"; tls.version:1.0; content:\"|01 00 00 AD|\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-ttl.c
+++ b/src/detect-ttl.c
@@ -322,7 +322,7 @@ static int DetectTtlInitTest(DetectEngineCtx **de_ctx, Signature **sig, DetectTt
 
     (*de_ctx)->flags |= DE_QUIET;
 
-    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr);
+    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr, NULL);
     if ((*de_ctx)->sig_list == NULL) {
         goto end;
     }
@@ -544,22 +544,30 @@ static int DetectTtlTestSig1(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"with in ttl limit\"; ttl: >16; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any any (msg:\"with in ttl limit\"; ttl: >16; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Less than 17\"; ttl: <17; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"Less than 17\"; ttl: <17; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Greater than 5\"; ttl:15; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"Greater than 5\"; ttl:15; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Equals tcp\"; ttl: 1-30; sid:4;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert ip any any -> any any (msg:\"Equals tcp\"; ttl: 1-30; sid:4;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -493,9 +493,9 @@ int DetectUriSigTest01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "content:\"me\"; uricontent:\"me\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert http any any -> any any (msg:" "\" Test uricontent\"; " "content:\"me\"; uricontent:\"me\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -561,23 +561,23 @@ static int DetectUriSigTest02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"foo\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"oisf\"; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"oisf\"; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -676,23 +676,23 @@ static int DetectUriSigTest03(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"foo\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-   s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; sid:2;)");
+   s = s->next = SigInit(de_ctx,
+                         "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; sid:2;)",
+                         NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"self\"; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"self\"; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -784,9 +784,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"foo\"; sid:1;)",
+                NULL);
     if (s == NULL ||
         s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
         s->sm_lists[DETECT_SM_LIST_PMATCH] != NULL ||
@@ -796,9 +796,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";sid:1;)",
+                NULL);
     if (s == NULL ||
         s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
         s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
@@ -808,10 +808,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; sid:1;)",
+                NULL);
     if (s == NULL ||
         s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
         s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
@@ -823,10 +822,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "content:\"foo\"; uricontent:\"bar\";"
-                                   " depth:10; offset: 5; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "content:\"foo\"; uricontent:\"bar\";" " depth:10; offset: 5; sid:1;)",
+                NULL);
     if (s == NULL ||
         s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
         s->sm_lists[DETECT_SM_LIST_PMATCH] == NULL ||
@@ -838,29 +836,25 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; within:3; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; within:3; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("sig 5 failed to parse: ");
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; distance:3; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; distance:3; sid:1;)",
+                NULL);
     if (s != NULL) {
         printf("sig 6 failed to parse: ");
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; within:30; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; content:" "\"two_contents\"; within:30; sid:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     } else if (s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
@@ -875,11 +869,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; within:30; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; uricontent:" "\"two_uricontents\"; within:30; sid:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     } else if (s->sm_lists[DETECT_SM_LIST_UMATCH] == NULL ||
@@ -894,11 +886,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; content:"
-                                   "\"two_contents\"; distance:30; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; content:" "\"two_contents\"; distance:30; sid:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     } else if (
@@ -914,11 +904,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; uricontent:" "\"two_uricontents\"; distance:30; sid:1;)",
+                NULL);
     if (s == NULL) {
         goto end;
     } else if (
@@ -934,13 +922,9 @@ static int DetectUriSigTest04(void)
         goto end;
     }
 
-    s = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent and content\"; "
-                                   "uricontent:\"foo\"; content:\"bar\";"
-                                   " depth:10; offset: 5; uricontent:"
-                                   "\"two_uricontents\"; distance:30; "
-                                   "within:60; content:\"two_contents\";"
-                                   " within:70; distance:45; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp any any -> any any (msg:" "\" Test uricontent and content\"; " "uricontent:\"foo\"; content:\"bar\";" " depth:10; offset: 5; uricontent:" "\"two_uricontents\"; distance:30; " "within:60; content:\"two_contents\";" " within:70; distance:45; sid:1;)",
+                NULL);
     if (s == NULL) {
         printf("sig 10 failed to parse: ");
         goto end;
@@ -1030,22 +1014,23 @@ static int DetectUriSigTest05(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"foo\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:" "\" Test uricontent\"; uricontent:\"foo\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"one\"; content:\"two\"; sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; uricontent:\"one\"; content:\"two\"; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-            "\" Test uricontent\"; uricontent:\"one\"; offset:1; depth:10; "
-            "uricontent:\"two\"; distance:1; within: 4; uricontent:\"three\"; "
-            "distance:1; within: 6; sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; uricontent:\"one\"; offset:1; depth:10; " "uricontent:\"two\"; distance:1; within: 4; uricontent:\"three\"; " "distance:1; within: 6; sid:3;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }
@@ -1158,33 +1143,24 @@ static int DetectUriSigTest06(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; content:\"bar\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"foo\"; content:\"bar\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "content:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "content:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "content:\"/three\"; distance:0; within: 7; "
-                                   "sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; offset:1; depth:10; " "content:\"one\"; offset:1; depth:10; " "uricontent:\"two\"; distance:1; within: 4; " "content:\"two\"; distance:1; within: 4; " "uricontent:\"three\"; distance:1; within: 6; " "content:\"/three\"; distance:0; within: 7; " "sid:2;)",
+                          NULL);
 
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; offset:1; depth:10; " "uricontent:\"two\"; distance:1; within: 4; " "uricontent:\"three\"; distance:1; within: 6; " "sid:3;)",
+                          NULL);
 
     if (s == NULL) {
         goto end;
@@ -1280,33 +1256,24 @@ static int DetectUriSigTest07(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"foo\"; content:\"bar\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"foo\"; content:\"bar\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "content:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:3; within: 4; "
-                                   "content:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"three\"; distance:1; within: 6; "
-                                   "content:\"/three\"; distance:0; within: 7; "
-                                   "sid:2;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; offset:1; depth:10; " "content:\"one\"; offset:1; depth:10; " "uricontent:\"two\"; distance:3; within: 4; " "content:\"two\"; distance:1; within: 4; " "uricontent:\"three\"; distance:1; within: 6; " "content:\"/three\"; distance:0; within: 7; " "sid:2;)",
+                          NULL);
 
     if (s == NULL) {
         goto end;
     }
 
-    s = s->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:"
-                                   "\" Test uricontent\"; "
-                                   "uricontent:\"one\"; offset:1; depth:10; "
-                                   "uricontent:\"two\"; distance:1; within: 4; "
-                                   "uricontent:\"six\"; distance:1; within: 6; "
-                                   "sid:3;)");
+    s = s->next = SigInit(de_ctx,
+                          "alert tcp any any -> any any (msg:" "\" Test uricontent\"; " "uricontent:\"one\"; offset:1; depth:10; " "uricontent:\"two\"; distance:1; within: 4; " "uricontent:\"six\"; distance:1; within: 6; " "sid:3;)",
+                          NULL);
 
     if (s == NULL) {
         goto end;
@@ -1373,8 +1340,8 @@ int DetectUriSigTest08(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1402,8 +1369,8 @@ int DetectUriSigTest09(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1431,8 +1398,8 @@ int DetectUriSigTest10(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"boo; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"boo; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1460,8 +1427,8 @@ int DetectUriSigTest11(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:boo\"; sid:238012;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:boo\"; sid:238012;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1491,8 +1458,8 @@ int DetectUriSigTest12(void)
 
     de_ctx->flags |= DE_QUIET;
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert udp any any -> any any "
-                                   "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)");
+                                   "alert udp any any -> any any " "(msg:\"test\"; uricontent:    !\"boo\"; sid:238012;)",
+                                   NULL);
     if (de_ctx->sig_list == NULL) {
         printf("de_ctx->sig_list == NULL: ");
         goto end;
@@ -1529,8 +1496,8 @@ int DetectUriContentParseTest13(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1558,8 +1525,8 @@ int DetectUriContentParseTest14(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1587,8 +1554,8 @@ int DetectUriContentParseTest15(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1616,8 +1583,8 @@ int DetectUriContentParseTest16(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1645,8 +1612,8 @@ int DetectUriContentParseTest17(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"aast|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1674,8 +1641,8 @@ int DetectUriContentParseTest18(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"aast|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1703,8 +1670,8 @@ int DetectUriContentParseTest19(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"aast|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1732,8 +1699,8 @@ int DetectUriContentParseTest20(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af|asdf\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1761,8 +1728,8 @@ int DetectUriContentParseTest21(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1790,8 +1757,8 @@ int DetectUriContentParseTest22(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af|af|af\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;
@@ -1819,8 +1786,8 @@ int DetectUriContentParseTest23(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)");
+                               "alert udp any any -> any any " "(msg:\"test\"; uricontent:\"|af|af|af|\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -1848,8 +1815,8 @@ int DetectUriContentParseTest24(void)
 
     de_ctx->flags |= DE_QUIET;
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(msg:\"test\"; uricontent:\"\"; sid:1;)");
+                               "alert tcp any any -> any any " "(msg:\"test\"; uricontent:\"\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list != NULL) {
         result = 0;
         goto end;

--- a/src/detect-urilen.c
+++ b/src/detect-urilen.c
@@ -497,7 +497,7 @@ static int DetectUrilenInitTest(DetectEngineCtx **de_ctx, Signature **sig,
 
     (*de_ctx)->flags |= DE_QUIET;
 
-    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr);
+    (*de_ctx)->sig_list = SigInit(*de_ctx, fullstr, NULL);
     if ((*de_ctx)->sig_list == NULL) {
         goto end;
     }
@@ -593,17 +593,15 @@ static int DetectUrilenSigTest01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = de_ctx->sig_list = SigInit(de_ctx,
-                                   "alert tcp any any -> any any "
-                                   "(msg:\"Testing urilen\"; "
-                                   "urilen: <5; sid:1;)");
+                                   "alert tcp any any -> any any " "(msg:\"Testing urilen\"; " "urilen: <5; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     s = s->next = SigInit(de_ctx,
-                          "alert tcp any any -> any any "
-                          "(msg:\"Testing http_method\"; "
-                           "urilen: >5; sid:2;)");
+                          "alert tcp any any -> any any " "(msg:\"Testing http_method\"; " "urilen: >5; sid:2;)",
+                          NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect-within.c
+++ b/src/detect-within.c
@@ -266,7 +266,7 @@ static int DetectWithinTestVarSetup(void)
     if (de_ctx == NULL) {
         goto end;
     }
-    de_ctx->sig_list = SigInit(de_ctx, sig);
+    de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -404,7 +404,8 @@ static int XBitsTestSig01(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:set,abc,track ip_pair; content:\"GET \"; sid:1;)");
+                              "alert ip any any -> any any (xbits:set,abc,track ip_pair; content:\"GET \"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         printf("bad sig: ");
         goto end;
@@ -462,31 +463,36 @@ static int XBitsTestSig02(void)
     de_ctx->flags |= DE_QUIET;
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:isset,abc,track ip_src; content:\"GET \"; sid:1;)");
+                              "alert ip any any -> any any (xbits:isset,abc,track ip_src; content:\"GET \"; sid:1;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:isnotset,abc,track ip_dst; content:\"GET \"; sid:2;)");
+                              "alert ip any any -> any any (xbits:isnotset,abc,track ip_dst; content:\"GET \"; sid:2;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:set,abc,track ip_pair; content:\"GET \"; sid:3;)");
+                              "alert ip any any -> any any (xbits:set,abc,track ip_pair; content:\"GET \"; sid:3;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:unset,abc,track ip_src; content:\"GET \"; sid:4;)");
+                              "alert ip any any -> any any (xbits:unset,abc,track ip_src; content:\"GET \"; sid:4;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }
 
     s = DetectEngineAppendSig(de_ctx,
-            "alert ip any any -> any any (xbits:toggle,abc,track ip_dst; content:\"GET \"; sid:5;)");
+                              "alert ip any any -> any any (xbits:toggle,abc,track ip_dst; content:\"GET \"; sid:5;)",
+                              NULL);
     if (s == NULL) {
         error_count++;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -421,14 +421,12 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     ConfNode *rule_files;
     ConfNode *file = NULL;
-    SigFileLoaderStat sig_stat;
+    SigFileLoaderStat *sig_stat = &de_ctx->sig_stat;
     int ret = 0;
     char *sfile = NULL;
     char varname[128] = "rule-files";
     int good_sigs = 0;
     int bad_sigs = 0;
-
-    memset(&sig_stat, 0, sizeof(SigFileLoaderStat));
 
     if (strlen(de_ctx->config_prefix) > 0) {
         snprintf(varname, sizeof(varname), "%s.rule-files",
@@ -453,7 +451,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                 TAILQ_FOREACH(file, &rule_files->head, next) {
                     sfile = DetectLoadCompleteSigPath(de_ctx, file->val);
                     good_sigs = bad_sigs = 0;
-                    ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
+                    ret = ProcessSigFiles(de_ctx, sfile, sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
                     if (ret != 0 || good_sigs == 0) {
@@ -468,7 +466,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
 
     /* If a Signature file is specified from commandline, parse it too */
     if (sig_file != NULL) {
-        ret = ProcessSigFiles(de_ctx, sig_file, &sig_stat, &good_sigs, &bad_sigs);
+        ret = ProcessSigFiles(de_ctx, sig_file, sig_stat, &good_sigs, &bad_sigs);
 
         if (ret != 0) {
             if (de_ctx->failure_fatal == 1) {
@@ -482,9 +480,9 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     }
 
     /* now we should have signatures to work with */
-    if (sig_stat.good_sigs_total <= 0) {
-        if (sig_stat.total_files > 0) {
-           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat.total_files);
+    if (sig_stat->good_sigs_total <= 0) {
+        if (sig_stat->total_files > 0) {
+           SCLogWarning(SC_ERR_NO_RULES_LOADED, "%d rule files specified, but no rule was loaded at all!", sig_stat->total_files);
         } else {
             SCLogInfo("No signatures supplied.");
             goto end;
@@ -492,10 +490,10 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     } else {
         /* we report the total of files and rules successfully loaded and failed */
         SCLogInfo("%" PRId32 " rule files processed. %" PRId32 " rules successfully loaded, %" PRId32 " rules failed",
-            sig_stat.total_files, sig_stat.good_sigs_total, sig_stat.bad_sigs_total);
+            sig_stat->total_files, sig_stat->good_sigs_total, sig_stat->bad_sigs_total);
     }
 
-    if ((sig_stat.bad_sigs_total || sig_stat.bad_files) && de_ctx->failure_fatal) {
+    if ((sig_stat->bad_sigs_total || sig_stat->bad_files) && de_ctx->failure_fatal) {
         ret = -1;
         goto end;
     }
@@ -511,6 +509,7 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
     ret = 0;
 
  end:
+    gettimeofday(&de_ctx->last_reload, NULL);
     if (RunmodeGetCurrent() == RUNMODE_ENGINE_ANALYSIS) {
         if (rule_engine_analysis_set) {
             CleanupRuleAnalyzer();

--- a/src/detect.c
+++ b/src/detect.c
@@ -4558,7 +4558,9 @@ static int SigTest03 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host: one.example.org\"; offset:20; depth:39; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host: one.example.org\"; offset:20; depth:39; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4608,7 +4610,9 @@ static int SigTest04 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host:\"; offset:20; depth:25; content:\"Host:\"; distance:42; within:47; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host:\"; offset:20; depth:25; content:\"Host:\"; distance:42; within:47; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -4657,7 +4661,9 @@ static int SigTest05 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host:\"; offset:20; depth:25; content:\"Host:\"; distance:48; within:52; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP TEST\"; content:\"Host:\"; offset:20; depth:25; content:\"Host:\"; distance:48; within:52; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         goto end;
@@ -4726,13 +4732,17 @@ static int SigTest06 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
 
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"two\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"two\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -4816,12 +4826,16 @@ static int SigTest07 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"three\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"three\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -4905,12 +4919,16 @@ static int SigTest08 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/1\\.0\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/1\\.0\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"one\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"one\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -4996,12 +5014,16 @@ static int SigTest09 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/1\\.0\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/1\\.0\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"two\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"HTTP URI test\"; uricontent:\"two\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -5079,12 +5101,16 @@ static int SigTest10 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Long content test (1)\"; content:\"ABCD\"; depth:4; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Long content test (1)\"; content:\"ABCD\"; depth:4; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Long content test (2)\"; content:\"VWXYZ\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Long content test (2)\"; content:\"VWXYZ\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -5160,11 +5186,15 @@ static int SigTest11 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (content:\"ABCDEFGHIJ\"; content:\"klmnop\"; content:\"1234\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (content:\"ABCDEFGHIJ\"; content:\"klmnop\"; content:\"1234\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (content:\"VWXYZabcde\"; content:\"5678\"; content:\"89\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (content:\"VWXYZabcde\"; content:\"5678\"; content:\"89\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -5215,7 +5245,9 @@ static int SigTest12 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"klmnop\"; content:\"1234\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"klmnop\"; content:\"1234\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5270,7 +5302,9 @@ static int SigTest13 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"1234\"; content:\"klmnop\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"1234\"; content:\"klmnop\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5316,7 +5350,9 @@ static int SigTest14 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"1234\"; content:\"klmnop\"; distance:0; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Content order test\"; content:\"ABCDEFGHIJ\"; content:\"1234\"; content:\"klmnop\"; distance:0; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5372,7 +5408,9 @@ static int SigTest15 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any !$HTTP_PORTS (msg:\"ET POLICY Inbound HTTP CONNECT Attempt on Off-Port\"; content:\"CONNECT \"; nocase; depth:8; content:\" HTTP/1.\"; nocase; within:1000; sid:2008284; rev:2;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any !$HTTP_PORTS (msg:\"ET POLICY Inbound HTTP CONNECT Attempt on Off-Port\"; content:\"CONNECT \"; nocase; depth:8; content:\" HTTP/1.\"; nocase; within:1000; sid:2008284; rev:2;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5424,7 +5462,9 @@ static int SigTest16 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any !$HTTP_PORTS (msg:\"ET POLICY Inbound HTTP CONNECT Attempt on Off-Port\"; content:\"CONNECT \"; nocase; depth:8; content:\" HTTP/1.\"; nocase; within:1000; sid:2008284; rev:2;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any !$HTTP_PORTS (msg:\"ET POLICY Inbound HTTP CONNECT Attempt on Off-Port\"; content:\"CONNECT \"; nocase; depth:8; content:\" HTTP/1.\"; nocase; within:1000; sid:2008284; rev:2;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -5478,7 +5518,9 @@ static int SigTest17 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any $HTTP_PORTS (msg:\"HTTP host cap\"; content:\"Host:\"; pcre:\"/^Host: (?P<pkt_http_host>.*)\\r\\n/m\"; noalert; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any $HTTP_PORTS (msg:\"HTTP host cap\"; content:\"Host:\"; pcre:\"/^Host: (?P<pkt_http_host>.*)\\r\\n/m\"; noalert; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5545,7 +5587,9 @@ static int SigTest18 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any !21:902 -> any any (msg:\"ET MALWARE Suspicious 220 Banner on Local Port\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:2003055; rev:4;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any !21:902 -> any any (msg:\"ET MALWARE Suspicious 220 Banner on Local Port\"; content:\"220\"; offset:0; depth:4; pcre:\"/220[- ]/\"; sid:2003055; rev:4;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5605,7 +5649,9 @@ static int SigTest19 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert ip $HOME_NET any -> 1.2.3.4 any (msg:\"IP-ONLY test (1)\"; sid:999; rev:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert ip $HOME_NET any -> 1.2.3.4 any (msg:\"IP-ONLY test (1)\"; sid:999; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5666,7 +5712,9 @@ static int SigTest20 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert ip $HOME_NET any -> [99.99.99.99,1.2.3.0/24,1.1.1.1,3.0.0.0/8] any (msg:\"IP-ONLY test (2)\"; sid:999; rev:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert ip $HOME_NET any -> [99.99.99.99,1.2.3.0/24,1.1.1.1,3.0.0.0/8] any (msg:\"IP-ONLY test (2)\"; sid:999; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5728,12 +5776,16 @@ static int SigTest21 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:set,TEST.one; flowbits:noalert; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:set,TEST.one; flowbits:noalert; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.one; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.one; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5808,12 +5860,16 @@ static int SigTest22 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:set,TEST.one; flowbits:noalert; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:set,TEST.one; flowbits:noalert; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.abc; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.abc; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5883,12 +5939,16 @@ static int SigTest23 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:toggle,TEST.one; flowbits:noalert; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"FLOWBIT SET\"; content:\"/one/\"; flowbits:toggle,TEST.one; flowbits:noalert; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.one; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"FLOWBIT TEST\"; content:\"/two/\"; flowbits:isset,TEST.one; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -5978,19 +6038,16 @@ int SigTest24IPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-            "alert ip any any -> any any "
-            "(content:\"/one/\"; ipv4-csum:valid; "
-            "msg:\"ipv4-csum keyword check(1)\"; sid:1;)");
+                               "alert ip any any -> any any " "(content:\"/one/\"; ipv4-csum:valid; " "msg:\"ipv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig 1 parse: ");
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-            "alert ip any any -> any any "
-            "(content:\"/one/\"; ipv4-csum:invalid; "
-            "msg:\"ipv4-csum keyword check(1)\"; "
-            "sid:2;)");
+                                     "alert ip any any -> any any " "(content:\"/one/\"; ipv4-csum:invalid; " "msg:\"ipv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         printf("sig 2 parse: ");
         goto end;
@@ -6082,19 +6139,16 @@ int SigTest25NegativeIPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any "
-                               "(content:\"/one/\"; ipv4-csum:invalid; "
-                               "msg:\"ipv4-csum keyword check(1)\"; sid:1;)");
+                               "alert ip any any -> any any " "(content:\"/one/\"; ipv4-csum:invalid; " "msg:\"ipv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert ip any any -> any any "
-                                     "(content:\"/one/\"; ipv4-csum:valid; "
-                                     "msg:\"ipv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert ip any any -> any any " "(content:\"/one/\"; ipv4-csum:valid; " "msg:\"ipv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -6196,18 +6250,15 @@ int SigTest26TCPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any "
-                               "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; "
-                               "msg:\"tcpv4-csum keyword check(1)\"; sid:1;)");
+                               "alert ip any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; " "msg:\"tcpv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert ip any any -> any any "
-                                     "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; "
-                                     "msg:\"tcpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert ip any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; " "msg:\"tcpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6310,20 +6361,15 @@ static int SigTest26TCPV4AndNegativeIPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any "
-                               "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; "
-                               "ipv4-csum:invalid; "
-                               "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; sid:1;)");
+                               "alert ip any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; " "ipv4-csum:invalid; " "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert ip any any -> any any "
-                                     "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; "
-                                     "ipv4-csum:invalid; "
-                                     "msg:\"tcpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert ip any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; " "ipv4-csum:invalid; " "msg:\"tcpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6436,20 +6482,15 @@ static int SigTest26TCPV4AndIPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert ip any any -> any any "
-                               "(tcpv4-csum:valid; "
-                               "ipv4-csum:valid; "
-                               "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; sid:1;)");
+                               "alert ip any any -> any any " "(tcpv4-csum:valid; " "ipv4-csum:valid; " "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert ip any any -> any any "
-                                     "(tcpv4-csum:invalid; "
-                                     "ipv4-csum:valid; "
-                                     "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert ip any any -> any any " "(tcpv4-csum:invalid; " "ipv4-csum:valid; " "msg:\"tcpv4-csum and ipv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6550,18 +6591,15 @@ static int SigTest27NegativeTCPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-            "alert tcp any any -> any any "
-            "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; dsize:20; "
-            "msg:\"tcpv4-csum keyword check(1)\"; sid:1;)");
+                               "alert tcp any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; dsize:20; " "msg:\"tcpv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert tcp any any -> any any "
-                                     "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; "
-                                     "msg:\"tcpv4-csum keyword check(2)\"; "
-                                     "sid:2;)");
+                                     "alert tcp any any -> any any " "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; " "msg:\"tcpv4-csum keyword check(2)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6678,18 +6716,15 @@ int SigTest28TCPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"|00 01 69|\"; tcpv6-csum:valid; dsize:12; "
-                               "msg:\"tcpv6-csum keyword check(1)\"; sid:1;)");
+                               "alert tcp any any -> any any " "(content:\"|00 01 69|\"; tcpv6-csum:valid; dsize:12; " "msg:\"tcpv6-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert tcp any any -> any any "
-                                     "(content:\"|00 01 69|\"; tcpv6-csum:invalid; dsize:12; "
-                                     "msg:\"tcpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert tcp any any -> any any " "(content:\"|00 01 69|\"; tcpv6-csum:invalid; dsize:12; " "msg:\"tcpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6806,19 +6841,15 @@ int SigTest29NegativeTCPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"|00 01 69|\"; tcpv6-csum:invalid; dsize:12; "
-                               "msg:\"tcpv6-csum keyword check(1)\"; "
-                               "sid:1;)");
+                               "alert tcp any any -> any any " "(content:\"|00 01 69|\"; tcpv6-csum:invalid; dsize:12; " "msg:\"tcpv6-csum keyword check(1)\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert tcp any any -> any any "
-                                     "(content:\"|00 01 69|\"; tcpv6-csum:valid; dsize:12; "
-                                     "msg:\"tcpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert tcp any any -> any any " "(content:\"|00 01 69|\"; tcpv6-csum:valid; dsize:12; " "msg:\"tcpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         goto end;
     }
@@ -6924,20 +6955,16 @@ int SigTest30UDPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(content:\"/one/\"; udpv4-csum:valid; "
-                               "msg:\"udpv4-csum keyword check(1)\"; "
-                               "sid:1;)");
+                               "alert udp any any -> any any " "(content:\"/one/\"; udpv4-csum:valid; " "msg:\"udpv4-csum keyword check(1)\"; " "sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert udp any any -> any any "
-                                     "(content:\"/one/\"; udpv4-csum:invalid; "
-                                     "msg:\"udpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert udp any any -> any any " "(content:\"/one/\"; udpv4-csum:invalid; " "msg:\"udpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7047,19 +7074,16 @@ int SigTest31NegativeUDPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(content:\"/one/\"; udpv4-csum:invalid; "
-                               "msg:\"udpv4-csum keyword check(1)\"; sid:1;)");
+                               "alert udp any any -> any any " "(content:\"/one/\"; udpv4-csum:invalid; " "msg:\"udpv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert udp any any -> any any "
-                                     "(content:\"/one/\"; udpv4-csum:valid; "
-                                     "msg:\"udpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert udp any any -> any any " "(content:\"/one/\"; udpv4-csum:valid; " "msg:\"udpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7164,19 +7188,16 @@ int SigTest32UDPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(content:\"/one/\"; udpv6-csum:valid; "
-                               "msg:\"udpv6-csum keyword check(1)\"; sid:1;)");
+                               "alert udp any any -> any any " "(content:\"/one/\"; udpv6-csum:valid; " "msg:\"udpv6-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert udp any any -> any any "
-                                     "(content:\"/one/\"; udpv6-csum:invalid; "
-                                     "msg:\"udpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert udp any any -> any any " "(content:\"/one/\"; udpv6-csum:invalid; " "msg:\"udpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7279,19 +7300,16 @@ int SigTest33NegativeUDPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert udp any any -> any any "
-                               "(content:\"/one/\"; udpv6-csum:invalid; "
-                               "msg:\"udpv6-csum keyword check(1)\"; sid:1;)");
+                               "alert udp any any -> any any " "(content:\"/one/\"; udpv6-csum:invalid; " "msg:\"udpv6-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert udp any any -> any any "
-                                     "(content:\"/one/\"; udpv6-csum:valid; "
-                                     "msg:\"udpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert udp any any -> any any " "(content:\"/one/\"; udpv6-csum:valid; " "msg:\"udpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7399,19 +7417,16 @@ int SigTest34ICMPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert icmp any any -> any any "
-                               "(content:\"/one/\"; icmpv4-csum:valid; "
-                               "msg:\"icmpv4-csum keyword check(1)\"; sid:1;)");
+                               "alert icmp any any -> any any " "(content:\"/one/\"; icmpv4-csum:valid; " "msg:\"icmpv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert icmp any any -> any any "
-                                     "(content:\"/one/\"; icmpv4-csum:invalid; "
-                                     "msg:\"icmpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert icmp any any -> any any " "(content:\"/one/\"; icmpv4-csum:invalid; " "msg:\"icmpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -7519,19 +7534,16 @@ int SigTest35NegativeICMPV4Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert icmp any any -> any any "
-                               "(content:\"/one/\"; icmpv4-csum:invalid; "
-                               "msg:\"icmpv4-csum keyword check(1)\"; sid:1;)");
+                               "alert icmp any any -> any any " "(content:\"/one/\"; icmpv4-csum:invalid; " "msg:\"icmpv4-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert icmp any any -> any any "
-                                     "(content:\"/one/\"; icmpv4-csum:valid; "
-                                     "msg:\"icmpv4-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert icmp any any -> any any " "(content:\"/one/\"; icmpv4-csum:valid; " "msg:\"icmpv4-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7648,19 +7660,16 @@ int SigTest36ICMPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert icmpv6 any any -> any any "
-                               "(content:\"/one/\"; icmpv6-csum:valid; "
-                               "msg:\"icmpv6-csum keyword check(1)\"; sid:1;)");
+                               "alert icmpv6 any any -> any any " "(content:\"/one/\"; icmpv6-csum:valid; " "msg:\"icmpv6-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert icmpv6 any any -> any any "
-                                     "(content:\"/one/\"; icmpv6-csum:invalid; "
-                                     "msg:\"icmpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert icmpv6 any any -> any any " "(content:\"/one/\"; icmpv6-csum:invalid; " "msg:\"icmpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7776,19 +7785,16 @@ int SigTest37NegativeICMPV6Keyword(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert icmpv6 any any -> any any "
-                               "(content:\"/one/\"; icmpv6-csum:invalid; "
-                               "msg:\"icmpv6-csum keyword check(1)\"; sid:1;)");
+                               "alert icmpv6 any any -> any any " "(content:\"/one/\"; icmpv6-csum:invalid; " "msg:\"icmpv6-csum keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
 
     de_ctx->sig_list->next = SigInit(de_ctx,
-                                     "alert icmpv6 any any -> any any "
-                                     "(content:\"/one/\"; icmpv6-csum:valid; "
-                                     "msg:\"icmpv6-csum keyword check(1)\"; "
-                                     "sid:2;)");
+                                     "alert icmpv6 any any -> any any " "(content:\"/one/\"; icmpv6-csum:valid; " "msg:\"icmpv6-csum keyword check(1)\"; " "sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -7901,19 +7907,15 @@ static int SigTest38(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"LEN1|20|\"; "
-                               "byte_test:4,=,8,0; "
-                               "msg:\"byte_test keyword check(1)\"; sid:1;)");
+                               "alert tcp any any -> any any " "(content:\"LEN1|20|\"; " "byte_test:4,=,8,0; " "msg:\"byte_test keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
     de_ctx->sig_list->next = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"LEN1|20|\"; "
-                               "byte_test:4,=,8,5,relative,string,dec; "
-                               "msg:\"byte_test keyword check(2)\"; sid:2;)");
+                                     "alert tcp any any -> any any " "(content:\"LEN1|20|\"; " "byte_test:4,=,8,5,relative,string,dec; " "msg:\"byte_test keyword check(2)\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -8032,24 +8034,16 @@ static int SigTest39(void)
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"LEN1|20|\"; "
-                               "byte_test:4,=,8,0; "
-                               "byte_jump:4,0; "
-                               "byte_test:6,=,0x4c454e312038,0,relative; "
-                               "msg:\"byte_jump keyword check(1)\"; sid:1;)");
+                               "alert tcp any any -> any any " "(content:\"LEN1|20|\"; " "byte_test:4,=,8,0; " "byte_jump:4,0; " "byte_test:6,=,0x4c454e312038,0,relative; " "msg:\"byte_jump keyword check(1)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result &= 0;
         goto end;
     }
     // XXX TODO
     de_ctx->sig_list->next = SigInit(de_ctx,
-                               "alert tcp any any -> any any "
-                               "(content:\"LEN1|20|\"; "
-                               "byte_test:4,=,8,4,relative,string,dec; "
-                               "byte_jump:4,4,relative,string,dec,post_offset 2; "
-                               "byte_test:4,=,0x4c454e32,0,relative; "
-                               "msg:\"byte_jump keyword check(2)\"; sid:2;)");
+                                     "alert tcp any any -> any any " "(content:\"LEN1|20|\"; " "byte_test:4,=,8,4,relative,string,dec; " "byte_jump:4,4,relative,string,dec,post_offset 2; " "byte_test:4,=,0x4c454e32,0,relative; " "msg:\"byte_jump keyword check(2)\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result &= 0;
         goto end;
@@ -8152,7 +8146,9 @@ static int SigTest36ContentAndIsdataatKeywords01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest36ContentAndIsdataatKeywords01 \"; content:\"HTTP\"; isdataat:404, relative; sid:101;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"SigTest36ContentAndIsdataatKeywords01 \"; content:\"HTTP\"; isdataat:404, relative; sid:101;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8271,7 +8267,9 @@ static int SigTest37ContentAndIsdataatKeywords02 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    Signature *s = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"SigTest37ContentAndIsdataatKeywords01 \"; content:\"HTTP\"; isdataat:500, relative; sid:101;)");
+    Signature *s = de_ctx->sig_list = SigInit(de_ctx,
+                                              "alert tcp any any -> any any (msg:\"SigTest37ContentAndIsdataatKeywords01 \"; content:\"HTTP\"; isdataat:500, relative; sid:101;)",
+                                              NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig parse failed: ");
         result = 0;
@@ -8378,7 +8376,9 @@ static int SigTest40NoPacketInspection01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> 1.2.3.4 any (msg:\"No Packet Inspection Test\"; flow:to_server; sid:2; rev:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> 1.2.3.4 any (msg:\"No Packet Inspection Test\"; flow:to_server; sid:2; rev:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8439,7 +8439,9 @@ int SigTest40NoPayloadInspection02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"No Payload TEST\"; content:\"220 (vsFTPd 2.0.5)\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"No Payload TEST\"; content:\"220 (vsFTPd 2.0.5)\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8499,7 +8501,9 @@ static int SigTestMemory01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8531,12 +8535,16 @@ static int SigTestMemory02 (void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any 456 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any 456 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any 1:1000 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any 1:1000 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -8565,17 +8573,23 @@ static int SigTestMemory03 (void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> 1.2.3.4 456 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> 1.2.3.4 456 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> 1.2.3.3-1.2.3.6 1:1000 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> 1.2.3.3-1.2.3.6 1:1000 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next->next = SigInit(de_ctx,"alert tcp any any -> !1.2.3.5 1:990 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:3;)");
+    de_ctx->sig_list->next->next = SigInit(de_ctx,
+                                           "alert tcp any any -> !1.2.3.5 1:990 (msg:\"HTTP URI cap\"; content:\"GET \"; depth:4; pcre:\"/GET (?P<pkt_http_uri>.*) HTTP\\/\\d\\.\\d\\r\\n/G\"; sid:3;)",
+                                           NULL);
     if (de_ctx->sig_list->next->next == NULL) {
         result = 0;
         goto end;
@@ -8610,7 +8624,9 @@ static int SigTestContent01 (void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8653,13 +8669,17 @@ static int SigTestContent02 (void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
 
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 31\"; content:\"0123456789012345678901234567890\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Test 31\"; content:\"0123456789012345678901234567890\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -8707,7 +8727,9 @@ static int SigTestContent03 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8752,7 +8774,9 @@ static int SigTestContent04 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -8798,12 +8822,16 @@ static int SigTestContent05 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         printf("sig1 parse failed: ");
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:1; within:32; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Test 32\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:1; within:32; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         printf("sig2 parse failed: ");
         goto end;
@@ -8858,12 +8886,16 @@ static int SigTestContent06 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Test 32 sig1\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert ip any any -> any any (msg:\"Test 32 sig1\"; content:\"01234567890123456789012345678901\"; content:\"abcdefghijklmnopqrstuvwxyzABCDEF\"; distance:0; within:32; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
-    de_ctx->sig_list->next = SigInit(de_ctx,"alert ip any any -> any any (msg:\"Test 32 sig2\"; content:\"01234567890123456789012345678901\"; content:\"abcdefg\"; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert ip any any -> any any (msg:\"Test 32 sig2\"; content:\"01234567890123456789012345678901\"; content:\"abcdefg\"; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL) {
         result = 0;
         goto end;
@@ -9009,7 +9041,9 @@ static int SigTestWithin01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"within test\"; content:\"Hi, this is a big test to check \"; content:\"content matches\"; distance:0; within:15; sid:556;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"within test\"; content:\"Hi, this is a big test to check \"; content:\"content matches\"; distance:0; within:15; sid:556;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9130,7 +9164,9 @@ static int SigTestDepthOffset01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"depth offset\"; content:\"456\"; offset:4; depth:3; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"depth offset\"; content:\"456\"; offset:4; depth:3; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
@@ -9169,8 +9205,9 @@ static int SigTestDetectAlertCounter(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any (msg:\"Test counter\"; "
-                               "content:\"boo\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any (msg:\"Test counter\"; " "content:\"boo\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL) {
         goto end;
     }
@@ -9252,9 +9289,9 @@ static int SigTestDropFlow01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop http any any -> any any "
-                                   "(msg:\"Test proto match\"; "
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop http any any -> any any " "(msg:\"Test proto match\"; " "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -9354,9 +9391,9 @@ static int SigTestDropFlow02(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"one\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 " "(msg:\"Test proto match\"; uricontent:\"one\";" "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
@@ -9475,18 +9512,18 @@ static int SigTestDropFlow03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"one\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 " "(msg:\"Test proto match\"; uricontent:\"one\";" "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     /* the no inspection flag should be set after the first sig gets triggered,
      * so the second packet should not match the next sig (because of no inspection) */
-    s = de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"two\";"
-                                   "sid:2;)");
+    s = de_ctx->sig_list->next = SigInit(de_ctx,
+                                         "alert tcp any any -> any 80 " "(msg:\"Test proto match\"; uricontent:\"two\";" "sid:2;)",
+                                         NULL);
     if (s == NULL) {
         goto end;
     }
@@ -9646,18 +9683,18 @@ static int SigTestDropFlow04(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"one\";"
-                                   "sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "drop tcp any any -> any 80 " "(msg:\"Test proto match\"; uricontent:\"one\";" "sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }
 
     /* the no inspection flag should be set after the first sig gets triggered,
      * so the second packet should not match the next sig (because of no inspection) */
-    s = de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any 80 "
-                                   "(msg:\"Test proto match\"; uricontent:\"two\";"
-                                   "sid:2;)");
+    s = de_ctx->sig_list->next = SigInit(de_ctx,
+                                         "alert tcp any any -> any 80 " "(msg:\"Test proto match\"; uricontent:\"two\";" "sid:2;)",
+                                         NULL);
     if (s == NULL) {
         goto end;
     }
@@ -9791,8 +9828,9 @@ static int SigTestPorts01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = de_ctx->sig_list = SigInit(de_ctx, "alert ip any any -> any 80 "
-                                   "(content:\"AAA\"; sid:1;)");
+    s = de_ctx->sig_list = SigInit(de_ctx,
+                                   "alert ip any any -> any 80 " "(content:\"AAA\"; sid:1;)",
+                                   NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/detect.c
+++ b/src/detect.c
@@ -328,7 +328,7 @@ static int DetectLoadSigFile(DetectEngineCtx *de_ctx, char *sig_file,
         de_ctx->rule_file = sig_file;
         de_ctx->rule_line = lineno - multiline;
 
-        sig = DetectEngineAppendSig(de_ctx, line);
+        sig = DetectEngineAppendSig(de_ctx, line, NULL);
         if (sig != NULL) {
             if (rule_engine_analysis_set || fp_engine_analysis_set) {
                 RetrieveFPForSig(sig);
@@ -9879,13 +9879,15 @@ static int SigTestBug01(void)
     }
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                                   "(content:\"Omymy\"; nocase; sid:1;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(content:\"Omymy\"; nocase; sid:1;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
-    s = DetectEngineAppendSig(de_ctx, "alert tcp any any -> any any "
-                                   "(content:\"!mymy\"; nocase; sid:2;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp any any -> any any " "(content:\"!mymy\"; nocase; sid:2;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -9949,11 +9951,11 @@ static int DetectAddressYamlParsing01 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)", NULL)) == NULL)
         goto end;
 
     result = 1;
@@ -9996,11 +9998,11 @@ static int DetectAddressYamlParsing02 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)", NULL)) == NULL)
         goto end;
 
     result = 1;
@@ -10043,11 +10045,11 @@ static int DetectAddressYamlParsing03 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)", NULL)) == NULL)
         goto end;
 
     result = 1;
@@ -10091,11 +10093,11 @@ static int DetectAddressYamlParsing04 (void)
 
     de_ctx->flags |= DE_QUIET;
 
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> any any (sid:1;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp any any -> $HOME_NET any (sid:2;)", NULL)) == NULL)
         goto end;
-    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)")) == NULL)
+    if ((DetectEngineAppendSig(de_ctx, "alert tcp $HOME_NET any -> $HOME_NET any (sid:3;)", NULL)) == NULL)
         goto end;
 
     result = 1;

--- a/src/detect.h
+++ b/src/detect.h
@@ -526,6 +526,14 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+/** \brief Signature loader statistics */
+typedef struct SigFileLoaderStat_ {
+    int bad_files;
+    int total_files;
+    int good_sigs_total;
+    int bad_sigs_total;
+} SigFileLoaderStat;
+
 typedef struct DetectEngineThreadKeywordCtxItem_ {
     void *(*InitFunc)(void *);
     void (*FreeFunc)(void *);
@@ -676,6 +684,12 @@ typedef struct DetectEngineCtx_ {
 
     DetectPort *tcp_whitelist;
     DetectPort *udp_whitelist;
+
+    /** time of last ruleset reload */
+    struct timeval last_reload;
+
+    /** signatures stats */
+    SigFileLoaderStat sig_stat;
 
 } DetectEngineCtx;
 
@@ -1085,14 +1099,6 @@ typedef struct DetectEngineMasterCtx_ {
     DetectEngineTenantMapping *tenant_mapping_list;
 
 } DetectEngineMasterCtx;
-
-/** \brief Signature loader statistics */
-typedef struct SigFileLoaderStat_ {
-    int bad_files;
-    int total_files;
-    int good_sigs_total;
-    int bad_sigs_total;
-} SigFileLoaderStat;
 
 /** Remember to add the options in SignatureIsIPOnly() at detect.c otherwise it wont be part of a signature group */
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -526,8 +526,17 @@ typedef struct ThresholdCtx_    {
     uint32_t th_size;
 } ThresholdCtx;
 
+typedef struct SigString_ {
+    char *filename;
+    char *sig_str;
+    char *sig_error;
+    int line;
+    TAILQ_ENTRY(SigString_) next;
+} SigString;
+
 /** \brief Signature loader statistics */
 typedef struct SigFileLoaderStat_ {
+    TAILQ_HEAD(, SigString_) failed_sigs;
     int bad_files;
     int total_files;
     int good_sigs_total;

--- a/src/log-droplog.c
+++ b/src/log-droplog.c
@@ -388,8 +388,9 @@ int LogDropLogTest01()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    de_ctx->sig_list = SigInit(de_ctx, "drop tcp any any -> any any "
-            "(msg:\"LogDropLog test\"; content:\"GET\"; Classtype:unknown; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "drop tcp any any -> any any " "(msg:\"LogDropLog test\"; content:\"GET\"; Classtype:unknown; sid:1;)",
+                               NULL);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
@@ -452,8 +453,9 @@ int LogDropLogTest02()
     FILE *fd = SCClassConfGenerateValidDummyClassConfigFD01();
     SCClassConfLoadClassficationConfigFile(de_ctx, fd);
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert udp any any -> any any "
-            "(msg:\"LogDropLog test\"; content:\"GET\"; Classtype:unknown; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert udp any any -> any any " "(msg:\"LogDropLog test\"; content:\"GET\"; Classtype:unknown; sid:1;)",
+                               NULL);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);

--- a/src/output-json-stats.h
+++ b/src/output-json-stats.h
@@ -34,5 +34,9 @@
 json_t *StatsToJSON(const StatsTable *st, uint8_t flags);
 #endif
 void TmModuleJsonStatsLogRegister (void);
+#ifdef HAVE_LIBJANSSON
+TmEcode OutputTenancyStatsLastReload();
+TmEcode OutputTenancyStatsRuleset();
+#endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_COUNTERS_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -248,6 +248,14 @@ int g_detect_disabled = 0;
 /** set caps or not */
 int sc_set_caps;
 
+/** Suricata instance */
+SCInstance suri;
+
+int SuriHasSigFile(void)
+{
+    return (suri.sig_file != NULL);
+}
+
 int EngineModeIsIPS(void)
 {
     return (g_engine_mode == ENGINE_MODE_IPS);
@@ -2440,8 +2448,6 @@ static int PostConfLoadedSetup(SCInstance *suri)
 
 int main(int argc, char **argv)
 {
-    SCInstance suri;
-
     SCInstanceInit(&suri);
     suri.progname = argv[0];
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2682,7 +2682,7 @@ int main(int argc, char **argv)
                 if (!(DetectEngineReloadIsStart())) {
                     DetectEngineReloadStart();
                     DetectEngineReload(&suri);
-                    DetectEngineReloadSetDone();
+                    DetectEngineReloadSetIdle();
                     sigusr2_count--;
                 }
             }
@@ -2691,10 +2691,10 @@ int main(int argc, char **argv)
             if (suri.sig_file != NULL) {
                 SCLogWarning(SC_ERR_LIVE_RULE_SWAP, "Live rule reload not "
                         "possible if -s or -S option used at runtime.");
-                DetectEngineReloadSetDone();
+                DetectEngineReloadSetIdle();
             } else {
                 DetectEngineReload(&suri);
-                DetectEngineReloadSetDone();
+                DetectEngineReloadSetIdle();
             }
         }
 

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -188,6 +188,8 @@ int RunmodeIsUnittests(void);
 int RunmodeGetCurrent(void);
 int IsRuleReloadSet(int quiet);
 
+int SuriHasSigFile(void);
+
 extern int run_mode;
 
 #endif /* __SURICATA_H__ */

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -702,16 +702,33 @@ TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
     SCReturnInt(TM_ECODE_OK);
 }
 
-TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+TmEcode UnixManagerReloadRulesWrapper(json_t *cmd, json_t *server_msg, void *data, int wait)
 {
     SCEnter();
-    DetectEngineReloadStart();
+    int r = DetectEngineReloadStart();
 
-    while (DetectEngineReloadIsDone() == 0)
-        usleep(100);
+    if (r == 0 && wait) {
+        while (DetectEngineReloadIsIdle() == 0)
+            usleep(100);
+    } else {
+        if (r == -1) {
+            json_object_set_new(server_msg, "message", json_string("Reload already in progress"));
+            SCReturnInt(TM_ECODE_FAILED);
+        }
+    }
 
     json_object_set_new(server_msg, "message", json_string("done"));
     SCReturnInt(TM_ECODE_OK);
+}
+
+TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 1);
+}
+
+TmEcode UnixManagerNonBlockingReloadRules(json_t *cmd, json_t *server_msg, void *data)
+{
+    return UnixManagerReloadRulesWrapper(cmd, server_msg, data, 0);
 }
 
 TmEcode UnixManagerLastReloadCommand(json_t *cmd,
@@ -963,6 +980,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -762,6 +762,53 @@ TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
     json_object_set_new(server_msg, "message", jdata);
     SCReturnInt(retval);
 }
+
+TmEcode UnixManagerShowFailedRules(json_t *cmd,
+                                   json_t *server_msg, void *data)
+{
+    SCEnter();
+    DetectEngineCtx *de_ctx = DetectEngineGetCurrent();
+    /* Since we need to deference de_ctx, we don't want to lost it. */
+    DetectEngineCtx *list = de_ctx;
+    json_t *js_sigs_array = json_array();
+
+    if (js_sigs_array == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        goto error;
+    }
+    while (list) {
+        SigString *sigs_str = NULL;
+        TAILQ_FOREACH(sigs_str, &list->sig_stat.failed_sigs, next) {
+            json_t *jdata = json_object();
+            if (jdata == NULL) {
+                json_object_set_new(server_msg, "message", json_string("Unable to get the sig"));
+                json_object_clear(js_sigs_array);
+                goto error;
+            }
+
+            json_object_set_new(jdata, "tenant_id", json_integer(list->tenant_id));
+            json_object_set_new(jdata, "rule", json_string(sigs_str->sig_str));
+            json_object_set_new(jdata, "filename", json_string(sigs_str->filename));
+            json_object_set_new(jdata, "line", json_integer(sigs_str->line));
+            if (sigs_str->sig_error) {
+                json_object_set_new(jdata, "error", json_string(sigs_str->sig_error));
+            }
+            json_array_append_new(js_sigs_array, jdata);
+        }
+        list = list->next;
+    }
+
+    json_object_set_new(server_msg, "message", js_sigs_array);
+    DetectEngineDeReference(&de_ctx);
+    SCReturnInt(TM_ECODE_OK);
+
+error:
+    DetectEngineDeReference(&de_ctx);
+    json_object_clear(js_sigs_array);
+    json_decref(js_sigs_array);
+    SCReturnInt(TM_ECODE_FAILED);
+}
+
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -983,6 +1030,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-failed-rules", UnixManagerShowFailedRules, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -705,6 +705,14 @@ TmEcode UnixManagerCaptureModeCommand(json_t *cmd,
 TmEcode UnixManagerReloadRulesWrapper(json_t *cmd, json_t *server_msg, void *data, int wait)
 {
     SCEnter();
+
+    if (SuriHasSigFile()) {
+        json_object_set_new(server_msg, "message",
+                            json_string("Live rule reload not possible if -s "
+                                        "or -S option used at runtime."));
+        SCReturnInt(TM_ECODE_FAILED);
+    }
+
     int r = DetectEngineReloadStart();
 
     if (r == 0 && wait) {

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -29,6 +29,8 @@
 #include "runmodes.h"
 #include "conf.h"
 
+#include "output-json-stats.h"
+
 #include "util-privs.h"
 #include "util-debug.h"
 #include "util-signal.h"
@@ -712,6 +714,37 @@ TmEcode UnixManagerReloadRules(json_t *cmd, json_t *server_msg, void *data)
     SCReturnInt(TM_ECODE_OK);
 }
 
+TmEcode UnixManagerLastReloadCommand(json_t *cmd,
+                                     json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsLastReload(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
+
+TmEcode UnixManagerRulesetStatsCommand(json_t *cmd,
+                                       json_t *server_msg, void *data)
+{
+    SCEnter();
+    TmEcode retval;
+    json_t *jdata = json_object();
+    if (jdata == NULL) {
+        json_object_set_new(server_msg, "message", json_string("Unable to get info"));
+        return TM_ECODE_FAILED;
+    }
+
+    retval = OutputTenancyStatsRuleset(&jdata);
+    json_object_set_new(server_msg, "message", jdata);
+    SCReturnInt(retval);
+}
 TmEcode UnixManagerConfGetCommand(json_t *cmd,
                                   json_t *server_msg, void *data)
 {
@@ -930,6 +963,8 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
     UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);
     UnixManagerRegisterCommand("register-tenant-handler", UnixSocketRegisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("unregister-tenant-handler", UnixSocketUnregisterTenantHandler, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("register-tenant", UnixSocketRegisterTenant, &command, UNIX_CMD_TAKE_ARGS);

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -1026,7 +1026,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     UnixManagerRegisterCommand("capture-mode", UnixManagerCaptureModeCommand, &command, 0);
     UnixManagerRegisterCommand("conf-get", UnixManagerConfGetCommand, &command, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("dump-counters", StatsOutputCounterSocket, NULL, 0);
-    UnixManagerRegisterCommand("reload-rules", UnixManagerReloadRules, NULL, 0);
+    UnixManagerRegisterCommand("ruleset-reload-rules", UnixManagerReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-reload-nonblocking", UnixManagerNonBlockingReloadRules, NULL, 0);
     UnixManagerRegisterCommand("ruleset-last-reload", UnixManagerLastReloadCommand, NULL, 0);
     UnixManagerRegisterCommand("ruleset-stats", UnixManagerRulesetStatsCommand, NULL, 0);

--- a/src/util-detect.c
+++ b/src/util-detect.c
@@ -1,0 +1,120 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
+ */
+
+#include "suricata-common.h"
+#include "suricata.h"
+#include "detect.h"
+#include "util-detect.h"
+
+/**
+ * \brief Allocate SigString list member
+ *
+ * \retval Pointer to SigString
+ */
+SigString *SigStringAlloc(void)
+{
+    SigString *sigstr = SCCalloc(1, sizeof(SigString));
+    if (unlikely(sigstr == NULL))
+        return NULL;
+
+    sigstr->line = 0;
+
+    return sigstr;
+}
+
+/**
+ * \brief Assigns the filename, signature, lineno to SigString list member
+ *
+ * \param sig pointer to SigString
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param sig_error signature parsing error
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+static int SigStringAddSig(SigString *sig, const char *sig_file,
+                           const char *sig_str, const char *sig_error,
+                           int line)
+{
+    if (sig_file == NULL || sig_str == NULL) {
+        return 0;
+    }
+
+    sig->filename = SCStrdup(sig_file);
+    if (sig->filename == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        return 0;
+    }
+
+    sig->sig_str = SCStrdup(sig_str);
+    if (sig->sig_str == NULL) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+        SCFree(sig->filename);
+        return 0;
+    }
+
+    if (sig_error) {
+        sig->sig_error = SCStrdup(sig_error);
+        if (sig->sig_error == NULL) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory");
+            SCFree(sig->filename);
+            SCFree(sig->sig_str);
+            return 0;
+        }
+    }
+
+    sig->line = line;
+
+    return 1;
+}
+
+/**
+ * \brief Append a new list member to SigString list
+ *
+ * \param list pointer to the start of the SigString list
+ * \param sig_file filename that contains the signature
+ * \param sig_str signature in string format
+ * \param line line line number
+ *
+ * \retval 1 on success 0 on failure
+ */
+int SigStringAppend(SigFileLoaderStat *sig_stats, const char *sig_file,
+                    const char *sig_str, const char *sig_error, int line)
+{
+    SigString *item = SigStringAlloc();
+    if (item == NULL) {
+        return 0;
+    }
+
+    if (!SigStringAddSig(item, sig_file, sig_str, sig_error, line)) {
+        SCFree(item);
+        return 0;
+    }
+
+    TAILQ_INSERT_TAIL(&sig_stats->failed_sigs, item, next);
+
+    return 1;
+}

--- a/src/util-detect.h
+++ b/src/util-detect.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2016 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,17 +18,11 @@
 /**
  * \file
  *
- * \author Brian Rectanus <brectanu@gmail.com>
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ * Detection engine helper functions
  */
 
-#ifndef __DETECT_HTTP_METHOD_H__
-#define __DETECT_HTTP_METHOD_H__
-
-/* prototypes */
-void DetectHttpMethodRegister(void);
-int DetectHttpMethodDoMatch(DetectEngineThreadCtx *, Signature *, SigMatch *,
-                            Flow *, uint8_t, void *);
-int DetectHttpMethodValidateRule(const Signature *s, char **sigerror);
-
-#endif /* __DETECT_HTTP_METHOD_H__ */
-
+SigString *SigStringAlloc(void);
+int SigStringAppend(SigFileLoaderStat *sigs_stats, const char *sig_file, const char *sig_str,
+                    const char *sig_error, int line);

--- a/src/util-mpm-ac-bs.c
+++ b/src/util-mpm-ac-bs.c
@@ -2439,12 +2439,14 @@ static int SCACBSTest30(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
-    de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL)
         goto end;
 

--- a/src/util-mpm-ac-tile.c
+++ b/src/util-mpm-ac-tile.c
@@ -2497,12 +2497,14 @@ static int SCACTileTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
-    de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL)
         goto end;
 

--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -2791,12 +2791,14 @@ static int SCACTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
-    de_ctx->sig_list->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                               "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)");
+    de_ctx->sig_list->next = SigInit(de_ctx,
+                                     "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; fast_pattern:3,3; sid:2;)",
+                                     NULL);
     if (de_ctx->sig_list->next == NULL)
         goto end;
 

--- a/src/util-mpm-hs.c
+++ b/src/util-mpm-hs.c
@@ -2091,15 +2091,15 @@ static int SCHSTest29(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(
-        de_ctx, "alert tcp any any -> any any "
-                "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)");
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; sid:1;)",
+                               NULL);
     if (de_ctx->sig_list == NULL)
         goto end;
     de_ctx->sig_list->next =
-        SigInit(de_ctx, "alert tcp any any -> any any "
-                        "(content:\"onetwothreefourfivesixseveneightnine\"; "
-                        "fast_pattern:3,3; sid:2;)");
+        SigInit(de_ctx,
+                "alert tcp any any -> any any " "(content:\"onetwothreefourfivesixseveneightnine\"; " "fast_pattern:3,3; sid:2;)",
+                NULL);
     if (de_ctx->sig_list->next == NULL)
         goto end;
 

--- a/src/util-rule-vars.c
+++ b/src/util-rule-vars.c
@@ -376,7 +376,9 @@ int SCRuleVarsPositiveTest03(void)
         goto end;
     SigFree(s);
 */
-    s = SigInit(de_ctx, "alert tcp [$HTTP_SERVERS,$HOME_NET,192.168.2.5] $HTTP_PORTS -> $EXTERNAL_NET [80,[!$HTTP_PORTS,$ORACLE_PORTS]] (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp [$HTTP_SERVERS,$HOME_NET,192.168.2.5] $HTTP_PORTS -> $EXTERNAL_NET [80,[!$HTTP_PORTS,$ORACLE_PORTS]] (msg:\"Rule Vars Test\"; sid:1;)",
+                NULL);
     if (s == NULL)
         goto end;
     SigFree(s);
@@ -410,21 +412,29 @@ int SCRuleVarsNegativeTest04(void)
         goto end;
     de_ctx->flags |= DE_QUIET;
 
-    s = SigInit(de_ctx, "alert tcp $HTTP_SERVER any -> any any (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp $HTTP_SERVER any -> any any (msg:\"Rule Vars Test\"; sid:1;)",
+                NULL);
     if (s != NULL)
         goto end;
 
-    s = SigInit(de_ctx, "alert tcp $http_servers any -> any any (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp $http_servers any -> any any (msg:\"Rule Vars Test\"; sid:1;)",
+                NULL);
     if (s != NULL)
         goto end;
     SigFree(s);
 
-    s = SigInit(de_ctx, "alert tcp $http_servers any -> any $HTTP_PORTS (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp $http_servers any -> any $HTTP_PORTS (msg:\"Rule Vars Test\"; sid:1;)",
+                NULL);
     if (s != NULL)
         goto end;
     SigFree(s);
 
-    s = SigInit(de_ctx, "alert tcp !$TELNET_SERVERS !80 -> any !$SSH_PORTS (msg:\"Rule Vars Test\"; sid:1;)");
+    s = SigInit(de_ctx,
+                "alert tcp !$TELNET_SERVERS !80 -> any !$SSH_PORTS (msg:\"Rule Vars Test\"; sid:1;)",
+                NULL);
     if (s != NULL)
         goto end;
     SigFree(s);

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -2671,7 +2671,9 @@ static int SCThresholdConfTest18(void)
         return result;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:2200029;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:2200029;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }
@@ -2746,7 +2748,9 @@ static int SCThresholdConfTest19(void)
         return result;
     de_ctx->flags |= DE_QUIET;
 
-    s = DetectEngineAppendSig(de_ctx, "alert tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:2200029;)");
+    s = DetectEngineAppendSig(de_ctx,
+                              "alert tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:2200029;)",
+                              NULL);
     if (s == NULL) {
         goto end;
     }

--- a/src/util-threshold-config.c
+++ b/src/util-threshold-config.c
@@ -1435,7 +1435,9 @@ int SCThresholdConfTest01(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1480,7 +1482,9 @@ int SCThresholdConfTest02(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:100;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:100;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1524,7 +1528,9 @@ int SCThresholdConfTest03(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1568,7 +1574,9 @@ int SCThresholdConfTest04(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1614,17 +1622,23 @@ int SCThresholdConfTest05(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
 
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit\"; gid:1; sid:10;)");
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any 80 (msg:\"Threshold limit\"; gid:1; sid:10;)",
+                              NULL);
     if (sig == NULL) {
         goto end;
     }
 
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any 80 (msg:\"Threshold limit\"; gid:1; sid:100;)");
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any 80 (msg:\"Threshold limit\"; gid:1; sid:100;)",
+                              NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1684,7 +1698,9 @@ int SCThresholdConfTest06(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1729,7 +1745,9 @@ int SCThresholdConfTest07(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1775,7 +1793,9 @@ int SCThresholdConfTest08(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1831,7 +1851,9 @@ int SCThresholdConfTest09(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"ratefilter test\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"ratefilter test\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -1957,7 +1979,9 @@ int SCThresholdConfTest10(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"ratefilter test\"; gid:1; sid:10;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"ratefilter test\"; gid:1; sid:10;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2057,9 +2081,15 @@ int SCThresholdConfTest11(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test limit\"; gid:1; sid:10;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test threshold\"; gid:1; sid:11;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test both\"; gid:1; sid:12;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"event_filter test limit\"; gid:1; sid:10;)",
+                                     NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"event_filter test threshold\"; gid:1; sid:11;)",
+                              NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"event_filter test both\"; gid:1; sid:12;)",
+                              NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2176,9 +2206,15 @@ int SCThresholdConfTest12(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test limit\"; gid:1; sid:10;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test threshold\"; gid:1; sid:11;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"event_filter test both\"; gid:1; sid:12;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"event_filter test limit\"; gid:1; sid:10;)",
+                                     NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"event_filter test threshold\"; gid:1; sid:11;)",
+                              NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"event_filter test both\"; gid:1; sid:12;)",
+                              NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2284,7 +2320,9 @@ int SCThresholdConfTest13(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; gid:1; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2344,9 +2382,15 @@ int SCThresholdConfTest14(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"suppress test\"; gid:1; sid:10000;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"suppress test 2\"; gid:1; sid:10;)");
-    sig = sig->next = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"suppress test 3\"; gid:1; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"suppress test\"; gid:1; sid:10000;)",
+                                     NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"suppress test 2\"; gid:1; sid:10;)",
+                              NULL);
+    sig = sig->next = SigInit(de_ctx,
+                              "alert tcp any any -> any any (msg:\"suppress test 3\"; gid:1; sid:1000;)",
+                              NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2407,7 +2451,9 @@ static int SCThresholdConfTest15(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any any (msg:\"suppress test\"; content:\"lalala\"; gid:1; sid:10000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "drop tcp any any -> any any (msg:\"suppress test\"; content:\"lalala\"; gid:1; sid:10000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2476,7 +2522,9 @@ static int SCThresholdConfTest16(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"drop tcp any any -> any any (msg:\"suppress test\"; gid:1; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "drop tcp any any -> any any (msg:\"suppress test\"; gid:1; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2545,7 +2593,9 @@ static int SCThresholdConfTest17(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"drop tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:10000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "drop tcp 192.168.0.10 any -> 192.168.0.100 any (msg:\"suppress test\"; gid:1; sid:10000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2774,7 +2824,9 @@ static int SCThresholdConfTest20(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; content:\"abc\"; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; content:\"abc\"; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }
@@ -2834,7 +2886,9 @@ static int SCThresholdConfTest21(void)
 
     de_ctx->flags |= DE_QUIET;
 
-    sig = de_ctx->sig_list = SigInit(de_ctx,"alert tcp any any -> any any (msg:\"Threshold limit\"; content:\"abc\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)");
+    sig = de_ctx->sig_list = SigInit(de_ctx,
+                                     "alert tcp any any -> any any (msg:\"Threshold limit\"; content:\"abc\"; threshold: type limit, track by_dst, count 5, seconds 60; sid:1000;)",
+                                     NULL);
     if (sig == NULL) {
         goto end;
     }

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -752,7 +752,7 @@ int UTHPacketMatchSigMpm(Packet *p, char *sig, uint16_t mpm_type)
     de_ctx->flags |= DE_QUIET;
     de_ctx->mpm_matcher = mpm_type;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig);
+    de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
     if (de_ctx->sig_list == NULL) {
         printf("signature == NULL: ");
         goto end;
@@ -811,7 +811,7 @@ int UTHPacketMatchSig(Packet *p, char *sig)
 
     de_ctx->flags |= DE_QUIET;
 
-    de_ctx->sig_list = SigInit(de_ctx, sig);
+    de_ctx->sig_list = SigInit(de_ctx, sig, NULL);
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -607,7 +607,7 @@ int UTHAppendSigs(DetectEngineCtx *de_ctx, char *sigs[], int numsigs)
                        " at position %d", i);
             return 0;
         }
-        s = DetectEngineAppendSig(de_ctx, sigs[i]);
+        s = DetectEngineAppendSig(de_ctx, sigs[i], NULL);
         if (s == NULL) {
             SCLogError(SC_ERR_INVALID_ARGUMENT, "Check the signature at"
                        " position %d (%s)", i, sigs[i]);


### PR DESCRIPTION
A patchset updated that aims at improving information regarding ruleset returned to the user by suricata.

This addresses comments from the last PR, in particular:
- Remove DONE state (https://github.com/inliniac/suricata/commit/9f540448b3a4c1d165e9aafd3aa8c5c1282a2ecf)
- Block live reload when -s/-S is specified (https://github.com/inliniac/suricata/commit/ee6d592661feaa4e2854a0c5f414a5f25244221d)

Last PR: https://github.com/inliniac/suricata/pull/1998
Ticket: https://redmine.openinfosecfoundation.org/issues/1585

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/119
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/118