### PR TITLE
issue 1961: depth: fail if numeric value has trailing text - v2

### DIFF
--- a/src/detect-depth.c
+++ b/src/detect-depth.c
@@ -37,6 +37,7 @@
 #include "flow-var.h"
 #include "app-layer.h"
 
+#include "util-byte.h"
 #include "util-debug.h"
 
 static int DetectDepthSetup (DetectEngineCtx *, Signature *, char *);
@@ -137,11 +138,10 @@ static int DetectDepthSetup (DetectEngineCtx *de_ctx, Signature *s, char *depths
         cd->depth = ((DetectByteExtractData *)bed_sm->ctx)->local_id;
         cd->flags |= DETECT_CONTENT_DEPTH_BE;
     } else {
-        cd->depth = (uint32_t)atoi(str);
-        if (cd->depth < cd->content_len) {
-            SCLogError(SC_ERR_INVALID_SIGNATURE, "depth - %"PRIu16
-                       " smaller than content length - %"PRIu32,
-                       cd->depth, cd->content_len);
+        if (ByteExtractStringUint16(&cd->depth, 0, 0, str) != (int)strlen(str))
+        {
+            SCLogError(SC_ERR_INVALID_SIGNATURE,
+                      "invalid value for depth: %s", str);
             goto end;
         }
         /* Now update the real limit, as depth is relative to the offset */


### PR DESCRIPTION
Catches the case where the depth is not terminated with a
semicolon (eg: "depth:17 classtype:trojan-activity") which
is usually a sign the rule has a missing semi-colon.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1961

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/50
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/402
