### PR TITLE
source-nfq: fix tunnel mark callback

### DIFF
--- a/src/source-nfq.c
+++ b/src/source-nfq.c
@@ -504,13 +504,12 @@ static void NFQReleasePacket(Packet *p)
 static int NFQBypassCallback(Packet *p)
 {
     if (IS_TUNNEL_PKT(p)) {
-        SCMutex *m = p->root ? &p->root->tunnel_mutex : &p->tunnel_mutex;
+        Packet *rp = p->root ? p->root : p;
+        SCMutex *m = &rp->tunnel_mutex;
         SCMutexLock(m);
-
-        p->root->nfq_v.mark = (nfq_config.bypass_mark & nfq_config.bypass_mask)
-                        | (p->nfq_v.mark & ~nfq_config.bypass_mask);
-        p->root->flags |= PKT_MARK_MODIFIED;
-
+        rp->nfq_v.mark = (nfq_config.bypass_mark & nfq_config.bypass_mask)
+            | (rp->nfq_v.mark & ~nfq_config.bypass_mask);
+        rp->flags |= PKT_MARK_MODIFIED;
         SCMutexUnlock(m);
     } else {
         p->nfq_v.mark = (nfq_config.bypass_mark & nfq_config.bypass_mask)


### PR DESCRIPTION
The root packet was accessed even if it is NULL causing a NULL dereference:
```
ASAN:SIGSEGV
=================================================================
==24408==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000060 (pc 0x00000076f948 bp 0x7f435c000240 sp 0x7f435c000220 T5)
ASAN:SIGSEGV
==24408==AddressSanitizer: while reporting a bug found another one. Ignoring.
    #0 0x76f947 in NFQBypassCallback /home/victor/dev/suricata/src/source-nfq.c:510
    #1 0x4d0f02 in PacketBypassCallback /home/victor/dev/suricata/src/decode.c:395
    #2 0x7b8a95 in StreamTcpPacket /home/victor/dev/suricata/src/stream-tcp.c:4661
    #3 0x7b9ddd in StreamTcp /home/victor/dev/suricata/src/stream-tcp.c:4913
    #4 0x68fa50 in FlowWorker /home/victor/dev/suricata/src/flow-worker.c:194
    #5 0x7f0abd in TmThreadsSlotVarRun /home/victor/dev/suricata/src/tm-threads.c:128
    #6 0x7f2958 in TmThreadsSlotVar /home/victor/dev/suricata/src/tm-threads.c:585
    #7 0x7f436368e6f9 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x76f9)
    #8 0x7f4362802b5c in clone (/lib/x86_64-linux-gnu/libc.so.6+0x106b5c)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/victor/dev/suricata/src/source-nfq.c:510 NFQBypassCallback
Thread T5 (W#04) created by T0 (Suricata-Main) here:
    #0 0x7f4364ff2253 in pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.2+0x36253)
    #1 0x7f9c48 in TmThreadSpawn /home/victor/dev/suricata/src/tm-threads.c:1843
    #2 0x8da7c0 in RunModeSetIPSAutoFp /home/victor/dev/suricata/src/util-runmodes.c:519
    #3 0x73e3ff in RunModeIpsNFQAutoFp /home/victor/dev/suricata/src/runmode-nfq.c:74
    #4 0x7503fa in RunModeDispatch /home/victor/dev/suricata/src/runmodes.c:382
    #5 0x7e5cb3 in main /home/victor/dev/suricata/src/suricata.c:2547
    #6 0x7f436271c82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
```
PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/221
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/3