### PR TITLE
defrag - cleanup too large events - v1

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -99,9 +99,9 @@ alert pkthdr any any -> any any (msg:"SURICATA VLAN unknown type"; decode-event:
 alert pkthdr any any -> any any (msg:"SURICATA VLAN too many layers"; decode-event:vlan.too_many_layers; sid:2200091; rev:1;)
 
 alert pkthdr any any -> any any (msg:"SURICATA IP raw invalid IP version "; decode-event:ipraw.invalid_ip_version; sid:2200068; rev:1;)
-alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large"; decode-event:ipv4.frag_too_large; sid:2200069; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Packet size too large"; decode-event:ipv4.frag_pkt_too_large; sid:2200069; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv4 Fragmentation overlap"; decode-event:ipv4.frag_overlap; sid:2200070; rev:1;)
-alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_too_large; sid:2200071; rev:1;)
+alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Packet size too large"; decode-event:ipv6.frag_pkt_too_large; sid:2200071; rev:2;)
 alert pkthdr any any -> any any (msg:"SURICATA FRAG IPv6 Fragmentation overlap"; decode-event:ipv6.frag_overlap; sid:2200072; rev:1;)
 
 # checksum rules

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -152,8 +152,8 @@ const struct DecodeEvents_ DEvents[] = {
     { "decoder.sctp.pkt_too_small", SCTP_PKT_TOO_SMALL, },
 
     /* Fragmentation reasembly events. */
-    { "decoder.ipv4.frag_too_large", IPV4_FRAG_PKT_TOO_LARGE, },
-    { "decoder.ipv6.frag_too_large", IPV6_FRAG_PKT_TOO_LARGE, },
+    { "decoder.ipv4.frag_pkt_too_large", IPV4_FRAG_PKT_TOO_LARGE, },
+    { "decoder.ipv6.frag_pkt_too_large", IPV6_FRAG_PKT_TOO_LARGE, },
     { "decoder.ipv4.frag_overlap", IPV4_FRAG_OVERLAP, },
     { "decoder.ipv6.frag_overlap", IPV6_FRAG_OVERLAP, },
     /* Fragment ignored due to internal error */

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -160,8 +160,6 @@ enum {
     IPV6_FRAG_PKT_TOO_LARGE,
     IPV4_FRAG_OVERLAP,
     IPV6_FRAG_OVERLAP,
-    IPV4_FRAG_TOO_LARGE,
-    IPV6_FRAG_TOO_LARGE,
 
     /* Fragment ignored due to internal error */
     IPV4_FRAG_IGNORED,

--- a/src/decode.c
+++ b/src/decode.c
@@ -427,13 +427,14 @@ void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
         StatsRegisterCounter("defrag.ipv6.timeouts", tv);
     dtv->counter_defrag_max_hit =
         StatsRegisterCounter("defrag.max_frag_hits", tv);
-    
+
     int i = 0;
     for (i = 0; i < DECODE_EVENT_PACKET_MAX; i++) {
+        BUG_ON(i != (int)DEvents[i].code);
         dtv->counter_invalid_events[i] = StatsRegisterCounter(
                 DEvents[i].event_name, tv);
     }
-    
+
     return;
 }
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -705,11 +705,8 @@ DefragInsertFrag(ThreadVars *tv, DecodeThreadVars *dtv, DefragTracker *tracker, 
 
 insert:
     if (data_len - ltrim <= 0) {
-        if (af == AF_INET) {
-            ENGINE_SET_EVENT(p, IPV4_FRAG_TOO_LARGE);
-        } else {
-            ENGINE_SET_EVENT(p, IPV6_FRAG_TOO_LARGE);
-        }
+        /* Full packet has been trimmed due to the overlap policy. Overlap
+         * already set. */
         goto done;
     }
 


### PR DESCRIPTION
Based on PR #2234 

The frag_too_large event was not being used properly and was only being sent when a fragment is dropped due to complete overlap, in which case an overlap event was already set.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/319
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/324
