### PR TITLE
docs: pdf and error cleanup - v1

### DIFF
--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -30,7 +30,7 @@ man1_MANS = suricata.1
 
 EXTRA_DIST += $(man1_MANS) userguide.pdf
 
-SPHINX_BUILD = sphinx-build -q
+SPHINX_BUILD = sphinx-build -q -W
 
 html:
 	sysconfdir=$(sysconfdir) \

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -28,7 +28,7 @@ endif
 if HAVE_SPHINXBUILD
 man1_MANS = suricata.1
 
-EXTRA_DIST += $(man1_MANS)
+EXTRA_DIST += $(man1_MANS) userguide.pdf
 
 SPHINX_BUILD = sphinx-build -q
 
@@ -39,13 +39,18 @@ html:
 		$(SPHINX_BUILD) -b html -d _build/doctrees \
 		$(top_srcdir)/doc/userguide _build/html
 
-pdf:
+_build/latex/Suricata.pdf:
 	sysconfdir=$(sysconfdir) \
 	localstatedir=$(localstatedir) \
 	version=$(PACKAGE_VERSION) \
 		$(SPHINX_BUILD) -b latex -d _build/doctrees \
 		$(top_srcdir)/doc/userguide _build/latex
 	cd _build/latex && $(MAKE) all-pdf
+
+userguide.pdf: _build/latex/Suricata.pdf
+	cp _build/latex/Suricata.pdf userguide.pdf
+
+pdf: userguide.pdf
 
 _build/man/suricata.1:
 	sysconfdir=$(sysconfdir) \
@@ -54,12 +59,15 @@ _build/man/suricata.1:
 		$(SPHINX_BUILD) -b man -d _build/doctrees \
 		$(top_srcdir)/doc/userguide _build/man
 
-man: _build/man/suricata.1
-
 suricata.1: _build/man/suricata.1
 	cp _build/man/suricata.1 suricata.1
 
+man: _build/man/suricata.1
+
+# Remove build artifacts that aren't tracked by autotools.
 clean-local:
 	rm -rf $(top_builddir)/doc/userguide/_build
 	rm -f $(top_builddir)/doc/userguide/suricata.1
-endif
+	rm -f $(top_builddir)/doc/userguide/suricata.pdf
+
+endif # HAVE_SPHINXBUILD

--- a/doc/userguide/command-line-options.rst
+++ b/doc/userguide/command-line-options.rst
@@ -79,15 +79,13 @@ For more information about runmodes see: :doc:`performance/runmodes`
 Capture Options
 ~~~~~~~~~~~~~~~
 
-.. option:: --af-packet
-.. option:: --af-packet=<device>
+.. option:: --af-packet[=<device>]
 
    Enable capture of packet using AF_PACKET on Linux. If no device is
    supplied, the list of devices from the af-packet section in the
    yaml is used.
 
-.. option:: --netmap
-.. option:: --netmap=<device>
+.. option:: --netmap[=<device>]
 
    Enable capture of packet using NETMAP on FreeBSD or Linux. If no
    device is supplied, the list of devices from the netmap section

--- a/doc/userguide/file-extraction/file-extraction.rst
+++ b/doc/userguide/file-extraction/file-extraction.rst
@@ -99,4 +99,4 @@ Suricata can calculate MD5 checksums of files on the fly and log them. See :doc:
 
    md5
    public-sha1-md5-data-sets
-
+   filemd5-and-whiteblacklisting-with-md5

--- a/doc/userguide/output/index.rst
+++ b/doc/userguide/output/index.rst
@@ -7,3 +7,4 @@ Output
    lua-output
    syslog-alerting-comp
    custom-http-logging
+   files-json/files-json

--- a/doc/userguide/performance/tuning-considerations.rst
+++ b/doc/userguide/performance/tuning-considerations.rst
@@ -15,7 +15,7 @@ Suggested setting: 1000 or higher. Max is ~65000.
 mpm-algo: <ac|hs|ac-bs|ac-ks>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Controls the pattern matcher algorithm. AC is the default. On supported platforms, :doc:`performance/Hyperscan` is the best option.
+Controls the pattern matcher algorithm. AC is the default. On supported platforms, :doc:`hyperscan` is the best option.
 
 detect.profile: <low|medium|high|custom>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/userguide/rules/enip-keyword.rst
+++ b/doc/userguide/rules/enip-keyword.rst
@@ -37,4 +37,4 @@ Examples::
 (cf. http://read.pudn.com/downloads166/ebook/763211/EIP-CIP-V1-1.0.pdf)
 
 Information on the protocol can be found here:
-http://literature.rockwellautomation.com/idc/groups/literature/documents/wp/enet-wp001_-en-p.pdf
+`<http://literature.rockwellautomation.com/idc/groups/literature/documents/wp/enet-wp001_-en-p.pdf>`_

--- a/doc/userguide/setting-up-ipsinline-for-linux.rst
+++ b/doc/userguide/setting-up-ipsinline-for-linux.rst
@@ -1,7 +1,8 @@
 Setting up IPS/inline for Linux
 ================================
 
-In this guide will be explained how to work with Suricata in layer3 inline mode and how to set iptables for that purpose.
+In this guide will be explained how to work with Suricata in layer3
+inline mode and how to set iptables for that purpose.
 
 First start with compiling Suricata with NFQ support. For instructions
 see `Ubuntu Installation


### PR DESCRIPTION
Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/1906

* Include the PDF in the distribution at doc/userguide/userguide.pdf.  I gave up trying to put it cleanly into the directory above it, but could look again.

* Use sphinx-build -W, this turns warnings into errors.

* Fix all documentation warnings.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/6
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/356
