### PR TITLE
unix-manager: fix output of version command

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -662,7 +662,7 @@ TmEcode UnixManagerVersionCommand(json_t *cmd,
     SCEnter();
     json_object_set_new(server_msg, "message", json_string(
 #ifdef REVISION
-                        PROG_VER  xstr(REVISION)
+                        PROG_VER " (rev "  xstr(REVISION) ")"
 #elif defined RELEASE
                         PROG_VER " RELEASE"
 #else


### PR DESCRIPTION
Make it consistent with the output of version command line flag.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/185
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/181