### PR TITLE
doc - pdf generation fixups - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1893,6 +1893,13 @@
     AM_CONDITIONAL([HAVE_SPHINXBUILD], [test "x$enable_sphinxbuild" != "xno"])
     AM_CONDITIONAL([HAVE_SURICATA_MAN], [test "x$have_suricata_man" = "xyes"])
 
+# pdflatex for the pdf version of the user manual
+    AC_PATH_PROG(HAVE_PDFLATEX, pdflatex, "no")
+    if test "$HAVE_PDFLATEX" = "no"; then
+       enable_pdflatex=no
+    fi
+    AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
+
 # get revision
     if test -f ./revision; then
         REVISION=`cat ./revision`

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -30,7 +30,9 @@ endif
 if HAVE_SPHINXBUILD
 man1_MANS = suricata.1
 
+if HAVE_PDFLATEX
 EXTRA_DIST += $(man1_MANS) userguide.pdf
+endif
 
 SPHINX_BUILD = sphinx-build -q
 

--- a/doc/userguide/Makefile.am
+++ b/doc/userguide/Makefile.am
@@ -47,7 +47,14 @@ _build/latex/Suricata.pdf:
 	version=$(PACKAGE_VERSION) \
 		$(SPHINX_BUILD) -W -b latex -d _build/doctrees \
 		$(top_srcdir)/doc/userguide _build/latex
-	cd _build/latex && $(MAKE) all-pdf
+# The Sphinx generated Makefile is GNU Make specific, so just do what
+# it does here - yes, multiple passes of pdflatex is required.
+	cd _build/latex && pdflatex Suricata.tex
+	cd _build/latex && pdflatex Suricata.tex
+	cd _build/latex && pdflatex Suricata.tex
+	cd _build/latex && makeindex -s python.ist Suricata.idx
+	cd _build/latex && pdflatex Suricata.tex
+	cd _build/latex && pdflatex Suricata.tex
 
 userguide.pdf: _build/latex/Suricata.pdf
 	cp _build/latex/Suricata.pdf userguide.pdf


### PR DESCRIPTION
Don't attempt to build PDF documentation if pdflatex is not installed (autoconf check).

Don't call the generated Makefile as its gnu make specific. Instead extract the relevant bits and put them into our own Makefile.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/44
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/396
