### PR TITLE
Fix port parsing in config file, added one more corresponding test.

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1325,8 +1325,6 @@ int DetectAddressTestConfVars(void)
             goto error;
         }
 
-        CleanVariableResolveList(&var_list);
-
         if (DetectAddressIsCompleteIPSpace(ghn)) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                        "address var - \"%s\" has the complete IP space negated "

--- a/src/util-var.c
+++ b/src/util-var.c
@@ -137,6 +137,10 @@ int AddVariableToResolveList(ResolvedVariablesList *list, const char *var)
     if (list == NULL || var == NULL)
         return 0;
 
+    if (var[0] != '$') {
+        return 0;
+    }
+
     TAILQ_FOREACH(p_item, list, next) {
         if (!strcmp(p_item->var_name, var)) {
             return -1;


### PR DESCRIPTION
Some examples from wiki caused parsing errors.
For example, "[1:80,![2,4]]" was treated as a mistake.

Also fixed loop detection in variables declaration.