### PR TITLE
magic: make optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1553,35 +1553,43 @@
     fi
 
   # libmagic
-    AC_ARG_WITH(libmagic_includes,
-            [  --with-libmagic-includes=DIR  libmagic include directory],
-            [with_libmagic_includes="$withval"],[with_libmagic_includes=no])
-    AC_ARG_WITH(libmagic_libraries,
-            [  --with-libmagic-libraries=DIR    libmagic library directory],
-            [with_libmagic_libraries="$withval"],[with_libmagic_libraries="no"])
+    enable_magic="no"
+    AC_ARG_ENABLE(libmagic,
+           AS_HELP_STRING([--enable-libmagic], [Enable libmagic support [default=yes]]),
+                        ,[enable_magic=yes])
+    if test "$enable_magic" = "yes"; then
+        AC_ARG_WITH(libmagic_includes,
+                [  --with-libmagic-includes=DIR  libmagic include directory],
+                [with_libmagic_includes="$withval"],[with_libmagic_includes=no])
+        AC_ARG_WITH(libmagic_libraries,
+                [  --with-libmagic-libraries=DIR    libmagic library directory],
+                [with_libmagic_libraries="$withval"],[with_libmagic_libraries="no"])
 
-    if test "$with_libmagic_includes" != "no"; then
-        CPPFLAGS="${CPPFLAGS} -I${with_libmagic_includes}"
-    fi
+        if test "$with_libmagic_includes" != "no"; then
+            CPPFLAGS="${CPPFLAGS} -I${with_libmagic_includes}"
+        fi
 
-    AC_CHECK_HEADER(magic.h,,[AC_ERROR(magic.h not found ...)])
+        AC_CHECK_HEADER(magic.h,,MAGIC="no")
+        if test "$MAGIC" != "no"; then
+            MAGIC=""
+            AC_CHECK_LIB(magic, magic_open,, MAGIC="no")
+        fi
 
-    if test "$with_libmagic_libraries" != "no"; then
-        LDFLAGS="${LDFLAGS}  -L${with_libmagic_libraries}"
-    fi
-
-    MAGIC=""
-    AC_CHECK_LIB(magic, magic_open,, MAGIC="no")
-
-    if test "$MAGIC" = "no"; then
-        echo
-        echo "   ERROR!  magic library not found, go get it"
-        echo "   from http://www.darwinsys.com/file/ or your distribution:"
-        echo
-        echo "   Ubuntu: apt-get install libmagic-dev"
-        echo "   Fedora: yum install file-devel"
-        echo
-        exit 1
+        if test "x$MAGIC" != "xno"; then
+            if test "$with_libmagic_libraries" != "no"; then
+                LDFLAGS="${LDFLAGS}  -L${with_libmagic_libraries}"
+            fi
+            AC_DEFINE([HAVE_MAGIC],[1],(Libmagic for file handling))
+        else
+            echo
+            echo "   WARNING!  magic library not found, go get it"
+            echo "   from http://www.darwinsys.com/file/ or your distribution:"
+            echo
+            echo "   Ubuntu: apt-get install libmagic-dev"
+            echo "   Fedora: yum install file-devel"
+            echo
+            enable_magic="no"
+        fi
     fi
 
   # Napatech - Using the 3GD API
@@ -1986,6 +1994,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
   Unix socket enabled:                     ${enable_unixsocket}
   Detection enabled:                       ${enable_detection}
 
+  Libmagic support:                        ${enable_magic}
   libnss support:                          ${enable_nss}
   libnspr support:                         ${enable_nspr}
   libjansson support:                      ${enable_jansson}

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -533,6 +533,7 @@ int SigGroupHeadBuildMatchArray(DetectEngineCtx *de_ctx, SigGroupHead *sgh,
  */
 void SigGroupHeadSetFilemagicFlag(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
 {
+#ifdef HAVE_MAGIC
     Signature *s = NULL;
     uint32_t sig = 0;
 
@@ -549,7 +550,7 @@ void SigGroupHeadSetFilemagicFlag(DetectEngineCtx *de_ctx, SigGroupHead *sgh)
             break;
         }
     }
-
+#endif
     return;
 }
 

--- a/src/detect-filemagic.c
+++ b/src/detect-filemagic.c
@@ -54,6 +54,27 @@
 
 #include "conf.h"
 
+#ifndef HAVE_MAGIC
+
+static int DetectFilemagicSetupNoSupport (DetectEngineCtx *de_ctx, Signature *s, char *str)
+{
+    SCLogError(SC_ERR_NO_MAGIC_SUPPORT, "no libmagic support built in, needed for filemagic keyword");
+    return -1;
+}
+
+/**
+ * \brief Registration function for keyword: filemagic
+ */
+void DetectFilemagicRegister(void)
+{
+    sigmatch_table[DETECT_FILEMAGIC].name = "filemagic";
+    sigmatch_table[DETECT_FILEMAGIC].desc = "match on the information libmagic returns about a file";
+    sigmatch_table[DETECT_FILEMAGIC].url = "https://redmine.openinfosecfoundation.org/projects/suricata/wiki/File-keywords#filemagic";
+    sigmatch_table[DETECT_FILEMAGIC].Setup = DetectFilemagicSetupNoSupport;
+}
+
+#else /* HAVE_MAGIC */
+
 static int DetectFilemagicMatch (ThreadVars *, DetectEngineThreadCtx *, Flow *,
         uint8_t, File *, Signature *, SigMatch *);
 static int DetectFilemagicSetup (DetectEngineCtx *, Signature *, char *);
@@ -453,3 +474,6 @@ void DetectFilemagicRegisterTests(void)
     UtRegisterTest("DetectFilemagicTestParse03", DetectFilemagicTestParse03);
 #endif /* UNITTESTS */
 }
+
+#endif /* HAVE_MAGIC */
+

--- a/src/detect-filemagic.h
+++ b/src/detect-filemagic.h
@@ -24,8 +24,8 @@
 #ifndef __DETECT_FILEMAGIC_H__
 #define __DETECT_FILEMAGIC_H__
 
+#ifdef HAVE_MAGIC
 #include "util-spm-bm.h"
-#include <magic.h>
 
 typedef struct DetectFilemagicThreadData {
     magic_t ctx;
@@ -40,7 +40,8 @@ typedef struct DetectFilemagicData {
 } DetectFilemagicData;
 
 /* prototypes */
-void DetectFilemagicRegister (void);
 int FilemagicGlobalLookup(File *file);
+#endif
+void DetectFilemagicRegister (void);
 
 #endif /* __DETECT_FILEMAGIC_H__ */

--- a/src/detect.c
+++ b/src/detect.c
@@ -952,7 +952,7 @@ DetectPostInspectFileFlagsUpdate(Flow *pflow, const SigGroupHead *sgh, uint8_t d
     if (sgh == NULL || sgh->filestore_cnt == 0) {
         FileDisableStoring(pflow, direction);
     }
-
+#ifdef HAVE_MAGIC
     /* see if this sgh requires us to consider file magic */
     if (!FileForceMagic() && (sgh == NULL ||
                 !(sgh->flags & SIG_GROUP_HEAD_HAVEFILEMAGIC)))
@@ -960,7 +960,7 @@ DetectPostInspectFileFlagsUpdate(Flow *pflow, const SigGroupHead *sgh, uint8_t d
         SCLogDebug("disabling magic for flow");
         FileDisableMagic(pflow, direction);
     }
-
+#endif
     /* see if this sgh requires us to consider file md5 */
     if (!FileForceMd5() && (sgh == NULL ||
                 !(sgh->flags & SIG_GROUP_HEAD_HAVEFILEMD5)))

--- a/src/detect.h
+++ b/src/detect.h
@@ -1001,7 +1001,9 @@ typedef struct SigTableElmt_ {
 
 } SigTableElmt;
 
+#ifdef HAVE_MAGIC
 #define SIG_GROUP_HEAD_HAVEFILEMAGIC    (1 << 20)
+#endif
 #define SIG_GROUP_HEAD_HAVEFILEMD5      (1 << 21)
 #define SIG_GROUP_HEAD_HAVEFILESIZE     (1 << 22)
 #define SIG_GROUP_HEAD_HAVEFILESHA1     (1 << 23)

--- a/src/log-file.c
+++ b/src/log-file.c
@@ -269,7 +269,7 @@ static void LogFileWriteJsonRecord(LogFileLogThread *aft, const Packet *p, const
     fprintf(fp, "\"filename\": \"");
     PrintRawJsonFp(fp, ff->name, ff->name_len);
     fprintf(fp, "\", ");
-
+#ifdef HAVE_MAGIC
     fprintf(fp, "\"magic\": \"");
     if (ff->magic) {
         PrintRawJsonFp(fp, (uint8_t *)ff->magic, strlen(ff->magic));
@@ -277,7 +277,7 @@ static void LogFileWriteJsonRecord(LogFileLogThread *aft, const Packet *p, const
         fprintf(fp, "unknown");
     }
     fprintf(fp, "\", ");
-
+#endif
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             fprintf(fp, "\"state\": \"CLOSED\", ");

--- a/src/log-filestore.c
+++ b/src/log-filestore.c
@@ -247,9 +247,10 @@ static void LogFilestoreLogCloseMetaFile(const File *ff)
     snprintf(metafilename, sizeof(metafilename), "%s.meta", filename);
     FILE *fp = fopen(metafilename, "a");
     if (fp != NULL) {
+#ifdef HAVE_MAGIC
         fprintf(fp, "MAGIC:             %s\n",
                 ff->magic ? ff->magic : "<unknown>");
-
+#endif
         switch (ff->state) {
             case FILE_STATE_CLOSED:
                 fprintf(fp, "STATE:             CLOSED\n");

--- a/src/output-file.c
+++ b/src/output-file.c
@@ -147,11 +147,11 @@ static TmEcode OutputFileLog(ThreadVars *tv, Packet *p, void *thread_data)
                 ff->state == FILE_STATE_ERROR)
             {
                 int file_logged = 0;
-
+#ifdef HAVE_MAGIC
                 if (FileForceMagic() && ff->magic == NULL) {
                     FilemagicGlobalLookup(ff);
                 }
-
+#endif
                 logger = list;
                 store = op_thread_data->store;
                 while (logger && store) {

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -165,10 +165,11 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
     if (ffc != NULL) {
         File *ff;
         for (ff = ffc->head; ff != NULL; ff = ff->next) {
+#ifdef HAVE_MAGIC
             if (FileForceMagic() && ff->magic == NULL) {
                 FilemagicGlobalLookup(ff);
             }
-
+#endif
             SCLogDebug("ff %p", ff);
             if (ff->flags & FILE_STORED) {
                 SCLogDebug("stored flag set");

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -119,8 +119,10 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     json_object_set_new(fjs, "filename", json_string(s));
     if (s != NULL)
         SCFree(s);
+#ifdef HAVE_MAGIC
     if (ff->magic)
         json_object_set_new(fjs, "magic", json_string((char *)ff->magic));
+#endif
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             json_object_set_new(fjs, "state", json_string("CLOSED"));

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -225,6 +225,10 @@
 #endif
 #endif
 
+#ifdef HAVE_MAGIC
+#include <magic.h>
+#endif
+
 #if CPPCHECK==1
 #define BUG_ON(x) if (((x))) exit(1)
 #else

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -678,6 +678,9 @@ void SCPrintBuildInfo(void)
 #ifdef TLS
     strlcat(features, "TLS ", sizeof(features));
 #endif
+#ifdef HAVE_MAGIC
+    strlcat(features, "MAGIC ", sizeof(features));
+#endif
     if (strlen(features) == 0) {
         strlcat(features, "none", sizeof(features));
     }
@@ -2388,10 +2391,10 @@ static int PostConfLoadedSetup(SCInstance *suri)
     }
 
     HostInitConfig(HOST_VERBOSE);
-
+#ifdef HAVE_MAGIC
     if (MagicInit() != 0)
         SCReturnInt(TM_ECODE_FAILED);
-
+#endif
     SCAsn1LoadConfig();
 
     CoredumpLoadConfig();
@@ -2554,7 +2557,9 @@ int main(int argc, char **argv)
 
     if (suri.run_mode == RUNMODE_CONF_TEST){
         SCLogNotice("Configuration provided was successfully loaded. Exiting.");
+#ifdef HAVE_MAGIC
         MagicDeinit();
+#endif
         exit(EXIT_SUCCESS);
     }
 
@@ -2743,7 +2748,9 @@ int main(int argc, char **argv)
         SCReferenceConfDeinit();
         SCClassConfDeinit();
     }
+#ifdef HAVE_MAGIC
     MagicDeinit();
+#endif
     TmqhCleanup();
     TmModuleRunDeInit();
     ParseSizeDeinit();

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -331,6 +331,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_NO_SHA1_SUPPORT);
         CASE_CODE (SC_ERR_NO_SHA256_SUPPORT);
         CASE_CODE (SC_ERR_DNP3_CONFIG);
+        CASE_CODE (SC_ERR_NO_MAGIC_SUPPORT);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -321,6 +321,7 @@ typedef enum {
     SC_ERR_NO_SHA256_SUPPORT,
     SC_ERR_ENIP_CONFIG,
     SC_ERR_DNP3_CONFIG,
+    SC_ERR_NO_MAGIC_SUPPORT,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -286,7 +286,7 @@ uint64_t FileSize(const File *file)
 static int FilePruneFile(File *file)
 {
     SCEnter();
-
+#ifdef HAVE_MAGIC
     if (!(file->flags & FILE_NOMAGIC)) {
         /* need magic but haven't set it yet, bail out */
         if (file->magic == NULL)
@@ -296,7 +296,7 @@ static int FilePruneFile(File *file)
     } else {
         SCLogDebug("file->flags & FILE_NOMAGIC == true");
     }
-
+#endif
     uint64_t left_edge = file->content_stored;
     if (file->flags & FILE_NOSTORE) {
         left_edge = FileSize(file);
@@ -443,11 +443,11 @@ static void FileFree(File *ff)
 
     if (ff->name != NULL)
         SCFree(ff->name);
-
+#ifdef HAVE_MAGIC
     /* magic returned by libmagic is strdup'd by MagicLookup. */
     if (ff->magic != NULL)
         SCFree(ff->magic);
-
+#endif
     if (ff->sb != NULL) {
         StreamingBufferFree(ff->sb);
     }

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -67,7 +67,9 @@ typedef struct File_ {
     uint64_t txid;                  /**< tx this file is part of */
     uint32_t file_id;
     uint8_t *name;
+#ifdef HAVE_MAGIC
     char *magic;
+#endif
     struct File_ *next;
 #ifdef HAVE_NSS
     HASHContext *md5_ctx;

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -651,7 +651,13 @@ static int LuaCallbackFileInfoPushToStackFromFile(lua_State *luastate, const Fil
     lua_pushnumber(luastate, file->txid);
     lua_pushlstring(luastate, (char *)file->name, file->name_len);
     lua_pushnumber(luastate, FileSize(file));
-    lua_pushstring (luastate, file->magic);
+    lua_pushstring (luastate,
+#ifdef HAVE_MAGIC
+                    file->magic
+#else
+                    "nomagic"
+#endif
+                    );
     lua_pushstring(luastate, md5ptr);
     lua_pushstring(luastate, sha1ptr);
     lua_pushstring(luastate, sha256ptr);

--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -28,10 +28,11 @@
  */
 
 #include "suricata-common.h"
+
+#ifdef HAVE_MAGIC
 #include "conf.h"
 
 #include "util-unittest.h"
-#include <magic.h>
 
 static magic_t g_magic_ctx = NULL;
 static SCMutex g_magic_lock;
@@ -654,7 +655,7 @@ end:
 }
 
 #endif /* UNITTESTS */
-
+#endif
 
 void MagicRegisterTests(void)
 {

--- a/src/util-magic.h
+++ b/src/util-magic.h
@@ -24,12 +24,12 @@
 #ifndef __UTIL_MAGIC_H__
 #define __UTIL_MAGIC_H__
 
-#include <magic.h>
-
+#ifdef HAVE_MAGIC
 int MagicInit(void);
 void MagicDeinit(void);
 char *MagicGlobalLookup(const uint8_t *, uint32_t);
 char *MagicThreadLookup(magic_t *, const uint8_t *, uint32_t);
+#endif
 void MagicRegisterTests(void);
 
 #endif /* __UTIL_MAGIC_H__ */


### PR DESCRIPTION
Make libmagic optional. If installed it will be enabled by default in
configure. Use --disable-libmagic to disable.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/26
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/534

https://redmine.openinfosecfoundation.org/issues/1951

cc: @duanehoward