### PR TITLE
luaL_newstate maybe null in mac osx

### DIFF
--- a/src/output-lua.c
+++ b/src/output-lua.c
@@ -522,8 +522,10 @@ static int LuaScriptInit(const char *filename, LogLuaScriptOptions *options) {
     int status;
 
     lua_State *luastate = luaL_newstate();
-    if (luastate == NULL)
+    if (luastate == NULL){
+        SCLogError(SC_ERR_LUA_ERROR, "function luaL_newstate is NULL: %s", lua_tostring(luastate, -1));
         goto error;
+    }
     luaL_openlibs(luastate);
 
     /* hackish, needed to allow unittests to pass buffers as scripts instead of files */


### PR DESCRIPTION
show info when call luaL_newstate fail. 
the error  often happen on mac osx when luajit link without "-pagezero_size 10000 -image_base 100000000"