### PR TITLE
dnp3 - shadow fixups

### DIFF
--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -363,7 +363,7 @@ static int DNP3DecodeObjectG{{object.group}}V{{object.variation}}(const uint8_t 
     DNP3ObjectG{{object.group}}V{{object.variation}} *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -392,13 +392,13 @@ static int DNP3DecodeObjectG{{object.group}}V{{object.variation}}(const uint8_t 
 #error "Unhandled field width: {{object.fields[0].width}}"
 {% endif %}
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -418,7 +418,7 @@ static int DNP3DecodeObjectG{{object.group}}V{{object.variation}}(const uint8_t 
 {
     DNP3ObjectG{{object.group}}V{{object.variation}} *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 {% if object._track_offset %}
     uint32_t offset;
 {% endif %}
@@ -558,12 +558,12 @@ static int DNP3DecodeObjectG{{object.group}}V{{object.variation}}(const uint8_t 
 {% endif %}
 {% endfor %}
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;

--- a/src/app-layer-dnp3-objects.c
+++ b/src/app-layer-dnp3-objects.c
@@ -353,7 +353,7 @@ static int DNP3ReadPrefix(
  *
  * \retval 1 if successfull, 0 on failure.
  */
-static int DNP3AddPoint(DNP3PointList *list, void *object, uint32_t index,
+static int DNP3AddPoint(DNP3PointList *list, void *object, uint32_t point_index,
     uint8_t prefix_code, uint32_t prefix)
 {
     DNP3Point *point = SCCalloc(1, sizeof(*point));
@@ -363,7 +363,7 @@ static int DNP3AddPoint(DNP3PointList *list, void *object, uint32_t index,
     TAILQ_INSERT_TAIL(list, point, next);
     point->data = object;
     point->prefix = prefix;
-    point->index = index;
+    point->index = point_index;
     switch (prefix_code) {
         case 0x00:
             break;
@@ -397,7 +397,7 @@ static int DNP3DecodeObjectG1V1(const uint8_t **buf, uint32_t *len,
     DNP3ObjectG1V1 *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -420,13 +420,13 @@ static int DNP3DecodeObjectG1V1(const uint8_t **buf, uint32_t *len,
 
             object->state = (octet >> j) & 0x1;
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -445,7 +445,7 @@ static int DNP3DecodeObjectG1V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG1V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -473,12 +473,12 @@ static int DNP3DecodeObjectG1V2(const uint8_t **buf, uint32_t *len,
             object->state = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -496,7 +496,7 @@ static int DNP3DecodeObjectG2V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG2V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -513,12 +513,12 @@ static int DNP3DecodeObjectG2V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -536,7 +536,7 @@ static int DNP3DecodeObjectG2V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG2V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -567,12 +567,12 @@ static int DNP3DecodeObjectG2V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -590,7 +590,7 @@ static int DNP3DecodeObjectG2V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG2V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -621,12 +621,12 @@ static int DNP3DecodeObjectG2V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -645,7 +645,7 @@ static int DNP3DecodeObjectG3V1(const uint8_t **buf, uint32_t *len,
     DNP3ObjectG3V1 *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -668,13 +668,13 @@ static int DNP3DecodeObjectG3V1(const uint8_t **buf, uint32_t *len,
 
             object->state = (octet >> j) & 0x3;
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -693,7 +693,7 @@ static int DNP3DecodeObjectG3V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG3V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -720,12 +720,12 @@ static int DNP3DecodeObjectG3V2(const uint8_t **buf, uint32_t *len,
             object->state = (octet >> 6) & 0x3;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -743,7 +743,7 @@ static int DNP3DecodeObjectG4V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG4V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -770,12 +770,12 @@ static int DNP3DecodeObjectG4V1(const uint8_t **buf, uint32_t *len,
             object->state = (octet >> 6) & 0x3;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -793,7 +793,7 @@ static int DNP3DecodeObjectG4V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG4V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -823,12 +823,12 @@ static int DNP3DecodeObjectG4V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -846,7 +846,7 @@ static int DNP3DecodeObjectG4V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG4V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -876,12 +876,12 @@ static int DNP3DecodeObjectG4V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -900,7 +900,7 @@ static int DNP3DecodeObjectG10V1(const uint8_t **buf, uint32_t *len,
     DNP3ObjectG10V1 *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -923,13 +923,13 @@ static int DNP3DecodeObjectG10V1(const uint8_t **buf, uint32_t *len,
 
             object->state = (octet >> j) & 0x1;
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -948,7 +948,7 @@ static int DNP3DecodeObjectG10V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG10V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -976,12 +976,12 @@ static int DNP3DecodeObjectG10V2(const uint8_t **buf, uint32_t *len,
             object->state = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -999,7 +999,7 @@ static int DNP3DecodeObjectG11V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG11V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1027,12 +1027,12 @@ static int DNP3DecodeObjectG11V1(const uint8_t **buf, uint32_t *len,
             object->state = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1050,7 +1050,7 @@ static int DNP3DecodeObjectG11V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG11V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1081,12 +1081,12 @@ static int DNP3DecodeObjectG11V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1104,7 +1104,7 @@ static int DNP3DecodeObjectG12V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG12V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1145,12 +1145,12 @@ static int DNP3DecodeObjectG12V1(const uint8_t **buf, uint32_t *len,
             object->reserved = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1168,7 +1168,7 @@ static int DNP3DecodeObjectG12V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG12V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1209,12 +1209,12 @@ static int DNP3DecodeObjectG12V2(const uint8_t **buf, uint32_t *len,
             object->reserved = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1233,7 +1233,7 @@ static int DNP3DecodeObjectG12V3(const uint8_t **buf, uint32_t *len,
     DNP3ObjectG12V3 *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -1256,13 +1256,13 @@ static int DNP3DecodeObjectG12V3(const uint8_t **buf, uint32_t *len,
 
             object->point = (octet >> j) & 0x1;
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -1281,7 +1281,7 @@ static int DNP3DecodeObjectG13V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG13V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1303,12 +1303,12 @@ static int DNP3DecodeObjectG13V1(const uint8_t **buf, uint32_t *len,
             object->commanded_state = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1326,7 +1326,7 @@ static int DNP3DecodeObjectG13V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG13V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1351,12 +1351,12 @@ static int DNP3DecodeObjectG13V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1374,7 +1374,7 @@ static int DNP3DecodeObjectG20V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1405,12 +1405,12 @@ static int DNP3DecodeObjectG20V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1428,7 +1428,7 @@ static int DNP3DecodeObjectG20V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1459,12 +1459,12 @@ static int DNP3DecodeObjectG20V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1482,7 +1482,7 @@ static int DNP3DecodeObjectG20V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1513,12 +1513,12 @@ static int DNP3DecodeObjectG20V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1536,7 +1536,7 @@ static int DNP3DecodeObjectG20V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1567,12 +1567,12 @@ static int DNP3DecodeObjectG20V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1590,7 +1590,7 @@ static int DNP3DecodeObjectG20V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1607,12 +1607,12 @@ static int DNP3DecodeObjectG20V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1630,7 +1630,7 @@ static int DNP3DecodeObjectG20V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1647,12 +1647,12 @@ static int DNP3DecodeObjectG20V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1670,7 +1670,7 @@ static int DNP3DecodeObjectG20V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1687,12 +1687,12 @@ static int DNP3DecodeObjectG20V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1710,7 +1710,7 @@ static int DNP3DecodeObjectG20V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG20V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1727,12 +1727,12 @@ static int DNP3DecodeObjectG20V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1750,7 +1750,7 @@ static int DNP3DecodeObjectG21V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1781,12 +1781,12 @@ static int DNP3DecodeObjectG21V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1804,7 +1804,7 @@ static int DNP3DecodeObjectG21V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1835,12 +1835,12 @@ static int DNP3DecodeObjectG21V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1858,7 +1858,7 @@ static int DNP3DecodeObjectG21V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1889,12 +1889,12 @@ static int DNP3DecodeObjectG21V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1912,7 +1912,7 @@ static int DNP3DecodeObjectG21V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -1943,12 +1943,12 @@ static int DNP3DecodeObjectG21V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -1966,7 +1966,7 @@ static int DNP3DecodeObjectG21V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2000,12 +2000,12 @@ static int DNP3DecodeObjectG21V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2023,7 +2023,7 @@ static int DNP3DecodeObjectG21V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2057,12 +2057,12 @@ static int DNP3DecodeObjectG21V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2080,7 +2080,7 @@ static int DNP3DecodeObjectG21V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2114,12 +2114,12 @@ static int DNP3DecodeObjectG21V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2137,7 +2137,7 @@ static int DNP3DecodeObjectG21V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2171,12 +2171,12 @@ static int DNP3DecodeObjectG21V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2194,7 +2194,7 @@ static int DNP3DecodeObjectG21V9(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V9 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2211,12 +2211,12 @@ static int DNP3DecodeObjectG21V9(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2234,7 +2234,7 @@ static int DNP3DecodeObjectG21V10(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V10 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2251,12 +2251,12 @@ static int DNP3DecodeObjectG21V10(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2274,7 +2274,7 @@ static int DNP3DecodeObjectG21V11(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V11 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2291,12 +2291,12 @@ static int DNP3DecodeObjectG21V11(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2314,7 +2314,7 @@ static int DNP3DecodeObjectG21V12(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG21V12 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2331,12 +2331,12 @@ static int DNP3DecodeObjectG21V12(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2354,7 +2354,7 @@ static int DNP3DecodeObjectG22V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2385,12 +2385,12 @@ static int DNP3DecodeObjectG22V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2408,7 +2408,7 @@ static int DNP3DecodeObjectG22V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2439,12 +2439,12 @@ static int DNP3DecodeObjectG22V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2462,7 +2462,7 @@ static int DNP3DecodeObjectG22V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2493,12 +2493,12 @@ static int DNP3DecodeObjectG22V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2516,7 +2516,7 @@ static int DNP3DecodeObjectG22V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2547,12 +2547,12 @@ static int DNP3DecodeObjectG22V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2570,7 +2570,7 @@ static int DNP3DecodeObjectG22V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2604,12 +2604,12 @@ static int DNP3DecodeObjectG22V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2627,7 +2627,7 @@ static int DNP3DecodeObjectG22V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2661,12 +2661,12 @@ static int DNP3DecodeObjectG22V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2684,7 +2684,7 @@ static int DNP3DecodeObjectG22V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2718,12 +2718,12 @@ static int DNP3DecodeObjectG22V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2741,7 +2741,7 @@ static int DNP3DecodeObjectG22V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG22V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2775,12 +2775,12 @@ static int DNP3DecodeObjectG22V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2798,7 +2798,7 @@ static int DNP3DecodeObjectG23V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2829,12 +2829,12 @@ static int DNP3DecodeObjectG23V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2852,7 +2852,7 @@ static int DNP3DecodeObjectG23V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2883,12 +2883,12 @@ static int DNP3DecodeObjectG23V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2906,7 +2906,7 @@ static int DNP3DecodeObjectG23V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2937,12 +2937,12 @@ static int DNP3DecodeObjectG23V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -2960,7 +2960,7 @@ static int DNP3DecodeObjectG23V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -2991,12 +2991,12 @@ static int DNP3DecodeObjectG23V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3014,7 +3014,7 @@ static int DNP3DecodeObjectG23V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3048,12 +3048,12 @@ static int DNP3DecodeObjectG23V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3071,7 +3071,7 @@ static int DNP3DecodeObjectG23V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3105,12 +3105,12 @@ static int DNP3DecodeObjectG23V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3128,7 +3128,7 @@ static int DNP3DecodeObjectG23V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3162,12 +3162,12 @@ static int DNP3DecodeObjectG23V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3185,7 +3185,7 @@ static int DNP3DecodeObjectG23V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG23V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3219,12 +3219,12 @@ static int DNP3DecodeObjectG23V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3242,7 +3242,7 @@ static int DNP3DecodeObjectG30V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3273,12 +3273,12 @@ static int DNP3DecodeObjectG30V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3296,7 +3296,7 @@ static int DNP3DecodeObjectG30V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3327,12 +3327,12 @@ static int DNP3DecodeObjectG30V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3350,7 +3350,7 @@ static int DNP3DecodeObjectG30V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3367,12 +3367,12 @@ static int DNP3DecodeObjectG30V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3390,7 +3390,7 @@ static int DNP3DecodeObjectG30V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3407,12 +3407,12 @@ static int DNP3DecodeObjectG30V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3430,7 +3430,7 @@ static int DNP3DecodeObjectG30V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3461,12 +3461,12 @@ static int DNP3DecodeObjectG30V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3484,7 +3484,7 @@ static int DNP3DecodeObjectG30V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG30V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3515,12 +3515,12 @@ static int DNP3DecodeObjectG30V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3538,7 +3538,7 @@ static int DNP3DecodeObjectG31V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3569,12 +3569,12 @@ static int DNP3DecodeObjectG31V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3592,7 +3592,7 @@ static int DNP3DecodeObjectG31V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3623,12 +3623,12 @@ static int DNP3DecodeObjectG31V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3646,7 +3646,7 @@ static int DNP3DecodeObjectG31V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3680,12 +3680,12 @@ static int DNP3DecodeObjectG31V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3703,7 +3703,7 @@ static int DNP3DecodeObjectG31V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3737,12 +3737,12 @@ static int DNP3DecodeObjectG31V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3760,7 +3760,7 @@ static int DNP3DecodeObjectG31V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3777,12 +3777,12 @@ static int DNP3DecodeObjectG31V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3800,7 +3800,7 @@ static int DNP3DecodeObjectG31V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3817,12 +3817,12 @@ static int DNP3DecodeObjectG31V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3840,7 +3840,7 @@ static int DNP3DecodeObjectG31V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3871,12 +3871,12 @@ static int DNP3DecodeObjectG31V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3894,7 +3894,7 @@ static int DNP3DecodeObjectG31V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG31V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3925,12 +3925,12 @@ static int DNP3DecodeObjectG31V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -3948,7 +3948,7 @@ static int DNP3DecodeObjectG32V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -3979,12 +3979,12 @@ static int DNP3DecodeObjectG32V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4002,7 +4002,7 @@ static int DNP3DecodeObjectG32V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4033,12 +4033,12 @@ static int DNP3DecodeObjectG32V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4056,7 +4056,7 @@ static int DNP3DecodeObjectG32V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4090,12 +4090,12 @@ static int DNP3DecodeObjectG32V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4113,7 +4113,7 @@ static int DNP3DecodeObjectG32V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4147,12 +4147,12 @@ static int DNP3DecodeObjectG32V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4170,7 +4170,7 @@ static int DNP3DecodeObjectG32V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4201,12 +4201,12 @@ static int DNP3DecodeObjectG32V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4224,7 +4224,7 @@ static int DNP3DecodeObjectG32V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4255,12 +4255,12 @@ static int DNP3DecodeObjectG32V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4278,7 +4278,7 @@ static int DNP3DecodeObjectG32V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4312,12 +4312,12 @@ static int DNP3DecodeObjectG32V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4335,7 +4335,7 @@ static int DNP3DecodeObjectG32V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG32V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4369,12 +4369,12 @@ static int DNP3DecodeObjectG32V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4392,7 +4392,7 @@ static int DNP3DecodeObjectG33V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4423,12 +4423,12 @@ static int DNP3DecodeObjectG33V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4446,7 +4446,7 @@ static int DNP3DecodeObjectG33V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4477,12 +4477,12 @@ static int DNP3DecodeObjectG33V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4500,7 +4500,7 @@ static int DNP3DecodeObjectG33V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4534,12 +4534,12 @@ static int DNP3DecodeObjectG33V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4557,7 +4557,7 @@ static int DNP3DecodeObjectG33V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4591,12 +4591,12 @@ static int DNP3DecodeObjectG33V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4614,7 +4614,7 @@ static int DNP3DecodeObjectG33V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4645,12 +4645,12 @@ static int DNP3DecodeObjectG33V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4668,7 +4668,7 @@ static int DNP3DecodeObjectG33V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4699,12 +4699,12 @@ static int DNP3DecodeObjectG33V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4722,7 +4722,7 @@ static int DNP3DecodeObjectG33V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4756,12 +4756,12 @@ static int DNP3DecodeObjectG33V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4779,7 +4779,7 @@ static int DNP3DecodeObjectG33V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG33V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4813,12 +4813,12 @@ static int DNP3DecodeObjectG33V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4836,7 +4836,7 @@ static int DNP3DecodeObjectG34V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG34V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4853,12 +4853,12 @@ static int DNP3DecodeObjectG34V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4876,7 +4876,7 @@ static int DNP3DecodeObjectG34V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG34V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4893,12 +4893,12 @@ static int DNP3DecodeObjectG34V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4916,7 +4916,7 @@ static int DNP3DecodeObjectG34V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG34V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4933,12 +4933,12 @@ static int DNP3DecodeObjectG34V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -4956,7 +4956,7 @@ static int DNP3DecodeObjectG40V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG40V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -4987,12 +4987,12 @@ static int DNP3DecodeObjectG40V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5010,7 +5010,7 @@ static int DNP3DecodeObjectG40V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG40V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5041,12 +5041,12 @@ static int DNP3DecodeObjectG40V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5064,7 +5064,7 @@ static int DNP3DecodeObjectG40V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG40V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5095,12 +5095,12 @@ static int DNP3DecodeObjectG40V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5118,7 +5118,7 @@ static int DNP3DecodeObjectG40V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG40V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5149,12 +5149,12 @@ static int DNP3DecodeObjectG40V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5172,7 +5172,7 @@ static int DNP3DecodeObjectG41V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG41V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5192,12 +5192,12 @@ static int DNP3DecodeObjectG41V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5215,7 +5215,7 @@ static int DNP3DecodeObjectG41V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG41V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5235,12 +5235,12 @@ static int DNP3DecodeObjectG41V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5258,7 +5258,7 @@ static int DNP3DecodeObjectG41V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG41V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5278,12 +5278,12 @@ static int DNP3DecodeObjectG41V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5301,7 +5301,7 @@ static int DNP3DecodeObjectG41V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG41V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5321,12 +5321,12 @@ static int DNP3DecodeObjectG41V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5344,7 +5344,7 @@ static int DNP3DecodeObjectG42V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5375,12 +5375,12 @@ static int DNP3DecodeObjectG42V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5398,7 +5398,7 @@ static int DNP3DecodeObjectG42V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5429,12 +5429,12 @@ static int DNP3DecodeObjectG42V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5452,7 +5452,7 @@ static int DNP3DecodeObjectG42V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5486,12 +5486,12 @@ static int DNP3DecodeObjectG42V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5509,7 +5509,7 @@ static int DNP3DecodeObjectG42V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5543,12 +5543,12 @@ static int DNP3DecodeObjectG42V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5566,7 +5566,7 @@ static int DNP3DecodeObjectG42V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5597,12 +5597,12 @@ static int DNP3DecodeObjectG42V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5620,7 +5620,7 @@ static int DNP3DecodeObjectG42V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5651,12 +5651,12 @@ static int DNP3DecodeObjectG42V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5674,7 +5674,7 @@ static int DNP3DecodeObjectG42V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5708,12 +5708,12 @@ static int DNP3DecodeObjectG42V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5731,7 +5731,7 @@ static int DNP3DecodeObjectG42V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG42V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5765,12 +5765,12 @@ static int DNP3DecodeObjectG42V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5788,7 +5788,7 @@ static int DNP3DecodeObjectG43V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5813,12 +5813,12 @@ static int DNP3DecodeObjectG43V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5836,7 +5836,7 @@ static int DNP3DecodeObjectG43V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5861,12 +5861,12 @@ static int DNP3DecodeObjectG43V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5884,7 +5884,7 @@ static int DNP3DecodeObjectG43V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5912,12 +5912,12 @@ static int DNP3DecodeObjectG43V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5935,7 +5935,7 @@ static int DNP3DecodeObjectG43V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -5963,12 +5963,12 @@ static int DNP3DecodeObjectG43V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -5986,7 +5986,7 @@ static int DNP3DecodeObjectG43V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6011,12 +6011,12 @@ static int DNP3DecodeObjectG43V5(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6034,7 +6034,7 @@ static int DNP3DecodeObjectG43V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6059,12 +6059,12 @@ static int DNP3DecodeObjectG43V6(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6082,7 +6082,7 @@ static int DNP3DecodeObjectG43V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6110,12 +6110,12 @@ static int DNP3DecodeObjectG43V7(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6133,7 +6133,7 @@ static int DNP3DecodeObjectG43V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG43V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6161,12 +6161,12 @@ static int DNP3DecodeObjectG43V8(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6184,7 +6184,7 @@ static int DNP3DecodeObjectG50V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG50V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6201,12 +6201,12 @@ static int DNP3DecodeObjectG50V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6224,7 +6224,7 @@ static int DNP3DecodeObjectG50V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG50V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6244,12 +6244,12 @@ static int DNP3DecodeObjectG50V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6267,7 +6267,7 @@ static int DNP3DecodeObjectG50V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG50V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6284,12 +6284,12 @@ static int DNP3DecodeObjectG50V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6307,7 +6307,7 @@ static int DNP3DecodeObjectG50V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG50V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6330,12 +6330,12 @@ static int DNP3DecodeObjectG50V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6353,7 +6353,7 @@ static int DNP3DecodeObjectG51V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG51V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6370,12 +6370,12 @@ static int DNP3DecodeObjectG51V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6393,7 +6393,7 @@ static int DNP3DecodeObjectG51V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG51V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6410,12 +6410,12 @@ static int DNP3DecodeObjectG51V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6433,7 +6433,7 @@ static int DNP3DecodeObjectG52V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG52V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6450,12 +6450,12 @@ static int DNP3DecodeObjectG52V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6473,7 +6473,7 @@ static int DNP3DecodeObjectG52V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG52V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6490,12 +6490,12 @@ static int DNP3DecodeObjectG52V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6513,7 +6513,7 @@ static int DNP3DecodeObjectG70V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6581,12 +6581,12 @@ static int DNP3DecodeObjectG70V1(const uint8_t **buf, uint32_t *len,
         }
         object->data[object->data_size] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6604,7 +6604,7 @@ static int DNP3DecodeObjectG70V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6645,12 +6645,12 @@ static int DNP3DecodeObjectG70V2(const uint8_t **buf, uint32_t *len,
         }
         object->password[object->password_size] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6668,7 +6668,7 @@ static int DNP3DecodeObjectG70V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6715,12 +6715,12 @@ static int DNP3DecodeObjectG70V3(const uint8_t **buf, uint32_t *len,
         }
         object->filename[object->filename_size] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6738,7 +6738,7 @@ static int DNP3DecodeObjectG70V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (!DNP3PrefixIsSize(prefix_code)) {
@@ -6781,12 +6781,12 @@ static int DNP3DecodeObjectG70V4(const uint8_t **buf, uint32_t *len,
         }
         object->optional_text[object->optional_text_len] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6804,7 +6804,7 @@ static int DNP3DecodeObjectG70V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (!DNP3PrefixIsSize(prefix_code)) {
@@ -6838,12 +6838,12 @@ static int DNP3DecodeObjectG70V5(const uint8_t **buf, uint32_t *len,
         }
         object->file_data[object->file_data_len] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6861,7 +6861,7 @@ static int DNP3DecodeObjectG70V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (!DNP3PrefixIsSize(prefix_code)) {
@@ -6898,12 +6898,12 @@ static int DNP3DecodeObjectG70V6(const uint8_t **buf, uint32_t *len,
         }
         object->optional_text[object->optional_text_len] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6921,7 +6921,7 @@ static int DNP3DecodeObjectG70V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -6962,12 +6962,12 @@ static int DNP3DecodeObjectG70V7(const uint8_t **buf, uint32_t *len,
         }
         object->filename[object->filename_size] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -6985,7 +6985,7 @@ static int DNP3DecodeObjectG70V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG70V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7013,12 +7013,12 @@ static int DNP3DecodeObjectG70V8(const uint8_t **buf, uint32_t *len,
         }
         object->file_specification[object->file_specification_len] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7037,7 +7037,7 @@ static int DNP3DecodeObjectG80V1(const uint8_t **buf, uint32_t *len,
     DNP3ObjectG80V1 *object = NULL;
     int bytes = (count / 8) + 1;
     uint32_t prefix = 0;
-    int index = start;
+    int point_index = start;
 
     if (!DNP3ReadPrefix(buf, len, prefix_code, &prefix)) {
         goto error;
@@ -7060,13 +7060,13 @@ static int DNP3DecodeObjectG80V1(const uint8_t **buf, uint32_t *len,
 
             object->state = (octet >> j) & 0x1;
 
-            if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+            if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
                 goto error;
             }
 
             object = NULL;
             count--;
-            index++;
+            point_index++;
         }
 
     }
@@ -7085,7 +7085,7 @@ static int DNP3DecodeObjectG81V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG81V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7113,12 +7113,12 @@ static int DNP3DecodeObjectG81V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7136,7 +7136,7 @@ static int DNP3DecodeObjectG83V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG83V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7176,12 +7176,12 @@ static int DNP3DecodeObjectG83V1(const uint8_t **buf, uint32_t *len,
             *len -= object->length;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7199,7 +7199,7 @@ static int DNP3DecodeObjectG86V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG86V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7227,12 +7227,12 @@ static int DNP3DecodeObjectG86V2(const uint8_t **buf, uint32_t *len,
             object->padding2 = (octet >> 7) & 0x1;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7250,7 +7250,7 @@ static int DNP3DecodeObjectG102V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG102V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7267,12 +7267,12 @@ static int DNP3DecodeObjectG102V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7290,7 +7290,7 @@ static int DNP3DecodeObjectG120V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7337,12 +7337,12 @@ static int DNP3DecodeObjectG120V1(const uint8_t **buf, uint32_t *len,
             *len -= object->challenge_data_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7360,7 +7360,7 @@ static int DNP3DecodeObjectG120V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7401,12 +7401,12 @@ static int DNP3DecodeObjectG120V2(const uint8_t **buf, uint32_t *len,
             *len -= object->mac_value_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7424,7 +7424,7 @@ static int DNP3DecodeObjectG120V3(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V3 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7444,12 +7444,12 @@ static int DNP3DecodeObjectG120V3(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7467,7 +7467,7 @@ static int DNP3DecodeObjectG120V4(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V4 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -7484,12 +7484,12 @@ static int DNP3DecodeObjectG120V4(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7507,7 +7507,7 @@ static int DNP3DecodeObjectG120V5(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V5 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7573,12 +7573,12 @@ static int DNP3DecodeObjectG120V5(const uint8_t **buf, uint32_t *len,
             *len -= object->mac_value_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7596,7 +7596,7 @@ static int DNP3DecodeObjectG120V6(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V6 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7637,12 +7637,12 @@ static int DNP3DecodeObjectG120V6(const uint8_t **buf, uint32_t *len,
             *len -= object->wrapped_key_data_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7660,7 +7660,7 @@ static int DNP3DecodeObjectG120V7(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V7 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7703,12 +7703,12 @@ static int DNP3DecodeObjectG120V7(const uint8_t **buf, uint32_t *len,
         }
         object->error_text[object->error_text_len] = '\0';
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7726,7 +7726,7 @@ static int DNP3DecodeObjectG120V8(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V8 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -7767,12 +7767,12 @@ static int DNP3DecodeObjectG120V8(const uint8_t **buf, uint32_t *len,
             *len -= object->certificate_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7790,7 +7790,7 @@ static int DNP3DecodeObjectG120V9(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V9 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     while (count--) {
@@ -7821,12 +7821,12 @@ static int DNP3DecodeObjectG120V9(const uint8_t **buf, uint32_t *len,
             *len -= object->mac_value_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7844,7 +7844,7 @@ static int DNP3DecodeObjectG120V10(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V10 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     if (prefix_code != 5) {
         goto error;
@@ -7918,12 +7918,12 @@ static int DNP3DecodeObjectG120V10(const uint8_t **buf, uint32_t *len,
             *len -= object->certification_data_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -7941,7 +7941,7 @@ static int DNP3DecodeObjectG120V11(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V11 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     if (prefix_code != 5) {
         goto error;
@@ -7987,12 +7987,12 @@ static int DNP3DecodeObjectG120V11(const uint8_t **buf, uint32_t *len,
             *len -= object->master_challenge_data_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8010,7 +8010,7 @@ static int DNP3DecodeObjectG120V12(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V12 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     if (prefix_code != 5) {
         goto error;
@@ -8050,12 +8050,12 @@ static int DNP3DecodeObjectG120V12(const uint8_t **buf, uint32_t *len,
             *len -= object->challenge_data_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8073,7 +8073,7 @@ static int DNP3DecodeObjectG120V13(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V13 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     if (prefix_code != 5) {
         goto error;
@@ -8113,12 +8113,12 @@ static int DNP3DecodeObjectG120V13(const uint8_t **buf, uint32_t *len,
             *len -= object->encrypted_update_key_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8136,7 +8136,7 @@ static int DNP3DecodeObjectG120V14(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V14 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -8171,12 +8171,12 @@ static int DNP3DecodeObjectG120V14(const uint8_t **buf, uint32_t *len,
             *len -= object->digital_signature_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8194,7 +8194,7 @@ static int DNP3DecodeObjectG120V15(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG120V15 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
     uint32_t offset;
 
     if (prefix_code != 5) {
@@ -8229,12 +8229,12 @@ static int DNP3DecodeObjectG120V15(const uint8_t **buf, uint32_t *len,
             *len -= object->mac_len;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8252,7 +8252,7 @@ static int DNP3DecodeObjectG121V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG121V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -8286,12 +8286,12 @@ static int DNP3DecodeObjectG121V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8309,7 +8309,7 @@ static int DNP3DecodeObjectG122V1(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG122V1 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -8343,12 +8343,12 @@ static int DNP3DecodeObjectG122V1(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;
@@ -8366,7 +8366,7 @@ static int DNP3DecodeObjectG122V2(const uint8_t **buf, uint32_t *len,
 {
     DNP3ObjectG122V2 *object = NULL;
     uint32_t prefix = 0;
-    uint32_t index = start;
+    uint32_t point_index = start;
 
     while (count--) {
 
@@ -8403,12 +8403,12 @@ static int DNP3DecodeObjectG122V2(const uint8_t **buf, uint32_t *len,
             goto error;
         }
 
-        if (!DNP3AddPoint(points, object, index, prefix_code, prefix)) {
+        if (!DNP3AddPoint(points, object, point_index, prefix_code, prefix)) {
             goto error;
         }
 
         object = NULL;
-        index++;
+        point_index++;
     }
 
     return 1;


### PR DESCRIPTION
Rename variables named "index" as they shadow a global, specifically char *index(...) from strings.h.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/51
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/403
