### PR TITLE
output-json-dns: implment more compact DNS log format

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -191,6 +191,11 @@ outputs:
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
+            # The style of logging:
+            #    discrete: the classic style of an event per question and answer
+            #    split: one event per request, one event per response
+            #    unified: one event containing request and response
+            style: discrete
             # control logging of queries and answers
             # default yes, no to disable
             query: yes     # enable logging of DNS queries


### PR DESCRIPTION
DNS log output format is selected using new outputs.eve-log.types.dns.style
configuration option

        - dns:
            # The style of logging:
            #    discrete: the classic style of an event per question and answer
            #    split: one event per request, one event per response
            #    unified: one event containing request and response
            style: split

To emit a single DNS log per DNS transacton use style: unified

To emit a pair of DNS logs per DNS transaction use style: split

the latter preserves individual timestamps of the query and answer arrival
times.

The classic DNS log format is preseved using style: discrete

DNS filtering capabilities are preserved with all log styles.

https://buildbot.openinfosecfoundation.org/builders/decanio/builds/31
https://buildbot.openinfosecfoundation.org/builders/decanio-pcap/builds/31