### PR TITLE
invalid event fixes v0

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -121,6 +121,7 @@ alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 packet too short"; d
 alert pkthdr any any -> any any (msg:"SURICATA IPv6-in-IPv6 invalid protocol"; decode-event:ipv6.ipv6_in_ipv6_wrong_version; sid:2200085; rev:1;)
 
 # MPLS rules
+alert pkthdr any any -> any any (msg:"SURICATA MPLS header too small"; decode-event:mpls.header_too_small; sid:2200111; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA MPLS bad router alert label"; decode-event:mpls.bad_label_router_alert; sid: 2200098; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA MPLS bad implicit null label"; decode-event:mpls.bad_label_implicit_null; sid: 2200099; rev:1;)
 alert pkthdr any any -> any any (msg:"SURICATA MPLS reserved label"; decode-event:mpls.bad_label_reserved; sid: 2200100; rev:1;)
@@ -140,5 +141,5 @@ alert pkthdr any any -> any any (msg:"SURICATA ERSPAN too many vlan layers"; dec
 # Cisco Fabric Path/DCE
 alert pkthdr any any -> any any (msg:"SURICATA DCE packet too small"; decode-event:dce.pkt_too_small; sid:2200110; rev:1;)
 
-# next sid is 2200111
+# next sid is 2200112
 

--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -99,10 +99,12 @@ alert pkthdr any any -> any any (msg:"SURICATA VLAN unknown type"; decode-event:
 alert pkthdr any any -> any any (msg:"SURICATA VLAN too many layers"; decode-event:vlan.too_many_layers; sid:2200091; rev:1;)
 
 alert pkthdr any any -> any any (msg:"SURICATA IP raw invalid IP version "; decode-event:ipraw.invalid_ip_version; sid:2200068; rev:1;)
-alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large"; decode-event:ipv4.frag_too_large; sid:2200069; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large"; decode-event:ipv4.frag_pkt_too_large; sid:2200069; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Fragmentation overlap"; decode-event:ipv4.frag_overlap; sid:2200070; rev:1;)
-alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_too_large; sid:2200071; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_pkt_too_large; sid:2200071; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragmentation overlap"; decode-event:ipv6.frag_overlap; sid:2200072; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 size too large"; decode-event:ipv4.frag_too_large; sid:2200112; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 size too large"; decode-event:ipv6.frag_too_large; sid:2200113; rev:1;)
 
 # checksum rules
 alert ip any any -> any any (msg:"SURICATA IPv4 invalid checksum"; ipv4-csum:invalid; sid:2200073; rev:1;)
@@ -141,5 +143,5 @@ alert pkthdr any any -> any any (msg:"SURICATA ERSPAN too many vlan layers"; dec
 # Cisco Fabric Path/DCE
 alert pkthdr any any -> any any (msg:"SURICATA DCE packet too small"; decode-event:dce.pkt_too_small; sid:2200110; rev:1;)
 
-# next sid is 2200112
+# next sid is 2200114
 

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -168,6 +168,7 @@ const struct DecodeEvents_ DEvents[] = {
     { "decoder.ipv6.ipv6_in_ipv6_wrong_version", IPV6_IN_IPV6_WRONG_IP_VER, },
 
     /* MPLS events */
+    { "decoder.mpls.header_too_small", MPLS_HEADER_TOO_SMALL, },
     { "decoder.mpls.bad_label_router_alert", MPLS_BAD_LABEL_ROUTER_ALERT, },
     { "decoder.mpls.bad_label_implicit_null", MPLS_BAD_LABEL_IMPLICIT_NULL, },
     { "decoder.mpls.bad_label_reserved", MPLS_BAD_LABEL_RESERVED, },

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -152,10 +152,12 @@ const struct DecodeEvents_ DEvents[] = {
     { "decoder.sctp.pkt_too_small", SCTP_PKT_TOO_SMALL, },
 
     /* Fragmentation reasembly events. */
-    { "decoder.ipv4.frag_too_large", IPV4_FRAG_PKT_TOO_LARGE, },
-    { "decoder.ipv6.frag_too_large", IPV6_FRAG_PKT_TOO_LARGE, },
+    { "decoder.ipv4.frag_pkt_too_large", IPV4_FRAG_PKT_TOO_LARGE, },
+    { "decoder.ipv6.frag_pkt_too_large", IPV6_FRAG_PKT_TOO_LARGE, },
     { "decoder.ipv4.frag_overlap", IPV4_FRAG_OVERLAP, },
     { "decoder.ipv6.frag_overlap", IPV6_FRAG_OVERLAP, },
+    { "decoder.ipv4.frag_too_large", IPV4_FRAG_TOO_LARGE, },
+    { "decoder.ipv6.frag_too_large", IPV6_FRAG_TOO_LARGE, },
     /* Fragment ignored due to internal error */
     { "decoder.ipv4.frag_ignored", IPV4_FRAG_IGNORED, },
     { "decoder.ipv6.frag_ignored", IPV6_FRAG_IGNORED, },

--- a/src/decode.c
+++ b/src/decode.c
@@ -427,13 +427,14 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
         StatsRegisterCounter("defrag.ipv6.timeouts", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
-    
+
     int i = 0;
     for (i = 0; i < DECODE_EVENT_PACKET_MAX; i++) {
+        BUG_ON(i != (int)DEvents[i].code);
         dtv->counter_invalid_events[i] = StatsRegisterCounter(
                 DEvents[i].event_name, tv);
     }
-    
+
     return;
 }
 


### PR DESCRIPTION
Discovered during the dev training in Paris: invalid event enum and name<>event array were not in sync.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/486
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/491
