### PR TITLE
Issue 1849 - fix ICMPv6 checksum verification if fcs present - v1

### DIFF
--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -814,10 +814,13 @@ int DetectICMPV6CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
         return cd->valid;
     }
 
-    if (p->level4_comp_csum == -1)
+    if (p->level4_comp_csum == -1) {
+        uint16_t len = IPV6_GET_RAW_PLEN(p->ip6h) -
+            ((uint8_t *)p->icmpv6h - (uint8_t *)p->ip6h - IPV6_HEADER_LEN);
         p->level4_comp_csum = ICMPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
                                                       (uint16_t *)p->icmpv6h,
-                                                      GET_PKT_LEN(p) - ((uint8_t *)p->icmpv6h - GET_PKT_DATA(p)));
+                                                      len);
+    }
 
     if (p->level4_comp_csum == p->icmpv6h->csum && cd->valid == 1)
         return 1;

--- a/src/util-unittest.h
+++ b/src/util-unittest.h
@@ -55,6 +55,17 @@ void UtRunModeRegister(void);
 extern int unittests_fatal;
 
 /**
+ * \breif Fail a test.
+ */
+#define FAIL do {                                      \
+        if (unittests_fatal) {                         \
+            BUG_ON(1);                                 \
+        } else {                                       \
+            return 0;                                  \
+        }                                              \
+    } while (0)
+
+/**
  * \brief Fail a test if expression evaluates to false.
  */
 #define FAIL_IF(expr) do {                             \


### PR DESCRIPTION
Calculate the length of the ICMPv6 packet from decoded information
instead of off the wire length. This will provide the correct
length if trailing data like an FCS is present.
    
Fixes issue:
https://redmine.openinfosecfoundation.org/issues/1849

Also, convert some unit tests to the new macros.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/304
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/309