### PR TITLE
dev eve output redis async v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
         brew install pkg-config libmagic libyaml nss nspr jansson libnet lua \
-            pcre hiredis libevent
+            pcre hiredis
     fi
   - ./qa/travis-libhtp.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,7 @@ before_install:
             libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev \
             libcap-ng0 make libmagic-dev libnetfilter-queue-dev \
             libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 \
-            libhiredis-dev
-
+            libhiredis-dev libevent-dev libevent-pthreads-2.0-5
 
         if [[ "$ENABLE_COCCI" == "yes" ]]; then
             sudo apt-get install -y coccinelle
@@ -127,7 +126,7 @@ before_install:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
         brew install pkg-config libmagic libyaml nss nspr jansson libnet lua \
-            pcre hiredis
+            pcre hiredis libevent
     fi
   - ./qa/travis-libhtp.sh
 

--- a/configure.ac
+++ b/configure.ac
@@ -1842,6 +1842,14 @@
         LDFLAGS="${LDFLAGS} -pie"
     fi
 
+#libevent includes and libraries
+    AC_ARG_WITH(libevent_includes,
+            [  --with-libevent-includes=DIR  libevent include directory],
+            [with_libevent_includes="$withval"],[with_libevent_includes="no"])
+    AC_ARG_WITH(libevent_libraries,
+            [  --with-libevent-libraries=DIR    libevent library directory],
+            [with_libevent_libraries="$withval"],[with_libevent_libraries="no"])
+
 # libhiredis
     AC_ARG_ENABLE(hiredis,
 	        AS_HELP_STRING([--enable-hiredis],[Enable Redis support]),
@@ -1854,6 +1862,7 @@
             [  --with-libhiredis-libraries=DIR    libhiredis library directory],
             [with_libhiredis_libraries="$withval"],[with_libhiredis_libraries="no"])
 
+    enable_hiredis_async="no"
     if test "$enable_hiredis" = "yes"; then
         if test "$with_libhiredis_includes" != "no"; then
             CPPFLAGS="${CPPFLAGS} -I${with_libhiredis_includes}"
@@ -1880,6 +1889,47 @@
         if test "$HIREDIS" = "yes"; then
             AC_DEFINE([HAVE_LIBHIREDIS],[1],[libhiredis available])
             enable_hiredis="yes"
+            #
+            # Check if async adapters and libevent is installed
+            #
+            AC_CHECK_HEADER("hiredis/adapters/libevent.h",HIREDIS_LIBEVENT_ADAPTER="yes",HIREDIS_LIBEVENT_ADAPTER="no")
+            if test "$HIREDIS_LIBEVENT_ADAPTER" = "yes"; then
+                #Look for libevent headers
+                if test "$with_libevent_includes" != "no"; then
+                    CPPFLAGS="${CPPFLAGS} -I${with_libevent_includes}"
+                fi
+                AC_CHECK_HEADER("event.h",LIBEVENT="yes",LIBEVENT="no")
+                if test "$LIBEVENT" = "yes"; then
+                    if test "$with_libevent_libraries" != "no"; then
+                        LDFLAGS="${LDFLAGS}  -L${with_libevent_libraries}"
+                    fi
+                    AC_CHECK_LIB(event, event_base_free,, HAVE_LIBEVENT="no")
+                    AC_CHECK_LIB(event_pthreads, evthread_use_pthreads,, HAVE_LIBEVENT_PTHREADS="no")
+                fi
+                if test "$HAVE_LIBEVENT" = "no" -o test "$HAVE_LIBEVENT_PTHREADS" = "no" ; then
+                    if test "$HAVE_LIBEVENT" = "no"; then
+                        echo
+                        echo "  Async mode for redis output will not be available."
+                        echo "  To enable it install libevent"
+                        echo
+                        echo "   Ubuntu: apt-get install libevent-dev"
+                        echo "   Fedora: dnf install event-devel"
+                        echo "   RHEL/CentOS: yum install event-devel"
+                        echo
+                   fi
+                   if test "$HAVE_LIBEVENT_PTHREADS" = "no"; then
+                        echo
+                        echo "  Async mode for redis output will not be available."
+                        echo "  To enable it install libevent with pthreads support"
+                        echo
+                        echo "   Ubuntu: apt-get install libevent-pthreads-2.0-5"
+                        echo
+                   fi
+                else
+                    AC_DEFINE([HAVE_LIBEVENT],[1],[libevent available])
+                    enable_hiredis_async="yes"
+                fi
+            fi
         fi
     fi
 
@@ -2012,6 +2062,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   libnspr support:                         ${enable_nspr}
   libjansson support:                      ${enable_jansson}
   hiredis support:                         ${enable_hiredis}
+  hiredis async with libevent:             ${enable_hiredis_async}
   Prelude support:                         ${enable_prelude}
   PCRE jit:                                ${pcre_jit_available}
   LUA support:                             ${enable_lua}

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -267,6 +267,7 @@ integration with 3rd party tools like logstash.
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list (default), channel
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every

--- a/doc/userguide/install.rst
+++ b/doc/userguide/install.rst
@@ -69,7 +69,7 @@ The following tools are required:
 
 For full features, also add:
 
-  libjansson, libnss, libgeoip, liblua5.1, libhiredis
+  libjansson, libnss, libgeoip, liblua5.1, libhiredis, libevent
 
 Ubuntu/Debian
 """""""""""""
@@ -85,7 +85,7 @@ Recommended::
     apt-get install libpcre3 libpcre3-dbg libpcre3-dev build-essential libpcap-dev   \
                     libnet1-dev libyaml-0-2 libyaml-dev pkg-config zlib1g zlib1g-dev \
                     libcap-ng-dev libcap-ng0 make libmagic-dev libjansson-dev        \
-                    libnss3-dev libgeoip-dev liblua5.1-dev libhiredis-dev
+                    libnss3-dev libgeoip-dev liblua5.1-dev libhiredis-dev libevent-dev
 
 Extra for iptables/nftables IPS integration::
 

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -24,6 +24,7 @@ The most common way to use this is through 'EVE', which is a firehose approach w
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list (default), channel
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
@@ -134,6 +135,7 @@ Output types::
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list (default), channel
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -384,6 +384,7 @@ util-ioctl.h util-ioctl.c \
 util-ip.h util-ip.c \
 util-logopenfile.h util-logopenfile.c \
 util-logopenfile-tile.h util-logopenfile-tile.c \
+util-logopenfile-redis.h util-logopenfile-redis.c \
 util-lua.c util-lua.h \
 util-luajit.c util-luajit.h \
 util-lua-common.c util-lua-common.h \

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -56,6 +56,7 @@
 #include "util-optimize.h"
 #include "util-buffer.h"
 #include "util-logopenfile.h"
+#include "util-logopenfile-redis.h"
 #include "util-device.h"
 
 #include "flow-var.h"

--- a/src/output.c
+++ b/src/output.c
@@ -72,6 +72,10 @@
 #include "output-json-dnp3.h"
 #include "output-json-vars.h"
 
+#ifdef HAVE_LIBEVENT_PTHREADS
+#include <event2/thread.h>
+#endif /* HAVE_LIBEVENT_PTHREADS */
+
 typedef struct RootLogger_ {
     ThreadInitFunc ThreadInit;
     ThreadDeinitFunc ThreadDeinit;
@@ -1002,8 +1006,16 @@ void OutputRegisterRootLogger(ThreadInitFunc ThreadInit,
     TAILQ_INSERT_TAIL(&RootLoggers, logger, entries);
 }
 
+//XXX FIXME  - What the best place and names for this
+void OutputLibEventUsePthreads() {
+#ifdef HAVE_LIBEVENT_PTHREADS
+    evthread_use_pthreads();
+#endif
+}
+
 void TmModuleLoggerRegister(void)
 {
+    OutputLibEventUsePthreads();
     OutputRegisterRootLoggers();
     OutputRegisterLoggers();
 }

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -336,6 +336,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_NO_MAGIC_SUPPORT);
         CASE_CODE (SC_ERR_REDIS);
         CASE_CODE (SC_ERR_VAR_LIMIT);
+        CASE_CODE (SC_ERR_NO_LIBEVENT);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -326,6 +326,7 @@ typedef enum {
     SC_ERR_NO_MAGIC_SUPPORT,
     SC_ERR_REDIS,
     SC_ERR_VAR_LIMIT,
+    SC_ERR_NO_LIBEVENT
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-logopenfile-redis.c
+++ b/src/util-logopenfile-redis.c
@@ -162,24 +162,24 @@ static int SCConfLogReopenRedis(LogFileCtx *log_ctx)
         SCMutexLock(&async_connect_mutex);
         ctx->async = redisAsyncConnect(redis_server, redis_port);
         SCMutexUnlock(&async_connect_mutex);
-        if (ctx->sync == NULL) {
+        if (ctx->async == NULL) {
             SCLogError(SC_ERR_SOCKET, "Error connecting to redis server.");
             log_ctx->redis_setup.tried = time(NULL);
             return -1;
         }
-        if (ctx->async != NULL && ctx->async->err) {
+        if (ctx->async->err) {
             SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: [%s]", ctx->async->errstr);
             redisAsyncFree(ctx->async);
             ctx->async = NULL;
             log_ctx->redis_setup.tried = time(NULL);
             return -1;
         }
-        if (ctx->async != NULL)  {
-            redisLibeventAttach(ctx->async,ctx->ev_base);
-            redisAsyncSetConnectCallback(ctx->async,RedisConnectCallback);
-            redisAsyncSetDisconnectCallback(ctx->async,RedisDisconnectCallback);
-            redisAsyncHandleWrite(ctx->async);
-        }
+
+        redisLibeventAttach(ctx->async,ctx->ev_base);
+        redisAsyncSetConnectCallback(ctx->async,RedisConnectCallback);
+        redisAsyncSetDisconnectCallback(ctx->async,RedisDisconnectCallback);
+        redisAsyncHandleWrite(ctx->async);
+
     } else
 #endif
     {

--- a/src/util-logopenfile-redis.c
+++ b/src/util-logopenfile-redis.c
@@ -1,0 +1,455 @@
+/* vi: set et ts=4: */
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Paulo Pacheco <fooinha@gmail.com>
+ *
+ * File-like output for logging:  redis
+ */
+#include "suricata-common.h" /* errno.h, string.h, etc. */
+#include "util-logopenfile-redis.h"
+#include "util-logopenfile.h"
+
+#ifdef HAVE_LIBHIREDIS
+
+#ifdef HAVE_LIBEVENT
+#include <hiredis/adapters/libevent.h>
+#endif /* HAVE_LIBEVENT */
+
+const char * redis_push_cmd = "LPUSH";
+const char * redis_publish_cmd = "PUBLISH";
+
+/** \brief SCLogRedisContextAlloc() - Allocates and initalizes redis context
+ *  \param async indicates that async mode will be used
+ *  \retval SCLogRedisContext * pointer if succesful, EXIT_FAILURE program if not
+ */
+static SCLogRedisContext * SCLogRedisContextAlloc(int async)
+{
+    SCLogRedisContext* ctx = (SCLogRedisContext*) SCMalloc(sizeof(SCLogRedisContext));
+    if (unlikely(ctx == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis context");
+        exit(EXIT_FAILURE);
+    }
+    ctx->sync = NULL;
+#if HAVE_LIBEVENT
+    ctx->ev_base = NULL;
+    ctx->async   = NULL;
+    if (async) {
+        ctx->ev_base = event_base_new();
+        if (unlikely(ctx->ev_base == NULL)) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis async event base");
+            exit(EXIT_FAILURE);
+        }
+    }
+#endif
+    return ctx;
+}
+
+/** \brief SCLogRedisContextFree() free redis context
+ *  \param async indicates that async mode was used
+ */
+void SCLogRedisContextFree(SCLogRedisContext *ctx, int async)
+{
+    if (ctx == NULL) {
+        return;
+    }
+#if HAVE_LIBEVENT
+    if (async) {
+        if (ctx->ev_base != NULL) {
+            event_base_free(ctx->ev_base);
+        }
+    }
+#endif
+    SCFree(ctx);
+}
+
+static int SCConfLogReopenRedis(LogFileCtx *log_ctx);
+
+#if HAVE_LIBEVENT
+
+#if HIREDIS_MAJOR == 0 && HIREDIS_MINOR < 11
+
+/** \brief RedisConnectCallback() Closes redis log more
+ *  \param c redis async context
+ */
+void RedisConnectCallback(const redisAsyncContext *c)
+{
+	SCLogInfo("Connected to redis server.");
+}
+#else
+
+/** \brief RedisConnectCallback() Closes redis log more
+ *  \param c redis async context
+ *  \param status status reported by async caller
+ */
+void RedisConnectCallback(const redisAsyncContext *c, int status)
+{
+	SCLogInfo("Connected to redis server. Status [%d]", status);
+}
+
+#endif // HIREDIS_MAJOR == 0 && HIREDIS_MINOR < 11
+
+/** \brief RedisDisconnectCallback() Callback when disconnection from redis happens.
+ *  \param c redis async context
+ *  \param status status reported by async caller
+ */
+void RedisDisconnectCallback(const redisAsyncContext *c, int status)
+{
+	SCLogInfo("Disconnected from redis server. Status [%d]", status);
+}
+
+
+/** \brief SCRedisAsyncCommandCallback() Callback when reply from redis happens.
+ *  \param c redis async context
+ *  \param r redis reply
+ *  \param privvata opaque datq with pointer to LogFileCtx
+ */
+static void SCRedisAsyncCommandCallback (redisAsyncContext *async, void *r, void *privdata)
+{
+    LogFileCtx *file_ctx = privdata;
+    redisReply *reply = r;
+    /* Disconnection or lost reply may have happened */
+    if (reply == NULL) {
+        SCConfLogReopenRedis(file_ctx);
+    }
+}
+
+#endif // HAVE_LIBEVENT
+
+/** \brief SCConfLogReopenRedis() Open or re-opens connection to redis for logging.
+ *  \param log_ctx Log file context allocated by caller
+ */
+static int SCConfLogReopenRedis(LogFileCtx *log_ctx)
+{
+	/* only try to reconnect once per second */
+	if (log_ctx->redis_setup.tried >= time(NULL)) {
+		return -1;
+	}
+	SCLogRedisContext * ctx = log_ctx->redis;
+	const char *redis_server = log_ctx->redis_setup.server;
+	int redis_port = log_ctx->redis_setup.port;
+#if HAVE_LIBEVENT
+    /* ASYNC */
+    if (log_ctx->redis_setup.async) {
+        if (ctx->ev_base != NULL) {
+            event_base_loopbreak(ctx->ev_base);
+        }
+        if (ctx->async != NULL)  {
+            redisAsyncFree(ctx->async);
+        }
+        ctx->async = redisAsyncConnect(redis_server, redis_port);
+        if ( ctx->async != NULL && ctx->async->err) {
+            SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: [%s]", ctx->async->errstr);
+            redisAsyncFree(ctx->async);
+            ctx->async = NULL;
+            log_ctx->redis_setup.tried = time(NULL);
+            return -1;
+        }
+        if (ctx->async != NULL)  {
+            redisLibeventAttach(ctx->async,ctx->ev_base);
+            redisAsyncSetConnectCallback(ctx->async,RedisConnectCallback);
+            redisAsyncSetDisconnectCallback(ctx->async,RedisDisconnectCallback);
+            redisAsyncHandleWrite(ctx->async);
+        }
+    } else
+#endif
+	{
+        /* SYNCHRONOUS */
+        if (ctx->sync != NULL)  {
+            redisFree(ctx->sync);
+        }
+        ctx->sync = redisConnect(redis_server, redis_port);
+        if (ctx->sync != NULL && ctx->sync->err) {
+            SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: [%s]", ctx->sync->errstr);
+            redisFree(ctx->sync);
+            ctx->sync = NULL;
+            log_ctx->redis_setup.tried = time(NULL);
+            return -1;
+        }
+    }
+    log_ctx->redis = ctx;
+    log_ctx->redis_setup.tried = 0;
+    log_ctx->redis_setup.batch_count = 0;
+    return 0;
+}
+
+/** \brief SCLogFileCloseRedis() Closes redis log more
+ *  \param log_ctx Log file context allocated by caller
+ */
+static void SCLogFileCloseRedis(LogFileCtx *log_ctx)
+{
+    SCLogRedisContext * ctx = log_ctx->redis;
+    if ( ctx == NULL) {
+        return;
+    }
+    /* asynchronous */
+    if (log_ctx->redis_setup.async) {
+#if HAVE_LIBEVENT == 1
+        if (ctx->async != NULL) {
+            redisAsyncFree(ctx->async);
+        }
+        if (ctx->ev_base) {
+            event_base_loopbreak(ctx->ev_base);
+        }
+        ctx->async = NULL;
+#endif
+    } else {
+        /* synchronous */
+        if (ctx->sync) {
+            redisReply *reply;
+            int i;
+            for (i = 0; i < log_ctx->redis_setup.batch_count; i++) {
+                redisGetReply(ctx->sync, (void **)&reply);
+                if (reply)
+                    freeReplyObject(reply);
+            }
+            redisFree(ctx->sync);
+            ctx->sync = NULL;
+        }
+        log_ctx->redis_setup.tried = 0;
+        log_ctx->redis_setup.batch_count = 0;
+    }
+}
+
+/** \brief configure and initializes redis output logging
+ *  \param conf ConfNode structure for the output section in question
+ *  \param log_ctx Log file context allocated by caller
+ *  \retval 0 on success
+ */
+int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
+{
+    LogFileCtx *log_ctx = lf_ctx;
+
+    const char *redis_server = NULL;
+    const char *redis_port = NULL;
+    const char *redis_mode = NULL;
+    const char *redis_key = NULL;
+    int async = 0;
+
+    if (redis_node) {
+        redis_server = ConfNodeLookupChildValue(redis_node, "server");
+        redis_port =  ConfNodeLookupChildValue(redis_node, "port");
+        redis_mode =  ConfNodeLookupChildValue(redis_node, "mode");
+        redis_key =  ConfNodeLookupChildValue(redis_node, "key");
+    }
+    if (!redis_server) {
+        redis_server = "127.0.0.1";
+        SCLogInfo("Using default redis server (127.0.0.1)");
+    }
+    if (!redis_port)
+        redis_port = "6379";
+    if (!redis_mode)
+        redis_mode = "list";
+    if (!redis_key)
+        redis_key = "suricata";
+    log_ctx->redis_setup.key = SCStrdup(redis_key);
+    ConfGetChildValueBool(redis_node, "async", &async);
+    log_ctx->redis_setup.async = async;
+#ifndef HAVE_LIBEVENT 
+    if (async) {
+        SCLogWarning(SC_ERR_NO_LIBEVENT, "async option not available.");
+    }
+    log_ctx->redis_setup.async = 0;
+#endif //ifndef HAVE_LIBEVENT
+    if (!log_ctx->redis_setup.key) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key name");
+        exit(EXIT_FAILURE);
+    }
+    log_ctx->redis_setup.batch_size = 0;
+    ConfNode *pipelining = ConfNodeLookupChild(redis_node, "pipelining");
+    if (pipelining) {
+        int enabled = 0;
+        int ret;
+        intmax_t val;
+        ret = ConfGetChildValueBool(pipelining, "enabled", &enabled);
+        if (ret && enabled) {
+            ret = ConfGetChildValueInt(pipelining, "batch-size", &val);
+            if (ret) {
+                log_ctx->redis_setup.batch_size = val;
+            } else {
+                log_ctx->redis_setup.batch_size = 10;
+            }
+        }
+    }
+    if (!strcmp(redis_mode, "list")) {
+        log_ctx->redis_setup.command = redis_push_cmd;
+        if (!log_ctx->redis_setup.command) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        log_ctx->redis_setup.command = redis_publish_cmd;
+        if (!log_ctx->redis_setup.command) {
+            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
+            exit(EXIT_FAILURE);
+        }
+    }
+    /* store server params for reconnection */
+    log_ctx->redis_setup.server = SCStrdup(redis_server);
+    if (!log_ctx->redis_setup.server) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");
+        exit(EXIT_FAILURE);
+    }
+    log_ctx->redis_setup.port = atoi(redis_port);
+    log_ctx->redis_setup.tried = 0;
+    log_ctx->redis = SCLogRedisContextAlloc(async);
+    SCConfLogReopenRedis(log_ctx);
+    log_ctx->Close = SCLogFileCloseRedis;
+
+    return 0;
+}
+
+/** \brief SCLogRedisWriteAsync() writes string to redis output in async mode
+ *  \param file_ctx Log file context allocated by caller
+ *  \param string Buffer to output
+ */
+static void SCLogRedisWriteAsync(LogFileCtx *file_ctx, const char *string)
+{
+    SCLogRedisContext * ctx = file_ctx->redis;
+    redisAsyncContext * redis_async = ctx->async;
+
+    if (unlikely(redis_async == NULL)) {
+        return;
+    }
+
+    redisAsyncCommand(redis_async,
+            SCRedisAsyncCommandCallback,
+            file_ctx,
+            "%s %s %s",
+            file_ctx->redis_setup.command,
+            file_ctx->redis_setup.key,
+            string);
+
+    event_base_loop(ctx->ev_base, EVLOOP_NONBLOCK);
+}
+
+/** \brief SCLogRedisWriteSync() writes string to redis output in sync mode
+ *  \param file_ctx Log file context allocated by caller
+ *  \param string Buffer to output
+ */
+static void SCLogRedisWriteSync(LogFileCtx *file_ctx, const char *string)
+{
+    SCLogRedisContext * ctx = file_ctx->redis;
+    redisContext *redis = ctx->sync;
+    if (unlikely(redis == NULL)) {
+        SCConfLogReopenRedis(file_ctx);
+    }
+    /* synchronous mode */
+    if (file_ctx->redis_setup.batch_size) {
+        redisAppendCommand(redis, "%s %s %s",
+                file_ctx->redis_setup.command,
+                file_ctx->redis_setup.key,
+                string);
+        if (file_ctx->redis_setup.batch_count == file_ctx->redis_setup.batch_size) {
+            redisReply *reply;
+            int i;
+            file_ctx->redis_setup.batch_count = 0;
+            for (i = 0; i <= file_ctx->redis_setup.batch_size; i++) {
+                if (redisGetReply(redis, (void **)&reply) == REDIS_OK) {
+                    freeReplyObject(reply);
+                } else {
+                    if (redis->err) {
+                        SCLogInfo("Error when fetching reply: %s (%d)",
+                                redis->errstr,
+                                redis->err);
+                    }
+                    switch (redis->err) {
+                        case REDIS_ERR_EOF:
+                        case REDIS_ERR_IO:
+                            SCLogInfo("Reopening connection to redis server");
+                            SCConfLogReopenRedis(file_ctx);
+                            if (file_ctx->redis) {
+                                SCLogInfo("Reconnected to redis server");
+                                return;
+                            } else {
+                                SCLogInfo("Unable to reconnect to redis server");
+                                return;
+                            }
+                            break;
+                        default:
+                            SCLogWarning(SC_ERR_INVALID_VALUE,
+                                    "Unsupported error code %d",
+                                    redis->err);
+                            return;
+                    }
+                }
+            }
+        } else {
+            file_ctx->redis_setup.batch_count++;
+        }
+    } else {
+        redisReply *reply = redisCommand(redis, "%s %s %b",
+                file_ctx->redis_setup.command,
+                file_ctx->redis_setup.key,
+                string);
+        /* We may lose the reply if disconnection happens*/
+        if (reply) {
+            switch (reply->type) {
+                case REDIS_REPLY_ERROR:
+                    SCLogWarning(SC_ERR_SOCKET, "Redis error: %s", reply->str);
+                    SCConfLogReopenRedis(file_ctx);
+                    break;
+                case REDIS_REPLY_INTEGER:
+                    SCLogDebug("Redis integer %lld", reply->integer);
+                    break;
+                default:
+                    SCLogError(SC_ERR_INVALID_VALUE,
+                            "Redis default triggered with %d", reply->type);
+                    SCConfLogReopenRedis(file_ctx);
+                    break;
+            }
+            freeReplyObject(reply);
+        } else {
+            SCConfLogReopenRedis(file_ctx);
+        }
+    }
+}
+
+/**
+ * \brief LogFileWriteRedis() writes log data to redis output.
+ * \param log_ctx Log file context allocated by caller
+ * \param string buffer with data to write
+ * \param string_len data length
+ * \retval 0 on sucess;
+ * \retval -1 on failure;
+ */
+int LogFileWriteRedis(void *lf_ctx, const char *string, size_t string_len)
+{
+    LogFileCtx *file_ctx = lf_ctx;
+    if (file_ctx->redis == NULL) {
+        SCConfLogReopenRedis(file_ctx);
+        if (file_ctx->redis == NULL) {
+            return -1;
+        } else {
+            SCLogInfo("Reconnected to redis server");
+        }
+    }
+#if HAVE_LIBEVENT
+    /* async mode on */
+    if (file_ctx->redis_setup.async) {
+        SCLogRedisWriteAsync(file_ctx, string);
+        return 0;
+    }
+#endif
+    /* sync mode */
+    SCLogRedisWriteSync(file_ctx, string);
+    return 0;
+}
+#endif //#ifdef HAVE_LIBHIREDIS

--- a/src/util-logopenfile-redis.h
+++ b/src/util-logopenfile-redis.h
@@ -1,0 +1,65 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Paulo Pacheco <fooinha@gmail.com>
+ */
+
+#ifndef __UTIL_LOGOPENFILE_REDIS_H__
+#define __UTIL_LOGOPENFILE_REDIS_H__
+
+#ifdef HAVE_LIBHIREDIS
+#include <hiredis/hiredis.h>
+
+#ifdef HAVE_LIBEVENT
+#include <hiredis/async.h>
+#endif /* HAVE_LIBEVENT */
+
+#include "conf.h"            /* ConfNode   */
+
+enum RedisMode { REDIS_LIST, REDIS_CHANNEL };
+
+typedef struct RedisSetup_ {
+    enum RedisMode mode;
+    const char *command;
+    char *key;
+    int  batch_size;
+    int  batch_count;
+    char *server;
+    int  port;
+    time_t tried;
+    int async;
+} RedisSetup;
+
+typedef struct SCLogRedisContext_ {
+       redisContext *sync;
+
+#if HAVE_LIBEVENT
+       redisAsyncContext *async;
+       struct event_base *ev_base;
+#endif /* HAVE_LIBEVENT */
+
+} SCLogRedisContext;
+
+int SCConfLogOpenRedis(ConfNode *, void *);
+int LogFileWriteRedis(void *, const char *, size_t);
+void SCLogRedisContextFree(SCLogRedisContext *, int);
+
+#endif /* HAVE_LIBHIREDIS */
+#endif /* __UTIL_LOGOPENFILE_REDIS_H__ */

--- a/src/util-logopenfile-redis.h
+++ b/src/util-logopenfile-redis.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2016 Open Information Security Foundation
+/* Copyright (C) 2016 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -48,13 +48,11 @@ typedef struct RedisSetup_ {
 } RedisSetup;
 
 typedef struct SCLogRedisContext_ {
-       redisContext *sync;
-
+    redisContext *sync;
 #if HAVE_LIBEVENT
-       redisAsyncContext *async;
-       struct event_base *ev_base;
+    redisAsyncContext *async;
+    struct event_base *ev_base;
 #endif /* HAVE_LIBEVENT */
-
 } SCLogRedisContext;
 
 int SCConfLogOpenRedis(ConfNode *, void *);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -436,7 +436,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
     else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
         SCMutexLock(&file_ctx->fp_mutex);
         LogFileWriteRedis(file_ctx, (const char *)MEMBUFFER_BUFFER(buffer),
-                          MEMBUFFER_OFFSET(buffer));
+                MEMBUFFER_OFFSET(buffer));
         SCMutexUnlock(&file_ctx->fp_mutex);
     }
 #endif

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -34,8 +34,9 @@
 #include "util-logopenfile.h"
 #include "util-logopenfile-tile.h"
 
-const char * redis_push_cmd = "LPUSH";
-const char * redis_publish_cmd = "PUBLISH";
+#ifdef HAVE_LIBHIREDIS
+#include "util-logopenfile-redis.h"
+#endif /* HAVE_LIBHIREDIS */
 
 /** \brief connect to the indicated local stream socket, logging any errors
  *  \param path filesystem path to connect to
@@ -194,7 +195,7 @@ static PcieFile *SCLogOpenPcieFp(LogFileCtx *log_ctx, const char *path,
                                  const char *append_setting)
 {
 #ifndef __tile__
-    SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY, 
+    SCLogError(SC_ERR_INVALID_YAML_CONF_ENTRY,
                "PCIe logging only supported on Tile-Gx Architecture.");
     return NULL;
 #else
@@ -342,138 +343,6 @@ int SCConfLogReopen(LogFileCtx *log_ctx)
     return 0;
 }
 
-
-#ifdef HAVE_LIBHIREDIS
-
-static void SCLogFileCloseRedis(LogFileCtx *log_ctx)
-{
-    if (log_ctx->redis) {
-        redisReply *reply;
-        int i;
-        for (i = 0; i < log_ctx->redis_setup.batch_count; i++) {
-            redisGetReply(log_ctx->redis, (void **)&reply);
-            if (reply)
-                freeReplyObject(reply);
-        }
-        redisFree(log_ctx->redis);
-        log_ctx->redis = NULL;
-    }
-    log_ctx->redis_setup.tried = 0;
-    log_ctx->redis_setup.batch_count = 0;
-}
-
-int SCConfLogOpenRedis(ConfNode *redis_node, LogFileCtx *log_ctx)
-{
-    const char *redis_server = NULL;
-    const char *redis_port = NULL;
-    const char *redis_mode = NULL;
-    const char *redis_key = NULL;
-
-    if (redis_node) {
-        redis_server = ConfNodeLookupChildValue(redis_node, "server");
-        redis_port =  ConfNodeLookupChildValue(redis_node, "port");
-        redis_mode =  ConfNodeLookupChildValue(redis_node, "mode");
-        redis_key =  ConfNodeLookupChildValue(redis_node, "key");
-    }
-    if (!redis_server) {
-        redis_server = "127.0.0.1";
-        SCLogInfo("Using default redis server (127.0.0.1)");
-    }
-    if (!redis_port)
-        redis_port = "6379";
-    if (!redis_mode)
-        redis_mode = "list";
-    if (!redis_key)
-        redis_key = "suricata";
-    log_ctx->redis_setup.key = SCStrdup(redis_key);
-
-    if (!log_ctx->redis_setup.key) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key name");
-        exit(EXIT_FAILURE);
-    }
-
-    log_ctx->redis_setup.batch_size = 0;
-
-    ConfNode *pipelining = ConfNodeLookupChild(redis_node, "pipelining");
-    if (pipelining) {
-        int enabled = 0;
-        int ret;
-        intmax_t val;
-        ret = ConfGetChildValueBool(pipelining, "enabled", &enabled);
-        if (ret && enabled) {
-            ret = ConfGetChildValueInt(pipelining, "batch-size", &val);
-            if (ret) {
-                log_ctx->redis_setup.batch_size = val;
-            } else {
-                log_ctx->redis_setup.batch_size = 10;
-            }
-        }
-    }
-
-    if (!strcmp(redis_mode, "list")) {
-        log_ctx->redis_setup.command = redis_push_cmd;
-        if (!log_ctx->redis_setup.command) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
-            exit(EXIT_FAILURE);
-        }
-    } else {
-        log_ctx->redis_setup.command = redis_publish_cmd;
-        if (!log_ctx->redis_setup.command) {
-            SCLogError(SC_ERR_MEM_ALLOC, "Unable to allocate redis key command");
-            exit(EXIT_FAILURE);
-        }
-    }
-    redisContext *c = redisConnect(redis_server, atoi(redis_port));
-    if (c != NULL && c->err) {
-        SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s", c->errstr);
-        exit(EXIT_FAILURE);
-    }
-
-    /* store server params for reconnection */
-    log_ctx->redis_setup.server = SCStrdup(redis_server);
-    if (!log_ctx->redis_setup.server) {
-        SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");
-        exit(EXIT_FAILURE);
-    }
-    log_ctx->redis_setup.port = atoi(redis_port);
-    log_ctx->redis_setup.tried = 0;
-
-    log_ctx->redis = c;
-
-    log_ctx->Close = SCLogFileCloseRedis;
-
-    return 0;
-}
-
-int SCConfLogReopenRedis(LogFileCtx *log_ctx)
-{
-    if (log_ctx->redis != NULL) {
-        redisFree(log_ctx->redis);
-        log_ctx->redis = NULL;
-    }
-
-    /* only try to reconnect once per second */
-    if (log_ctx->redis_setup.tried >= time(NULL)) {
-        return -1;
-    }
-
-    redisContext *c = redisConnect(log_ctx->redis_setup.server, log_ctx->redis_setup.port);
-    if (c != NULL && c->err) {
-        if (log_ctx->redis_setup.tried == 0) {
-            SCLogError(SC_ERR_SOCKET, "Error connecting to redis server: %s\n", c->errstr);
-        }
-        redisFree(c);
-        log_ctx->redis_setup.tried = time(NULL);
-        return -1;
-    }
-    log_ctx->redis = c;
-    log_ctx->redis_setup.tried = 0;
-    log_ctx->redis_setup.batch_count = 0;
-    return 0;
-}
-
-#endif
-
 /** \brief LogFileNewCtx() Get a new LogFileCtx
  *  \retval LogFileCtx * pointer if succesful, NULL if error
  *  */
@@ -494,7 +363,7 @@ LogFileCtx *LogFileNewCtx(void)
 
 #ifdef HAVE_LIBHIREDIS
     lf_ctx->redis_setup.batch_count = 0;
-#endif
+#endif /* HAVE_LIBHIREDIS */
 
     return lf_ctx;
 }
@@ -517,12 +386,13 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
 
 #ifdef HAVE_LIBHIREDIS
     if (lf_ctx->type == LOGFILE_TYPE_REDIS) {
-        if (lf_ctx->redis)
-            redisFree(lf_ctx->redis);
         if (lf_ctx->redis_setup.server)
             SCFree(lf_ctx->redis_setup.server);
         if (lf_ctx->redis_setup.key)
             SCFree(lf_ctx->redis_setup.key);
+        if (lf_ctx->redis) {
+            SCLogRedisContextFree(lf_ctx->redis, lf_ctx->redis_setup.async);
+        }
     }
 #endif
 
@@ -546,91 +416,6 @@ int LogFileFreeCtx(LogFileCtx *lf_ctx)
     SCReturnInt(1);
 }
 
-#ifdef HAVE_LIBHIREDIS
-static int  LogFileWriteRedis(LogFileCtx *file_ctx, const char *string, size_t string_len)
-{
-    if (file_ctx->redis == NULL) {
-        SCConfLogReopenRedis(file_ctx);
-        if (file_ctx->redis == NULL) {
-            return -1;
-        } else {
-            SCLogInfo("Reconnected to redis server");
-        }
-    }
-    /* TODO go async here ? */
-    if (file_ctx->redis_setup.batch_size) {
-        redisAppendCommand(file_ctx->redis, "%s %s %s",
-                file_ctx->redis_setup.command,
-                file_ctx->redis_setup.key,
-                string);
-        if (file_ctx->redis_setup.batch_count == file_ctx->redis_setup.batch_size) {
-            redisReply *reply;
-            int i;
-            file_ctx->redis_setup.batch_count = 0;
-            for (i = 0; i <= file_ctx->redis_setup.batch_size; i++) {
-                if (redisGetReply(file_ctx->redis, (void **)&reply) == REDIS_OK) {
-                    freeReplyObject(reply);
-                } else {
-                    if (file_ctx->redis->err) {
-                        SCLogInfo("Error when fetching reply: %s (%d)",
-                                file_ctx->redis->errstr,
-                                file_ctx->redis->err);
-                    }
-                    switch (file_ctx->redis->err) {
-                        case REDIS_ERR_EOF:
-                        case REDIS_ERR_IO:
-                            SCLogInfo("Reopening connection to redis server");
-                            SCConfLogReopenRedis(file_ctx);
-                            if (file_ctx->redis) {
-                                SCLogInfo("Reconnected to redis server");
-                                return 0;
-                            } else {
-                                SCLogInfo("Unable to reconnect to redis server");
-                                return 0;
-                            }
-                            break;
-                        default:
-                            SCLogWarning(SC_ERR_INVALID_VALUE,
-                                    "Unsupported error code %d",
-                                    file_ctx->redis->err);
-                            return 0;
-                    }
-                }
-            }
-        } else {
-            file_ctx->redis_setup.batch_count++;
-        }
-    } else {
-        redisReply *reply = redisCommand(file_ctx->redis, "%s %s %b",
-                file_ctx->redis_setup.command,
-                file_ctx->redis_setup.key,
-                string, string_len);
-
-        /*  We may lose the reply if disconnection happens! */
-        if (reply) {
-            switch (reply->type) {
-                case REDIS_REPLY_ERROR:
-                    SCLogWarning(SC_ERR_SOCKET, "Redis error: %s", reply->str);
-                    SCConfLogReopenRedis(file_ctx);
-                    break;
-                case REDIS_REPLY_INTEGER:
-                    SCLogDebug("Redis integer %lld", reply->integer);
-                    break;
-                default:
-                    SCLogError(SC_ERR_INVALID_VALUE,
-                            "Redis default triggered with %d", reply->type);
-                    SCConfLogReopenRedis(file_ctx);
-                    break;
-            }
-            freeReplyObject(reply);
-        } else {
-            SCConfLogReopenRedis(file_ctx);
-        }
-    }
-    return 0;
-}
-#endif
-
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
 {
     if (file_ctx->type == LOGFILE_TYPE_SYSLOG) {
@@ -651,7 +436,7 @@ int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer)
     else if (file_ctx->type == LOGFILE_TYPE_REDIS) {
         SCMutexLock(&file_ctx->fp_mutex);
         LogFileWriteRedis(file_ctx, (const char *)MEMBUFFER_BUFFER(buffer),
-                MEMBUFFER_OFFSET(buffer));
+                          MEMBUFFER_OFFSET(buffer));
         SCMutexUnlock(&file_ctx->fp_mutex);
     }
 #endif

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -29,8 +29,9 @@
 #include "util-buffer.h"
 
 #ifdef HAVE_LIBHIREDIS
-#include "hiredis/hiredis.h"
-#endif
+#include "util-logopenfile-redis.h"
+#endif /* HAVE_LIBHIREDIS */
+
 
 typedef struct {
     uint16_t fileno;
@@ -46,20 +47,6 @@ typedef struct SyslogSetup_ {
     int alert_syslog_level;
 } SyslogSetup;
 
-#ifdef HAVE_LIBHIREDIS
-enum RedisMode { REDIS_LIST, REDIS_CHANNEL };
-
-typedef struct RedisSetup_ {
-    enum RedisMode mode;
-    const char *command;
-    char *key;
-    int  batch_size;
-    int  batch_count;
-    char *server;
-    int  port;
-    time_t tried;
-} RedisSetup;
-#endif
 
 /** Global structure for Output Context */
 typedef struct LogFileCtx_ {
@@ -67,7 +54,7 @@ typedef struct LogFileCtx_ {
         FILE *fp;
         PcieFile *pcie_fp;
 #ifdef HAVE_LIBHIREDIS
-        redisContext *redis;
+        void *redis;
 #endif
     };
 
@@ -134,7 +121,6 @@ int LogFileFreeCtx(LogFileCtx *);
 int LogFileWrite(LogFileCtx *file_ctx, MemBuffer *buffer);
 
 int SCConfLogOpenGeneric(ConfNode *conf, LogFileCtx *, const char *, int);
-int SCConfLogOpenRedis(ConfNode *conf, LogFileCtx *log_ctx);
 int SCConfLogReopen(LogFileCtx *);
 
 #endif /* __UTIL_LOGOPENFILE_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -148,6 +148,7 @@ outputs:
       #redis:
       #  server: 127.0.0.1
       #  port: 6379
+      #  async: true ## if redis replies are read asynchronously
       #  mode: list ## possible values: list (default), channel
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every


### PR DESCRIPTION
Initial support for reading redis replies asynchronously.
The libevent adapter for the hiredis async API is used.

Command batch pipelining for the async: true mode is also implemented.

If each reply was 7 bytes with a batch of 10 commands ... we get 70 bytes at Recv.

```
State      Recv-Q Send-Q Local Address:Port                 Peer Address:Port
ESTAB      70      0      10.10.10.3:53560                10.10.10.4:6379
```

The next write will triggers a read for all replies from socket.

Thanx @regit for review.

Replaces #2362, #2369, #2379.
It is merged with dependent PR #2377.

Thanx
