### PR TITLE
fast-pattern: 38 arguments in call to SigMatchGetLastSMFromLists - v1

### DIFF
--- a/src/detect-fast-pattern.c
+++ b/src/detect-fast-pattern.c
@@ -194,7 +194,7 @@ static int DetectFastPatternSetup(DetectEngineCtx *de_ctx, Signature *s, char *a
         return -1;
     }
 
-    SigMatch *pm = SigMatchGetLastSMFromLists(s, 28,
+    SigMatch *pm = SigMatchGetLastSMFromLists(s, 38,
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_PMATCH],
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_UMATCH],
             DETECT_CONTENT, s->sm_lists_tail[DETECT_SM_LIST_HCBDMATCH],


### PR DESCRIPTION
Was preventing fast_pattern from being applied to tls_sni:
https://redmine.openinfosecfoundation.org/issues/1936

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/34
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/384
