### PR TITLE
doc: document that that ;, \, " need to be escaped in rules - v1

### DIFF
--- a/doc/userguide/rules/intro.rst
+++ b/doc/userguide/rules/intro.rst
@@ -172,6 +172,12 @@ There are specific settings for:
 * payloads
 * flows
 
+.. note:: The characters ``;`` and ``"`` have special meaning in the
+          Suricata rule language and must be escaped when used in a
+          rule option value. For example::
+
+	    msg:"Message with semicolon\;";
+
 For more information about these settings, you can click on the
 following headlines:
 

--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -26,9 +26,10 @@ It is a convention that msg is always the first keyword of a signature.
 
 Another example of msg in a signature:
 
-.. image:: meta/msg.png
-
 In this example the red, bold-faced part is the msg.
+
+.. note:: The following characters must be escaped inside the msg:
+	      ``;`` ``\`` ``"``
 
 Sid (signature id)
 ------------------

--- a/doc/userguide/rules/payload-keywords.rst
+++ b/doc/userguide/rules/payload-keywords.rst
@@ -93,6 +93,9 @@ For example::
 You see ``content:!”Firefox/3.6.13”;``. This means an alert will be
 generated if the the used version of Firefox is not 3.6.13.
 
+.. note:: The following characters must be escaped inside the content:
+             ``;`` ``\`` ``"``
+
 Nocase
 ------
 

--- a/doc/userguide/rules/pcre.rst
+++ b/doc/userguide/rules/pcre.rst
@@ -54,6 +54,9 @@ qualities of pcre as well.  These are:
 * ``E``: Ignores newline characters at the end of the buffer/payload.
 * ``G``: Inverts the greediness.
 
+.. note:: The following characters must be escaped inside the content:
+             ``;`` ``\`` ``"``
+
 Suricata's modifiers
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Notes on escaping certain characters in rule options.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1960

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/46
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/398
