### PR TITLE
util-decode-der-get: fix coverity warning

### DIFF
--- a/src/util-decode-der-get.c
+++ b/src/util-decode-der-get.c
@@ -120,10 +120,8 @@ static time_t UtctimeToTime(char *utctime)
     year = strtol(yy, NULL, 10);
     if (year >= 50)
         snprintf(buf, sizeof(buf), "%i%s", 19, utctime);
-    else if (year < 50)
-        snprintf(buf, sizeof(buf), "%i%s", 20, utctime);
     else
-        goto error;
+        snprintf(buf, sizeof(buf), "%i%s", 20, utctime);
 
     time = GentimeToTime(buf);
     if (time == -1)


### PR DESCRIPTION
```
*** CID 1373380:  Control flow issues  (DEADCODE)
/src/util-decode-der-get.c: 126 in UtctimeToTime()
120         year = strtol(yy, NULL, 10);
121         if (year >= 50)
122             snprintf(buf, sizeof(buf), "%i%s", 19, utctime);
123         else if (year < 50)
124             snprintf(buf, sizeof(buf), "%i%s", 20, utctime);
125         else
>>>     CID 1373380:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "goto error;".
126             goto error;
127
128         time = GentimeToTime(buf);
129         if (time == -1)
130             goto error;
131
```
prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/53
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/53