### PR TITLE
lua: add function to check if flow has alerts

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -1943,6 +1943,12 @@ end:
     }
     PACKET_PROFILING_DETECT_END(p, PROF_DETECT_CLEANUP);
 
+    if (alerts > 0 && pflow) {
+        /* don't set flag if alert is decoder event */
+        if ((PKT_IS_IPV4(p)) || (PKT_IS_IPV6(p)))
+            pflow->flags |= FLOW_HAS_ALERTS;
+    }
+
     SCReturnInt((int)(alerts > 0));
 }
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -77,7 +77,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /** alproto detect done.  Right now we need it only for udp */
 #define FLOW_ALPROTO_DETECT_DONE          0x00004000
 
-// vacany 1x
+/** flow has alerts */
+#define FLOW_HAS_ALERTS                   0x00010000
 
 /** Pattern matcher alproto detection done */
 #define FLOW_TS_PM_ALPROTO_DETECT_DONE    0x00008000

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -220,6 +220,40 @@ static int LuaCallbackFlowTimeString(lua_State *luastate)
 }
 
 /** \internal
+ *  \brief fill lua stack with flow has alerts
+ *  \param luastate the lua state
+ *  \param flow flow
+ *  \retval cnt number of data items placed on the stack
+ *
+ *  Places alerts (bool)
+ */
+static int LuaCallbackHasAlertsPushToStackFromFlow(lua_State *luastate, const Flow *flow)
+{
+    if (flow->flags & FLOW_HAS_ALERTS) {
+        lua_pushboolean(luastate, 1);
+    } else {
+        lua_pushboolean(luastate, 0);
+    }
+    return 1;
+}
+
+/** \internal
+ *  \brief Wrapper for getting flow has alerts info into a lua script
+ *  \retval cnt number of items placed on the stack
+ */
+static int LuaCallbackFlowHasAlerts(lua_State *luastate)
+{
+    int r = 0;
+    Flow *flow = LuaStateGetFlow(luastate);
+    if (flow == NULL)
+        return LuaCallbackError(luastate, "internal error: no flow");
+
+    r = LuaCallbackHasAlertsPushToStackFromFlow(luastate, flow);
+
+    return r;
+}
+
+/** \internal
  *  \brief fill lua stack with header info
  *  \param luastate the lua state
  *  \param p packet
@@ -732,6 +766,8 @@ int LuaRegisterFunctions(lua_State *luastate)
     lua_setglobal(luastate, "SCFlowAppLayerProto");
     lua_pushcfunction(luastate, LuaCallbackStatsFlow);
     lua_setglobal(luastate, "SCFlowStats");
+    lua_pushcfunction(luastate, LuaCallbackFlowHasAlerts);
+    lua_setglobal(luastate, "SCFlowHasAlerts");
 
     lua_pushcfunction(luastate, LuaCallbackStreamingBuffer);
     lua_setglobal(luastate, "SCStreamingBuffer");


### PR DESCRIPTION
Add function SCFlowHasAlerts to check if any of the packets in a flow has triggered an alert.

This makes it simple to e.g write a Lua script to signal a full capture solution to extract a session Suricata has triggered alerts on.

Example script:

``` lua
function init (args)
    local needs = {}
    needs["type"] = "flow"
    return needs
end

function setup (args)
    filename = SCLogPath() .. "/" .. "flows_with_alerts.log"
    file = assert(io.open(filename, "a"))
end

function log (args)
    ipver, srcip, dstip, proto, sp, dp = SCFlowTuple()
    has_alerts = SCFlowHasAlerts()

    if has_alerts then
        file:write(srcip .. ":" .. sp .. " -> " .. dstip  ..
                   ":" .. dp .. " (proto: " .. proto .. ")\n")
        file:flush()
    end
end

function deinit (args)
    file:close(file)
end
```

prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/52
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/52
