### PR TITLE
logging: don't log that json is disabled in each logger - v1

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -740,7 +740,6 @@ void JsonAlertLogRegister (void)
 
 void JsonAlertLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -878,7 +878,6 @@ void JsonDnsLogRegister (void)
 
 void JsonDnsLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -438,7 +438,6 @@ void JsonDropLogRegister (void)
 
 void JsonDropLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -310,7 +310,6 @@ void JsonFileLogRegister (void)
 
 void JsonFileLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -483,7 +483,6 @@ void JsonFlowLogRegister (void)
 
 void JsonFlowLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -599,7 +599,6 @@ void JsonHttpLogRegister (void)
 
 void JsonHttpLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-netflow.c
+++ b/src/output-json-netflow.c
@@ -447,7 +447,6 @@ void JsonNetFlowLogRegister(void)
 
 void JsonNetFlowLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -273,7 +273,6 @@ void JsonSmtpLogRegister (void) {
 
 void JsonSmtpLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -326,7 +326,6 @@ void JsonSshLogRegister (void)
 
 void JsonSshLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -387,7 +387,6 @@ void JsonStatsLogRegister(void) {
 
 void JsonStatsLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -210,8 +210,6 @@ void JsonTemplateLogRegister(void)
 
 void JsonTemplateLogRegister(void)
 {
-    SCLogInfo("Cannot register JSON output for template. "
-        "JSON support was disabled during build.");
 }
 
 #endif /* HAVE_LIBJANSSON */

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -347,7 +347,6 @@ void JsonTlsLogRegister (void)
 
 void JsonTlsLogRegister (void)
 {
-    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
 #endif


### PR DESCRIPTION
A warning log is already emitted if eve-log is enabled in the
configuration but json support is not built so the logger
registration functions can be silent.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/15
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/365
