### PR TITLE
decode: add Cisco HDLC decoder - v5

### DIFF
--- a/rules/decoder-events.rules
+++ b/rules/decoder-events.rules
@@ -141,5 +141,8 @@ alert pkthdr any any -> any any (msg:"SURICATA ERSPAN too many vlan layers"; dec
 # Cisco Fabric Path/DCE
 alert pkthdr any any -> any any (msg:"SURICATA DCE packet too small"; decode-event:dce.pkt_too_small; sid:2200110; rev:1;)
 
-# next sid is 2200112
+# CHDLC
+alert pkthdr any any -> any any (msg:"SURICATA CHDLC packet too small"; decode-event:chdlc.pkt_too_small; sid:2200112; rev:1;)
+
+# next sid is 2200113
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,6 +44,7 @@ conf-yaml-loader.c conf-yaml-loader.h \
 counters.c counters.h \
 data-queue.c data-queue.h \
 decode.c decode.h \
+decode-chdlc.h decode-chdlc.c \
 decode-erspan.c decode-erspan.h \
 decode-ethernet.c decode-ethernet.h \
 decode-events.c decode-events.h \

--- a/src/decode-chdlc.c
+++ b/src/decode-chdlc.c
@@ -1,0 +1,70 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \ingroup decode
+ *
+ * @{
+ */
+
+/**
+ * \file
+ *
+ * \author Endace Technology Limited, Jason Ish <jason.ish@endace.com>
+ *
+ * Decoder for Cisco HDLC.
+ */
+
+#include "suricata-common.h"
+#include "decode-chdlc.h"
+#include "decode-ethernet.h"
+
+int DecodeCHDLC(ThreadVars *tv, DecodeThreadVars *dtv, Packet *p,
+    uint8_t *pkt, uint16_t len, PacketQueue *pq)
+{
+    if (unlikely(len < sizeof(CHDLCHdr))) {
+        ENGINE_SET_INVALID_EVENT(p, CHDLC_PKT_TOO_SMALL);
+        return TM_ECODE_FAILED;
+    }
+
+    p->chdlch = (CHDLCHdr *)pkt;
+    if (unlikely(p->chdlch == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+
+    int offset = sizeof(CHDLCHdr);
+
+    /* Switch on the protocol field, which contains the same values as
+     * ethertypes in ethernet. */
+    switch (ntohs(p->chdlch->protocol)) {
+        case ETHERNET_TYPE_IP:
+            DecodeIPV4(tv, dtv, p, pkt + offset, len - offset, pq);
+            break;
+        case ETHERNET_TYPE_IPV6:
+            DecodeIPV6(tv, dtv, p, pkt + offset, len - offset, pq);
+            break;
+        default:
+            SCLogDebug("Unsupported CHDLC protocol: %d", p->chdlch->protocol);
+            break;
+    }
+
+    return TM_ECODE_OK;
+}
+
+/**
+ * @}
+ */

--- a/src/decode-chdlc.h
+++ b/src/decode-chdlc.h
@@ -1,0 +1,35 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Endace Technology Limited, Jason Ish <jason.ish@endace.com>
+ *
+ * Decoder for Cisco HDLC.
+ */
+
+#ifndef __DECODE_CHDLC_H__
+#define __DECODE_CHDLC_H__
+
+typedef struct CHDLCHdr_ {
+    uint8_t address;
+    uint8_t control;
+    uint16_t protocol;
+} __attribute__((__packed__)) CHDLCHdr;
+
+#endif /* ! __DECODE_CHDLC_H__ */

--- a/src/decode-events.c
+++ b/src/decode-events.c
@@ -182,6 +182,9 @@ const struct DecodeEvents_ DEvents[] = {
     /* Cisco Fabric Path/DCE events. */
     { "decoder.dce.pkt_too_small", DCE_PKT_TOO_SMALL, },
 
+    /* CHDLC events */
+    { "decoder.chdlc.pkt_too_small", CHDLC_PKT_TOO_SMALL, },
+
     /* STREAM EVENTS */
     { "stream.3whs_ack_in_wrong_dir", STREAM_3WHS_ACK_IN_WRONG_DIR, },
     { "stream.3whs_async_wrong_seq", STREAM_3WHS_ASYNC_WRONG_SEQ, },

--- a/src/decode-events.h
+++ b/src/decode-events.h
@@ -188,6 +188,9 @@ enum {
     /* Cisco Fabric Path/DCE events. */
     DCE_PKT_TOO_SMALL,
 
+    /* Cisco HDLC events. */
+    CHDLC_PKT_TOO_SMALL, /**< CHDLC packet smaller than minimum size. */
+
     /* END OF DECODE EVENTS ON SINGLE PACKET */
     DECODE_EVENT_PACKET_MAX,
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -66,6 +66,7 @@ enum PktSrcEnum {
 
 #include "action-globals.h"
 
+#include "decode-chdlc.h"
 #include "decode-erspan.h"
 #include "decode-ethernet.h"
 #include "decode-gre.h"
@@ -466,6 +467,7 @@ typedef struct Packet_
 
     /* header pointers */
     EthernetHdr *ethh;
+    CHDLCHdr *chdlch;
 
     /* Checksum for IP packets. */
     int32_t level3_comp_csum;
@@ -943,6 +945,8 @@ int DecodeGRE(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, P
 int DecodeVLAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 int DecodeMPLS(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
 int DecodeERSPAN(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *, uint16_t, PacketQueue *);
+int DecodeCHDLC(ThreadVars *, DecodeThreadVars *, Packet *, uint8_t *,
+    uint16_t, PacketQueue *);
 
 void AddressDebugPrint(Address *);
 
@@ -1062,6 +1066,7 @@ int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
 #define LINKTYPE_LINUX_SLL  113
 #define LINKTYPE_PPP        9
 #define LINKTYPE_RAW        DLT_RAW
+#define LINKTYPE_CHDLC      DLT_C_HDLC
 #define PPP_OVER_GRE        11
 #define VLAN_OVER_GRE       13
 

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2247,7 +2247,8 @@ TmEcode DecodeAFP(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packet
             DecodeNull(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         default:
-            SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodeAFP", p->datalink);
+            FatalError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodeAFP", p->datalink);
+            /* Not reached. */
             break;
     }
 

--- a/src/source-erf-dag.c
+++ b/src/source-erf-dag.c
@@ -527,9 +527,11 @@ ProcessErfDagRecord(ErfDagThreadVars *ewtn, char *prec)
             pkt_data = erf_payload->eth.dst;
             break;
         default:
-            /* Shouldn't reach here. */
-            SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED,
+            /* If we get here, exit with a fatal error as we shouldn't
+             * see mixed link types. */
+            FatalError(SC_ERR_DATALINK_UNIMPLEMENTED,
                 "Processing of DAG record type: %d not implemented.", dr->type);
+            /* Not reached. */
             SCReturnInt(TM_ECODE_FAILED);
             break;
     }

--- a/src/source-erf-file.c
+++ b/src/source-erf-file.c
@@ -177,8 +177,9 @@ static inline TmEcode ReadErfRecord(ThreadVars *tv, Packet *p, void *data)
             pad = ERF_TYPE_ETH_PAD;
             break;
         default:
-            SCLogError(SC_ERR_UNIMPLEMENTED,
+            FatalError(SC_ERR_UNIMPLEMENTED,
                 "DAG record type %d not implemented.", dr.type);
+            /* Not reached. */
             SCReturnInt(TM_ECODE_FAILED);
             break;
     }

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -466,7 +466,7 @@ TmEcode DecodeIPFW(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
 
     } else {
         /* We don't support anything besides IP packets for now, bridged packets? */
-        SCLogInfo("IPFW unknown protocol support %02x", *GET_PKT_DATA(p));
+        SCLogDebug("IPFW unknown protocol support %02x", *GET_PKT_DATA(p));
        SCReturnInt(TM_ECODE_FAILED);
     }
 

--- a/src/source-napatech.c
+++ b/src/source-napatech.c
@@ -365,9 +365,10 @@ TmEcode NapatechDecode(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq,
             DecodeEthernet(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         default:
-            SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED,
+            FatalError(SC_ERR_DATALINK_UNIMPLEMENTED,
                     "Error: datalink type %" PRId32 " not yet supported in module NapatechDecode",
                     p->datalink);
+            /* Not reached. */
             break;
     }
 

--- a/src/source-pcap-file.c
+++ b/src/source-pcap-file.c
@@ -332,7 +332,9 @@ TmEcode ReceivePcapFileThreadInit(ThreadVars *tv, void *initdata, void **data)
         case LINKTYPE_NULL:
             pcap_g.Decoder = DecodeNull;
             break;
-
+        case LINKTYPE_CHDLC:
+            pcap_g.Decoder = DecodeCHDLC;
+            break;
         default:
             SCLogError(SC_ERR_UNIMPLEMENTED, "datalink type %" PRId32 " not "
                       "(yet) supported in module PcapFile.\n", pcap_g.datalink);

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -730,7 +730,8 @@ TmEcode DecodePcap(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
             DecodeCHDLC(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
         default:
-            SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodePcap", p->datalink);
+            FatalError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodePcap", p->datalink);
+            /* Not reached. */
             break;
     }
 

--- a/src/source-pcap.c
+++ b/src/source-pcap.c
@@ -726,6 +726,9 @@ TmEcode DecodePcap(ThreadVars *tv, Packet *p, void *data, PacketQueue *pq, Packe
         case LINKTYPE_NULL:
             DecodeNull(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
             break;
+        case LINKTYPE_CHDLC:
+            DecodeCHDLC(tv, dtv, p, GET_PKT_DATA(p), GET_PKT_LEN(p), pq);
+            break;
         default:
             SCLogError(SC_ERR_DATALINK_UNIMPLEMENTED, "Error: datalink type %" PRId32 " not yet supported in module DecodePcap", p->datalink);
             break;


### PR DESCRIPTION
Previous PR: #2206 

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1807

Changes in this PR:
- Rebase required.
- Add fatal errors on unsupported link types (or debug logging).

Cisco HDLC decoder. Support added for PCAP, ERF and DAG.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/1
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/351
