### PR TITLE
macos - compiler warning cleanup - v1

### DIFF
--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -170,7 +170,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p, Flow *f,
 {
     LogDnsLogThread *aft = (LogDnsLogThread *)data;
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
-    SCLogDebug("pcap_cnt %ju", p->pcap_cnt);
+    SCLogDebug("pcap_cnt %"PRIu64, p->pcap_cnt);
     char timebuf[64];
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
 

--- a/src/output-tx.c
+++ b/src/output-tx.c
@@ -193,7 +193,7 @@ static TmEcode OutputTxLog(ThreadVars *tv, Packet *p, void *thread_data)
                     "tc_log_progress %d", logger, logger->LogCondition,
                     logger->ts_log_progress, logger->tc_log_progress);
             if (logger->alproto == alproto) {
-                SCLogDebug("alproto match, logging tx_id %ju", tx_id);
+                SCLogDebug("alproto match, logging tx_id %"PRIu64, tx_id);
 
                 if (AppLayerParserGetTxLogged(p->proto, alproto, alstate, tx,
                         logger->id)) {
@@ -243,7 +243,7 @@ next:
         }
 
         if (!logger_not_logged) {
-            SCLogDebug("updating log tx_id %ju", tx_id);
+            SCLogDebug("updating log tx_id %"PRIu64, tx_id);
             AppLayerParserSetTransactionLogId(f->alparser);
         }
     }

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -515,7 +515,9 @@ TmEcode DecodeIPFWThreadDeinit(ThreadVars *tv, void *data)
 TmEcode IPFWSetVerdict(ThreadVars *tv, IPFWThreadVars *ptv, Packet *p)
 {
     uint32_t verdict;
+#if 0
     struct pollfd IPFWpoll;
+#endif
     IPFWQueueVars *nq = NULL;
 
     SCEnter();
@@ -531,8 +533,10 @@ TmEcode IPFWSetVerdict(ThreadVars *tv, IPFWThreadVars *ptv, Packet *p)
         SCReturnInt(TM_ECODE_FAILED);
     }
 
+#if 0
     IPFWpoll.fd = nq->fd;
     IPFWpoll.events = POLLWRNORM;
+#endif
 
     if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
         verdict = IPFW_DROP;

--- a/src/source-ipfw.c
+++ b/src/source-ipfw.c
@@ -300,7 +300,7 @@ TmEcode ReceiveIPFWLoop(ThreadVars *tv, void *data, void *slot)
 
         PacketCopyData(p, pkt, pktlen);
         SCLogDebug("Packet info: pkt_len: %" PRIu32 " (pkt %02x, pkt_data %02x)",
-                   GET_PKT_LEN(p), *pkt, GET_PKT_DATA(p));
+                   GET_PKT_LEN(p), *pkt, *(GET_PKT_DATA(p)));
 
         if (TmThreadsSlotProcessPkt(tv, ((TmSlot *) slot)->slot_next, p)
                 != TM_ECODE_OK) {


### PR DESCRIPTION
Mostly format strings, as well as an unused variable. I only ifdef'd this out, as the code that uses it is ifdef'd out as well.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/45
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/397