### PR TITLE
Issue 1893 - TLS direction fixes - v1

### DIFF
--- a/src/detect-tls.c
+++ b/src/detect-tls.c
@@ -653,13 +653,20 @@ static int DetectTlsFingerprintMatch (ThreadVars *t, DetectEngineThreadCtx *det_
 
     int ret = 0;
 
-    if (ssl_state->server_connp.cert0_fingerprint != NULL) {
+    SSLStateConnp *connp = NULL;
+    if (flags & STREAM_TOSERVER) {
+        connp = &ssl_state->client_connp;
+    } else {
+        connp = &ssl_state->server_connp;
+    }
+
+    if (connp->cert0_fingerprint != NULL) {
         SCLogDebug("TLS: Fingerprint is [%s], looking for [%s]\n",
-                   ssl_state->server_connp.cert0_fingerprint,
+                   connp->cert0_fingerprint,
                    tls_data->fingerprint);
 
         if (tls_data->fingerprint &&
-            (strstr(ssl_state->server_connp.cert0_fingerprint,
+            (strstr(connp->cert0_fingerprint,
                     tls_data->fingerprint) != NULL)) {
             if (tls_data->flags & DETECT_CONTENT_NEGATED) {
                 ret = 0;

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -160,7 +160,7 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
             ssl_state->server_connp.cert0_subject == NULL)
         return 0;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "tls");
+    json_t *js = CreateJSONHeader((Packet *)p, 1, "tls");
     if (unlikely(js == NULL))
         return 0;
 


### PR DESCRIPTION
Issue: https://redmine.openinfosecfoundation.org/issues/1893

The first commit fixes the direction on the TLS events to set the src_ip to be the client, and the dest_ip to be the server regardless of IDS or IPS mode.

The second commit adds direction to the fingerprint match.  Before this, if you and an any -> any rule it would trigger in the to_server and to_client directions.  It should only trigger in the to_client direction.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/341
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/346
