### PR TITLE
netmap: Ignore interface 'up' status

### DIFF
--- a/src/source-netmap.c
+++ b/src/source-netmap.c
@@ -327,8 +327,7 @@ static int NetmapOpen(char *ifname, int promisc, NetmapDevice **pdevice, int ver
         goto error_fd;
     }
     if ((if_flags & IFF_UP) == 0) {
-        SCLogWarning(SC_ERR_NETMAP_CREATE, "Interface '%s' is down", ifname);
-        goto error_fd;
+        SCLogWarning(SC_ERR_NETMAP_CREATE, "Interface '%s' is down, ignoring", ifname);
     }
     /* if needed, try to set iface in promisc mode */
     if (promisc && (if_flags & (IFF_PROMISC|IFF_PPROMISC)) == 0) {


### PR DESCRIPTION
Let's ignore interface status as reported in kernel, when using kernel bypass packet capture mechanisms.

I have tested it and it presents no issues whatsoever (on FreeBSD).
