### PR TITLE
FTP: adds patterns from server to client

### DIFF
--- a/src/app-layer-ftp.c
+++ b/src/app-layer-ftp.c
@@ -329,6 +329,16 @@ static int FTPRegisterPatternsForProtocolDetection(void)
     {
         return -1;
     }
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_FTP,
+                                               "220 ", 4, 0, STREAM_TOCLIENT) < 0)
+    {
+        return -1;
+    }
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_FTP,
+                                               "331 ", 4, 0, STREAM_TOCLIENT) < 0)
+    {
+        return -1;
+    }
 
     return 0;
 }


### PR DESCRIPTION
Without registering server side patterns the flow stats for
FTP can't be incremented, and the app-layer FTP stats were always 0.