### PR TITLE
Bypass v7

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ detect-base64-decode.c detect-base64-decode.h \
 detect-byte-extract.c detect-byte-extract.h \
 detect-bytejump.c detect-bytejump.h \
 detect-bytetest.c detect-bytetest.h \
+detect-bypass.c detect-bypass.h \
 detect.c detect.h \
 detect-classtype.c detect-classtype.h \
 detect-content.c detect-content.h \

--- a/src/decode.c
+++ b/src/decode.c
@@ -385,6 +385,9 @@ void PacketDefragPktSetupParent(Packet *parent)
 void PacketBypassCallback(Packet *p)
 {
     if (p->BypassPacketsFlow) {
+        /* only set bypassed state if succesful */
+        SC_ATOMIC_SET(p->flow->flow_state, FLOW_STATE_BYPASSED);
+
         p->BypassPacketsFlow(p);
     }
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -384,6 +384,12 @@ void PacketDefragPktSetupParent(Packet *parent)
 
 void PacketBypassCallback(Packet *p)
 {
+    /* Don't try to bypass if flow is already out */
+    int state = SC_ATOMIC_GET(p->flow->flow_state);
+    if (state == FLOW_STATE_BYPASSED) {
+        return;
+    }
+
     if (p->BypassPacketsFlow) {
         /* only set bypassed state if succesful */
         SC_ATOMIC_SET(p->flow->flow_state, FLOW_STATE_BYPASSED);

--- a/src/decode.c
+++ b/src/decode.c
@@ -382,6 +382,13 @@ void PacketDefragPktSetupParent(Packet *parent)
     DecodeSetNoPayloadInspectionFlag(parent);
 }
 
+void PacketBypassCallback(Packet *p)
+{
+    if (p->BypassPacketsFlow) {
+        p->BypassPacketsFlow(p);
+    }
+}
+
 void DecodeRegisterPerfCounters(DecodeThreadVars *dtv, ThreadVars *tv)
 {
     /* register counters */

--- a/src/decode.c
+++ b/src/decode.c
@@ -384,9 +384,11 @@ void PacketDefragPktSetupParent(Packet *parent)
 
 void PacketBypassCallback(Packet *p)
 {
-    /* Don't try to bypass if flow is already out */
+    /* Don't try to bypass if flow is already out or
+     * if we have failed to do it once */
     int state = SC_ATOMIC_GET(p->flow->flow_state);
-    if (state == FLOW_STATE_BYPASSED) {
+    if ((state == FLOW_STATE_BYPASSED) ||
+           (p->flow->flags & FLOW_BYPASS_FAILED)) {
         return;
     }
 
@@ -395,6 +397,8 @@ void PacketBypassCallback(Packet *p)
         SC_ATOMIC_SET(p->flow->flow_state, FLOW_STATE_BYPASSED);
 
         p->BypassPacketsFlow(p);
+    } else {
+        p->flow->flags |= FLOW_BYPASS_FAILED;
     }
 }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -448,6 +448,8 @@ typedef struct Packet_
     /** The release function for packet structure and data */
     void (*ReleasePacket)(struct Packet_ *);
 
+    void (*BypassPacketsFlow)(struct Packet_ *);
+
     /* pkt vars */
     PktVar *pktvar;
 
@@ -774,6 +776,7 @@ void CaptureStatsSetup(ThreadVars *tv, CaptureStats *s);
         (p)->vlanh[1] = NULL;                   \
         (p)->payload = NULL;                    \
         (p)->payload_len = 0;                   \
+        (p)->BypassPacketsFlow = NULL;          \
         (p)->pktlen = 0;                        \
         (p)->alerts.cnt = 0;                    \
         (p)->alerts.drop.action = 0;            \
@@ -902,6 +905,7 @@ int PacketCopyData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketSetData(Packet *p, uint8_t *pktdata, int pktlen);
 int PacketCopyDataOffset(Packet *p, int offset, uint8_t *data, int datalen);
 const char *PktSrcToString(enum PktSrcEnum pkt_src);
+void PacketBypassCallback(Packet *p);
 
 DecodeThreadVars *DecodeThreadVarsAlloc(ThreadVars *);
 void DecodeThreadVarsFree(ThreadVars *, DecodeThreadVars *);

--- a/src/detect-bypass.c
+++ b/src/detect-bypass.c
@@ -1,0 +1,244 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Giuseppe Longo <glongo@stamus-networks.com>
+ *
+ */
+
+#include "suricata-common.h"
+#include "threads.h"
+#include "app-layer.h"
+#include "app-layer-parser.h"
+#include "debug.h"
+#include "decode.h"
+
+#include "detect.h"
+#include "detect-parse.h"
+
+#include "detect-engine.h"
+#include "detect-engine-mpm.h"
+#include "detect-engine-state.h"
+#include "detect-engine-sigorder.h"
+
+#include "flow.h"
+#include "flow-var.h"
+#include "flow-util.h"
+
+#include "stream-tcp.h"
+
+#include "util-debug.h"
+#include "util-spm-bm.h"
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "util-device.h"
+
+int DetectBypassMatch(ThreadVars *, DetectEngineThreadCtx *, Packet *, Signature *, const SigMatchCtx *);
+static int DetectBypassSetup(DetectEngineCtx *, Signature *, char *);
+static void DetectBypassRegisterTests(void);
+
+/**
+ * \brief Registration function for keyword: bypass
+ */
+void DetectBypassRegister(void)
+{
+    sigmatch_table[DETECT_BYPASS].name = "bypass";
+    sigmatch_table[DETECT_BYPASS].desc = "call the bypass callback when the match of a sig is complete";
+    sigmatch_table[DETECT_BYPASS].url = "";
+    sigmatch_table[DETECT_BYPASS].Match = DetectBypassMatch;
+    sigmatch_table[DETECT_BYPASS].AppLayerMatch = NULL;
+    sigmatch_table[DETECT_BYPASS].Setup = DetectBypassSetup;
+    sigmatch_table[DETECT_BYPASS].Free  = NULL;
+    sigmatch_table[DETECT_BYPASS].RegisterTests = DetectBypassRegisterTests;
+    sigmatch_table[DETECT_BYPASS].flags = SIGMATCH_NOOPT;
+}
+
+static int DetectBypassSetup(DetectEngineCtx *de_ctx, Signature *s, char *str)
+{
+    SigMatch *sm = NULL;
+
+    if (s->flags & SIG_FLAG_FILESTORE) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
+                   "bypass can't work with filestore keyword");
+        return -1;
+    }
+    s->flags |= SIG_FLAG_BYPASS;
+
+    sm = SigMatchAlloc();
+    if (sm == NULL)
+        return -1;
+
+    sm->type = DETECT_BYPASS;
+    sm->ctx = NULL;
+    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
+
+    return 0;
+}
+
+int DetectBypassMatch(ThreadVars *tv, DetectEngineThreadCtx *det_ctx, Packet *p, Signature *s, const SigMatchCtx *ctx)
+{
+    PacketBypassCallback(p);
+
+    return 1;
+}
+
+#ifdef UNITTESTS
+static int callback_var = 0;
+
+static void BypassCallback()
+{
+    callback_var = 1;
+}
+
+static void ResetCallbackVar()
+{
+    callback_var = 0;
+}
+
+static int DetectBypassTestSig01(void)
+{
+    TcpSession ssn;
+    Packet *p1 = NULL;
+    Packet *p2 = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf1[] =
+        "GET /index.html HTTP/1.0\r\n"
+        "Host: This is dummy message body\r\n"
+        "User-Agent: www.openinfosecfoundation.org\r\n"
+        "Content-Type: text/html\r\n"
+        "\r\n";
+    uint32_t http_len1 = sizeof(http_buf1) - 1;
+    uint8_t http_buf2[] =
+        "HTTP/1.0 200 ok\r\n"
+        "Content-Type: text/html\r\n"
+        "Content-Length: 7\r\n"
+        "\r\n"
+        "message";
+    uint32_t http_len2 = sizeof(http_buf2) - 1;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+    LiveDevice *livedev = SCMalloc(sizeof(LiveDevice));
+    FAIL_IF(livedev == NULL);
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p1 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    FAIL_IF(p1 == NULL);
+    p2 = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+    FAIL_IF(p2 == NULL);
+
+    p1->BypassPacketsFlow = BypassCallback;
+    p2->BypassPacketsFlow = BypassCallback;
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p1->flow = &f;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->flowflags |= FLOW_PKT_ESTABLISHED;
+    p1->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p1->livedev = livedev;
+    p2->flow = &f;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->flowflags |= FLOW_PKT_ESTABLISHED;
+    p2->flags |= PKT_HAS_FLOW|PKT_STREAM_EST;
+    p2->livedev = livedev;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    FAIL_IF(de_ctx == NULL);
+
+    de_ctx->flags |= DE_QUIET;
+
+    char *sigs[3];
+    sigs[0] = "alert tcp any any -> any any (bypass; content:\"GET \"; sid:1;)";
+    sigs[1] = "alert http any any -> any any "
+              "(bypass; content:\"message\"; http_server_body; "
+              "sid:2;)";
+    sigs[2] = "alert http any any -> any any "
+              "(bypass; content:\"message\"; http_host; "
+              "sid:3;)";
+    FAIL_IF(UTHAppendSigs(de_ctx, sigs, 3) == 0);
+
+    SCSigRegisterSignatureOrderingFuncs(de_ctx);
+    SCSigOrderSignatures(de_ctx);
+    SCSigSignatureOrderingModuleCleanup(de_ctx);
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    SCMutexLock(&f.m);
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf1, http_len1);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        SCMutexUnlock(&f.m);
+        return 0;
+    }
+    SCMutexUnlock(&f.m);
+
+    http_state = f.alstate;
+    FAIL_IF(http_state == NULL);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
+
+    FAIL_IF(PacketAlertCheck(p1, 1));
+
+    SCMutexLock(&f.m);
+    r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOCLIENT, http_buf2, http_len2);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: \n", r);
+        SCMutexUnlock(&f.m);
+        return 0;
+    }
+    SCMutexUnlock(&f.m);
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
+
+    FAIL_IF(!(PacketAlertCheck(p2, 2)));
+    FAIL_IF(!(PacketAlertCheck(p1, 3)));
+
+    FAIL_IF(callback_var == 0);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    ResetCallbackVar();
+    SCFree(livedev);
+    PASS;
+}
+#endif /* UNITTESTS */
+
+void DetectBypassRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectBypassTestSig01", DetectBypassTestSig01);
+#endif /* UNITTESTS */
+}

--- a/src/detect-bypass.h
+++ b/src/detect-bypass.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ *  \author Giuseppe Longo <glongo@stamus-networks.com>
+ */
+
+#ifndef __DETECT_BYPASS_H__
+#define __DETECT_BYPASS_H__
+
+void DetectBypassRegister(void);
+
+#endif /* __DETECT_BYPASS_H__ */

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -63,6 +63,7 @@ static int DetectFilestoreMatch (ThreadVars *, DetectEngineThreadCtx *,
         Flow *, uint8_t, File *, Signature *, SigMatch *);
 static int DetectFilestoreSetup (DetectEngineCtx *, Signature *, char *);
 static void DetectFilestoreFree(void *);
+static void DetectFilestoreRegisterTests(void);
 
 /**
  * \brief Registration function for keyword: filestore
@@ -75,7 +76,7 @@ void DetectFilestoreRegister(void)
     sigmatch_table[DETECT_FILESTORE].FileMatch = DetectFilestoreMatch;
     sigmatch_table[DETECT_FILESTORE].Setup = DetectFilestoreSetup;
     sigmatch_table[DETECT_FILESTORE].Free  = DetectFilestoreFree;
-    sigmatch_table[DETECT_FILESTORE].RegisterTests = NULL;
+    sigmatch_table[DETECT_FILESTORE].RegisterTests = DetectFilestoreRegisterTests;
     sigmatch_table[DETECT_FILESTORE].flags = SIGMATCH_OPTIONAL_OPT;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
@@ -291,6 +292,13 @@ static int DetectFilestoreSetup (DetectEngineCtx *de_ctx, Signature *s, char *st
     int ret = 0, res = 0;
     int ov[MAX_SUBSTRINGS];
 
+    /* filestore and bypass keywords can't work together */
+    if (s->flags & SIG_FLAG_BYPASS) {
+        SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
+                   "filestore can't work with bypass keyword");
+        return -1;
+    }
+
     sm = SigMatchAlloc();
     if (sm == NULL)
         goto error;
@@ -407,4 +415,114 @@ static void DetectFilestoreFree(void *ptr)
     if (ptr != NULL) {
         SCFree(ptr);
     }
+}
+
+#ifdef UNITTESTS
+/*
+ * The purpose of this test is to confirm that
+ * filestore and bypass keywords can't
+ * can't work together
+ */
+static int DetectFilestoreTest01(void)
+{
+    TcpSession ssn;
+    Packet *p = NULL;
+    ThreadVars th_v;
+    DetectEngineCtx *de_ctx = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    HtpState *http_state = NULL;
+    Flow f;
+    uint8_t http_buf[] =
+        "GET /index.html HTTP/1.0\r\n"
+        "User-Agent: www.openinfosecfoundation.org\r\n"
+        "Host: This is dummy message body\r\n"
+        "Content-Type: text/html\r\n"
+        "\r\n";
+    uint32_t http_len = sizeof(http_buf) - 1;
+    int result = 1;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&th_v, 0, sizeof(th_v));
+    memset(&f, 0, sizeof(f));
+    memset(&ssn, 0, sizeof(ssn));
+
+    p = UTHBuildPacket(NULL, 0, IPPROTO_TCP);
+
+    FLOW_INITIALIZE(&f);
+    f.protoctx = (void *)&ssn;
+    f.proto = IPPROTO_TCP;
+    f.flags |= FLOW_IPV4;
+
+    p->flow = &f;
+    p->flowflags |= FLOW_PKT_TOSERVER;
+    p->flowflags |= FLOW_PKT_ESTABLISHED;
+    p->flags |= PKT_HAS_FLOW | PKT_STREAM_EST;
+    f.alproto = ALPROTO_HTTP;
+
+    StreamTcpInitConfig(TRUE);
+
+    de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL)
+        goto end;
+
+    de_ctx->flags |= DE_QUIET;
+
+    de_ctx->sig_list = SigInit(de_ctx,"alert http any any -> any any "
+                               "(bypass; filestore; "
+                               "content:\"message\"; http_host; "
+                               "sid:1;)");
+    if (de_ctx->sig_list == NULL)
+        goto end;
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
+
+    SCMutexLock(&f.m);
+    int r = AppLayerParserParse(alp_tctx, &f, ALPROTO_HTTP, STREAM_TOSERVER, http_buf, http_len);
+    if (r != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", r);
+        result = 0;
+        SCMutexUnlock(&f.m);
+        goto end;
+    }
+    SCMutexUnlock(&f.m);
+
+    http_state = f.alstate;
+    if (http_state == NULL) {
+        printf("no http state: \n");
+        result = 0;
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
+
+    if (!(PacketAlertCheck(p, 1))) {
+        printf("sid 1 didn't match but should have\n");
+        goto end;
+    }
+
+    result = 0;
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        SigCleanSignatures(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    StreamTcpFreeConfig(TRUE);
+    FLOW_DESTROY(&f);
+    UTHFreePackets(&p, 1);
+    return result;
+}
+#endif /* UNITTESTS */
+
+void DetectFilestoreRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("DetectFilestoreTest01", DetectFilestoreTest01);
+#endif /* UNITTESTS */
 }

--- a/src/detect.c
+++ b/src/detect.c
@@ -164,6 +164,7 @@
 #include "detect-app-layer-protocol.h"
 #include "detect-template.h"
 #include "detect-template-buffer.h"
+#include "detect-bypass.h"
 
 #include "util-rule-vars.h"
 
@@ -4460,6 +4461,7 @@ void SigTableSetup(void)
     DetectBase64DataRegister();
     DetectTemplateRegister();
     DetectTemplateBufferRegister();
+    DetectBypassRegister();
 }
 
 void SigTableRegisterTests(void)

--- a/src/detect.h
+++ b/src/detect.h
@@ -272,6 +272,7 @@ typedef struct DetectPort_ {
 
 #define SIG_FLAG_TLSSTORE               (1<<21)
 
+#define SIG_FLAG_BYPASS                (1<<22)
 /* signature init flags */
 #define SIG_FLAG_INIT_DEONLY         1  /**< decode event only signature */
 #define SIG_FLAG_INIT_PACKET         (1<<1)  /**< signature has matches against a packet (as opposed to app layer) */
@@ -1240,6 +1241,8 @@ enum {
 
     DETECT_TEMPLATE,
     DETECT_AL_TEMPLATE_BUFFER,
+
+    DETECT_BYPASS,
 
     /* make sure this stays last */
     DETECT_TBLSIZE,

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -348,6 +348,8 @@ static uint32_t FlowManagerHashRowTimeout(Flow *f, struct timeval *ts,
                 f->flow_end_flags |= FLOW_END_FLAG_STATE_ESTABLISHED;
             else if (state == FLOW_STATE_CLOSED)
                 f->flow_end_flags |= FLOW_END_FLAG_STATE_CLOSED;
+            else if (state == FLOW_STATE_BYPASSED)
+                f->flow_end_flags |= FLOW_END_FLAG_STATE_BYPASSED;
 
             if (emergency)
                 f->flow_end_flags |= FLOW_END_FLAG_EMERGENCY;

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -110,6 +110,7 @@ typedef struct FlowTimeoutCounters_ {
     uint32_t new;
     uint32_t est;
     uint32_t clo;
+    uint32_t byp;
     uint32_t tcp_reuse;
 
     uint32_t flows_checked;
@@ -377,6 +378,9 @@ static uint32_t FlowManagerHashRowTimeout(Flow *f, struct timeval *ts,
                 case FLOW_STATE_CLOSED:
                     counters->clo++;
                     break;
+                case FLOW_STATE_BYPASSED:
+                    counters->byp++;
+                    break;
             }
             counters->flows_removed++;
         } else {
@@ -552,6 +556,7 @@ typedef struct FlowManagerThreadData_ {
     uint16_t flow_mgr_cnt_clo;
     uint16_t flow_mgr_cnt_new;
     uint16_t flow_mgr_cnt_est;
+    uint16_t flow_mgr_cnt_byp;
     uint16_t flow_mgr_spare;
     uint16_t flow_emerg_mode_enter;
     uint16_t flow_emerg_mode_over;
@@ -602,6 +607,7 @@ static TmEcode FlowManagerThreadInit(ThreadVars *t, void *initdata, void **data)
     ftd->flow_mgr_cnt_clo = StatsRegisterCounter("flow_mgr.closed_pruned", t);
     ftd->flow_mgr_cnt_new = StatsRegisterCounter("flow_mgr.new_pruned", t);
     ftd->flow_mgr_cnt_est = StatsRegisterCounter("flow_mgr.est_pruned", t);
+    ftd->flow_mgr_cnt_est = StatsRegisterCounter("flow_mgr.bypassed_pruned", t);
     ftd->flow_mgr_spare = StatsRegisterCounter("flow.spare", t);
     ftd->flow_emerg_mode_enter = StatsRegisterCounter("flow.emerg_mode_entered", t);
     ftd->flow_emerg_mode_over = StatsRegisterCounter("flow.emerg_mode_over", t);
@@ -688,7 +694,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
             FlowUpdateSpareFlows();
 
         /* try to time out flows */
-        FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,};
+        FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0};
         FlowTimeoutHash(&ts, 0 /* check all */, ftd->min, ftd->max, &counters);
 
 
@@ -708,6 +714,7 @@ static TmEcode FlowManager(ThreadVars *th_v, void *thread_data)
         StatsAddUI64(th_v, ftd->flow_mgr_cnt_clo, (uint64_t)counters.clo);
         StatsAddUI64(th_v, ftd->flow_mgr_cnt_new, (uint64_t)counters.new);
         StatsAddUI64(th_v, ftd->flow_mgr_cnt_est, (uint64_t)counters.est);
+        StatsAddUI64(th_v, ftd->flow_mgr_cnt_byp, (uint64_t)counters.byp);
         StatsAddUI64(th_v, ftd->flow_tcp_reuse, (uint64_t)counters.tcp_reuse);
 
         StatsSetUI64(th_v, ftd->flow_mgr_flows_checked, (uint64_t)counters.flows_checked);
@@ -1360,7 +1367,7 @@ static int FlowMgrTest05 (void)
     struct timeval ts;
     TimeGet(&ts);
     /* try to time out flows */
-    FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,};
+    FlowTimeoutCounters counters = { 0, 0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0};
     FlowTimeoutHash(&ts, 0 /* check all */, 0, flow_config.hash_size, &counters);
 
     if (flow_recycle_q.len > 0) {

--- a/src/flow-manager.c
+++ b/src/flow-manager.c
@@ -67,6 +67,8 @@
 
 #include "output-flow.h"
 
+#define FLOW_TIMEOUT    5
+
 /* Run mode selected at suricata.c */
 extern int run_mode;
 
@@ -207,6 +209,9 @@ static inline uint32_t FlowGetFlowTimeout(const Flow *f, enum FlowState state)
             break;
         case FLOW_STATE_CLOSED:
             timeout = flow_timeouts[f->protomap].closed_timeout;
+            break;
+        case FLOW_STATE_BYPASSED:
+            timeout = FLOW_TIMEOUT;
             break;
     }
     return timeout;

--- a/src/flow.h
+++ b/src/flow.h
@@ -425,6 +425,7 @@ enum FlowState {
     FLOW_STATE_NEW = 0,
     FLOW_STATE_ESTABLISHED,
     FLOW_STATE_CLOSED,
+    FLOW_STATE_BYPASSED,
 };
 
 typedef struct FlowProtoTimeout_ {

--- a/src/flow.h
+++ b/src/flow.h
@@ -77,7 +77,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /** alproto detect done.  Right now we need it only for udp */
 #define FLOW_ALPROTO_DETECT_DONE          0x00004000
 
-// vacany 1x
+/** we have tried bypass but we did fail */
+#define FLOW_BYPASS_FAILED                0x00010000
 
 /** Pattern matcher alproto detection done */
 #define FLOW_TS_PM_ALPROTO_DETECT_DONE    0x00008000

--- a/src/flow.h
+++ b/src/flow.h
@@ -190,6 +190,7 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 #define FLOW_END_FLAG_TIMEOUT           0x10
 #define FLOW_END_FLAG_FORCED            0x20
 #define FLOW_END_FLAG_SHUTDOWN          0x40
+#define FLOW_END_FLAG_STATE_BYPASSED    0x80
 
 /** Mutex or RWLocks for the flow. */
 //#define FLOWLOCK_RWLOCK

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -219,6 +219,8 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
         state = "established";
     else if (f->flow_end_flags & FLOW_END_FLAG_STATE_CLOSED)
         state = "closed";
+    else if (f->flow_end_flags & FLOW_END_FLAG_STATE_BYPASSED)
+        state = "bypassed";
 
     json_object_set_new(hjs, "state",
             json_string(state));

--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -132,7 +132,6 @@ typedef struct NFQThreadVars_
     int datalen; /** Length of per function and thread data */
 
     CaptureStats stats;
-
 } NFQThreadVars;
 /* shared vars for all for nfq queues and threads */
 static NFQGlobalVars nfq_g;
@@ -169,6 +168,8 @@ typedef struct NFQCnf_ {
     NFQMode mode;
     uint32_t mark;
     uint32_t mask;
+    uint32_t bypass_mark;
+    uint32_t bypass_mask;
     uint32_t next_queue;
     uint32_t flags;
     uint8_t batchcount;
@@ -261,6 +262,14 @@ void NFQInitConfig(char quiet)
 
     if ((ConfGetInt("nfq.repeat-mask", &value)) == 1) {
         nfq_config.mask = (uint32_t)value;
+    }
+
+    if ((ConfGetInt("nfq.bypass-mark", &value)) == 1) {
+        nfq_config.bypass_mark = (uint32_t)value;
+    }
+
+    if ((ConfGetInt("nfq.bypass-mask", &value)) == 1) {
+        nfq_config.bypass_mask = (uint32_t)value;
     }
 
     if ((ConfGetInt("nfq.route-queue", &value)) == 1) {
@@ -492,6 +501,14 @@ static void NFQReleasePacket(Packet *p)
     PacketFreeOrRelease(p);
 }
 
+static void NFQBypassCallback(Packet *p)
+{
+    p->nfq_v.mark = (nfq_config.bypass_mark & nfq_config.bypass_mask) | (p->nfq_v.mark & ~nfq_config.bypass_mask);
+    p->flags |= PKT_MARK_MODIFIED;
+
+    return;
+}
+
 static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
                        struct nfq_data *nfa, void *data)
 {
@@ -507,6 +524,10 @@ static int NFQCallBack(struct nfq_q_handle *qh, struct nfgenmsg *nfmsg,
     PKT_SET_SRC(p, PKT_SRC_WIRE);
 
     p->nfq_v.nfq_index = ntv->nfq_index;
+    /* if bypass mask is set then we may want to bypass so set pointer */
+    if (nfq_config.bypass_mask) {
+        p->BypassPacketsFlow = NFQBypassCallback;
+    }
     ret = NFQSetupPkt(p, qh, (void *)nfa);
     if (ret == -1) {
 #ifdef COUNTERS

--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -45,6 +45,7 @@
 #include "util-host-os-info.h"
 #include "util-unittest-helper.h"
 #include "util-byte.h"
+#include "util-device.h"
 
 #include "stream-tcp.h"
 #include "stream-tcp-private.h"

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -416,6 +416,21 @@ void StreamTcpInitConfig(char quiet)
         SCLogConfig("stream.\"inline\": %s", stream_inline ? "enabled" : "disabled");
     }
 
+    int bypass = 0;
+    if ((ConfGetBool("stream.bypass", &bypass)) == 1) {
+        if (bypass == 1) {
+            stream_config.bypass = 1;
+        } else {
+            stream_config.bypass = 0;
+        }
+    } else {
+        stream_config.bypass = 0;
+    }
+
+    if (!quiet) {
+        SCLogInfo("stream.\"bypass\": %s", bypass ? "enabled" : "disabled");
+    }
+
     if ((ConfGetInt("stream.max-synack-queued", &value)) == 1) {
         if (value >= 0 && value <= 255) {
             stream_config.max_synack_queued = (uint8_t)value;
@@ -5764,6 +5779,11 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
         cnt++;
     }
     return cnt;
+}
+
+int StreamTcpBypassEnabled(void)
+{
+    return stream_config.bypass;
 }
 
 #ifdef UNITTESTS

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4635,6 +4635,15 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
         /* check for conditions that may make us not want to log this packet */
 
         /* streams that hit depth */
+        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) &&
+             (ssn->server.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED))
+        {
+            /* we can call bypass callback, if enabled */
+            if (StreamTcpBypassEnabled()) {
+                PacketBypassCallback(p);
+            }
+        }
+
         if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED) ||
              (ssn->server.flags & STREAMTCP_STREAM_FLAG_DEPTH_REACHED))
         {
@@ -4646,6 +4655,10 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
             (PKT_IS_TOCLIENT(p) && (ssn->server.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY)))
         {
             p->flags |= PKT_STREAM_NOPCAPLOG;
+            /* we can call bypass callback, if enabled */
+            if (StreamTcpBypassEnabled()) {
+                PacketBypassCallback(p);
+            }
         }
     }
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -63,6 +63,7 @@ typedef struct TcpStreamCnf_ {
     uint16_t reassembly_toclient_chunk_size;
 
     int check_overlap_different_data;
+    int bypass;
 
     /** reassembly -- inline mode
      *
@@ -228,7 +229,8 @@ void StreamTcpSessionClear(void *ssnptr);
 void StreamTcpSessionCleanup(TcpSession *ssn);
 /* cleanup stream, but don't free the stream */
 void StreamTcpStreamCleanup(TcpStream *stream);
-
+/* check if bypass is enabled */
+int StreamTcpBypassEnabled(void);
 
 uint32_t StreamTcpGetStreamSize(TcpStream *stream);
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1421,6 +1421,8 @@ nfq:
 #  mode: accept
 #  repeat-mark: 1
 #  repeat-mask: 1
+#  bypass-mark: 1
+#  bypass-mask: 1
 #  route-queue: 2
 #  batchcount: 20
 #  fail-open: yes

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1110,6 +1110,7 @@ flow-timeouts:
 #   async-oneside: false        # don't enable async stream handling
 #   inline: no                  # stream inline mode
 #   max-synack-queued: 5        # Max different SYN/ACKs to queue
+#   bypass: no                  # Bypass packets when stream.depth is reached
 #
 #   reassembly:
 #     memcap: 64mb              # Can be specified in kb, mb, gb.  Just a number


### PR DESCRIPTION
This is an update of #2228 changing a lot of things.

Main change is that it introduces a bypassed state in flow which will allow suricata to get rid fast of bypassed flows instead of waiting for "established" timeout. This will lower the pressure on the flow table. Also as the bypassed information is added in the EVE entry of flow the user will know that bypass has been done on the flow.
  
Another change is that definition of bypass is not done anymore at registration but it is done inside the capture. For instance, in NFQ capture (which is the only one implemented in this PR), the bypass is activated if the bypass_mask is set in the configuration file.
  
Also remarks on PR #2228 have been addressed.
  
PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/193
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/189