### PR TITLE
rule load opt v9

### DIFF
--- a/src/detect-engine-address.h
+++ b/src/detect-engine-address.h
@@ -32,7 +32,7 @@ void DetectAddressHeadFree(DetectAddressHead *);
 void DetectAddressHeadCleanup(DetectAddressHead *);
 
 int DetectAddressParseString(DetectAddress *, char *);
-int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, char *);
+int DetectAddressParse(const DetectEngineCtx *, DetectAddressHead *, const char *);
 
 DetectAddress *DetectAddressInit(void);
 void DetectAddressFree(DetectAddress *);
@@ -58,5 +58,10 @@ int DetectAddressMatchIPv6(DetectMatchAddressIPv6 *, uint16_t, Address *);
 int DetectAddressTestConfVars(void);
 
 void DetectAddressTests(void);
+
+int DetectAddressMapInit(DetectEngineCtx *de_ctx);
+void DetectAddressMapFree(DetectEngineCtx *de_ctx);
+const DetectAddressHead *DetectParseAddress(DetectEngineCtx *de_ctx,
+        const char *string);
 
 #endif /* __DETECT_ADDRESS_H__ */

--- a/src/detect-engine-iponly.c
+++ b/src/detect-engine-iponly.c
@@ -1561,25 +1561,17 @@ void IPOnlyAddSignature(DetectEngineCtx *de_ctx, DetectEngineIPOnlyCtx *io_ctx,
 
 static int IPOnlyTestSig01(void)
 {
-    int result = 0;
-    DetectEngineCtx de_ctx;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(de_ctx == NULL);
+    de_ctx->flags |= DE_QUIET;
 
-    memset(&de_ctx, 0, sizeof(DetectEngineCtx));
+    Signature *s = SigInit(de_ctx,"alert tcp any any -> any any (sid:400001; rev:1;)");
+    FAIL_IF(s == NULL);
 
-    de_ctx.flags |= DE_QUIET;
-
-    Signature *s = SigInit(&de_ctx,"alert tcp any any -> any any (msg:\"SigTest40-01 sig is IPOnly \"; sid:400001; rev:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-    if(SignatureIsIPOnly(&de_ctx, s))
-        result = 1;
-    else
-        printf("expected a IPOnly signature: ");
-
+    FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
     SigFree(s);
-end:
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**
@@ -1589,27 +1581,17 @@ end:
 
 static int IPOnlyTestSig02 (void)
 {
-    int result = 0;
-    DetectEngineCtx de_ctx;
-    memset (&de_ctx, 0, sizeof(DetectEngineCtx));
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(de_ctx == NULL);
+    de_ctx->flags |= DE_QUIET;
 
-    memset(&de_ctx, 0, sizeof(DetectEngineCtx));
+    Signature *s = SigInit(de_ctx,"alert tcp any any -> any 80 (sid:400001; rev:1;)");
+    FAIL_IF(s == NULL);
 
-    de_ctx.flags |= DE_QUIET;
-
-    Signature *s = SigInit(&de_ctx,"alert tcp any any -> any 80 (msg:\"SigTest40-02 sig is not IPOnly \"; sid:400001; rev:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-    if ((SignatureIsIPOnly(&de_ctx, s)))
-        result = 1;
-    else
-        printf("got a non-IPOnly signature: ");
-
+    FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
     SigFree(s);
-
-end:
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 /**
@@ -2119,52 +2101,36 @@ int IPOnlyTestSig12(void)
 
 static int IPOnlyTestSig13(void)
 {
-    int result = 0;
-    DetectEngineCtx de_ctx;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(de_ctx == NULL);
+    de_ctx->flags |= DE_QUIET;
 
-    memset(&de_ctx, 0, sizeof(DetectEngineCtx));
-
-    de_ctx.flags |= DE_QUIET;
-
-    Signature *s = SigInit(&de_ctx,
+    Signature *s = SigInit(de_ctx,
                            "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; "
                            "flowbits:set,myflow1; sid:1; rev:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-    if (SignatureIsIPOnly(&de_ctx, s))
-        result = 1;
-    else
-        printf("expected a IPOnly signature: ");
+    FAIL_IF(s == NULL);
 
+    FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 0);
     SigFree(s);
-end:
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 static int IPOnlyTestSig14(void)
 {
-    int result = 0;
-    DetectEngineCtx de_ctx;
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF(de_ctx == NULL);
+    de_ctx->flags |= DE_QUIET;
 
-    memset(&de_ctx, 0, sizeof(DetectEngineCtx));
-
-    de_ctx.flags |= DE_QUIET;
-
-    Signature *s = SigInit(&de_ctx,
+    Signature *s = SigInit(de_ctx,
                            "alert tcp any any -> any any (msg:\"Test flowbits ip only\"; "
                            "flowbits:set,myflow1; flowbits:isset,myflow2; sid:1; rev:1;)");
-    if (s == NULL) {
-        goto end;
-    }
-    if (SignatureIsIPOnly(&de_ctx, s))
-        printf("expected a IPOnly signature: ");
-    else
-        result = 1;
+    FAIL_IF(s == NULL);
 
+    FAIL_IF(SignatureIsIPOnly(de_ctx, s) == 1);
     SigFree(s);
-end:
-    return result;
+    DetectEngineCtxFree(de_ctx);
+    PASS;
 }
 
 int IPOnlyTestSig15(void)

--- a/src/detect-engine.c
+++ b/src/detect-engine.c
@@ -854,6 +854,7 @@ static DetectEngineCtx *DetectEngineCtxInitReal(int minimal, const char *prefix)
     ThresholdHashInit(de_ctx);
     VariableNameInitHash(de_ctx);
     DetectParseDupSigHashInit(de_ctx);
+    DetectAddressMapInit(de_ctx);
 
     /* init iprep... ignore errors for now */
     (void)SRepInit(de_ctx);
@@ -963,6 +964,8 @@ void DetectEngineCtxFree(DetectEngineCtx *de_ctx)
 
     DetectEngineCtxFreeThreadKeywordData(de_ctx);
     SRepDestroy(de_ctx);
+
+    DetectAddressMapFree(de_ctx);
 
     /* if we have a config prefix, remove the config from the tree */
     if (strlen(de_ctx->config_prefix) > 0) {

--- a/src/detect.h
+++ b/src/detect.h
@@ -425,7 +425,7 @@ typedef struct Signature_ {
     DetectReference *references;
 
     /** address settings for this signature */
-    DetectAddressHead src, dst;
+    const DetectAddressHead *src, *dst;
 
     /* used at init to determine max dsize */
     SigMatch *dsize_sm;
@@ -676,6 +676,9 @@ typedef struct DetectEngineCtx_ {
 
     DetectPort *tcp_whitelist;
     DetectPort *udp_whitelist;
+
+    /** table for storing the string representation with the parsers result */
+    HashListTable *address_table;
 
 } DetectEngineCtx;
 

--- a/src/util-var.c
+++ b/src/util-var.c
@@ -130,7 +130,7 @@ void GenericVarRemove(GenericVar **list, GenericVar *gv)
 }
 
 // Checks if a variable is already in a resolve list and if it's not, adds it.
-int AddVariableToResolveList(ResolvedVariablesList *list, char *var)
+int AddVariableToResolveList(ResolvedVariablesList *list, const char *var)
 {
     ResolvedVariable *p_item;
 

--- a/src/util-var.h
+++ b/src/util-var.h
@@ -70,7 +70,7 @@ void GenericVarFree(GenericVar *);
 void GenericVarAppend(GenericVar **, GenericVar *);
 void GenericVarRemove(GenericVar **, GenericVar *);
 
-int AddVariableToResolveList(ResolvedVariablesList *list, char *var);
+int AddVariableToResolveList(ResolvedVariablesList *list, const char *var);
 void CleanVariableResolveList(ResolvedVariablesList *var_list);
 
 #endif /* __UTIL_VAR_H__ */


### PR DESCRIPTION
Optimize rule address parsing. In a ruleset many of the rule address vars are indentical. This patch caches the parsing result. Rules now reference that result instead of each having their own copy of it. Should speed up parsing and slightly reduce memory usage.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/490
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/495