### PR TITLE
rule-parsing: reject unescaped double quote within content section

### DIFF
--- a/src/detect-content.c
+++ b/src/detect-content.c
@@ -186,6 +186,9 @@ int DetectContentDataParse(const char *keyword, const char *contentstr,
                     }
                     escape = 0;
                     converted = 1;
+                } else if (str[i] == '"') {
+                    SCLogError(SC_ERR_INVALID_SIGNATURE, "Invalid unescaped double quote within content section");
+                    goto error;
                 } else {
                     str[x] = str[i];
                     x++;
@@ -2309,6 +2312,29 @@ int DetectContentParseTest44(void)
     return result;
 }
 
+/**
+ * \test Parsing test to check for unescaped quote within content section
+ */
+int DetectContentParseTest45(void)
+{
+    DetectEngineCtx *de_ctx = NULL;
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    de_ctx->flags |= DE_QUIET;
+    de_ctx->sig_list = SigInit(de_ctx,
+                               "alert tcp any any -> any any "
+                               "(msg:\"test\"; content:\"|ff|\" content:\"TEST\"; sid:1;)");
+    FAIL_IF_NOT_NULL(de_ctx->sig_list);
+
+    SigGroupCleanup(de_ctx);
+    SigCleanSignatures(de_ctx);
+    DetectEngineCtxFree(de_ctx);
+
+    PASS;
+}
+
 static int SigTestNegativeTestContent(char *rule, uint8_t *buf)
 {
     uint16_t buflen = strlen((char *)buf);
@@ -2877,6 +2903,7 @@ void DetectContentRegisterTests(void)
     UtRegisterTest("DetectContentParseTest42", DetectContentParseTest42);
     UtRegisterTest("DetectContentParseTest43", DetectContentParseTest43);
     UtRegisterTest("DetectContentParseTest44", DetectContentParseTest44);
+    UtRegisterTest("DetectContentParseTest45", DetectContentParseTest45);
 
     /* The reals */
     UtRegisterTest("DetectContentLongPatternMatchTest01",


### PR DESCRIPTION
A double quote within the first and last double quote is an indication for a wrong rule, like the later one in https://redmine.openinfosecfoundation.org/issues/312
This also adds the unittest requested by PR #2188 and improved it as requested by PR #2227

PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/36
PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/36