### PR TITLE
Dynamic stream reassembly v14

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -114,6 +114,9 @@ typedef struct AppLayerParserProtoCtx_
     DetectEngineState *(*GetTxDetectState)(void *tx);
     int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *);
 
+    /* each app-layer has its own value */
+    uint32_t stream_depth;
+
     /* Indicates the direction the parser is ready to see the data
      * the first time for a flow.  Values accepted -
      * STREAM_TOSERVER, STREAM_TOCLIENT */
@@ -184,11 +187,22 @@ int AppLayerParserSetup(void)
 {
     SCEnter();
 
+    AppProto alproto = 0;
+    int flow_proto = 0;
+
     memset(&alp_ctx, 0, sizeof(alp_ctx));
 
     /* set the default tx handler if none was set explicitly */
     if (AppLayerGetActiveTxIdFuncPtr == NULL) {
         RegisterAppLayerGetActiveTxIdFunc(AppLayerTransactionGetActiveDetectLog);
+    }
+
+    /* lets set a default value for stream_depth */
+    for (flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
+        for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {
+            alp_ctx.ctxs[flow_proto][alproto].stream_depth =
+                stream_config.reassembly_depth;
+        }
     }
 
     SCReturnInt(0);
@@ -1152,6 +1166,20 @@ void AppLayerParserTriggerRawStreamReassembly(Flow *f)
         StreamTcpReassembleTriggerRawReassembly(f->protoctx);
 
     SCReturn;
+}
+
+void AppLayerParserSetStreamDepth(uint8_t ipproto, AppProto alproto, uint32_t stream_depth)
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].stream_depth = stream_depth;
+
+    SCReturn;
+}
+
+uint32_t AppLayerParserGetStreamDepth(uint8_t ipproto, AppProto alproto)
+{
+    SCReturnInt(alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].stream_depth);
 }
 
 /***** Cleanup *****/

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -28,6 +28,7 @@
 #include "app-layer-events.h"
 #include "detect-engine-state.h"
 #include "util-file.h"
+#include "stream-tcp-private.h"
 
 #define APP_LAYER_PARSER_EOF                    0x01
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
@@ -149,6 +150,9 @@ void AppLayerParserRegisterDetectStateFuncs(uint8_t ipproto, AppProto alproto,
         int (*StateHasTxDetectState)(void *alstate),
         DetectEngineState *(*GetTxDetectState)(void *tx),
         int (*SetTxDetectState)(void *alstate, void *tx, DetectEngineState *));
+void AppLayerParserRegisterGetStreamDepth(uint8_t ipproto,
+                                          AppProto alproto,
+                         uint32_t (*GetStreamDepth)(void));
 
 /***** Get and transaction functions *****/
 
@@ -205,6 +209,8 @@ int AppLayerParserProtocolIsTxEventAware(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolSupportsTxs(uint8_t ipproto, AppProto alproto);
 int AppLayerParserProtocolHasLogger(uint8_t ipproto, AppProto alproto);
 void AppLayerParserTriggerRawStreamReassembly(Flow *f);
+void AppLayerParserSetStreamDepth(uint8_t ipproto, AppProto alproto, uint32_t stream_depth);
+uint32_t AppLayerParserGetStreamDepth(uint8_t ipproto, AppProto alproto);
 
 /***** Cleanup *****/
 

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -33,6 +33,7 @@
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp-private.h"
 #include "stream-tcp-inline.h"
+#include "stream-tcp.h"
 #include "flow.h"
 #include "flow-util.h"
 #include "flow-private.h"
@@ -190,6 +191,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
             f->alproto = *alproto;
             StreamTcpSetStreamFlagAppProtoDetectionCompleted(stream);
+            StreamTcpSetReassemblyDepth(ssn, AppLayerParserGetStreamDepth(f->proto, *alproto));
 
             /* account flow if we have both side */
             if (*alproto_otherdir != ALPROTO_UNKNOWN) {
@@ -375,6 +377,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
                                                      APPLAYER_DETECT_PROTOCOL_ONLY_ONE_DIRECTION);
                     StreamTcpSetStreamFlagAppProtoDetectionCompleted(stream);
                     f->data_al_so_far[dir] = 0;
+                    StreamTcpSetReassemblyDepth(ssn, AppLayerParserGetStreamDepth(f->proto, *alproto));
                 } else {
                     f->data_al_so_far[dir] = data_len;
                 }

--- a/src/detect-filestore.c
+++ b/src/detect-filestore.c
@@ -198,6 +198,10 @@ int DetectFilestorePostMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx, Pack
 #endif
     }
 
+    /* set filestore depth for stream reassembling */
+    TcpSession *ssn = (TcpSession *)p->flow->protoctx;
+    StreamTcpSetReassemblyDepth(ssn, FileReassemblyDepth());
+
     if (p->flowflags & FLOW_PKT_TOCLIENT)
         flags |= STREAM_TOCLIENT;
     else

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -46,6 +46,7 @@
 #include "util-atomic.h"
 #include "util-file.h"
 #include "util-time.h"
+#include "util-misc.h"
 
 #include "output.h"
 
@@ -483,6 +484,21 @@ static OutputCtx *LogFilestoreLogInitCtx(ConfNode *conf)
 
     FileForceHashParseCfg(conf);
     SCLogInfo("storing files in %s", g_logfile_base_dir);
+
+    const char *stream_depth_str = ConfNodeLookupChildValue(conf, "stream-depth");
+    if (stream_depth_str != NULL && strcmp(stream_depth_str, "no")) {
+        uint32_t stream_depth = 0;
+        if (ParseSizeStringU32(stream_depth_str,
+                               &stream_depth) < 0) {
+            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing "
+                       "file-store.stream-depth "
+                       "from conf file - %s.  Killing engine",
+                       stream_depth_str);
+            exit(EXIT_FAILURE);
+        } else {
+            FileReassemblyDepthEnable(stream_depth);
+        }
+    }
 
     SCReturnPtr(output_ctx, "OutputCtx");
 }

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -81,6 +81,7 @@ typedef struct TcpStream_ {
     /* reassembly */
     uint32_t ra_app_base_seq;       /**< reassembled seq. We've reassembled up to this point. */
     uint32_t ra_raw_base_seq;       /**< reassembled seq. We've reassembled up to this point. */
+    uint32_t reassembly_depth;      /**< reassembly depth for the stream */
 
     TcpSegment *seg_list;           /**< list of TCP segments that are not yet (fully) used in reassembly */
     TcpSegment *seg_list_tail;      /**< Last segment in the reassembled stream seg list*/

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -647,6 +647,8 @@ TcpSession *StreamTcpNewSession (Packet *p, int id)
         }
 
         ssn->state = TCP_NONE;
+        ssn->client.reassembly_depth = stream_config.reassembly_depth;
+        ssn->server.reassembly_depth = stream_config.reassembly_depth;
         ssn->flags = stream_config.ssn_init_flags;
         ssn->tcp_packet_flags = p->tcph ? p->tcph->th_flags : 0;
 
@@ -5797,6 +5799,14 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
 int StreamTcpBypassEnabled(void)
 {
     return stream_config.bypass;
+}
+
+void StreamTcpSetReassemblyDepth(TcpSession *ssn, uint32_t size)
+{
+    ssn->server.reassembly_depth = size;
+    ssn->client.reassembly_depth = size;
+
+    return;
 }
 
 #ifdef UNITTESTS

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -123,6 +123,7 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag,
                         StreamSegmentCallback CallbackFunc,
                         void *data);
 void StreamTcpReassembleConfigEnableOverlapCheck(void);
+void StreamTcpSetReassemblyDepth(TcpSession *ssn, uint32_t size);
 
 /** ------- Inline functions: ------ */
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -28,6 +28,7 @@
 #include "debug.h"
 #include "flow.h"
 #include "stream.h"
+#include "stream-tcp.h"
 #include "runmodes.h"
 #include "util-hash.h"
 #include "util-debug.h"
@@ -66,6 +67,16 @@ static int g_file_force_sha256 = 0;
  */
 static int g_file_force_tracking = 0;
 
+/** \brief switch to use g_file_store_reassembly_depth
+ *         to reassembly files
+ */
+static int g_file_store_enable = 0;
+
+/** \brief stream_config.reassembly_depth equivalent
+ *         for files
+ */
+static uint32_t g_file_store_reassembly_depth = 0;
+
 /* prototypes */
 static void FileFree(File *);
 
@@ -97,6 +108,20 @@ void FileForceSha256Enable(void)
 int FileForceFilestore(void)
 {
     return g_file_force_filestore;
+}
+
+void FileReassemblyDepthEnable(uint32_t size)
+{
+    g_file_store_enable = 1;
+    g_file_store_reassembly_depth = size;
+}
+
+uint32_t FileReassemblyDepth(void)
+{
+    if (g_file_store_enable == 1)
+        return g_file_store_reassembly_depth;
+    else
+        return stream_config.reassembly_depth;
 }
 
 int FileForceMagic(void)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -182,6 +182,8 @@ void FilePrune(FileContainer *ffc);
 
 void FileForceFilestoreEnable(void);
 int FileForceFilestore(void);
+void FileReassemblyDepthEnable(uint32_t size);
+uint32_t FileReassemblyDepth(void);
 
 void FileDisableMagic(Flow *f, uint8_t);
 void FileForceMagicEnable(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -394,7 +394,7 @@ outputs:
   # file "file.<id>.meta" is created.
   #
   # File extraction depends on a lot of things to be fully done:
-  # - stream reassembly depth. For optimal results, set this to 0 (unlimited)
+  # - file-store stream-depth. For optimal results, set this to 0 (unlimited)
   # - http request / response body sizes. Again set to 0 for optimal results.
   # - rules that contain the "filestore" keyword.
   - file-store:
@@ -405,6 +405,7 @@ outputs:
       # sha1 and sha256
       #force-hash: [md5]
       force-filestore: no # force storing of all files
+      stream-depth: 1mb # reassemble 1mb into a stream, set to no to disable
       #waldo: file.waldo # waldo file to store the file_id across runs
 
   # output module to log files tracked in a easily parsable json format

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -700,6 +700,9 @@ app-layer:
       # If the limit is reached, app-layer-event:modbus.flooded; will match.
       #request-flood: 500
 
+      # Stream reassembly size for modbus, default is 0
+      stream-depth: 0
+
       enabled: no
       detection-ports:
         dp: 502


### PR DESCRIPTION
This patchset implements some changes on stream reassembly,
permitting us to set a reassembly depth per protocol
and also for a filestore keyword.

Some protocol like modbus require an infinite stream depth
because session are kept open and we want to analyze everything.
For this reason, having a stream reassembly depth per stream
permits us to set a stream size per protocol.

----

This PR brings some improvements:

- It implements a different approach to set stream depth value for each app-layer respect the last PR:
Instead to have the old 'SetupTcpSession' which requires a register API and an API in app-layer, this time stream_depth is set when an app-layer  is registered.

- Minor issue fixed in setting 'stream depth' for file-store

- Unittests added

Last PR: https://github.com/inliniac/suricata/pull/1907

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/133
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/132
