### PR TITLE
Issue 1924 - dns malformed response - v1

### DIFF
--- a/rules/dns-events.rules
+++ b/rules/dns-events.rules
@@ -1,8 +1,8 @@
 # Response (answer) we didn't see a Request for. Could be packet loss.
-alert dns any any -> any any (msg:"SURICATA DNS Unsollicited response"; flow:to_client; app-layer-event:dns.unsollicited_response; sid:2240001; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS Unsolicited response"; flow:to_client; app-layer-event:dns.unsollicited_response; sid:2240001; rev:1;)
 # Malformed data in request. Malformed means length fields are wrong, etc.
-alert dns any any -> any any (msg:"SURICATA DNS malformed request data"; flow:to_client; app-layer-event:dns.malformed_data; sid:2240002; rev:1;)
-alert dns any any -> any any (msg:"SURICATA DNS malformed response data"; flow:to_server; app-layer-event:dns.malformed_data; sid:2240003; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS malformed request data"; flow:to_server; app-layer-event:dns.malformed_data; sid:2240002; rev:1;)
+alert dns any any -> any any (msg:"SURICATA DNS malformed response data"; flow:to_client; app-layer-event:dns.malformed_data; sid:2240003; rev:1;)
 # Response flag set on to_server packet
 alert dns any any -> any any (msg:"SURICATA DNS Not a request"; flow:to_server; app-layer-event:dns.not_a_request; sid:2240004; rev:1;)
 # Response flag not set on to_client packet

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -833,6 +833,7 @@ const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_
     }
 
     const DNSAnswerHeader *head = (DNSAnswerHeader *)data;
+    uint16_t datalen = ntohs(head->len);
 
     data += sizeof(DNSAnswerHeader);
 
@@ -848,7 +849,7 @@ const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_
     switch (ntohs(head->type)) {
         case DNS_RECORD_TYPE_A:
         {
-            if (ntohs(head->len) == 4) {
+            if (datalen == 0 || datalen == 4) {
                 //PrintRawDataFp(stdout, data, ntohs(head->len));
                 //char a[16];
                 //PrintInet(AF_INET, (const void *)data, a, sizeof(a));
@@ -862,12 +863,12 @@ const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_
                 goto bad_data;
             }
 
-            data += ntohs(head->len);
+            data += datalen;
             break;
         }
         case DNS_RECORD_TYPE_AAAA:
         {
-            if (ntohs(head->len) == 16) {
+            if (datalen == 0 || datalen == 16) {
                 //char a[46];
                 //PrintInet(AF_INET6, (const void *)data, a, sizeof(a));
                 //SCLogInfo("AAAA %s TTL %u", a, ntohl(head->ttl));
@@ -880,7 +881,7 @@ const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_
                 goto bad_data;
             }
 
-            data += ntohs(head->len);
+            data += datalen;
             break;
         }
         case DNS_RECORD_TYPE_MX:


### PR DESCRIPTION
Fix issue https://redmine.openinfosecfoundation.org/issues/1924

Allow DNS messages with a data length of 0 without marking them as malformed.

Also fixes the direction on the malformed rules.

Prscript:
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/392
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/40
