### PR TITLE
lua: add an SCPacketTimestamp function

### DIFF
--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -99,6 +99,18 @@ Initialize with:
       return needs
   end
 
+SCPacketTimestamp
+~~~~~~~~~~~~~~~~~
+
+Get packets timestamp as 2 numbers: seconds & microseconds elapsed since
+1970-01-01 00:00:00 UTC.
+
+::
+
+  function log(args)
+      local sec, usec = SCPacketTimestamp()
+  end
+
 SCPacketTimeString
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -159,6 +159,21 @@ static int LuaCallbackPacketPayload(lua_State *luastate)
 }
 
 /** \internal
+ *  \brief fill lua stack with packet timestamp
+ *  \param luastate the lua state
+ *  \param p packet
+ *  \retval cnt number of data items placed on the stack
+ *
+ *  Places: seconds (number), microseconds (number)
+ */
+static int LuaCallbackTimestampPushToStack(lua_State *luastate, const struct timeval *ts)
+{
+    lua_pushnumber(luastate, (double)ts->tv_sec);
+    lua_pushnumber(luastate, (double)ts->tv_usec);
+    return 2;
+}
+
+/** \internal
  *  \brief fill lua stack with header info
  *  \param luastate the lua state
  *  \param p packet
@@ -172,6 +187,19 @@ static int LuaCallbackTimeStringPushToStackFromPacket(lua_State *luastate, const
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
     lua_pushstring (luastate, timebuf);
     return 1;
+}
+
+/** \internal
+ *  \brief Wrapper for getting packet timestamp (as numbers) into a lua script
+ *  \retval cnt number of items placed on the stack
+ */
+static int LuaCallbackPacketTimestamp(lua_State *luastate)
+{
+    const Packet *p = LuaStateGetPacket(luastate);
+    if (p == NULL)
+        return LuaCallbackError(luastate, "internal error: no packet");
+
+    return LuaCallbackTimestampPushToStack(luastate, &p->ts);
 }
 
 /** \internal
@@ -719,6 +747,8 @@ int LuaRegisterFunctions(lua_State *luastate)
     /* registration of the callbacks */
     lua_pushcfunction(luastate, LuaCallbackPacketPayload);
     lua_setglobal(luastate, "SCPacketPayload");
+    lua_pushcfunction(luastate, LuaCallbackPacketTimestamp);
+    lua_setglobal(luastate, "SCPacketTimestamp");
     lua_pushcfunction(luastate, LuaCallbackPacketTimeString);
     lua_setglobal(luastate, "SCPacketTimeString");
     lua_pushcfunction(luastate, LuaCallbackTuple);


### PR DESCRIPTION
The SCPacketTimestamp function returns packet timestamps as 2 real numbers (seconds & microseconds)

Example:

  local sec, usec = SCPacketTimestamp()

Replaces previous PR #1847