### PR TITLE
Modbus midstream v5

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -317,7 +317,7 @@ static AppLayerProtoDetectProbingParserPort *AppLayerProtoDetectGetProbingParser
  * lead to a PP, we try the sp.
  *
  */
-static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
+static AppProto AppLayerProtoDetectPPGetProto(Flow *f, Packet *p,
                                               uint8_t *buf, uint32_t buflen,
                                               uint8_t ipproto, uint8_t direction)
 {
@@ -349,7 +349,10 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
             SCLogDebug("toserver - Probing parser found for source port %"PRIu16, f->sp);
 
             /* found based on source port, so use sp registration */
-            pe2 = pp_port_sp->sp;
+            pe2 = pp_port_sp->dp;
+            StreamTcpPacketSwitchDir(NULL, p);
+            FlowSwitchDirection(f);
+            f->flags |= FLOW_ALPROTO_REVERTED;
         } else {
             SCLogDebug("toserver - No probing parser registered for source port %"PRIu16,
                     f->sp);
@@ -360,7 +363,7 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         alproto_masks = &f->probing_parser_toclient_alproto_masks;
         if (pp_port_dp != NULL) {
             SCLogDebug("toclient - Probing parser found for destination port %"PRIu16, f->dp);
-
+ 
             /* found based on destination port, so use dp registration */
             pe1 = pp_port_dp->dp;
         } else {
@@ -372,7 +375,10 @@ static AppProto AppLayerProtoDetectPPGetProto(Flow *f,
         if (pp_port_sp != NULL) {
             SCLogDebug("toclient - Probing parser found for source port %"PRIu16, f->sp);
 
-            pe2 = pp_port_sp->sp;
+            /* found based on source port, so use sp registration */
+            pe2 = pp_port_sp->dp;
+            StreamTcpPacketSwitchDir(NULL, p);
+            f->flags |= FLOW_ALPROTO_REVERTED;
         } else {
             SCLogDebug("toclient - No probing parser registered for source port %"PRIu16,
                         f->sp);
@@ -1284,7 +1290,7 @@ static int AppLayerProtoDetectPMRegisterPattern(uint8_t ipproto, AppProto alprot
 /***** Protocol Retrieval *****/
 
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
-                                     Flow *f,
+                                     Flow *f, Packet *p,
                                      uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction)
 {
@@ -1307,7 +1313,7 @@ AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
     }
 
     if (!FLOW_IS_PP_DONE(f, direction))
-        alproto = AppLayerProtoDetectPPGetProto(f, buf, buflen, ipproto, direction);
+        alproto = AppLayerProtoDetectPPGetProto(f, p, buf, buflen, ipproto, direction);
 
  end:
     SCReturnCT(alproto, "AppProto");

--- a/src/app-layer-detect-proto.h
+++ b/src/app-layer-detect-proto.h
@@ -45,7 +45,7 @@ typedef AppProto (*ProbingParserFPtr)(uint8_t *input, uint32_t input_len,
  * \retval The app layer protocol.
  */
 AppProto AppLayerProtoDetectGetProto(AppLayerProtoDetectThreadCtx *tctx,
-                                     Flow *f,
+                                     Flow *f, Packet *p,
                                      uint8_t *buf, uint32_t buflen,
                                      uint8_t ipproto, uint8_t direction);
 

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -43,6 +43,7 @@
 #include "util-misc.h"
 
 #include "stream.h"
+#include "stream-tcp.h"
 
 #include "app-layer-protos.h"
 #include "app-layer-parser.h"
@@ -1342,8 +1343,13 @@ static int ModbusParseResponse(Flow                 *f,
             if (tx == NULL)
                 SCReturnInt(0);
 
-            SCLogDebug("MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE");
-            ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE);
+            /* check that midstream is enable and that we are at start of flow */
+            if (StreamTcpMidstreamIsEnabled() && (f->data_al_so_far[0] == 0)) {
+                AppLayerParserManualSetTransactionInspectId(pstate, header.transactionId + 1, 0);
+            } else {
+                SCLogDebug("MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE");
+                ModbusSetEvent(modbus, MODBUS_DECODER_EVENT_UNSOLICITED_RESPONSE);
+            }
         } else {
             /* Store PDU length */
             tx->length = header.length;

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -972,7 +972,13 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* invoke the recursive parser, but only on data. We may get empty msgs on EOF */
     if (input_len > 0 || (flags & STREAM_EOF)) {
         /* invoke the parser */
-        if (p->Parser[(flags & STREAM_TOSERVER) ? 0 : 1](f, alstate, pstate,
+        int dir;
+        if (f->flags & FLOW_ALPROTO_REVERTED) {
+            dir = (flags & STREAM_TOSERVER) ? 1 : 0;
+        } else {
+            dir = (flags & STREAM_TOSERVER) ? 0 : 1;
+        }
+        if (p->Parser[dir](f, alstate, pstate,
                 input, input_len,
                 alp_tctx->alproto_local_storage[f->protomap][alproto]) < 0)
         {

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -601,6 +601,13 @@ uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint
     SCReturnCT(pstate->inspect_id[direction & STREAM_TOSERVER ? 0 : 1], "uint64_t");
 }
 
+void AppLayerParserManualSetTransactionInspectId(AppLayerParserState *pstate,
+                                                 const uint32_t tx_id,
+                                                 const uint8_t flags)
+{
+    pstate->inspect_id[0] = tx_id;
+}
+
 void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
                                            const uint8_t ipproto, const AppProto alproto,
                                            void *alstate, const uint8_t flags)

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -164,6 +164,9 @@ void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
 int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
                               void *tx, uint32_t logger);
 uint64_t AppLayerParserGetTransactionInspectId(AppLayerParserState *pstate, uint8_t direction);
+void AppLayerParserManualSetTransactionInspectId(AppLayerParserState *pstate,
+                                                 const uint32_t tx_id,
+                                                 const uint8_t flags);
 void AppLayerParserSetTransactionInspectId(AppLayerParserState *pstate,
                                 const uint8_t ipproto, const AppProto alproto, void *alstate,
                                 const uint8_t flags);

--- a/src/app-layer-smb.c
+++ b/src/app-layer-smb.c
@@ -2223,7 +2223,7 @@ int SMBParserTest05(void)
     alpd_tctx = AppLayerProtoDetectGetCtxThread();
 
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
-                                          &f,
+                                          &f, NULL,
                                           smbbuf1, smblen1,
                                           IPPROTO_TCP, STREAM_TOSERVER);
     if (alproto != ALPROTO_UNKNOWN) {
@@ -2233,7 +2233,7 @@ int SMBParserTest05(void)
     }
 
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
-                                          &f,
+                                          &f, NULL,
                                           smbbuf2, smblen2,
                                           IPPROTO_TCP, STREAM_TOSERVER);
     if (alproto != ALPROTO_SMB) {
@@ -2307,7 +2307,7 @@ int SMBParserTest06(void)
     alpd_tctx = AppLayerProtoDetectGetCtxThread();
 
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
-                                          &f,
+                                          &f, NULL,
                                           smbbuf1, smblen1,
                                           IPPROTO_TCP, STREAM_TOSERVER);
     if (alproto != ALPROTO_UNKNOWN) {
@@ -2317,7 +2317,7 @@ int SMBParserTest06(void)
     }
 
     alproto = AppLayerProtoDetectGetProto(alpd_tctx,
-                                          &f,
+                                          &f, NULL,
                                           smbbuf2, smblen2,
                                           IPPROTO_TCP, STREAM_TOSERVER);
     if (alproto != ALPROTO_SMB) {

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -168,7 +168,7 @@ int AppLayerHandleTCPData(ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 
         PACKET_PROFILING_APP_PD_START(app_tctx);
         *alproto = AppLayerProtoDetectGetProto(app_tctx->alpd_tctx,
-                                f,
+                                f, p,
                                 data, data_len,
                                 IPPROTO_TCP, flags);
         PACKET_PROFILING_APP_PD_END(app_tctx);
@@ -527,7 +527,7 @@ int AppLayerHandleUdp(ThreadVars *tv, AppLayerThreadCtx *tctx, Packet *p, Flow *
 
         PACKET_PROFILING_APP_PD_START(tctx);
         f->alproto = AppLayerProtoDetectGetProto(tctx->alpd_tctx,
-                                  f,
+                                  f, p,
                                   p->payload, p->payload_len,
                                   IPPROTO_UDP, flags);
         PACKET_PROFILING_APP_PD_END(tctx);

--- a/src/flow.c
+++ b/src/flow.c
@@ -191,6 +191,18 @@ int FlowGetPacketDirection(const Flow *f, const Packet *p)
     return TOSERVER;
 }
 
+void FlowSwitchDirection(Flow *f)
+{
+    FlowAddress addr = f->src;
+    Port p = f->sp;
+
+    f->src = f->dst;
+    f->sp = f->dp;
+
+    f->dst = addr;
+    f->dp = p;
+}
+
 /**
  *  \brief Check to update "seen" flags
  *

--- a/src/flow.h
+++ b/src/flow.h
@@ -568,5 +568,7 @@ uint8_t FlowGetDisruptionFlags(const Flow *f, uint8_t flags);
 
 void FlowHandlePacketUpdate(Flow *f, Packet *p);
 
+void FlowSwitchDirection(Flow *f);
+
 #endif /* __FLOW_H__ */
 

--- a/src/flow.h
+++ b/src/flow.h
@@ -43,75 +43,73 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /* per flow flags */
 
 /** At least on packet from the source address was seen */
-#define FLOW_TO_SRC_SEEN                  0x00000001
+#define FLOW_TO_SRC_SEEN                  BIT_U32(0)
 /** At least on packet from the destination address was seen */
-#define FLOW_TO_DST_SEEN                  0x00000002
+#define FLOW_TO_DST_SEEN                  BIT_U32(1)
 /** Don't return this from the flow hash. It has been replaced. */
-#define FLOW_TCP_REUSED                   0x00000004
+#define FLOW_TCP_REUSED                   BIT_U32(2)
 /** no magic on files in this flow */
-#define FLOW_FILE_NO_MAGIC_TS             0x00000008
-#define FLOW_FILE_NO_MAGIC_TC             0x00000010
+#define FLOW_FILE_NO_MAGIC_TS             BIT_U32(3)
+#define FLOW_FILE_NO_MAGIC_TC             BIT_U32(4)
 
 /** Flow was inspected against IP-Only sigs in the toserver direction */
-#define FLOW_TOSERVER_IPONLY_SET          0x00000020
+#define FLOW_TOSERVER_IPONLY_SET          BIT_U32(5)
 /** Flow was inspected against IP-Only sigs in the toclient direction */
-#define FLOW_TOCLIENT_IPONLY_SET          0x00000040
+#define FLOW_TOCLIENT_IPONLY_SET          BIT_U32(6)
 
 /** Packet belonging to this flow should not be inspected at all */
-#define FLOW_NOPACKET_INSPECTION          0x00000080
+#define FLOW_NOPACKET_INSPECTION          BIT_U32(7)
 /** Packet payloads belonging to this flow should not be inspected */
-#define FLOW_NOPAYLOAD_INSPECTION         0x00000100
+#define FLOW_NOPAYLOAD_INSPECTION         BIT_U32(8)
 
 /** All packets in this flow should be dropped */
-#define FLOW_ACTION_DROP                  0x00000200
+#define FLOW_ACTION_DROP                  BIT_U32(9)
 
 /** Sgh for toserver direction set (even if it's NULL) */
-#define FLOW_SGH_TOSERVER                 0x00000400
+#define FLOW_SGH_TOSERVER                 BIT_U32(10)
 /** Sgh for toclient direction set (even if it's NULL) */
-#define FLOW_SGH_TOCLIENT                 0x00000800
+#define FLOW_SGH_TOCLIENT                 BIT_U32(11)
 
 /** packet to server direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOSERVER_DROP_LOGGED         0x00001000
+#define FLOW_TOSERVER_DROP_LOGGED         BIT_U32(12)
 /** packet to client direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOCLIENT_DROP_LOGGED         0x00002000
+#define FLOW_TOCLIENT_DROP_LOGGED         BIT_U32(13)
 /** alproto detect done.  Right now we need it only for udp */
-#define FLOW_ALPROTO_DETECT_DONE          0x00004000
-
-// vacany 1x
+#define FLOW_ALPROTO_DETECT_DONE          BIT_U32(14)
 
 /** Pattern matcher alproto detection done */
-#define FLOW_TS_PM_ALPROTO_DETECT_DONE    0x00008000
+#define FLOW_TS_PM_ALPROTO_DETECT_DONE    BIT_U32(15)
 /** Probing parser alproto detection done */
-#define FLOW_TS_PP_ALPROTO_DETECT_DONE    0x00010000
+#define FLOW_TS_PP_ALPROTO_DETECT_DONE    BIT_U32(16)
 /** Pattern matcher alproto detection done */
-#define FLOW_TC_PM_ALPROTO_DETECT_DONE    0x00020000
+#define FLOW_TC_PM_ALPROTO_DETECT_DONE    BIT_U32(17)
 /** Probing parser alproto detection done */
-#define FLOW_TC_PP_ALPROTO_DETECT_DONE    0x00040000
-#define FLOW_TIMEOUT_REASSEMBLY_DONE      0x00080000
+#define FLOW_TC_PP_ALPROTO_DETECT_DONE    BIT_U32(18)
+#define FLOW_TIMEOUT_REASSEMBLY_DONE      BIT_U32(19)
 /** even if the flow has files, don't store 'm */
-#define FLOW_FILE_NO_STORE_TS             0x00100000
-#define FLOW_FILE_NO_STORE_TC             0x00200000
+#define FLOW_FILE_NO_STORE_TS             BIT_U32(20)
+#define FLOW_FILE_NO_STORE_TC             BIT_U32(21)
 
 /** flow is ipv4 */
-#define FLOW_IPV4                         0x00400000
+#define FLOW_IPV4                         BIT_U32(22)
 /** flow is ipv6 */
-#define FLOW_IPV6                         0x00800000
+#define FLOW_IPV6                         BIT_U32(23)
 
 /** no md5 on files in this flow */
-#define FLOW_FILE_NO_MD5_TS               0x01000000
-#define FLOW_FILE_NO_MD5_TC               0x02000000
+#define FLOW_FILE_NO_MD5_TS               BIT_U32(24)
+#define FLOW_FILE_NO_MD5_TC               BIT_U32(25)
 
 /** no sha1 on files in this flow */
-#define FLOW_FILE_NO_SHA1_TS              0x04000000
-#define FLOW_FILE_NO_SHA1_TC              0x08000000
+#define FLOW_FILE_NO_SHA1_TS              BIT_U32(26)
+#define FLOW_FILE_NO_SHA1_TC              BIT_U32(27)
 
 /** no sha256 on files in this flow */
-#define FLOW_FILE_NO_SHA256_TS            0x10000000
-#define FLOW_FILE_NO_SHA256_TC            0x20000000
+#define FLOW_FILE_NO_SHA256_TS            BIT_U32(28)
+#define FLOW_FILE_NO_SHA256_TC            BIT_U32(29)
 
 /** no size tracking of files in this flow */
-#define FLOW_FILE_NO_SIZE_TS              0x40000000
-#define FLOW_FILE_NO_SIZE_TC              0x80000000
+#define FLOW_FILE_NO_SIZE_TS              BIT_U32(30)
+#define FLOW_FILE_NO_SIZE_TC              BIT_U32(31)
 
 #define FLOW_IS_IPV4(f) \
     (((f)->flags & FLOW_IPV4) == FLOW_IPV4)

--- a/src/flow.h
+++ b/src/flow.h
@@ -43,69 +43,71 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /* per flow flags */
 
 /** Don't return this from the flow hash. It has been replaced. */
-#define FLOW_TCP_REUSED                   BIT_U32(2)
+#define FLOW_TCP_REUSED                   BIT_U32(0)
 /** no magic on files in this flow */
-#define FLOW_FILE_NO_MAGIC_TS             BIT_U32(3)
-#define FLOW_FILE_NO_MAGIC_TC             BIT_U32(4)
+#define FLOW_FILE_NO_MAGIC_TS             BIT_U32(1)
+#define FLOW_FILE_NO_MAGIC_TC             BIT_U32(2)
 
 /** Flow was inspected against IP-Only sigs in the toserver direction */
-#define FLOW_TOSERVER_IPONLY_SET          BIT_U32(5)
+#define FLOW_TOSERVER_IPONLY_SET          BIT_U32(3)
 /** Flow was inspected against IP-Only sigs in the toclient direction */
-#define FLOW_TOCLIENT_IPONLY_SET          BIT_U32(6)
+#define FLOW_TOCLIENT_IPONLY_SET          BIT_U32(4)
 
 /** Packet belonging to this flow should not be inspected at all */
-#define FLOW_NOPACKET_INSPECTION          BIT_U32(7)
+#define FLOW_NOPACKET_INSPECTION          BIT_U32(5)
 /** Packet payloads belonging to this flow should not be inspected */
-#define FLOW_NOPAYLOAD_INSPECTION         BIT_U32(8)
+#define FLOW_NOPAYLOAD_INSPECTION         BIT_U32(6)
 
 /** All packets in this flow should be dropped */
-#define FLOW_ACTION_DROP                  BIT_U32(9)
+#define FLOW_ACTION_DROP                  BIT_U32(7)
 
 /** Sgh for toserver direction set (even if it's NULL) */
-#define FLOW_SGH_TOSERVER                 BIT_U32(10)
+#define FLOW_SGH_TOSERVER                 BIT_U32(8)
 /** Sgh for toclient direction set (even if it's NULL) */
-#define FLOW_SGH_TOCLIENT                 BIT_U32(11)
+#define FLOW_SGH_TOCLIENT                 BIT_U32(9)
 
 /** packet to server direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOSERVER_DROP_LOGGED         BIT_U32(12)
+#define FLOW_TOSERVER_DROP_LOGGED         BIT_U32(10)
 /** packet to client direction has been logged in drop file (only in IPS mode) */
-#define FLOW_TOCLIENT_DROP_LOGGED         BIT_U32(13)
+#define FLOW_TOCLIENT_DROP_LOGGED         BIT_U32(11)
 /** alproto detect done.  Right now we need it only for udp */
-#define FLOW_ALPROTO_DETECT_DONE          BIT_U32(14)
+#define FLOW_ALPROTO_DETECT_DONE          BIT_U32(12)
 
 /** Pattern matcher alproto detection done */
-#define FLOW_TS_PM_ALPROTO_DETECT_DONE    BIT_U32(15)
+#define FLOW_TS_PM_ALPROTO_DETECT_DONE    BIT_U32(13)
 /** Probing parser alproto detection done */
-#define FLOW_TS_PP_ALPROTO_DETECT_DONE    BIT_U32(16)
+#define FLOW_TS_PP_ALPROTO_DETECT_DONE    BIT_U32(14)
 /** Pattern matcher alproto detection done */
-#define FLOW_TC_PM_ALPROTO_DETECT_DONE    BIT_U32(17)
+#define FLOW_TC_PM_ALPROTO_DETECT_DONE    BIT_U32(15)
 /** Probing parser alproto detection done */
-#define FLOW_TC_PP_ALPROTO_DETECT_DONE    BIT_U32(18)
-#define FLOW_TIMEOUT_REASSEMBLY_DONE      BIT_U32(19)
+#define FLOW_TC_PP_ALPROTO_DETECT_DONE    BIT_U32(16)
+#define FLOW_TIMEOUT_REASSEMBLY_DONE      BIT_U32(17)
 /** even if the flow has files, don't store 'm */
-#define FLOW_FILE_NO_STORE_TS             BIT_U32(20)
-#define FLOW_FILE_NO_STORE_TC             BIT_U32(21)
+#define FLOW_FILE_NO_STORE_TS             BIT_U32(18)
+#define FLOW_FILE_NO_STORE_TC             BIT_U32(19)
 
 /** flow is ipv4 */
-#define FLOW_IPV4                         BIT_U32(22)
+#define FLOW_IPV4                         BIT_U32(20)
 /** flow is ipv6 */
-#define FLOW_IPV6                         BIT_U32(23)
+#define FLOW_IPV6                         BIT_U32(21)
 
 /** no md5 on files in this flow */
-#define FLOW_FILE_NO_MD5_TS               BIT_U32(24)
-#define FLOW_FILE_NO_MD5_TC               BIT_U32(25)
+#define FLOW_FILE_NO_MD5_TS               BIT_U32(22)
+#define FLOW_FILE_NO_MD5_TC               BIT_U32(23)
 
 /** no sha1 on files in this flow */
-#define FLOW_FILE_NO_SHA1_TS              BIT_U32(26)
-#define FLOW_FILE_NO_SHA1_TC              BIT_U32(27)
+#define FLOW_FILE_NO_SHA1_TS              BIT_U32(24)
+#define FLOW_FILE_NO_SHA1_TC              BIT_U32(25)
 
 /** no sha256 on files in this flow */
-#define FLOW_FILE_NO_SHA256_TS            BIT_U32(28)
-#define FLOW_FILE_NO_SHA256_TC            BIT_U32(29)
+#define FLOW_FILE_NO_SHA256_TS            BIT_U32(26)
+#define FLOW_FILE_NO_SHA256_TC            BIT_U32(27)
 
 /** no size tracking of files in this flow */
-#define FLOW_FILE_NO_SIZE_TS              BIT_U32(30)
-#define FLOW_FILE_NO_SIZE_TC              BIT_U32(31)
+#define FLOW_FILE_NO_SIZE_TS              BIT_U32(28)
+#define FLOW_FILE_NO_SIZE_TC              BIT_U32(29)
+/** flow has been caught midstream in server first */
+#define FLOW_ALPROTO_REVERTED             BIT_U32(30)
 
 #define FLOW_IS_IPV4(f) \
     (((f)->flags & FLOW_IPV4) == FLOW_IPV4)

--- a/src/flow.h
+++ b/src/flow.h
@@ -42,10 +42,6 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 
 /* per flow flags */
 
-/** At least on packet from the source address was seen */
-#define FLOW_TO_SRC_SEEN                  BIT_U32(0)
-/** At least on packet from the destination address was seen */
-#define FLOW_TO_DST_SEEN                  BIT_U32(1)
 /** Don't return this from the flow hash. It has been replaced. */
 #define FLOW_TCP_REUSED                   BIT_U32(2)
 /** no magic on files in this flow */

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4914,6 +4914,11 @@ TmEcode StreamTcp (ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
     return TM_ECODE_OK;
 }
 
+int StreamTcpMidstreamIsEnabled()
+{
+    return (stream_config.midstream == TRUE);
+}
+
 TmEcode StreamTcpThreadInit(ThreadVars *tv, void *initdata, void **data)
 {
     SCEnter();

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -217,6 +217,7 @@ static inline int StreamNeedsReassembly(TcpSession *ssn, int direction)
 
 TmEcode StreamTcp (ThreadVars *, Packet *, void *, PacketQueue *, PacketQueue *);
 void StreamTcpExitPrintStats(ThreadVars *, void *);
+int StreamTcpMidstreamIsEnabled(void);
 TmEcode StreamTcpThreadInit(ThreadVars *, void *, void **);
 TmEcode StreamTcpThreadDeinit(ThreadVars *tv, void *data);
 void StreamTcpRegisterTests (void);


### PR DESCRIPTION
This is a series of fixes for problems @glongo and me have found when working on modbus protocol.

Main one is a fix of midstream algorithm that was not detecting correctly the server/client inversion. Commits a085fb9 to 3099ce2 are addressing that.

The two last patches fixe a problem in modbus not continuing correctly transaction inspection in case of message loss.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/217
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/213