### PR TITLE
eve dns json output - style , alerts and unit tests.

### DIFF
--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -53,7 +53,7 @@
 /** \internal
  *  \brief Parse DNS request packet
  */
-static int DNSUDPRequestParse(Flow *f, void *dstate,
+int DNSUDPRequestParse(Flow *f, void *dstate,
                               AppLayerParserState *pstate,
                               uint8_t *input, uint32_t input_len,
                               void *local_data)
@@ -175,7 +175,7 @@ insufficient_data:
  *  Parses a DNS UDP record and fills the DNS state
  *
  */
-static int DNSUDPResponseParse(Flow *f, void *dstate,
+int DNSUDPResponseParse(Flow *f, void *dstate,
                                AppLayerParserState *pstate,
                                uint8_t *input, uint32_t input_len,
                                void *local_data)

--- a/src/app-layer-dns-udp.h
+++ b/src/app-layer-dns-udp.h
@@ -31,7 +31,18 @@
 #include "util-byte.h"
 
 void RegisterDNSUDPParsers(void);
-void DNSUDPParserTests(void);
+
+#ifdef UNITTESTS
 void DNSUDPParserRegisterTests(void);
+int DNSUDPRequestParse(Flow *f, void *dstate,
+                              AppLayerParserState *pstate,
+                              uint8_t *input, uint32_t input_len,
+                              void *local_data);
+int DNSUDPResponseParse(Flow *f, void *dstate,
+                               AppLayerParserState *pstate,
+                               uint8_t *input, uint32_t input_len,
+                               void *local_data);
+#endif
+
 
 #endif /* __APP_LAYER_DNS_UDP_H__ */

--- a/src/detect-dns-query.c
+++ b/src/detect-dns-query.c
@@ -254,10 +254,10 @@ static int DetectDnsQueryTest02(void)
     p1 = UTHBuildPacketReal(buf1, sizeof(buf1), IPPROTO_UDP,
                            "192.168.1.5", "192.168.1.1",
                            41424, 53);
-    p2 = UTHBuildPacketReal(buf1, sizeof(buf1), IPPROTO_UDP,
-                           "192.168.1.5", "192.168.1.1",
-                           41424, 53);
-    p3 = UTHBuildPacketReal(buf1, sizeof(buf1), IPPROTO_UDP,
+    p2 = UTHBuildPacketReal(buf2, sizeof(buf2), IPPROTO_UDP,
+                           "192.168.1.1", "192.168.5.1",
+                           53, 41424);
+    p3 = UTHBuildPacketReal(buf3, sizeof(buf3), IPPROTO_UDP,
                            "192.168.1.5", "192.168.1.1",
                            41424, 53);
 

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -28,8 +28,12 @@
 #define __OUTPUT_JSON_ALERT_H__
 
 void JsonAlertLogRegister(void);
+
 #ifdef HAVE_LIBJANSSON
 void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js);
+#ifdef UNITTESTS
+void AlertJsonDns(const Flow *f, json_t *js);
+#endif /*UNITTESTS */
 #endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_ALERT_H__ */

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -21,6 +21,9 @@
  * \author Tom DeCanio <td@npulsetech.com>
  *
  * Implements JSON DNS logging portion of the engine.
+ *
+ * \author Paulo Pacheco <fooinha@gmail.com>
+ *
  */
 
 #include "suricata-common.h"
@@ -50,7 +53,16 @@
 
 #include "output-json.h"
 
+
 #ifdef HAVE_LIBJANSSON
+#define OUTPUT_BUFFER_SIZE 65536
+
+typedef struct OutputDoc_ {
+    json_t *js;
+    TAILQ_ENTRY(OutputDoc_) next;
+} OutputDoc;
+
+typedef TAILQ_HEAD(OutputDocList_, OutputDoc_) OutputDocList;
 
 /* we can do query logging as well, but it's disabled for now as the
  * TX id handling doesn't expect it */
@@ -59,6 +71,11 @@
 #define LOG_QUERIES    BIT_U64(0)
 #define LOG_ANSWERS    BIT_U64(1)
 
+#define LOG_TO_SERVER  LOG_QUERIES
+#define LOG_TO_CLIENT  LOG_ANSWERS
+
+/* Should split these into separate flags fields when we run out of bits below.
+ */
 #define LOG_A          BIT_U64(2)
 #define LOG_NS         BIT_U64(3)
 #define LOG_MD         BIT_U64(4)
@@ -119,6 +136,15 @@
 #define LOG_URI        BIT_U64(59)
 
 #define LOG_ALL_RRTYPES (~(uint64_t)(LOG_QUERIES|LOG_ANSWERS))
+
+typedef enum {
+    DNS_DISCRETE, /* the classic style of an event per question and answer */
+    DNS_SPLIT,    /* one event per request, one event per response */
+    DNS_UNIFIED   /* one event containing request and response */
+} DnsOutputMode;
+
+
+#define ALL_FILTERS     ~0UL
 
 typedef enum {
     DNS_RRTYPE_A = 0,
@@ -247,7 +273,8 @@ static struct {
 
 typedef struct LogDnsFileCtx_ {
     LogFileCtx *file_ctx;
-    uint64_t flags; /** Store mode */
+    DnsOutputMode mode;   /** output mode */
+    uint64_t filter; /** filter bits */
 } LogDnsFileCtx;
 
 typedef struct LogDnsLogThread_ {
@@ -258,206 +285,181 @@ typedef struct LogDnsLogThread_ {
     MemBuffer *buffer;
 } LogDnsLogThread;
 
-static int DNSRRTypeEnabled(uint16_t type, uint64_t flags)
+static int DNSRRTypeEnabled(uint16_t type, uint64_t filters)
 {
-    if (likely(flags == ~0UL)) {
+    if (likely(filters == ALL_FILTERS)) {
         return 1;
     }
 
     switch (type) {
         case DNS_RECORD_TYPE_A:
-            return ((flags & LOG_A) != 0) ? 1 : 0;
+            return ((filters & LOG_A) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NS:
-            return ((flags & LOG_NS) != 0) ? 1 : 0;
+            return ((filters & LOG_NS) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MD:
-            return ((flags & LOG_MD) != 0) ? 1 : 0;
+            return ((filters & LOG_MD) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MF:
-            return ((flags & LOG_MF) != 0) ? 1 : 0;
+            return ((filters & LOG_MF) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_CNAME:
-            return ((flags & LOG_CNAME) != 0) ? 1 : 0;
+            return ((filters & LOG_CNAME) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_SOA:
-            return ((flags & LOG_SOA) != 0) ? 1 : 0;
+            return ((filters & LOG_SOA) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MB:
-            return ((flags & LOG_MB) != 0) ? 1 : 0;
+            return ((filters & LOG_MB) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MG:
-            return ((flags & LOG_MG) != 0) ? 1 : 0;
+            return ((filters & LOG_MG) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MR:
-            return ((flags & LOG_MR) != 0) ? 1 : 0;
+            return ((filters & LOG_MR) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NULL:
-            return ((flags & LOG_NULL) != 0) ? 1 : 0;
+            return ((filters & LOG_NULL) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_WKS:
-            return ((flags & LOG_WKS) != 0) ? 1 : 0;
+            return ((filters & LOG_WKS) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_PTR:
-            return ((flags & LOG_PTR) != 0) ? 1 : 0;
+            return ((filters & LOG_PTR) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_HINFO:
-            return ((flags & LOG_HINFO) != 0) ? 1 : 0;
+            return ((filters & LOG_HINFO) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MINFO:
-            return ((flags & LOG_MINFO) != 0) ? 1 : 0;
+            return ((filters & LOG_MINFO) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MX:
-            return ((flags & LOG_MX) != 0) ? 1 : 0;
+            return ((filters & LOG_MX) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_TXT:
-            return ((flags & LOG_TXT) != 0) ? 1 : 0;
+            return ((filters & LOG_TXT) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_RP:
-            return ((flags & LOG_RP) != 0) ? 1 : 0;
+            return ((filters & LOG_RP) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_AFSDB:
-            return ((flags & LOG_AFSDB) != 0) ? 1 : 0;
+            return ((filters & LOG_AFSDB) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_X25:
-            return ((flags & LOG_X25) != 0) ? 1 : 0;
+            return ((filters & LOG_X25) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_ISDN:
-            return ((flags & LOG_ISDN) != 0) ? 1 : 0;
+            return ((filters & LOG_ISDN) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_RT:
-            return ((flags & LOG_RT) != 0) ? 1 : 0;
+            return ((filters & LOG_RT) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NSAP:
-            return ((flags & LOG_NSAP) != 0) ? 1 : 0;
+            return ((filters & LOG_NSAP) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NSAPPTR:
-            return ((flags & LOG_NSAPPTR) != 0) ? 1 : 0;
+            return ((filters & LOG_NSAPPTR) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_SIG:
-            return ((flags & LOG_SIG) != 0) ? 1 : 0;
+            return ((filters & LOG_SIG) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_KEY:
-            return ((flags & LOG_KEY) != 0) ? 1 : 0;
+            return ((filters & LOG_KEY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_PX:
-            return ((flags & LOG_PX) != 0) ? 1 : 0;
+            return ((filters & LOG_PX) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_GPOS:
-            return ((flags & LOG_GPOS) != 0) ? 1 : 0;
+            return ((filters & LOG_GPOS) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_AAAA:
-            return ((flags & LOG_AAAA) != 0) ? 1 : 0;
+            return ((filters & LOG_AAAA) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_LOC:
-            return ((flags & LOG_LOC) != 0) ? 1 : 0;
+            return ((filters & LOG_LOC) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NXT:
-            return ((flags & LOG_NXT) != 0) ? 1 : 0;
+            return ((filters & LOG_NXT) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_SRV:
-            return ((flags & LOG_SRV) != 0) ? 1 : 0;
+            return ((filters & LOG_SRV) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_ATMA:
-            return ((flags & LOG_ATMA) != 0) ? 1 : 0;
+            return ((filters & LOG_ATMA) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NAPTR:
-            return ((flags & LOG_NAPTR) != 0) ? 1 : 0;
+            return ((filters & LOG_NAPTR) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_KX:
-            return ((flags & LOG_KX) != 0) ? 1 : 0;
+            return ((filters & LOG_KX) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_CERT:
-            return ((flags & LOG_CERT) != 0) ? 1 : 0;
+            return ((filters & LOG_CERT) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_A6:
-            return ((flags & LOG_A6) != 0) ? 1 : 0;
+            return ((filters & LOG_A6) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_DNAME:
-            return ((flags & LOG_DNAME) != 0) ? 1 : 0;
+            return ((filters & LOG_DNAME) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_OPT:
-            return ((flags & LOG_OPT) != 0) ? 1 : 0;
+            return ((filters & LOG_OPT) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_APL:
-            return ((flags & LOG_APL) != 0) ? 1 : 0;
+            return ((filters & LOG_APL) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_DS:
-            return ((flags & LOG_DS) != 0) ? 1 : 0;
+            return ((filters & LOG_DS) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_SSHFP:
-            return ((flags & LOG_SSHFP) != 0) ? 1 : 0;
+            return ((filters & LOG_SSHFP) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_IPSECKEY:
-            return ((flags & LOG_IPSECKEY) != 0) ? 1 : 0;
+            return ((filters & LOG_IPSECKEY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_RRSIG:
-            return ((flags & LOG_RRSIG) != 0) ? 1 : 0;
+            return ((filters & LOG_RRSIG) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NSEC:
-            return ((flags & LOG_NSEC) != 0) ? 1 : 0;
+            return ((filters & LOG_NSEC) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_DNSKEY:
-            return ((flags & LOG_DNSKEY) != 0) ? 1 : 0;
+            return ((filters & LOG_DNSKEY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_DHCID:
-            return ((flags & LOG_DHCID) != 0) ? 1 : 0;
+            return ((filters & LOG_DHCID) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NSEC3:
-            return ((flags & LOG_NSEC3) != 0) ? 1 : 0;
+            return ((filters & LOG_NSEC3) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_NSEC3PARAM:
-            return ((flags & LOG_NSEC3PARAM) != 0) ? 1 : 0;
+            return ((filters & LOG_NSEC3PARAM) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_TLSA:
-            return ((flags & LOG_TLSA) != 0) ? 1 : 0;
+            return ((filters & LOG_TLSA) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_HIP:
-            return ((flags & LOG_HIP) != 0) ? 1 : 0;
+            return ((filters & LOG_HIP) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_CDS:
-            return ((flags & LOG_CDS) != 0) ? 1 : 0;
+            return ((filters & LOG_CDS) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_CDNSKEY:
-            return ((flags & LOG_CDNSKEY) != 0) ? 1 : 0;
+            return ((filters & LOG_CDNSKEY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_SPF:
-            return ((flags & LOG_SPF) != 0) ? 1 : 0;
+            return ((filters & LOG_SPF) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_TKEY:
-            return ((flags & LOG_TKEY) != 0) ? 1 : 0;
+            return ((filters & LOG_TKEY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_TSIG:
-            return ((flags & LOG_TSIG) != 0) ? 1 : 0;
+            return ((filters & LOG_TSIG) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_MAILA:
-            return ((flags & LOG_MAILA) != 0) ? 1 : 0;
+            return ((filters & LOG_MAILA) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_ANY:
-            return ((flags & LOG_ANY) != 0) ? 1 : 0;
+            return ((filters & LOG_ANY) != 0) ? 1 : 0;
         case DNS_RECORD_TYPE_URI:
-            return ((flags & LOG_URI) != 0) ? 1 : 0;
+            return ((filters & LOG_URI) != 0) ? 1 : 0;
         default:
             return 0;
     }
 }
 
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry) __attribute__((nonnull));
-
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry)
+static json_t * QueryJson(DNSTransaction *tx, DNSQueryEntry *entry, DnsOutputMode style) __attribute__((nonnull));
+static json_t * QueryJson(DNSTransaction *tx, DNSQueryEntry *entry, DnsOutputMode style)
 {
-    SCLogDebug("got a DNS request and now logging !!");
 
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
+    json_t *js = json_object();
+    if (unlikely(js == NULL)) {
+        return NULL;
     }
-
-    json_t *djs = json_object();
-    if (djs == NULL) {
-        return;
-    }
-
-    /* reset */
-    MemBufferReset(aft->buffer);
 
     /* type */
-    json_object_set_new(djs, "type", json_string("query"));
+    if (style != DNS_UNIFIED)
+        json_object_set_new(js, "type", json_string("query"));
 
-    /* id */
-    json_object_set_new(djs, "id", json_integer(tx->tx_id));
 
     /* query */
     char *c;
     c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSQueryEntry)), entry->len);
     if (c != NULL) {
-        json_object_set_new(djs, "rrname", json_string(c));
+        json_object_set_new(js, "rrname", json_string(c));
         SCFree(c);
     }
 
     /* name */
     char record[16] = "";
     DNSCreateTypeString(entry->type, record, sizeof(record));
-    json_object_set_new(djs, "rrtype", json_string(record));
+    json_object_set_new(js, "rrtype", json_string(record));
 
-    /* tx id (tx counter) */
-    json_object_set_new(djs, "tx_id", json_integer(tx_id));
-
-    /* dns */
-    json_object_set_new(js, "dns", djs);
-    OutputJSONBuffer(js, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(js, "dns");
+    return js;
 }
 
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry) __attribute__((nonnull));
-
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry)
+static json_t * AnswerJson(DNSTransaction *tx, DNSAnswerEntry *entry, DnsOutputMode style) __attribute__((nonnull));
+static json_t * AnswerJson(DNSTransaction *tx, DNSAnswerEntry *entry, DnsOutputMode style)
 {
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
+   json_t *js = json_object();
 
-    json_t *js = json_object();
-    if (js == NULL)
-        return;
+    if (unlikely(js == NULL))
+        return NULL;
+
+    if (unlikely(entry == NULL))
+        return NULL;
 
     /* type */
-    json_object_set_new(js, "type", json_string("answer"));
+    if (style == DNS_DISCRETE) {
+        json_object_set_new(js, "type", json_string("answer"));
+    }
 
-    /* id */
-    json_object_set_new(js, "id", json_integer(tx->tx_id));
-
-    /* rcode */
-    char rcode[16] = "";
-    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
-    json_object_set_new(js, "rcode", json_string(rcode));
+    /* we are logging an answer RR */
 
     /* query */
     if (entry->fqdn_len > 0) {
@@ -491,7 +493,7 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
         json_object_set_new(js, "rdata", json_string(""));
     } else if (entry->type == DNS_RECORD_TYPE_TXT || entry->type == DNS_RECORD_TYPE_CNAME ||
             entry->type == DNS_RECORD_TYPE_MX || entry->type == DNS_RECORD_TYPE_PTR ||
-            entry->type == DNS_RECORD_TYPE_NS) {
+            entry->type == DNS_RECORD_TYPE_NS || entry->type == DNS_RECORD_TYPE_SOA ) {
         if (entry->data_len != 0) {
             char buffer[256] = "";
             uint16_t copy_len = entry->data_len < (sizeof(buffer) - 1) ?
@@ -536,39 +538,23 @@ static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
         }
     }
 
-    /* reset */
-    MemBufferReset(aft->buffer);
-    json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(djs, "dns");
+   return js;
 
-    return;
 }
 
-static void OutputFailure(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSQueryEntry *entry) __attribute__((nonnull));
 
-static void OutputFailure(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSQueryEntry *entry)
+static json_t *FailureJson(DNSTransaction *tx, DNSQueryEntry *entry, DnsOutputMode style) __attribute__((nonnull));
+static json_t *FailureJson(DNSTransaction *tx, DNSQueryEntry *entry, DnsOutputMode style)
 {
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
+    json_t *js = json_object();
+    if (unlikely(js == NULL)) {
+        return NULL;
     }
 
-    json_t *js = json_object();
-    if (js == NULL)
-        return;
-
     /* type */
-    json_object_set_new(js, "type", json_string("answer"));
-
-    /* id */
-    json_object_set_new(js, "id", json_integer(tx->tx_id));
-
-    /* rcode */
-    char rcode[16] = "";
-    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
-    json_object_set_new(js, "rcode", json_string(rcode));
+    if (style == DNS_DISCRETE) {
+        json_object_set_new(js, "type", json_string("answer"));
+    }
 
     /* no answer RRs, use query for rname */
     char *c;
@@ -578,93 +564,364 @@ static void OutputFailure(LogDnsLogThread *aft, json_t *djs,
         SCFree(c);
     }
 
-    /* reset */
-    MemBufferReset(aft->buffer);
-    json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(djs, "dns");
-
-    return;
+    return js;
 }
 
-static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uint64_t tx_id)
+/* Fills JSON object with DNS Transaction information */
+void FillsDNSTransactionJSON(json_t * js,  DNSTransaction *tx, uint64_t flags, DnsOutputMode style)
 {
 
-    SCLogDebug("got a DNS response and now logging !!");
+    if (unlikely(js == NULL)) {
+        return;
+    }
 
-    /* rcode != noerror */
+    if (unlikely(tx == NULL)) {
+        return;
+    }
+
+    if (tx->reply_lost) {
+       json_object_set_new(js, "info", json_string("reply lost"));
+    }
+
+    /* rcode */
+    char rcode[16] = "";
+    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
+    json_object_set_new(js, "rcode", json_string(rcode));
+
+    /* tx_id */
+    json_object_set_new(js, "tx_id", json_integer(tx->tx_id));
+
     if (tx->rcode) {
-        /* Most DNS servers do not support multiple queries because
-         * the rcode in response is not per-query.  Multiple queries
-         * are likely to lead to FORMERR, so log this. */
-        DNSQueryEntry *query = NULL;
-        TAILQ_FOREACH(query, &tx->query_list, next) {
-            OutputFailure(aft, js, tx, query);
+
+        if (likely(flags & LOG_QUERIES) != 0) {
+
+            json_t *arrjs = json_array();
+
+            DNSQueryEntry *query = NULL;
+            TAILQ_FOREACH(query, &tx->query_list, next) {
+
+               if (! likely(DNSRRTypeEnabled(query->type, flags))) {
+                   continue;
+               }
+
+               json_t *entryjs = FailureJson(tx, query, style);
+               if (entryjs) {
+                   json_array_append_new(arrjs, entryjs);
+               }
+            }
+
+            if (json_array_size(arrjs) > 0)
+                json_object_set_new(js, "fail", arrjs);
         }
+
     }
 
-    DNSAnswerEntry *entry = NULL;
-    TAILQ_FOREACH(entry, &tx->answer_list, next) {
-        OutputAnswer(aft, js, tx, entry);
-    }
+   /* if answer */
+   if (tx->replied) {
+       if (likely(flags & LOG_ANSWERS) != 0) {
+           if (TAILQ_EMPTY(&tx->answer_list)) {
+               json_object_set_new(js, "info", json_string("empty answer"));
+           }
 
-    entry = NULL;
-    TAILQ_FOREACH(entry, &tx->authority_list, next) {
-        OutputAnswer(aft, js, tx, entry);
-    }
+           /* list of answers */
+           json_t *ansarrjs = json_array();
 
+           /* foreach answer */
+           DNSAnswerEntry *entry = NULL;
+           TAILQ_FOREACH(entry, &tx->answer_list, next) {
+
+              if (! likely(DNSRRTypeEnabled(entry->type, flags)))
+                  continue;
+
+              json_t *entryjs = AnswerJson(tx, entry, style);
+              if (entryjs) {
+                  json_array_append_new(ansarrjs, entryjs);
+              }
+           }
+           if (json_array_size(ansarrjs) > 0)
+               json_object_set_new(js, "answers", ansarrjs);
+       }
+   }
+
+   if (likely(flags & LOG_QUERIES) != 0) {
+       /* list of queries */
+       json_t *qarrjs = json_array();
+       /* foreach query */
+       DNSQueryEntry *entry = NULL;
+       TAILQ_FOREACH(entry, &tx->query_list, next) {
+           if (! likely(DNSRRTypeEnabled(entry->type, flags)))
+               continue;
+           json_t *entryjs = QueryJson(tx, entry, style);
+           if (entryjs) {
+               json_array_append_new(qarrjs, entryjs);
+           }
+       }
+
+       if (json_array_size(qarrjs) > 0)
+           json_object_set_new(js, "queries",qarrjs);
+    }
 }
+
+static OutputDoc * AllocOuputDoc(json_t *js)
+{
+
+    if (js == NULL)
+        return NULL;
+    OutputDoc *doc = SCMalloc(sizeof(OutputDoc));
+    if (unlikely(doc == NULL))
+        return NULL;
+
+    json_incref(js);
+    doc->js = js;
+    return doc;
+}
+
+static void FreeOuputDocList(OutputDocList * docs) {
+
+    if (docs == NULL)
+        return;
+
+    OutputDoc *doc;
+    TAILQ_FOREACH(doc, docs, next) {
+        json_decref(doc->js);
+        SCFree(doc);
+    }
+
+    SCFree(docs);
+}
+
+static OutputDocList *TransactionJSONList(json_t *js, DNSTransaction *tx, uint64_t flags, DnsOutputMode style) __attribute__((nonnull));
+
+static OutputDocList *TransactionJSONList(json_t *js, DNSTransaction *tx, uint64_t flags, DnsOutputMode style)
+{
+
+    OutputDocList *docs = SCMalloc(sizeof(OutputDocList));
+    if (unlikely(docs == NULL))
+        return NULL;
+
+    TAILQ_INIT(docs);
+
+    json_t *tjs = json_object();
+    if (unlikely(tjs == NULL)) {
+        return docs;
+    }
+
+    /* Fill tjs with all parts of DNS transaction */
+    FillsDNSTransactionJSON(tjs, tx, flags, style);
+
+    /* Nothing to write */
+    if (json_object_size(tjs) < 1 ) {
+        json_decref(tjs);
+        return docs;
+    }
+
+    /* Outputs a single event containing request and response */
+    if (style == DNS_UNIFIED) {
+
+        json_object_set_new(tjs, "type", json_string("unified"));
+        /* dns node */
+        json_object_set(js, "dns", tjs);
+
+        /* Insert into docs list */
+        OutputDoc *doc = AllocOuputDoc(js);
+        if (doc != NULL) {
+            TAILQ_INSERT_TAIL(docs, doc, next);
+        }
+
+        json_decref(tjs);
+        return docs;
+    }
+
+    /* Not unified style */
+    if (! tx->replied) {
+
+        /* Queries output part */
+        json_t *queries = json_object_get(tjs, "queries");
+
+        if (queries && json_array_size(queries) >= 1 ) {
+            json_object_set(js, "dns", json_array_get(queries, 0));
+
+            /* Insert into docs list */
+            OutputDoc *doc = AllocOuputDoc(js);
+            if (doc != NULL) {
+                TAILQ_INSERT_TAIL(docs, doc, next);
+            }
+        }
+
+        json_decref(tjs);
+        return docs;
+    }
+
+   /* Answers output part */
+    json_t *answers = json_object_get(tjs, "answers");
+
+    /* No answers to output */
+    if (answers == NULL || json_array_size(answers) < 1 ) {
+        json_decref(tjs);
+        return docs;
+    }
+
+    /* Make a copy of event json for answers base */
+    json_t * cloned = json_deep_copy(js);
+
+    if (unlikely(cloned == NULL)) {
+        json_decref(tjs);
+        return docs;
+    }
+
+    /*  split: one event per request, one event per response */
+    if (style == DNS_SPLIT && cloned) {
+        json_t *ajs = json_object();
+        if (unlikely(ajs == NULL)) {
+            json_decref(tjs);
+            return docs;
+        }
+
+        json_object_set(ajs, "answers", answers);
+
+        json_t * rcode = json_object_get(tjs, "rcode");
+        json_t * tx_id = json_object_get(tjs, "tx_id");
+
+        if (rcode != NULL)
+             json_object_set(ajs, "rcode", rcode);
+
+        if (tx_id != NULL)
+             json_object_set(ajs, "tx_id", tx_id);
+
+
+        json_object_set(cloned, "dns", ajs);
+        json_decref(tjs);
+
+        /* Insert into docs list */
+        OutputDoc *doc = AllocOuputDoc(cloned);
+        if (doc != NULL) {
+            TAILQ_INSERT_TAIL(docs, doc, next);
+        }
+
+        json_decref(ajs);
+        return docs;
+    }
+
+    /* # discrete: the classic style of an event per question and answer */
+    /* This is the historical log format */
+    if (style == DNS_DISCRETE) {
+
+        size_t sz = json_array_size(answers);
+        json_t *value = NULL;
+        json_t *copy = NULL;
+
+        json_t * rcode = json_object_get(tjs, "rcode");
+        json_t * tx_id = json_object_get(tjs, "tx_id");
+
+        /* Log each answer separately */
+        //json_array_foreach(answers, index, value) {
+        for (size_t index = 0; index < sz; ++index) {
+
+            value = json_array_get(answers, index);
+            if ( ! value )
+                continue;
+
+            json_object_set(cloned, "dns", value);
+            if (rcode != NULL)
+                json_object_set_new(cloned, "rcode", rcode);
+            if (tx_id != NULL)
+                json_object_set_new(cloned, "tx_id", tx_id);
+
+            /* Insert into docs list */
+            OutputDoc *doc = AllocOuputDoc(cloned);
+            if (doc != NULL) {
+                TAILQ_INSERT_TAIL(docs, doc, next);
+            }
+
+            copy = json_deep_copy(js);
+            cloned = copy;
+        }
+        json_decref(tjs);
+        json_decref(copy);
+    }
+    return docs;
+}
+
+static void OutputLogTransactionJSON(LogFileCtx *file_ctx, MemBuffer *buffer, json_t *js, DNSTransaction *tx, uint64_t flags, DnsOutputMode style) __attribute__((nonnull));
+
+/* Outputs to file log the DNS transaction with using configured output style */
+static void OutputLogTransactionJSON(LogFileCtx *file_ctx, MemBuffer *buffer, json_t *js, DNSTransaction *tx, uint64_t flags, DnsOutputMode style)
+{
+
+    OutputDocList * docs = TransactionJSONList(js, tx, flags, style);
+    OutputDoc *doc = NULL;
+    TAILQ_FOREACH(doc, docs, next) {
+        /* reset */
+        MemBufferReset(buffer);
+        OutputJSONBuffer(doc->js, file_ctx, &buffer);
+    }
+    FreeOuputDocList(docs);
+}
+
+/* Makes the Json output for an alert */
+void JsonDnsLogJSON(json_t * js,  DNSState *dns_state)
+{
+    if (unlikely(js == NULL))
+        return;
+    if (unlikely(dns_state == NULL))
+        return;
+    FillsDNSTransactionJSON(js, dns_state->curr, ALL_FILTERS, DNS_UNIFIED);
+}
+
+/* Logs a DNS Event to Json to output log */
+static void JsonDnsLogger(LogDnsLogThread *td, DNSTransaction *tx, const Packet *p, uint64_t filters)
+{
+    json_t *js = NULL;
+
+    if (! td || ! td->dnslog_ctx)
+       return;
+
+    if (likely(td->dnslog_ctx->filter & filters) != 0) {
+        js = CreateJSONHeader(p, 0, "dns");
+        if (unlikely(js == NULL))
+            return ;
+
+        OutputLogTransactionJSON(td->dnslog_ctx->file_ctx,
+                td->buffer, js, tx, td->dnslog_ctx->filter, td->dnslog_ctx->mode);
+        json_decref(js);
+    }
+}
+
+static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
+    const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id) __attribute__((nonnull));
 
 static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 
-    LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
-    LogDnsFileCtx *dnslog_ctx = td->dnslog_ctx;
-    DNSTransaction *tx = txptr;
-    json_t *js;
-
-    if (likely(dnslog_ctx->flags & LOG_QUERIES) != 0) {
-        DNSQueryEntry *query = NULL;
-        TAILQ_FOREACH(query, &tx->query_list, next) {
-            js = CreateJSONHeader((Packet *)p, 1, "dns");
-            if (unlikely(js == NULL))
-                return TM_ECODE_OK;
-
-            LogQuery(td, js, tx, tx_id, query);
-
-            json_decref(js);
-        }
-    }
+    JsonDnsLogger(
+        (LogDnsLogThread *)thread_data,
+        (DNSTransaction *) txptr,
+        p,
+        LOG_TO_SERVER
+    );
 
     SCReturnInt(TM_ECODE_OK);
 }
 
 static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
+    const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id) __attribute__((nonnull));
+static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
 {
     SCEnter();
 
-    LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
-    LogDnsFileCtx *dnslog_ctx = td->dnslog_ctx;
-    DNSTransaction *tx = txptr;
-    json_t *js;
-
-    if (likely(dnslog_ctx->flags & LOG_ANSWERS) != 0) {
-        js = CreateJSONHeader((Packet *)p, 0, "dns");
-        if (unlikely(js == NULL))
-            return TM_ECODE_OK;
-
-        LogAnswers(td, js, tx, tx_id);
-
-        json_decref(js);
-    }
+    JsonDnsLogger(
+        (LogDnsLogThread *) thread_data,
+        (DNSTransaction *) txptr,
+        p,
+        LOG_TO_CLIENT
+    );
 
     SCReturnInt(TM_ECODE_OK);
 }
 
-#define OUTPUT_BUFFER_SIZE 65536
 static TmEcode LogDnsLogThreadInit(ThreadVars *t, void *initdata, void **data)
 {
     LogDnsLogThread *aft = SCMalloc(sizeof(LogDnsLogThread));
@@ -725,28 +982,41 @@ static void LogDnsLogDeInitCtxSub(OutputCtx *output_ctx)
 
 static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
 {
-    dnslog_ctx->flags = ~0UL;
+    dnslog_ctx->filter = ALL_FILTERS;
+    dnslog_ctx->mode = DNS_DISCRETE;
 
     if (conf) {
         const char *query = ConfNodeLookupChildValue(conf, "query");
         if (query != NULL) {
             if (ConfValIsTrue(query)) {
-                dnslog_ctx->flags |= LOG_QUERIES;
+                dnslog_ctx->filter |= LOG_QUERIES;
             } else {
-                dnslog_ctx->flags &= ~LOG_QUERIES;
+                dnslog_ctx->filter &= ~LOG_QUERIES;
+            }
+        }
+        const char *style = ConfNodeLookupChildValue(conf, "style");
+        if (style != NULL) {
+            if (strcasecmp(style, "unified")==0) {
+                dnslog_ctx->mode = DNS_UNIFIED;
+            } else if (strcasecmp(style, "split")==0) {
+                dnslog_ctx->mode = DNS_SPLIT;
+            } else if (strcasecmp(style, "discrete")==0) {
+                dnslog_ctx->mode = DNS_DISCRETE;
+            } else {
+                SCLogError(SC_ERR_FATAL, "Invalid logging style for DNS Events.");
             }
         }
         const char *response = ConfNodeLookupChildValue(conf, "answer");
         if (response != NULL) {
             if (ConfValIsTrue(response)) {
-                dnslog_ctx->flags |= LOG_ANSWERS;
+                dnslog_ctx->filter |= LOG_ANSWERS;
             } else {
-                dnslog_ctx->flags &= ~LOG_ANSWERS;
+                dnslog_ctx->filter &= ~LOG_ANSWERS;
             }
         }
         ConfNode *custom;
         if ((custom = ConfNodeLookupChild(conf, "custom")) != NULL) {
-            dnslog_ctx->flags &= ~LOG_ALL_RRTYPES;
+            dnslog_ctx->filter &= ~LOG_ALL_RRTYPES;
             ConfNode *field;
             TAILQ_FOREACH(field, &custom->head, next)
             {
@@ -758,7 +1028,7 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
                         if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
                                        field->val) == 0)
                         {
-                            dnslog_ctx->flags |= dns_rrtype_fields[f].flags;
+                            dnslog_ctx->filter |= dns_rrtype_fields[f].flags;
                             break;
                         }
                     }
@@ -874,10 +1144,736 @@ void JsonDnsLogRegister (void)
         NULL);
 }
 
+/************************************Unittests*******************************/
+
+#ifdef UNITTESTS
+#include "threads.h"
+
+#include "flow-util.h"
+#include "detect-engine.h"
+#include "detect-parse.h"
+
+#include "util-unittest.h"
+#include "util-unittest-helper.h"
+#include "output-json-alert.h"
+
+
+#define JSON_DNS_OUTPUT_UNITTEST_DUMP_ENABLE 0
+
+#define JSON_DNS_OUTPUT_UNITTEST_DUMP(js)           \
+{                                                   \
+  if (JSON_DNS_OUTPUT_UNITTEST_DUMP_ENABLE) {       \
+    printf("\n ---------------- \n");               \
+    json_dumpf(js, stdout, JSON_INDENT(2));         \
+    printf("\n ---------------- \n");               \
+  }                                                 \
+}
+
+
+#define FAIL_IF_STR_DIFFERS(left, right)             \
+{                                                    \
+    const char * l = left;                           \
+    const char * r = right;                          \
+    FAIL_IF(l == NULL);                              \
+    FAIL_IF(r == NULL);                              \
+    int i = strncasecmp(l, r, strlen(l));            \
+    FAIL_IF(i != 0 );                                \
+}
+
+#define JUMP_IF_STR_DIFFERS(left, right, label)      \
+{                                                    \
+    const char * l = left;                           \
+    const char * r = right;                          \
+    FAIL_IF(l == NULL);                              \
+    FAIL_IF(r == NULL);                              \
+    int i = strncasecmp(l, r, strlen(l));            \
+    if (i != 0) goto label;                          \
+}
+
+/* google.com */
+static uint8_t bufQuery[] = {
+   0x10, 0x32, 0x01, 0x00, 0x00, 0x01,
+   0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+   0x06, 0x67, 0x6F, 0x6F, 0x67, 0x6C,
+   0x65, 0x03, 0x63, 0x6F, 0x6D, 0x00,
+   0x00, 0x10, 0x00, 0x01,
+};
+
+/* response google.com */
+static uint8_t bufResponse[] = {
+    0x10, 0x32,                             /* tx id */
+    0x81, 0x80,                             /* flags: resp, recursion desired, recusion available */
+    0x00, 0x01,                             /* 1 query */
+    0x00, 0x01,                             /* 1 answer */
+    0x00, 0x00, 0x00, 0x00,                 /* no auth rr, additional rr */
+    /* query record */
+    0x06, 0x67, 0x6F, 0x6F, 0x67, 0x6C,     /* name */
+    0x65, 0x03, 0x63, 0x6F, 0x6D, 0x00,     /* name cont */
+    0x00, 0x01, 0x00, 0x01,                 /* type a, class in */
+    /* answer */
+    0xc0, 0x0c,                             /* ref to name in query above */
+    0x00, 0x01, 0x00, 0x01,                 /* type a, class in */
+    0x00, 0x01, 0x40, 0xef,                 /* ttl */
+    0x00, 0x04,                             /* data len */
+    0x01, 0x02, 0x03, 0x04 };               /* addr */
+
+static DNSState *MakesDNSStateFromRequest(Flow *f, uint8_t *input, uint32_t input_len) {
+
+    /* Create a DNS state */
+    DNSState *dns_state = DNSStateAlloc();
+    FAIL_IF(dns_state == NULL);
+
+    /* Create App Layer Parser State */
+    AppLayerParserState *pstate = AppLayerParserStateAlloc();
+    FAIL_IF(pstate== NULL);
+
+    /* Parses the DNS UDP Request */
+    FAIL_IF ( DNSUDPRequestParse(f, dns_state, pstate, input, input_len, NULL) == -1 );
+
+    AppLayerParserStateFree(pstate);
+
+    return dns_state;
+}
+
+static DNSState *MakesDNSStateFromRequestAndResponse(Flow *f,
+        uint8_t *request, uint32_t request_len, uint8_t *response, uint32_t response_len) {
+
+    /* Create a DNS state */
+    DNSState *dns_state = DNSStateAlloc();
+    FAIL_IF(dns_state == NULL);
+
+    /* Create App Layer Parser State */
+    AppLayerParserState *pstate = AppLayerParserStateAlloc();
+    FAIL_IF(pstate== NULL);
+
+    /* Parses the DNS UDP Request */
+    FAIL_IF ( DNSUDPRequestParse(f, dns_state, pstate, request, request_len, NULL) == -1 );
+    FAIL_IF ( DNSUDPResponseParse(f, dns_state, pstate, response, response_len, NULL) == -1 );
+
+    AppLayerParserStateFree(pstate);
+
+    return dns_state;
+}
+
+/**
+ *  \test Tests the JSON Output for a DNS Query with DNS_DISCRETE style
+ *
+ *  \retval On success it returns 1 and on failure 0.
+ */
+static int OutputJsonDnsQueryDiscreteTest01 (void)
+{
+
+    /* Create the file context */
+    LogFileCtx *file_ctx = LogFileNewCtx();
+    FAIL_IF(file_ctx == NULL);
+
+    /* Create memory butffer */
+    MemBuffer * buffer = MemBufferCreateNew(OUTPUT_BUFFER_SIZE);
+    FAIL_IF(buffer == NULL);
+
+    /* Create DNS file context */
+    LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
+    FAIL_IF(dnslog_ctx == NULL);
+
+    /* Configure DNS file context configuration options */
+    dnslog_ctx->mode = DNS_DISCRETE;
+    dnslog_ctx->filter &= LOG_ALL_RRTYPES;
+
+    /* Create a DNS packet for tests */
+    Packet *p = UTHBuildPacketReal(bufQuery, sizeof(bufQuery), IPPROTO_UDP,
+                          "192.168.1.5", "192.168.1.1", 41424, 53);
+    FAIL_IF(p == NULL);
+
+    /* Create flow */
+    Flow f;
+    FLOW_INITIALIZE(&f);
+    f.flags |= FLOW_IPV4;
+    f.proto = IPPROTO_UDP;
+    f.protomap = FlowGetProtoMapping(f.proto);
+
+    p->flow = &f;
+    p->flags |= PKT_HAS_FLOW;
+    p->flowflags |= FLOW_PKT_TOSERVER;
+    f.alproto = ALPROTO_DNS;
+
+    /* Create a DNS state from the flow and query */
+    DNSState *dns_state = MakesDNSStateFromRequest(&f, bufQuery, sizeof(bufQuery));
+
+    /* Create a JSON object for output */
+    json_t *js = CreateJSONHeader(p, 0, "dns");
+    FAIL_IF(js == NULL);
+
+    FAIL_IF_STR_DIFFERS("dns",      json_string_value( json_object_get(js, "event_type") ));
+
+    /* Outputs JSON */
+
+
+    OutputDocList * docs = TransactionJSONList(js,  TAILQ_FIRST(&dns_state->tx_list) , ALL_FILTERS, DNS_DISCRETE);
+    FAIL_IF(docs == NULL);
+
+    OutputDoc *doc = TAILQ_FIRST(docs);
+    FAIL_IF(doc == NULL);
+
+    json_t *tjs = doc->js;
+    FAIL_IF(tjs == NULL);
+
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(js);
+
+    /* Check output format */
+    json_t *dns = json_object_get(js, "dns");
+    FAIL_IF (dns == NULL);
+
+    /* Check string values */
+    FAIL_IF_STR_DIFFERS("query",      json_string_value( json_object_get(dns, "type") ));
+    FAIL_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(dns, "rrname") ));
+    FAIL_IF_STR_DIFFERS("TXT",        json_string_value( json_object_get(dns, "rrtype")));
+
+    /* Free some stuff */
+    json_decref(tjs);
+    json_decref(js);
+    FreeOuputDocList(docs);
+    DNSStateFree(dns_state);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p);
+    SCFree(dnslog_ctx);
+    MemBufferFree(buffer);
+    LogFileFreeCtx(file_ctx);
+
+    PASS;
+}
+
+/**
+ *  \test Tests the JSON Output for a DNS Response with DNS_UNIFIED style
+ *
+ *  \retval On success it returns 1 and on failure 0.
+ */
+
+static int OutputJsonDnsResponseUnifiedTest02 (void)
+{
+
+    /* Create the file context */
+    LogFileCtx *file_ctx = LogFileNewCtx();
+    FAIL_IF(file_ctx == NULL);
+
+    /* Create memory butffer */
+    MemBuffer * buffer = MemBufferCreateNew(OUTPUT_BUFFER_SIZE);
+    FAIL_IF(buffer == NULL);
+
+    /* Create DNS file context */
+    LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
+    FAIL_IF(dnslog_ctx == NULL);
+
+    /* Configure DNS file context configuration options */
+    dnslog_ctx->mode = DNS_UNIFIED;
+    dnslog_ctx->filter &= LOG_ALL_RRTYPES;
+
+    /* Create a DNS packets for tests */
+    Packet *p1 = NULL, *p2 = NULL;
+    p1 = UTHBuildPacketReal(bufQuery, sizeof(bufQuery), IPPROTO_UDP,
+                           "192.168.1.5", "192.168.1.1", 41424, 53);
+
+    p2 = UTHBuildPacketReal(bufResponse, sizeof(bufResponse), IPPROTO_UDP,
+                           "192.168.1.1", "192.168.1.5", 53, 41424);
+
+    FAIL_IF(p1 == NULL);
+    FAIL_IF(p2 == NULL);
+
+    /* Create flow */
+    Flow f;
+    FLOW_INITIALIZE(&f);
+    f.flags |= FLOW_IPV4;
+    f.proto = IPPROTO_UDP;
+    f.protomap = FlowGetProtoMapping(f.proto);
+
+    p1->flow = &f;
+    p1->flags |= PKT_HAS_FLOW;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->pcap_cnt = 1;
+
+    p2->flow = &f;
+    p2->flags |= PKT_HAS_FLOW;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->pcap_cnt = 2;
+
+    /* Create a DNS state from the flow and response */
+    DNSState *dns_state =  MakesDNSStateFromRequestAndResponse(&f,
+            bufQuery, sizeof(bufQuery), bufResponse, sizeof(bufResponse));
+
+    /* Create a JSON object for output */
+    json_t *js = CreateJSONHeader(p2, 0, "dns");
+    FAIL_IF(js == NULL);
+
+    /* Outputs JSON */
+    OutputDocList * docs = TransactionJSONList(js,  TAILQ_FIRST(&dns_state->tx_list) , ALL_FILTERS, DNS_UNIFIED);
+    FAIL_IF(docs == NULL);
+
+    OutputDoc *doc = TAILQ_FIRST(docs);
+    FAIL_IF(doc == NULL);
+
+    json_t *tjs = doc->js;
+    FAIL_IF(tjs == NULL);
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(tjs);
+    FAIL_IF_STR_DIFFERS("dns",      json_string_value( json_object_get(js, "event_type") ));
+
+    json_t *dns = json_object_get(js, "dns");
+    FAIL_IF (dns == NULL);
+
+    /* "type": "unified", */
+    FAIL_IF_STR_DIFFERS("unified",      json_string_value( json_object_get(dns, "type") ));
+    FAIL_IF_STR_DIFFERS("NOERROR",    json_string_value( json_object_get(dns, "rcode") ));
+    FAIL_IF( 4146 !=                 json_integer_value( json_object_get(dns, "tx_id")));
+
+    /* Check queries and answers arrays */
+    json_t *queries = json_object_get(dns, "queries");
+    json_t *answers = json_object_get(dns, "answers");
+
+    FAIL_IF(queries == NULL);
+    FAIL_IF(answers == NULL);
+    FAIL_IF (! json_is_array(queries));
+    FAIL_IF (! json_is_array(answers));
+    FAIL_IF(json_array_size(queries) != 1);
+    FAIL_IF(json_array_size(answers) != 1);
+
+    json_t *query = json_array_get(queries, 0);
+    json_t *answer = json_array_get(answers, 0);
+
+    FAIL_IF(query == NULL);
+    FAIL_IF(answer == NULL);
+
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(js);
+
+/*
+  {
+    "rrname": "google.com",
+    "rrtype": "TXT",
+    "tx_id": 4146
+  }
+
+*/
+
+    /* Check string values */
+    FAIL_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(query, "rrname") ));
+    FAIL_IF_STR_DIFFERS("TXT",        json_string_value( json_object_get(query, "rrtype")));
+
+/*
+ {
+    "rrtype": "A",
+    "rrname": "google.com",
+    "ttl": 16623,
+    "rdata": "1.2.3.4"
+  }
+*/
+
+    /* Check string values */
+    FAIL_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(answer, "rrname") ));
+    FAIL_IF_STR_DIFFERS("A",          json_string_value( json_object_get(answer, "rrtype")));
+    FAIL_IF_STR_DIFFERS("1.2.3.4",    json_string_value( json_object_get(answer, "rdata")));
+    FAIL_IF( 16623 !=                json_integer_value( json_object_get(answer, "ttl")));
+
+    /* Free some stuff */
+    json_decref(tjs);
+    json_decref(js);
+    DNSStateFree(dns_state);
+    FreeOuputDocList(docs);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p2);
+    UTHFreePacket(p1);
+    SCFree(dnslog_ctx);
+    MemBufferFree(buffer);
+    LogFileFreeCtx(file_ctx);
+
+    PASS;
+}
+/**
+ *  \test Tests the JSON Output for a DNS Alert with DNS_UNIFIED style
+ *
+ *  \retval On success it returns 1 and on failure 0.
+ */
+
+static int OutputJsonDnsResponseUnifiedAlertTest03 (void)
+{
+
+    int result = 0;
+    Flow f;
+    DNSState *dns_state = NULL;
+    Packet *p1 = NULL, *p2 = NULL;
+    Signature *s = NULL;
+    ThreadVars tv;
+    json_t *js = NULL;
+    DetectEngineThreadCtx *det_ctx = NULL;
+    AppLayerParserThreadCtx *alp_tctx = AppLayerParserThreadCtxAlloc();
+
+    memset(&tv, 0, sizeof(ThreadVars));
+    memset(&f, 0, sizeof(Flow));
+
+    p1 = UTHBuildPacketReal(bufQuery, sizeof(bufQuery), IPPROTO_UDP,
+                           "192.168.1.5", "192.168.1.1",
+                           41424, 53);
+    p2 = UTHBuildPacketReal(bufResponse, sizeof(bufResponse), IPPROTO_UDP,
+                           "192.168.1.1", "192.168.5.1",
+                           53, 41424);
+
+    FLOW_INITIALIZE(&f);
+    f.flags |= FLOW_IPV4;
+    f.proto = IPPROTO_UDP;
+    f.protomap = FlowGetProtoMapping(f.proto);
+    f.alproto = ALPROTO_DNS;
+
+    p1->flow = &f;
+    p1->flags |= PKT_HAS_FLOW;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->pcap_cnt = 1;
+
+    p2->flow = &f;
+    p2->flags |= PKT_HAS_FLOW;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->pcap_cnt = 2;
+
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    if (de_ctx == NULL) {
+        goto end;
+    }
+    de_ctx->flags |= DE_QUIET;
+
+    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
+                              "(msg:\"Test dns_query option\"; "
+                              "dns_query; content:\"google.com\"; nocase; sid:1;)");
+    if (s == NULL) {
+        goto end;
+    }
+    s = DetectEngineAppendSig(de_ctx, "alert dns any any -> any any "
+                              "(msg:\"Test dns_query option\"; "
+                              "dns_query; content:\"google.net\"; nocase; sid:2;)");
+    if (s == NULL) {
+        goto end;
+    }
+
+    SigGroupBuild(de_ctx);
+    DetectEngineThreadCtxInit(&tv, (void *)de_ctx, (void *)&det_ctx);
+
+    SCMutexLock(&f.m);
+    int ret = AppLayerParserParse(&tv, alp_tctx, &f, ALPROTO_DNS, STREAM_TOSERVER, bufQuery, sizeof(bufQuery));
+    if (ret != 0) {
+        printf("toserver chunk 1 returned %" PRId32 ", expected 0: ", ret);
+        SCMutexUnlock(&f.m);
+        goto end;
+    }
+    SCMutexUnlock(&f.m);
+
+    dns_state = f.alstate;
+    if (dns_state == NULL) {
+        printf("no dns state: ");
+        goto end;
+    }
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p1);
+
+    if (!(PacketAlertCheck(p1, 1))) {
+        printf("(p1) sig 1 didn't alert, but it should have: ");
+        goto end;
+    }
+    if (PacketAlertCheck(p1, 2)) {
+        printf("(p1) sig 2 did alert, but it should not have: ");
+        goto end;
+    }
+
+    SCMutexLock(&f.m);
+    ret = AppLayerParserParse(&tv, alp_tctx, &f, ALPROTO_DNS, STREAM_TOCLIENT, bufResponse, sizeof(bufResponse));
+    if (ret != 0) {
+        printf("toserver client 1 returned %" PRId32 ", expected 0: ", ret);
+        SCMutexUnlock(&f.m);
+        goto end;
+    }
+    SCMutexUnlock(&f.m);
+
+    /* do detect */
+    SigMatchSignatures(&tv, de_ctx, det_ctx, p2);
+
+    if (PacketAlertCheck(p2, 1)) {
+        printf("(p2) sig 1 alerted, but it should not have: ");
+        goto end;
+    }
+    if (PacketAlertCheck(p2, 2)) {
+        printf("(p2) sig 2 alerted, but it should not have: ");
+        goto end;
+    }
+
+    js = CreateJSONHeader((Packet *)p2, 0, "alert");
+    if (unlikely(js == NULL)) {
+        goto end;
+    }
+
+    AlertJsonDns(&f, js);
+
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(js);
+
+    JUMP_IF_STR_DIFFERS("alert",      json_string_value( json_object_get(js, "event_type") ), end);
+
+    json_t *dns = json_object_get(js, "dns");
+    FAIL_IF (dns == NULL);
+    JUMP_IF_STR_DIFFERS("NOERROR",    json_string_value( json_object_get(dns, "rcode")), end);
+    FAIL_IF( 4146 !=                 json_integer_value( json_object_get(dns, "tx_id")));
+
+    /* Check queries and answers arrays */
+    json_t *queries = json_object_get(dns, "queries");
+    json_t *answers = json_object_get(dns, "answers");
+
+    FAIL_IF(queries == NULL);
+    FAIL_IF(answers == NULL);
+    FAIL_IF (! json_is_array(queries));
+    FAIL_IF (! json_is_array(answers));
+    FAIL_IF(json_array_size(queries) != 1);
+    FAIL_IF(json_array_size(answers) != 1);
+
+    json_t *query = json_array_get(queries, 0);
+    json_t *answer = json_array_get(answers, 0);
+
+    FAIL_IF(query == NULL);
+    FAIL_IF(answer == NULL);
+
+
+/*
+  {
+    "rrname": "google.com",
+    "rrtype": "TXT",
+    "tx_id": 4146
+  }
+
+*/
+
+    /* Check string values */
+    JUMP_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(query, "rrname")), end);
+    JUMP_IF_STR_DIFFERS("TXT",        json_string_value( json_object_get(query, "rrtype")), end);
+
+/*
+ {
+    "rrtype": "A",
+    "rrname": "google.com",
+    "ttl": 16623,
+    "rdata": "1.2.3.4"
+  }
+*/
+
+    /* Check string values */
+    JUMP_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(answer, "rrname")), end);
+    JUMP_IF_STR_DIFFERS("A",          json_string_value( json_object_get(answer, "rrtype")), end);
+    JUMP_IF_STR_DIFFERS("1.2.3.4",    json_string_value( json_object_get(answer, "rdata")), end);
+    FAIL_IF( 16623 !=                json_integer_value( json_object_get(answer, "ttl")));
+
+
+    result = 1;
+
+end:
+    if (alp_tctx != NULL)
+        AppLayerParserThreadCtxFree(alp_tctx);
+    if (det_ctx != NULL) {
+        DetectEngineThreadCtxDeinit(&tv, det_ctx);
+    }
+    if (de_ctx != NULL)
+        SigGroupCleanup(de_ctx);
+    if (de_ctx != NULL)
+        DetectEngineCtxFree(de_ctx);
+
+    json_decref(js);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p1);
+    UTHFreePacket(p2);
+    return result;
+
+}
+/**
+ *  \test Tests the JSON Output for a DNS Query with DNS_STYLE style
+ *
+ *  \retval On success it returns 1 and on failure 0.
+ */
+
+static int OutputJsonDnsResponseSplitTest04 (void)
+{
+    /* Create the file context */
+    LogFileCtx *file_ctx = LogFileNewCtx();
+    FAIL_IF(file_ctx == NULL);
+
+    /* Create memory butffer */
+    MemBuffer * buffer = MemBufferCreateNew(OUTPUT_BUFFER_SIZE);
+    FAIL_IF(buffer == NULL);
+
+    /* Create DNS file context */
+    LogDnsFileCtx *dnslog_ctx = SCMalloc(sizeof(LogDnsFileCtx));
+    FAIL_IF(dnslog_ctx == NULL);
+
+    /* Configure DNS file context configuration options */
+    dnslog_ctx->mode = DNS_UNIFIED;
+    dnslog_ctx->filter &= LOG_ALL_RRTYPES;
+
+    /* Create a DNS packets for tests */
+    Packet *p1 = NULL, *p2 = NULL;
+    p1 = UTHBuildPacketReal(bufQuery, sizeof(bufQuery), IPPROTO_UDP,
+                           "192.168.1.5", "192.168.1.1", 41424, 53);
+
+    p2 = UTHBuildPacketReal(bufResponse, sizeof(bufResponse), IPPROTO_UDP,
+                           "192.168.1.1", "192.168.1.5", 53, 41424);
+
+    FAIL_IF(p1 == NULL);
+    FAIL_IF(p2 == NULL);
+
+    /* Create flow */
+    Flow f;
+    FLOW_INITIALIZE(&f);
+    f.flags |= FLOW_IPV4;
+    f.proto = IPPROTO_UDP;
+    f.protomap = FlowGetProtoMapping(f.proto);
+
+    p1->flow = &f;
+    p1->flags |= PKT_HAS_FLOW;
+    p1->flowflags |= FLOW_PKT_TOSERVER;
+    p1->pcap_cnt = 1;
+
+    p2->flow = &f;
+    p2->flags |= PKT_HAS_FLOW;
+    p2->flowflags |= FLOW_PKT_TOCLIENT;
+    p2->pcap_cnt = 2;
+
+    /* Create a DNS state from the flow and response */
+    DNSState *dns_state =  MakesDNSStateFromRequest(&f, bufQuery, sizeof(bufQuery));
+
+    /* Create a JSON object for output */
+    json_t *js = CreateJSONHeader(p2, 0, "dns");
+    FAIL_IF(js == NULL);
+
+
+    /* Outputs JSON */
+    OutputDocList * docs = TransactionJSONList(js,  TAILQ_FIRST(&dns_state->tx_list) , ALL_FILTERS, DNS_SPLIT);
+    FAIL_IF(docs == NULL);
+
+    OutputDoc *doc = TAILQ_FIRST(docs);
+    FAIL_IF(doc == NULL);
+
+    json_t *qjs = doc->js;
+    FAIL_IF(qjs == NULL);
+
+    FAIL_IF_STR_DIFFERS("dns",      json_string_value( json_object_get(qjs, "event_type") ));
+
+
+
+    json_t *dns = json_object_get(qjs, "dns");
+    FAIL_IF (dns == NULL);
+
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(qjs);
+
+/*
+  {
+    "rrname": "google.com",
+    "rrtype": "TXT",
+    "tx_id": 4146
+  }
+
+*/
+
+    /* Check string values */
+    FAIL_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(dns, "rrname") ));
+    FAIL_IF_STR_DIFFERS("TXT",        json_string_value( json_object_get(dns, "rrtype")));
+
+    DNSStateFree(dns_state);
+    FreeOuputDocList(docs);
+    json_decref(js);
+
+    /* Answer */
+
+/*
+ {
+    "rrtype": "A",
+    "rrname": "google.com",
+    "ttl": 16623,
+    "rdata": "1.2.3.4"
+  }
+*/
+
+
+    /* Create a DNS state from the flow and response */
+    dns_state =  MakesDNSStateFromRequestAndResponse(&f,
+            bufQuery, sizeof(bufQuery), bufResponse, sizeof(bufResponse));
+
+    /* Create a JSON object for output */
+    js = CreateJSONHeader(p2, 0, "dns");
+    FAIL_IF(js == NULL);
+
+    /* Outputs JSON */
+    docs = TransactionJSONList(js,  TAILQ_FIRST(&dns_state->tx_list) , ALL_FILTERS, DNS_SPLIT);
+    FAIL_IF(docs == NULL);
+
+    doc = TAILQ_FIRST(docs);
+    FAIL_IF(doc == NULL);
+
+    json_t *ajs = doc->js;
+    FAIL_IF(ajs == NULL);
+
+    JSON_DNS_OUTPUT_UNITTEST_DUMP(ajs);
+    FAIL_IF_STR_DIFFERS("dns",      json_string_value( json_object_get(ajs, "event_type") ));
+
+    dns = json_object_get(ajs, "dns");
+    FAIL_IF (dns == NULL);
+
+    json_t *answers = json_object_get(dns, "answers");
+
+    FAIL_IF(answers == NULL);
+    FAIL_IF (! json_is_array(answers));
+    FAIL_IF(json_array_size(answers) != 1);
+
+    json_t *answer = json_array_get(answers, 0);
+    FAIL_IF(answer == NULL);
+
+    /* Check string values */
+    FAIL_IF_STR_DIFFERS("google.com", json_string_value( json_object_get(answer, "rrname") ));
+    FAIL_IF_STR_DIFFERS("A",          json_string_value( json_object_get(answer, "rrtype")));
+    FAIL_IF_STR_DIFFERS("1.2.3.4",    json_string_value( json_object_get(answer, "rdata")));
+    FAIL_IF( 16623 !=                json_integer_value( json_object_get(answer, "ttl")));
+
+    FAIL_IF_STR_DIFFERS("NOERROR",    json_string_value( json_object_get(dns, "rcode") ));
+    FAIL_IF( 4146 !=                 json_integer_value( json_object_get(dns, "tx_id")));
+
+    /* Free some stuff */
+    json_decref(qjs);
+    json_decref(ajs);
+    json_decref(js);
+    FreeOuputDocList(docs);
+    DNSStateFree(dns_state);
+    FLOW_DESTROY(&f);
+    UTHFreePacket(p2);
+    UTHFreePacket(p1);
+    SCFree(dnslog_ctx);
+    MemBufferFree(buffer);
+    LogFileFreeCtx(file_ctx);
+
+    PASS;
+
+}
+
+
+/**
+ *  \brief   Function to register DNS output JSON Tests
+ */
+void OutputJsonDnsRegisterTests (void)
+{
+    UtRegisterTest("OutputJsonDnsQueryDiscreteTest01 -- Tests discrete query", OutputJsonDnsQueryDiscreteTest01);
+    UtRegisterTest("OutputJsonDnsResponseUnifiedTest02 -- Tests unified response", OutputJsonDnsResponseUnifiedTest02);
+    UtRegisterTest("OutputJsonDnsResponseUnifiedAlertTest03 -- Tests unified response", OutputJsonDnsResponseUnifiedAlertTest03);
+    UtRegisterTest("OutputJsonDnsResponseSplitTest04 -- Tests split style", OutputJsonDnsResponseSplitTest04);
+
+}
+#endif /* UNITTESTS */
+
 #else
+
+#include "output-json-dns.h"
+#include "util-debug.h"
 
 void JsonDnsLogRegister (void)
 {
+    SCLogInfo("Can't register JSON output - JSON support was disabled during build.");
 }
 
+void OutputJsonDnsRegisterTests (void)
+{
+}
 #endif

--- a/src/output-json-dns.h
+++ b/src/output-json-dns.h
@@ -26,4 +26,15 @@
 
 void JsonDnsLogRegister(void);
 
+#ifdef HAVE_LIBJANSSON
+#include "app-layer-dns-common.h"
+
+void JsonDnsLogJSON(json_t *js, DNSState *tx);
+#endif /*HAVE_LIBJANSSON*/
+
+#ifdef UNITTESTS
+void OutputJsonDnsRegisterTests (void);
+#endif /*UNITTESTS */
+
+
 #endif /* __OUTPUT_JSON_DNS_H__ */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -80,6 +80,8 @@
 #include "app-layer-ssh.h"
 #include "app-layer-smtp.h"
 
+#include "output-json-dns.h"
+
 #include "util-action.h"
 #include "util-radix-tree.h"
 #include "util-host-os-info.h"
@@ -222,6 +224,7 @@ static void RegisterUnittests(void)
     AppLayerUnittestsRegister();
     MimeDecRegisterTests();
     StreamingBufferRegisterTests();
+    OutputJsonDnsRegisterTests();
 }
 #endif
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -168,6 +168,7 @@ outputs:
             ssh: yes                 # enable dumping of ssh fields
             smtp: yes                # enable dumping of smtp fields
             dnp3: yes                # enable dumping of DNP3 fields
+            dns: yes                 # enable dumping of dns fields
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.
@@ -196,6 +197,11 @@ outputs:
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
         - dns:
+            # The style of logging:
+            #    discrete: the classic style of an event per question and answer
+            #    split: one event per request, one event per response
+            #    unified: one event containing request and response
+            style: discrete
             # control logging of queries and answers
             # default yes, no to disable
             query: yes     # enable logging of DNS queries


### PR DESCRIPTION
eve: adds dns fields for eve alert's json output

eve: more compact log for dns output json ( as defined by @decanio  ) 

```
DNS log output format is selected using new outputs.eve-log.types.dns.style configuration option

- dns:
    # The style of logging:
    #    discrete: the classic style of an event per question and answer
    #    split: one event per request, one event per response
    #    unified: one event containing request and response
    style: discrete

To emit a single DNS log per DNS transacton use style: unified

To emit a pair of DNS logs per DNS transaction use style: split
the latter preserves individual timestamps of the query and answer arrival times.

The classic DNS log format is preseved using style: discrete

DNS filtering capabilities are preserved with all log styles.
```

eve: dns json output log unit tests
