### PR TITLE
stream: fix depth reached detection

### DIFF
--- a/src/stream-tcp-reassemble.c
+++ b/src/stream-tcp-reassemble.c
@@ -1805,6 +1805,7 @@ static uint32_t StreamTcpReassembleCheckDepth(TcpStream *stream,
             /* complete fit */
             SCReturnUInt(size);
         } else {
+            stream->flags |= STREAMTCP_STREAM_FLAG_DEPTH_REACHED;
             /* partial fit, return only what fits */
             uint32_t part = (stream->isn + stream_config.reassembly_depth) - seq;
 #if DEBUG


### PR DESCRIPTION
When a segment only partially fit in streaming depth, the stream
depth reached flag was not set resulting in a continuous
inspection of the rest of the session.

By setting the stream depth reached flag when the segment partially
fit we avoid to reenter the code and we don't take anymore a code
path resulting in the flag not to be set.

This is a rework of #2215. Remark did lead to a simplified code.

Ticket with test case: https://redmine.openinfosecfoundation.org/issues/1898

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/198
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/194