### PR TITLE
log-pcap: fix build warnings - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -612,7 +612,7 @@ static TmEcode PcapLogInitRingBuffer(PcapLogData *pl)
 
         PcapFileName *pf = SCCalloc(sizeof(*pf), 1);
         if (unlikely(pf == NULL)) {
-            return TM_ECODE_FAILED;
+            goto fail;
         }
         char path[PATH_MAX];
         snprintf(path, PATH_MAX - 1, "%s/%s", pattern, entry->d_name);

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -629,7 +629,7 @@ static TmEcode PcapLogInitRingBuffer(PcapLogData *pl)
             TAILQ_INSERT_TAIL(&pl->pcap_file_list, pf, next);
         } else {
             /* Ordered insert. */
-            PcapFileName *it = TAILQ_FIRST(&pl->pcap_file_list);
+            PcapFileName *it = NULL;
             TAILQ_FOREACH(it, &pl->pcap_file_list, next) {
                 if (pf->secs < it->secs) {
                     break;


### PR DESCRIPTION
The first issue is a Coverity warning where the open directory can be leaked.

The second is just a scan-build cleanup where a value was initialized to the first value of a TAILQ but never used.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/48
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/400
