### PR TITLE
util-decode-mime: remove quote from boundary= string.

### DIFF
--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -62,7 +62,7 @@
 #define CTNT_DISP_STR     "content-disposition"
 #define CTNT_TRAN_STR     "content-transfer-encoding"
 #define MSG_ID_STR        "message-id"
-#define BND_START_STR     "boundary=\""
+#define BND_START_STR     "boundary="
 #define TOK_END_STR       "\""
 #define MSG_STR           "message/"
 #define MULTIPART_STR     "multipart/"


### PR DESCRIPTION
util-decode-mime: remove quote from boundary= string.

remove quote from the end of the boundary= string.  This was throwing off
the mime parser so that it wouldn't always catch mime boundaries causing
things like missed attachments.

https://buildbot.openinfosecfoundation.org/builders/decanio/builds/26
https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/26