### PR TITLE
macOS: thread return value affects newer macOS as well - v1

### DIFF
--- a/src/threads.c
+++ b/src/threads.c
@@ -89,10 +89,9 @@ int ThreadMacrosTest03RWLocks(void)
     int r = 0;
     r |= SCRWLockInit(&rwl_write, NULL);
     r |= SCRWLockWRLock(&rwl_write);
-/* work around OS X 10.10 Yosemite returning EDEADLK. All other
- * OS' (and versions of OS X that I tested) seem to return EBUSY
- * instead. */
-#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__==101000
+/* OS X/macOS 10.10 (Yosemite) and newer return EDEADLK. Older versions
+ * and other tested OS's return EBUSY. */
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__>=101000
     r |= (SCRWLockTryWRLock(&rwl_write) == EDEADLK)? 0 : 1;
 #else
     r |= (SCRWLockTryWRLock(&rwl_write) == EBUSY)? 0 : 1;


### PR DESCRIPTION
ALl OS X/macOS versions since 10.10 return EDEADLK here instead
of EBUSY. Assume they will moving forward as well.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/16
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/366