### PR TITLE
RFC: Prototype for extracting files and metadata to Redis.

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -1,4 +1,5 @@
 /* Copyright (C) 2007-2012 Open Information Security Foundation
+ * Copyright (C) 2016 Lockheed Martin Corporation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -41,6 +42,11 @@
  *         regardless of the rules.
  */
 static int g_file_force_filestore = 0;
+
+/** \brief switch to store files to Redis instead
+ *         of disk.
+ */
+static int g_file_store_redis = 0;
 
 /** \brief switch to force magic checks on all files
  *         regardless of the rules.
@@ -88,6 +94,16 @@ void FileForceFilestoreEnable(void)
 void FileForceMagicEnable(void)
 {
     g_file_force_magic = 1;
+}
+
+void FileStoreRedisEnable(void)
+{
+    g_file_store_redis = 1;
+}
+
+int FileStoreRedis(void)
+{
+    return g_file_store_redis;
 }
 
 void FileForceMd5Enable(void)

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -1,4 +1,5 @@
 /* Copyright (C) 2007-2011 Open Information Security Foundation
+ * Copyright (C) 2016 Lockheed Martin Corporation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -188,6 +189,8 @@ uint32_t FileReassemblyDepth(void);
 void FileDisableMagic(Flow *f, uint8_t);
 void FileForceMagicEnable(void);
 int FileForceMagic(void);
+void FileStoreRedisEnable(void);
+int FileStoreRedis(void);
 
 void FileDisableMd5(Flow *f, uint8_t);
 void FileForceMd5Enable(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -406,6 +406,7 @@ outputs:
   # - rules that contain the "filestore" keyword.
   - file-store:
       enabled: no       # set to yes to enable
+      #store-redis: no  # enable to extract files and metadata to redis instead of disk
       log-dir: files    # directory to store the files
       force-magic: no   # force logging magic on all stored files
       # force logging of checksums, available hash functions are md5,


### PR DESCRIPTION
Please review proof of concept and provide feedback. This is something that is a priority for us, so I'm happy to continue developing this feature to completion.

NOTES:
- This has only really been tested with forced extraction on all files - I ran into some issues getting the HTTP request/response headers when using the filestore keyword with signatures - I may have missed something silly though
 - There's certainly opportunities for improvement with constructing the metadata. In the prototype, I was partially experimenting with how I could extract HTTP header fields from the libHTP APIs. Ultimately, we'd at least like to see raw request/response headers, TCP quad, direction (request or response). Other folks might appreciate adding the flow ID also.

TODO:
- Cleaner separation from FileStore module (Register separate FileDataModule??)
- Decide how to handle truncated files
- Ensure that design is compatible with TLS cert extraction and future SMTP extraction
- Create configurable parameters in suricata.yaml
    * Redis instance (IP and port)
    * Redis Queue Name
    * Redis key expiry - currently hardcoded to 5 min
    * Redis key prefix (i.e. suricata_<hostname>_) - good practice so that keys are distinguishable from other keys in Redis
    * Hashing algorithm - Redis keys currently contain md5 as part of key, doesn't need to be limited to md5
    * Caching enable/disable/expiry - enable caching to not store files we have already seen recently
 - Unit testing
 - I've probably missed a few other TODOs
