### PR TITLE
flowbits: validate that there are no spaces in the name - v1

### DIFF
--- a/src/detect-flowbits.c
+++ b/src/detect-flowbits.c
@@ -45,7 +45,7 @@
 #include "util-unittest.h"
 #include "util-debug.h"
 
-#define PARSE_REGEX         "([a-z]+)(?:,\\s*([^\\s]*))?"
+#define PARSE_REGEX         "([a-z]+)(?:,\\s*(.*))?"
 static pcre *parse_regex;
 static pcre_extra *parse_regex_study;
 
@@ -181,6 +181,20 @@ static int DetectFlowbitParse(char *str, char *cmd, int cmd_len, char *name,
         if (rc < 0) {
             SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_copy_substring failed");
             return 0;
+        }
+
+        /* Trim trailing whitespace. */
+        while (isblank(name[strlen(name) - 1])) {
+            name[strlen(name) - 1] = '\0';
+        }
+
+        /* Validate name, spaces are not allowed. */
+        for (size_t i = 0; i < strlen(name); i++) {
+            if (isblank(name[i])) {
+                SCLogError(SC_ERR_INVALID_SIGNATURE,
+                    "spaces not allowed in flowbit names");
+                return 0;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue: https://redmine.openinfosecfoundation.org/issues/1889

To catch the issue where the ';' is missing we have to expand the
regex to capture the whole name string, not just the leading
valid stuff. Then verify that there are no spaces in the name
(Snort has the same restriction) and fail if there is.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/310
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/315
