### PR TITLE
Fix port parsing in config file, added one more corresponding test v2

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -1325,8 +1325,6 @@ int DetectAddressTestConfVars(void)
             goto error;
         }
 
-        CleanVariableResolveList(&var_list);
-
         if (DetectAddressIsCompleteIPSpace(ghn)) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                        "address var - \"%s\" has the complete IP space negated "

--- a/src/detect-engine-port.c
+++ b/src/detect-engine-port.c
@@ -1121,6 +1121,8 @@ static int DetectPortParseDo(const DetectEngineCtx *de_ctx,
                     goto error;
             }
             n_set = 0;
+        } else if (depth == 1 && s[u] == ',') {
+            range = 0;
         }
     }
 
@@ -2018,6 +2020,7 @@ end:
         DetectPortCleanupList(dd);
     return result;
 }
+
 /**
  * \test Test general functions
  */
@@ -2391,6 +2394,34 @@ end:
 }
 
 /**
+ * \test Test general functions
+ */
+static int PortTestFunctions07(void)
+{
+    DetectPort *dd = NULL;
+
+    // This one should fail due to negation in a range
+    FAIL_IF(DetectPortParse(NULL, &dd, "[80:!99]") == 0);
+
+    // Correct: from 80 till 100 but 99 excluded
+    FAIL_IF_NOT(DetectPortParse(NULL, &dd, "[80:100,!99]") == 0);
+    FAIL_IF_NULL(dd->next);
+    FAIL_IF_NOT(dd->port == 80);
+    FAIL_IF_NOT(dd->port2 == 98);
+    FAIL_IF_NOT(dd->next->port == 100);
+
+    // Also good: from 1 till 80 except of 2 and 4
+    FAIL_IF_NOT(DetectPortParse(NULL, &dd, "[1:80,![2,4]]") == 0);
+    FAIL_IF_NOT(dd->port == 1);
+    FAIL_IF_NULL(DetectPortLookupGroup(dd, 3));
+    FAIL_IF_NOT_NULL(DetectPortLookupGroup(dd, 2));
+    FAIL_IF_NULL(DetectPortLookupGroup(dd, 80));
+
+    DetectPortCleanupList(dd);
+    PASS;
+}
+
+/**
  * \test Test packet Matches
  * \param raw_eth_pkt pointer to the ethernet packet
  * \param pktsize size of the packet
@@ -2713,6 +2744,7 @@ void DetectPortTests(void)
     UtRegisterTest("PortTestFunctions04", PortTestFunctions04);
     UtRegisterTest("PortTestFunctions05", PortTestFunctions05);
     UtRegisterTest("PortTestFunctions06", PortTestFunctions06);
+    UtRegisterTest("PortTestFunctions07", PortTestFunctions07);
     UtRegisterTest("PortTestMatchReal01", PortTestMatchReal01);
     UtRegisterTest("PortTestMatchReal02", PortTestMatchReal02);
     UtRegisterTest("PortTestMatchReal03", PortTestMatchReal03);

--- a/src/util-var.c
+++ b/src/util-var.c
@@ -137,6 +137,10 @@ int AddVariableToResolveList(ResolvedVariablesList *list, const char *var)
     if (list == NULL || var == NULL)
         return 0;
 
+    if (var[0] != '$') {
+        return 0;
+    }
+
     TAILQ_FOREACH(p_item, list, next) {
         if (!strcmp(p_item->var_name, var)) {
             return -1;


### PR DESCRIPTION
Reworked #2351

Some examples from wiki caused parsing errors.
For example, "[1:80,![2,4]]" was treated as a mistake.

Also fixed loop detection in variables declaration.