### PR TITLE
Add NULL-terminator to app-layer template (fix #1930)

### DIFF
--- a/src/app-layer-template.c
+++ b/src/app-layer-template.c
@@ -68,6 +68,9 @@ enum {
 
 SCEnumCharMap template_decoder_event_table[] = {
     {"EMPTY_MESSAGE", TEMPLATE_DECODER_EVENT_EMPTY_MESSAGE},
+
+    // event table must be NULL-terminated
+    { NULL, -1 },
 };
 
 static TemplateTransaction *TemplateTxAlloc(TemplateState *echo)


### PR DESCRIPTION
Fix the template app-layer: event table has to be NULL-terminated
