### PR TITLE
pcap-log: seed ring buffer with existing files - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -25,6 +25,10 @@
  * Pcap packet logging module.
  */
 
+#include <sys/types.h>
+#include <dirent.h>
+#include <fnmatch.h>
+
 #include "suricata-common.h"
 #include "debug.h"
 #include "detect.h"
@@ -80,6 +84,14 @@ SC_ATOMIC_DECLARE(uint32_t, thread_cnt);
 typedef struct PcapFileName_ {
     char *filename;
     char *dirname;
+
+    /* Like a struct timeval, but with fixed size. This is only used when
+     * seeding the ring buffer on start. */
+    struct {
+        uint64_t secs;
+        uint32_t usecs;
+    };
+
     TAILQ_ENTRY(PcapFileName_) next; /**< Pointer to next Pcap File for tailq. */
 } PcapFileName;
 
@@ -137,6 +149,11 @@ typedef struct PcapLogData_ {
 typedef struct PcapLogThreadData_ {
     PcapLogData *pcap_log;
 } PcapLogThreadData;
+
+/* Pattern for extracting timestamp from pcap log files. */
+static const char timestamp_pattern[] = ".*?(\\d+)(\\.(\\d+))?";
+static pcre *pcre_timestamp_code = NULL;
+static pcre_extra *pcre_timestamp_extra = NULL;
 
 /* global pcap data for when we're using multi mode. At exit we'll
  * merge counters into this one and then report counters. */
@@ -475,6 +492,191 @@ static PcapLogData *PcapLogDataCopy(const PcapLogData *pl)
     return copy;
 }
 
+static int PcapLogGetTimeOfFile(const char *filename, uint64_t *secs,
+    uint32_t *usecs)
+{
+    int pcre_ovecsize = 4 * 3;
+    int pcre_ovec[pcre_ovecsize];
+    char buf[PATH_MAX];
+
+    int n = pcre_exec(pcre_timestamp_code, pcre_timestamp_extra,
+        filename, strlen(filename), 0, 0, pcre_ovec,
+        pcre_ovecsize);
+    if (n != 2 && n != 4) {
+        /* No match. */
+        return 0;
+    }
+
+    if (n >= 2) {
+        /* Extract seconds. */
+        if (pcre_copy_substring(filename, pcre_ovec, pcre_ovecsize,
+                1, buf, sizeof(buf)) < 0) {
+            return 0;
+        }
+        if (ByteExtractStringUint64(secs, 10, 0, buf) < 0) {
+            return 0;
+        }
+    }
+    if (n == 4) {
+        /* Extract microseconds. */
+        if (pcre_copy_substring(filename, pcre_ovec, pcre_ovecsize,
+                3, buf, sizeof(buf)) < 0) {
+            return 0;
+        }
+        if (ByteExtractStringUint32(usecs, 10, 0, buf) < 0) {
+            return 0;
+        }
+    }
+    
+    return 1;
+}
+
+static TmEcode PcapLogInitRingBuffer(PcapLogData *pl)
+{
+    char pattern[PATH_MAX];
+
+    SCLogNotice("Initializing PCAP ring buffer for %s/%s.",
+        pl->dir, pl->prefix);
+
+    strlcpy(pattern, pl->dir, PATH_MAX);
+    if (pattern[strlen(pattern) - 1] != '/') {
+        strlcat(pattern, "/", PATH_MAX);
+    }
+    if (pl->mode == LOGMODE_MULTI) {
+        for (int i = 0; i < pl->filename_part_cnt; i++) {
+            char *part = pl->filename_parts[i];
+            if (part == NULL || strlen(part) == 0) {
+                continue;
+            }
+            if (part[0] != '%' || strlen(part) < 2) {
+                strlcat(pattern, part, PATH_MAX);
+                continue;
+            }
+            switch (part[1]) {
+                case 'i':
+                    SCLogError(SC_ERR_INVALID_ARGUMENT,
+                        "Thread ID not allowed inring buffer mode.");
+                    return TM_ECODE_FAILED;
+                case 'n': {
+                    char tmp[PATH_MAX];
+                    snprintf(tmp, PATH_MAX, "%"PRIu32, pl->thread_number);
+                    strlcat(pattern, tmp, PATH_MAX);
+                    break;
+                }
+                case 't':
+                    strlcat(pattern, "*", PATH_MAX);
+                    break;
+                default:
+                    SCLogError(SC_ERR_INVALID_ARGUMENT,
+                        "Unsupported format character: %%%s", part);
+                    return TM_ECODE_FAILED;
+            }
+        }
+    } else {
+        strlcat(pattern, pl->prefix, PATH_MAX);
+        strlcat(pattern, ".*", PATH_MAX);
+    }
+
+    char *basename = strrchr(pattern, '/');
+    *basename++ = '\0';
+
+    /* Pattern is now just the directory name. */
+    DIR *dir = opendir(pattern);
+    if (dir == NULL) {
+        SCLogWarning(SC_ERR_DIR_OPEN, "Failed to open directory %s: %s",
+            pattern, strerror(errno));
+        return TM_ECODE_FAILED;
+    }
+
+    for (;;) {
+        struct dirent *entry = readdir(dir);
+        if (entry == NULL) {
+            break;
+        }
+        if (fnmatch(basename, entry->d_name, 0) != 0) {
+            continue;
+        }
+
+        uint64_t secs = 0;
+        uint32_t usecs = 0;
+
+        if (!PcapLogGetTimeOfFile(entry->d_name, &secs, &usecs)) {
+            /* Failed to get time stamp out of file name. Not necessarily a
+             * failure as the file might just not be a pcap log file. */
+            continue;
+        }
+
+        PcapFileName *pf = SCCalloc(sizeof(*pf), 1);
+        if (unlikely(pf == NULL)) {
+            return TM_ECODE_FAILED;
+        }
+        char path[PATH_MAX];
+        snprintf(path, PATH_MAX - 1, "%s/%s", pattern, entry->d_name);
+        if ((pf->filename = SCStrdup(path)) == NULL) {
+            goto fail;
+        }
+        if ((pf->dirname = SCStrdup(pattern)) == NULL) {
+            goto fail;
+        }
+        pf->secs = secs;
+        pf->usecs = usecs;
+
+        if (TAILQ_EMPTY(&pl->pcap_file_list)) {
+            TAILQ_INSERT_TAIL(&pl->pcap_file_list, pf, next);
+        } else {
+            /* Ordered insert. */
+            PcapFileName *it = TAILQ_FIRST(&pl->pcap_file_list);
+            TAILQ_FOREACH(it, &pl->pcap_file_list, next) {
+                if (pf->secs < it->secs) {
+                    break;
+                } else if (pf->secs == it->secs && pf->usecs < it->usecs) {
+                    break;
+                }
+            }
+            if (it == NULL) {
+                TAILQ_INSERT_TAIL(&pl->pcap_file_list, pf, next);
+            } else {
+                TAILQ_INSERT_BEFORE(it, pf, next);
+            }
+        }
+        pl->file_cnt++;
+        continue;
+
+    fail:
+        if (pf != NULL) {
+            if (pf->filename != NULL) {
+                SCFree(pf->filename);
+            }
+            if (pf->dirname != NULL) {
+                SCFree(pf->dirname);
+            }
+            SCFree(pf);
+        }
+        break;
+    }
+
+    if (pl->file_cnt > pl->max_files) {
+        PcapFileName *pf = TAILQ_FIRST(&pl->pcap_file_list);
+        while (pf != NULL && pl->file_cnt > pl->max_files) {
+            SCLogInfo("Removing PCAP file %s", pf->filename);
+            if (remove(pf->filename) != 0) {
+                SCLogInfo("Failed to remove PCAP file %s: %s", pf->filename,
+                    strerror(errno));
+            }
+            TAILQ_REMOVE(&pl->pcap_file_list, pf, next);
+            pf = TAILQ_FIRST(&pl->pcap_file_list);
+            pl->file_cnt--;
+        }
+    }
+
+    closedir(dir);
+
+    /* For some reason file count is initialized at one, instead of 0. */
+    SCLogNotice("Ring buffer initialized with %d files.", pl->file_cnt - 1);
+
+    return TM_ECODE_OK;
+}
+
 static TmEcode PcapLogDataInit(ThreadVars *t, void *initdata, void **data)
 {
     if (initdata == NULL) {
@@ -500,7 +702,9 @@ static TmEcode PcapLogDataInit(ThreadVars *t, void *initdata, void **data)
     td->pcap_log->pkt_cnt = 0;
     td->pcap_log->pcap_dead_handle = NULL;
     td->pcap_log->pcap_dumper = NULL;
-    td->pcap_log->file_cnt = 1;
+    if (td->pcap_log->file_cnt < 1) {
+        td->pcap_log->file_cnt = 1;
+    }
 
     struct timeval ts;
     memset(&ts, 0x00, sizeof(struct timeval));
@@ -518,6 +722,12 @@ static TmEcode PcapLogDataInit(ThreadVars *t, void *initdata, void **data)
 
     *data = (void *)td;
 
+    if (pl->max_files && (pl->mode == LOGMODE_MULTI || pl->threads == 1)) {
+        if (PcapLogInitRingBuffer(td->pcap_log) == TM_ECODE_FAILED) {
+            return TM_ECODE_FAILED;
+        }
+    }
+    
     return TM_ECODE_OK;
 }
 
@@ -701,6 +911,9 @@ error:
  * */
 static OutputCtx *PcapLogInitCtx(ConfNode *conf)
 {
+    const char *pcre_errbuf;
+    int pcre_erroffset;
+
     PcapLogData *pl = SCMalloc(sizeof(PcapLogData));
     if (unlikely(pl == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Failed to allocate Memory for PcapLogData");
@@ -726,6 +939,19 @@ static OutputCtx *PcapLogInitCtx(ConfNode *conf)
     TAILQ_INIT(&pl->pcap_file_list);
 
     SCMutexInit(&pl->plog_lock, NULL);
+
+    /* Initialize PCREs. */
+    pcre_timestamp_code = pcre_compile(timestamp_pattern, 0, &pcre_errbuf,
+        &pcre_erroffset, NULL);
+    if (pcre_timestamp_code == NULL) {
+        FatalError(SC_ERR_PCRE_COMPILE,
+            "Failed to compile \"%s\" at offset %"PRIu32": %s",
+            timestamp_pattern, pcre_erroffset, pcre_errbuf);
+    }
+    pcre_timestamp_extra = pcre_study(pcre_timestamp_code, 0, &pcre_errbuf);
+    if (pcre_timestamp_extra == NULL) {
+        FatalError(SC_ERR_PCRE_STUDY, "Fail to study pcre: %s", pcre_errbuf);
+    }
 
     /* conf params */
 
@@ -1071,7 +1297,7 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
         SCLogError(SC_ERR_MEM_ALLOC, "Error allocating memory. For filename");
         goto error;
     }
-    SCLogDebug("Opening pcap file log %s", pf->filename);
+    SCLogNotice("Opening pcap file log %s", pf->filename);
     TAILQ_INSERT_TAIL(&pl->pcap_file_list, pf, next);
 
     PCAPLOG_PROFILE_END(pl->profile_open);

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -329,6 +329,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_INVALID_HASH);
         CASE_CODE (SC_ERR_NO_SHA1_SUPPORT);
         CASE_CODE (SC_ERR_NO_SHA256_SUPPORT);
+        CASE_CODE (SC_ERR_DIR_OPEN);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -319,6 +319,7 @@ typedef enum {
     SC_ERR_INVALID_HASH,
     SC_ERR_NO_SHA1_SUPPORT,
     SC_ERR_NO_SHA256_SUPPORT,
+    SC_ERR_DIR_OPEN,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -341,7 +341,11 @@ outputs:
       max-files: 2000
 
       mode: normal # normal, multi or sguil.
-      #sguil-base-dir: /nsm_data/
+
+      # Directory to place pcap files. If not provided the default log
+      # directory will be used. Required for "sguil" mode.
+      #dir: /nsm_data/
+
       #ts-format: usec # sec or usec second format (default) is filename.sec usec is filename.sec.usec
       use-stream-depth: no #If set to "yes" packets seen after reaching stream inspection depth are ignored. "no" logs all packets
       honor-pass-rules: no # If set to "yes", flows in which a pass rule matched will stopped being logged.


### PR DESCRIPTION
First cut at seending the pcap-log ring buffer with files already on disk with the goal of making it self maintaining over restarts.

I'm thinking it might be a good idea to force the timestamp at the end of the file.  This is the case with non-multi mode, but in multi mode you have to explicitly provide %t.  This would make %n the only variable that would make sense, as %i isn't consistent across restarts.  Thoughts?

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/337
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/342
