### PR TITLE
Fix port parsing in config file, added one more corresponding test V3

### DIFF
--- a/src/detect-engine-address.c
+++ b/src/detect-engine-address.c
@@ -826,12 +826,6 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
     char *rule_var_address = NULL;
     char *temp_rule_var_address = NULL;
 
-    if (AddVariableToResolveList(var_list, s) == -1) {
-        SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "Found a loop in a address "
-                   "groups declaration. This is likely a misconfiguration.");
-        goto error;
-    }
-
     SCLogDebug("s %s negate %s", s, negate ? "true" : "false");
 
     for (u = 0, x = 0; u < size && x < sizeof(address); u++) {
@@ -995,6 +989,12 @@ static int DetectAddressParse2(const DetectEngineCtx *de_ctx,
                 address[x] = '\0';
             }
             x = 0;
+
+            if (AddVariableToResolveList(var_list, address) == -1) {
+                SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, "Found a loop in a address "
+                    "groups declaration. This is likely a misconfiguration.");
+                goto error;
+            }
 
             if (d_set == 1) {
                 rule_var_address = SCRuleVarsGetConfVar(de_ctx, address,
@@ -1324,8 +1324,6 @@ int DetectAddressTestConfVars(void)
                         "Please check it's syntax", seq_node->name, seq_node->val);
             goto error;
         }
-
-        CleanVariableResolveList(&var_list);
 
         if (DetectAddressIsCompleteIPSpace(ghn)) {
             SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,

--- a/src/util-var.c
+++ b/src/util-var.c
@@ -137,6 +137,10 @@ int AddVariableToResolveList(ResolvedVariablesList *list, const char *var)
     if (list == NULL || var == NULL)
         return 0;
 
+    if (var[0] != '$') {
+        return 0;
+    }
+
     TAILQ_FOREACH(p_item, list, next) {
         if (!strcmp(p_item->var_name, var)) {
             return -1;


### PR DESCRIPTION
Some examples from wiki caused parsing errors.
For example, "[1:80,![2,4]]" was treated as a mistake.

Also fixed loop detection in variables declaration. For example,
'A: "HOME_NET, !$HOME_NET"' resulted in parsing error.
