### PR TITLE
doc - fixups - v4

### DIFF
--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST = \
 	what-is-suricata.rst \
 	make-sense-alerts.rst \
 	setting-up-ipsinline-for-linux.rst \
+	unix-socket.rst \
 	capture-hardware \
 	configuration \
 	file-extraction \
@@ -19,7 +20,8 @@ EXTRA_DIST = \
 	performance \
 	reputation \
 	rules \
-	setting-up-ipsinline-for-linux
+	setting-up-ipsinline-for-linux \
+	partials
 
 if HAVE_SURICATA_MAN
 man1_MANS = suricata.1

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -70,6 +70,6 @@ man: _build/man/suricata.1
 clean-local:
 	rm -rf $(top_builddir)/doc/userguide/_build
 	rm -f $(top_builddir)/doc/userguide/suricata.1
-	rm -f $(top_builddir)/doc/userguide/suricata.pdf
+	rm -f $(top_builddir)/doc/userguide/userguide.pdf
 
 endif # HAVE_SPHINXBUILD

--- a/doc/userguide/conf.py
+++ b/doc/userguide/conf.py
@@ -87,7 +87,12 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = [
+    '_build',
+
+    # Documents that are included, rather than in a TOC.
+    'partials',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
Previous PR: #2330 

- Explicitly exclude partials/ from as they are not intended to be used in a TOC, but only included by other files. This is to keep older versions of Sphinx from erroring out, newer versions handle this case fine.
- Documents were missing from EXTRA_DIST causing make distcheck to fail.
- The wrong pdf file name was being removed causing make distcheck to fail.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/14
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/364
