### PR TITLE
doc: exclude docs in partials/ from reference errors

### DIFF
--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -87,7 +87,12 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = [
+    '_build',
+
+    # Documents that are included, rather than in a TOC.
+    'partials',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
These docs are already included with the include statement,
but older versions of Sphinx still complain that they
are not in a table of contents.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/8
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/358
