### PR TITLE
Issue 1867 - Flow arguments: not_established, no_frag, only_frag - v1

### DIFF
--- a/doc/userguide/rules/flow-keywords.rst
+++ b/doc/userguide/rules/flow-keywords.rst
@@ -59,37 +59,48 @@ only (only_stream) or on packet only (no_stream).
 
 So with the flow keyword you can match on:
 
-::
+to_client
+  Match on packets from server to client.
+to_server
+  Match on packets from client to server.
+from_client
+  Match on packets from client to server (same as to_server).
+from_server
+  Match on packets from server to client (same as to_client).
+established
+  Match on established connections.
+not_established
+  Match on packets that are not part of an established connection.
+stateless
+  Match on packets that are and are not part of an established connection.
+only_stream
+  Match on packets that have been reassembled by the stream engine.
+no_stream
+  Match on packets that have not been reassembled by the stream
+  engine. Will not match packets that have been reeassembled.
+only_frag
+  Match packets that have been reassembled from fragments.
+no_frag
+  Match packets that have not been reassembled from fragments.
 
-  to_client                       established           only_stream
-  from_client                     stateless             no_stream
-  to_server
-  from_server
+Multiple flow options can be combined, for example::
 
-**NOTE:** *from_server* and *to_client* are the same, and so are
- *to_server* and _from_client_. This comes from the original Snort
- language and we support it for compatibility reasons.
+  flow:to_client, established
+  flow:to_server, established, only_stream
+  flow:to_server, not_established, no_frag
 
-These options can be combined. You can use
-up to three options. For example:
+The determination of *established* depends on the protocol:
 
-::
+* For TCP a connection will be established after a three way
+  handshake.
 
-  flow:to_client, established;
-  flow:from_client, established, only_stream;
+  .. image:: flow-keywords/Flow1.png
 
-There are different ways in which can be checked whether the
-connection is established or not. With tcp-traffic a connection starts
-with the three-way-handshake. In the flow is a part in which the state
-is set. There will be checked in which state the connection is.  In
-other cases there will be just checked if traffic comes from two
-sides.
+* For other protocols (for example UDP), the connection will be
+  considered established after seeing traffic from both sides of the
+  connection.
 
-Example:
-
-.. image:: flow-keywords/Flow1.png
-
-.. image:: flow-keywords/Flow2.png
+  .. image:: flow-keywords/Flow2.png
 
 Flowint
 ~~~~~~~

--- a/src/decode.h
+++ b/src/decode.h
@@ -1096,6 +1096,9 @@ int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder);
  *  flow engine: Packet::flow_hash will be set */
 #define PKT_WANTS_FLOW                  (1<<22)
 
+#define PKT_REBUILT_FRAGMENT            (1<<23)     /**< Packet is rebuilt from
+                                                     * fragments. */
+
 /** \brief return 1 if the packet is a pseudo packet */
 #define PKT_IS_PSEUDOPKT(p) ((p)->flags & PKT_PSEUDO_STREAM_END)
 

--- a/src/defrag.c
+++ b/src/defrag.c
@@ -294,6 +294,7 @@ Defrag4Reassemble(ThreadVars *tv, DefragTracker *tracker, Packet *p)
         goto error_remove_tracker;
     }
     PKT_SET_SRC(rp, PKT_SRC_DEFRAG);
+    rp->flags |= PKT_REBUILT_FRAGMENT;
     rp->recursion_level = p->recursion_level;
 
     int fragmentable_offset = 0;

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -76,10 +76,25 @@ void DetectFlowRegister (void)
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 }
 
-static inline int FlowMatch(const uint8_t pflowflags, const uint16_t tflags,
-                            const uint8_t dflags, const uint8_t match_cnt)
+/**
+ * \param pflags packet flags (p->flags)
+ * \param pflowflags packet flow flags (p->flowflags)
+ * \param tflags detection flags (det_ctx->flags)
+ * \param dflags detect flow flags
+ * \param match_cnt number of matches to trigger
+ */
+static inline int FlowMatch(const uint32_t pflags, const uint8_t pflowflags,
+    const uint16_t tflags, const uint16_t dflags, const uint8_t match_cnt)
 {
     uint8_t cnt = 0;
+
+    if ((dflags & DETECT_FLOW_FLAG_NO_FRAG) &&
+        (!(pflags & PKT_REBUILT_FRAGMENT))) {
+        cnt++;
+    } else if ((dflags & DETECT_FLOW_FLAG_ONLY_FRAG) &&
+        (pflags & PKT_REBUILT_FRAGMENT)) {
+        cnt++;
+    }
 
     if ((dflags & DETECT_FLOW_FLAG_TOSERVER) && (pflowflags & FLOW_PKT_TOSERVER)) {
         cnt++;
@@ -135,7 +150,7 @@ int DetectFlowMatch (ThreadVars *t, DetectEngineThreadCtx *det_ctx, Packet *p, S
 
     const DetectFlowData *fd = (const DetectFlowData *)ctx;
 
-    int ret = FlowMatch(p->flowflags, det_ctx->flags, fd->flags, fd->match_cnt);;
+    int ret = FlowMatch(p->flags, p->flowflags, det_ctx->flags, fd->flags, fd->match_cnt);;
     SCLogDebug("returning %" PRId32 " fd->match_cnt %" PRId32 " fd->flags 0x%02X p->flowflags 0x%02X",
         ret, fd->match_cnt, fd->flags, p->flowflags);
     SCReturnInt(ret);
@@ -263,6 +278,24 @@ DetectFlowData *DetectFlowParse (char *flowstr)
                     goto error;
                 }
                 fd->flags |= DETECT_FLOW_FLAG_NOSTREAM;
+            } else if (strcasecmp(args[i], "no_frag") == 0) {
+                if (fd->flags & DETECT_FLOW_FLAG_NO_FRAG) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set no_frag flag is already set");
+                    goto error;
+                } else if (fd->flags & DETECT_FLOW_FLAG_ONLY_FRAG) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set no_frag flag, only_frag already set");
+                    goto error;
+                }
+                fd->flags |= DETECT_FLOW_FLAG_NO_FRAG;
+            } else if (strcasecmp(args[i], "only_frag") == 0) {
+                if (fd->flags & DETECT_FLOW_FLAG_ONLY_FRAG) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set only_frag flag is already set");
+                    goto error;
+                } else if (fd->flags & DETECT_FLOW_FLAG_NO_FRAG) {
+                    SCLogError(SC_ERR_FLAGS_MODIFIER, "cannot set only_frag flag, no_frag already set");
+                    goto error;
+                }
+                fd->flags |= DETECT_FLOW_FLAG_ONLY_FRAG;
             } else {
                 SCLogError(SC_ERR_INVALID_VALUE, "invalid flow option \"%s\"", args[i]);
                 goto error;
@@ -365,7 +398,7 @@ PrefilterPacketFlowMatch(DetectEngineThreadCtx *det_ctx, Packet *p, const void *
     if (PrefilterPacketHeaderExtraMatch(ctx, p) == FALSE)
         return;
 
-    if (FlowMatch(p->flowflags, det_ctx->flags, ctx->v1.u8[0], ctx->v1.u8[1]))
+    if (FlowMatch(p->flags, p->flowflags, det_ctx->flags, ctx->v1.u8[0], ctx->v1.u8[1]))
     {
         PrefilterAddSids(&det_ctx->pmq, ctx->sigs_array, ctx->sigs_cnt);
     }
@@ -926,6 +959,75 @@ static int DetectFlowTestParseNotEstablished(void)
     PASS;
 }
 
+/**
+ * \test Test parsing of the "no_frag" flow argument.
+ */
+static int DetectFlowTestParseNoFrag(void)
+{
+    DetectFlowData *fd = NULL;
+    fd = DetectFlowParse("no_frag");
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_NO_FRAG);
+    DetectFlowFree(fd);
+    PASS;
+}
+
+/**
+ * \test Test parsing of the "only_frag" flow argument.
+ */
+static int DetectFlowTestParseOnlyFrag(void)
+{
+    DetectFlowData *fd = NULL;
+    fd = DetectFlowParse("only_frag");
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ONLY_FRAG);
+    DetectFlowFree(fd);
+    PASS;
+}
+
+/**
+ * \test Test that parsing of only_frag and no_frag together fails.
+ */
+static int DetectFlowTestParseNoFragOnlyFrag(void)
+{
+    DetectFlowData *fd = NULL;
+    fd = DetectFlowParse("no_frag,only_frag");
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
+}
+
+/**
+ * \test Test no_frag matching.
+ */
+static int DetectFlowTestNoFragMatch(void)
+{
+    uint32_t pflags = 0;
+    DetectFlowData *fd = DetectFlowParse("no_frag");
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_NO_FRAG);
+    FAIL_IF_NOT(fd->match_cnt == 1);
+    FAIL_IF_NOT(FlowMatch(pflags, 0, 0, fd->flags, fd->match_cnt));
+    pflags |= PKT_REBUILT_FRAGMENT;
+    FAIL_IF(FlowMatch(pflags, 0, 0, fd->flags, fd->match_cnt));
+    PASS;
+}
+
+/**
+ * \test Test only_frag matching.
+ */
+static int DetectFlowTestOnlyFragMatch(void)
+{
+    uint32_t pflags = 0;
+    DetectFlowData *fd = DetectFlowParse("only_frag");
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ONLY_FRAG);
+    FAIL_IF_NOT(fd->match_cnt == 1);
+    FAIL_IF(FlowMatch(pflags, 0, 0, fd->flags, fd->match_cnt));
+    pflags |= PKT_REBUILT_FRAGMENT;
+    FAIL_IF_NOT(FlowMatch(pflags, 0, 0, fd->flags, fd->match_cnt));
+    PASS;
+}
+
 #endif /* UNITTESTS */
 
 /**
@@ -970,6 +1072,13 @@ void DetectFlowRegisterTests(void)
     UtRegisterTest("DetectFlowTestParse21", DetectFlowTestParse21);
     UtRegisterTest("DetectFlowTestParseNotEstablished",
         DetectFlowTestParseNotEstablished);
+    UtRegisterTest("DetectFlowTestParseNoFrag", DetectFlowTestParseNoFrag);
+    UtRegisterTest("DetectFlowTestParseOnlyFrag", 
+        DetectFlowTestParseOnlyFrag);
+    UtRegisterTest("DetectFlowTestParseNoFragOnlyFrag",
+        DetectFlowTestParseNoFragOnlyFrag);
+    UtRegisterTest("DetectFlowTestNoFragMatch", DetectFlowTestNoFragMatch);
+    UtRegisterTest("DetectFlowTestOnlyFragMatch", DetectFlowTestOnlyFragMatch);
 
     UtRegisterTest("DetectFlowSigTest01", DetectFlowSigTest01);
 #endif /* UNITTESTS */

--- a/src/detect-flow.c
+++ b/src/detect-flow.c
@@ -408,15 +408,11 @@ static _Bool PrefilterFlowIsPrefilterable(const Signature *s)
  */
 int DetectFlowTestParse01 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established");
-    if (fd != NULL) {
-        DetectFlowFree(fd);
-        result = 1;
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -424,19 +420,12 @@ int DetectFlowTestParse01 (void)
  */
 int DetectFlowTestParse02 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_ESTABLISHED && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->match_cnt == 1);
+    PASS;
 }
 
 /**
@@ -444,19 +433,12 @@ int DetectFlowTestParse02 (void)
  */
 int DetectFlowTestParse03 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("stateless");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -464,19 +446,12 @@ int DetectFlowTestParse03 (void)
  */
 int DetectFlowTestParse04 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -484,19 +459,12 @@ int DetectFlowTestParse04 (void)
  */
 int DetectFlowTestParse05 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_server");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -504,19 +472,12 @@ int DetectFlowTestParse05 (void)
  */
 int DetectFlowTestParse06 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -524,19 +485,12 @@ int DetectFlowTestParse06 (void)
  */
 int DetectFlowTestParse07 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_client");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -544,19 +498,12 @@ int DetectFlowTestParse07 (void)
  */
 int DetectFlowTestParse08 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established,to_client");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -564,19 +511,14 @@ int DetectFlowTestParse08 (void)
  */
 int DetectFlowTestParse09 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client,stateless");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -584,19 +526,14 @@ int DetectFlowTestParse09 (void)
  */
 int DetectFlowTestParse10 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,stateless");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -604,19 +541,14 @@ int DetectFlowTestParse10 (void)
  */
 int DetectFlowTestParse11 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse(" from_server , stateless ");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -625,15 +557,11 @@ int DetectFlowTestParse11 (void)
  */
 int DetectFlowTestParseNocase01 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("ESTABLISHED");
-    if (fd != NULL) {
-        DetectFlowFree(fd);
-        result = 1;
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -641,19 +569,13 @@ int DetectFlowTestParseNocase01 (void)
  */
 int DetectFlowTestParseNocase02 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("ESTABLISHED");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_ESTABLISHED && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -661,19 +583,11 @@ int DetectFlowTestParseNocase02 (void)
  */
 int DetectFlowTestParseNocase03 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("STATELESS");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_STATELESS && fd->match_cnt == 1);         DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -681,19 +595,12 @@ int DetectFlowTestParseNocase03 (void)
  */
 int DetectFlowTestParseNocase04 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_CLIENT");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -701,19 +608,12 @@ int DetectFlowTestParseNocase04 (void)
  */
 int DetectFlowTestParseNocase05 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_SERVER");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -721,19 +621,12 @@ int DetectFlowTestParseNocase05 (void)
  */
 int DetectFlowTestParseNocase06 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOCLIENT, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -741,19 +634,12 @@ int DetectFlowTestParseNocase06 (void)
  */
 int DetectFlowTestParseNocase07 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_CLIENT");
-    if (fd != NULL) {
-        if (fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_TOSERVER, 1, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags == DETECT_FLOW_FLAG_TOSERVER && fd->match_cnt == 1);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -761,19 +647,14 @@ int DetectFlowTestParseNocase07 (void)
  */
 int DetectFlowTestParseNocase08 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("ESTABLISHED,TO_CLIENT");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -781,19 +662,14 @@ int DetectFlowTestParseNocase08 (void)
  */
 int DetectFlowTestParseNocase09 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("TO_CLIENT,STATELESS");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2) {
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -801,19 +677,14 @@ int DetectFlowTestParseNocase09 (void)
  */
 int DetectFlowTestParseNocase10 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,STATELESS");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -821,37 +692,25 @@ int DetectFlowTestParseNocase10 (void)
  */
 int DetectFlowTestParseNocase11 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse(" FROM_SERVER , STATELESS ");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_STATELESS  && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->match_cnt == 2){
-            result = 1;
-        } else {
-            printf("expected: 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_STATELESS + DETECT_FLOW_FLAG_TOCLIENT, 2, fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_STATELESS &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->match_cnt == 2);
+    DetectFlowFree(fd);
+    PASS;
 }
-
 
 /**
  * \test DetectFlowTestParse12 is a test for setting an invalid seperator :
  */
 int DetectFlowTestParse12 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server:stateless");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -859,32 +718,21 @@ int DetectFlowTestParse12 (void)
  */
 int DetectFlowTestParse13 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("invalidoptiontest");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
+
 /**
  * \test DetectFlowTestParse14 is a test for a empty option
  */
 int DetectFlowTestParse14 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -892,16 +740,10 @@ int DetectFlowTestParse14 (void)
  */
 int DetectFlowTestParse15 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("established,stateless");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -909,16 +751,10 @@ int DetectFlowTestParse15 (void)
  */
 int DetectFlowTestParse16 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client,to_server");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -927,16 +763,10 @@ int DetectFlowTestParse16 (void)
  */
 int DetectFlowTestParse17 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("to_client,from_server");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -944,20 +774,15 @@ int DetectFlowTestParse17 (void)
  */
 int DetectFlowTestParse18 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,established,only_stream");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM && fd->match_cnt == 3) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_ONLYSTREAM, 3,
-                    fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM &&
+        fd->match_cnt == 3);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -965,20 +790,15 @@ int DetectFlowTestParse18 (void)
  */
 int DetectFlowTestParseNocase18 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,ESTABLISHED,ONLY_STREAM");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM && fd->match_cnt == 3) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_ONLYSTREAM, 3,
-                    fd->flags, fd->match_cnt);
-        }
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->flags & DETECT_FLOW_FLAG_ONLYSTREAM &&
+        fd->match_cnt == 3);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 
@@ -987,16 +807,10 @@ int DetectFlowTestParseNocase18 (void)
  */
 int DetectFlowTestParse19 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,established,only_stream,a");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 /**
@@ -1004,21 +818,15 @@ int DetectFlowTestParse19 (void)
  */
 int DetectFlowTestParse20 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,established,no_stream");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_NOSTREAM && fd->match_cnt == 3) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_NOSTREAM, 3,
-                    fd->flags, fd->match_cnt);
-        }
-
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->flags & DETECT_FLOW_FLAG_NOSTREAM &&
+        fd->match_cnt == 3);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -1026,21 +834,15 @@ int DetectFlowTestParse20 (void)
  */
 int DetectFlowTestParseNocase20 (void)
 {
-    int result = 0;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("FROM_SERVER,ESTABLISHED,NO_STREAM");
-    if (fd != NULL) {
-        if (fd->flags & DETECT_FLOW_FLAG_ESTABLISHED && fd->flags & DETECT_FLOW_FLAG_TOCLIENT && fd->flags & DETECT_FLOW_FLAG_NOSTREAM && fd->match_cnt == 3) {
-            result = 1;
-        } else {
-            printf("expected 0x%02X cnt %" PRId32 " got 0x%02X cnt %" PRId32 ": ", DETECT_FLOW_FLAG_ESTABLISHED + DETECT_FLOW_FLAG_TOCLIENT + DETECT_FLOW_FLAG_NOSTREAM, 3,
-                    fd->flags, fd->match_cnt);
-        }
-
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NULL(fd);
+    FAIL_IF_NOT(fd->flags & DETECT_FLOW_FLAG_ESTABLISHED &&
+        fd->flags & DETECT_FLOW_FLAG_TOCLIENT &&
+        fd->flags & DETECT_FLOW_FLAG_NOSTREAM &&
+        fd->match_cnt == 3);
+    DetectFlowFree(fd);
+    PASS;
 }
 
 /**
@@ -1048,21 +850,14 @@ int DetectFlowTestParseNocase20 (void)
  */
 int DetectFlowTestParse21 (void)
 {
-    int result = 1;
     DetectFlowData *fd = NULL;
     fd = DetectFlowParse("from_server,a,no_stream");
-    if (fd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId32 ": ",fd->flags, fd->match_cnt);
-        result = 0;
-        DetectFlowFree(fd);
-    }
-
-    return result;
+    FAIL_IF_NOT_NULL(fd);
+    PASS;
 }
 
 static int DetectFlowSigTest01(void)
 {
-    int result = 0;
     ThreadVars th_v;
     DecodeThreadVars dtv;
     DetectEngineCtx *de_ctx = NULL;
@@ -1071,10 +866,7 @@ static int DetectFlowSigTest01(void)
     uint16_t buflen = strlen((char *)buf);
 
     Packet *p = UTHBuildPacket(buf, buflen, IPPROTO_TCP);
-    if (p->flow != NULL) {
-        printf("packet has flow set\n");
-        goto end;
-    }
+    FAIL_IF_NULL(p);
 
     char *sig1 = "alert tcp any any -> any any (msg:\"dummy\"; "
         "content:\"nova\"; flow:no_stream; sid:1;)";
@@ -1083,29 +875,18 @@ static int DetectFlowSigTest01(void)
     memset(&th_v, 0, sizeof(th_v));
 
     de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        printf("de_ctx == NULL: ");
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
     de_ctx->flags |= DE_QUIET;
 
     de_ctx->sig_list = SigInit(de_ctx, sig1);
-    if (de_ctx->sig_list == NULL) {
-        printf("signature == NULL: ");
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx->sig_list);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx, (void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p);
-    if (PacketAlertCheck(p, 1) != 1) {
-        goto end;
-    }
+    FAIL_IF(PacketAlertCheck(p, 1) != 1);
 
-    result = 1;
-
- end:
     if (det_ctx != NULL)
         DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
 
@@ -1118,7 +899,7 @@ static int DetectFlowSigTest01(void)
     if (p != NULL)
         UTHFreePacket(p);
 
-    return result;
+    PASS;
 }
 #endif /* UNITTESTS */
 

--- a/src/detect-flow.h
+++ b/src/detect-flow.h
@@ -24,17 +24,19 @@
 #ifndef __DETECT_FLOW_H__
 #define __DETECT_FLOW_H__
 
-#define DETECT_FLOW_FLAG_TOSERVER        0x01
-#define DETECT_FLOW_FLAG_TOCLIENT        0x02
-#define DETECT_FLOW_FLAG_ESTABLISHED     0x04
-#define DETECT_FLOW_FLAG_NOT_ESTABLISHED 0x08
-#define DETECT_FLOW_FLAG_STATELESS       0x10
-#define DETECT_FLOW_FLAG_ONLYSTREAM      0x20
-#define DETECT_FLOW_FLAG_NOSTREAM        0x40
+#define DETECT_FLOW_FLAG_TOSERVER        BIT_U16(0)
+#define DETECT_FLOW_FLAG_TOCLIENT        BIT_U16(1)
+#define DETECT_FLOW_FLAG_ESTABLISHED     BIT_U16(2)
+#define DETECT_FLOW_FLAG_NOT_ESTABLISHED BIT_U16(3)
+#define DETECT_FLOW_FLAG_STATELESS       BIT_U16(4)
+#define DETECT_FLOW_FLAG_ONLYSTREAM      BIT_U16(5)
+#define DETECT_FLOW_FLAG_NOSTREAM        BIT_U16(6)
+#define DETECT_FLOW_FLAG_NO_FRAG         BIT_U16(7)
+#define DETECT_FLOW_FLAG_ONLY_FRAG       BIT_U16(8)
 
 typedef struct DetectFlowData_ {
-    uint8_t flags;     /* flags to match */
-    uint8_t match_cnt; /* number of matches we need */
+    uint16_t flags;     /* flags to match */
+    uint8_t match_cnt;  /* number of matches we need */
 } DetectFlowData;
 
 /* prototypes */

--- a/src/detect-flow.h
+++ b/src/detect-flow.h
@@ -24,12 +24,13 @@
 #ifndef __DETECT_FLOW_H__
 #define __DETECT_FLOW_H__
 
-#define DETECT_FLOW_FLAG_TOSERVER       0x01
-#define DETECT_FLOW_FLAG_TOCLIENT       0x02
-#define DETECT_FLOW_FLAG_ESTABLISHED    0x04
-#define DETECT_FLOW_FLAG_STATELESS      0x08
-#define DETECT_FLOW_FLAG_ONLYSTREAM     0x10
-#define DETECT_FLOW_FLAG_NOSTREAM       0x20
+#define DETECT_FLOW_FLAG_TOSERVER        0x01
+#define DETECT_FLOW_FLAG_TOCLIENT        0x02
+#define DETECT_FLOW_FLAG_ESTABLISHED     0x04
+#define DETECT_FLOW_FLAG_NOT_ESTABLISHED 0x08
+#define DETECT_FLOW_FLAG_STATELESS       0x10
+#define DETECT_FLOW_FLAG_ONLYSTREAM      0x20
+#define DETECT_FLOW_FLAG_NOSTREAM        0x40
 
 typedef struct DetectFlowData_ {
     uint8_t flags;     /* flags to match */


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1911

Add support for these Snort compatible arguments to the "flow" keyword:
- not_established
- no_frag
- only_frag

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/21
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/371
