### PR TITLE
issue 1938 - suricata log rotation - v1

### DIFF
--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -689,7 +689,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
     iface_ctx->iface = SC_LOG_OP_IFACE_FILE;
     iface_ctx->type = type;
 
-    if ( (iface_ctx->file_d = fopen(file, "w+")) == NULL) {
+    if ( (iface_ctx->file_d = fopen(file, "a")) == NULL) {
         printf("Error opening file %s\n", file);
         goto error;
     }

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -127,6 +127,9 @@ typedef struct SCLogOPIfaceCtx_ {
     /* the output file descriptor for the above file */
     FILE * file_d;
 
+    /* registered to be set on a file rotation signal */
+    int rotation_flag;
+
     /* the facility code if the interface is SC_LOG_IFACE_SYSLOG */
     int facility;
 


### PR DESCRIPTION
Apply SIGHUP based log rotation to the application log.

Addresses issue 1938:
https://redmine.openinfosecfoundation.org/issues/1938

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/43
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/395