### PR TITLE
compiler warnings - format string fixups

### DIFF
--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1762,11 +1762,10 @@ static int ModbusParserTest01(void) {
     }
 
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
-
     if ((tx->function != 1) || (tx->read.address != 0x7890) || (tx->read.quantity != 19)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 1, tx->function);
-        printf("expected address %" PRIu8 ", got %" PRIu8 ": ", 0x7890, tx->read.address);
-        printf("expected quantity %" PRIu8 ", got %" PRIu8 ": ", 19, tx->read.quantity);
+        printf("expected function %d, got %" PRIu8 ": ", 1, tx->function);
+        printf("expected address %d, got %" PRIu16 ": ", 0x7890, tx->read.address);
+        printf("expected quantity %d, got %" PRIu16 ": ", 19, tx->read.quantity);
         goto end;
     }
 
@@ -1782,7 +1781,7 @@ static int ModbusParserTest01(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -1833,12 +1832,12 @@ static int ModbusParserTest02(void) {
 
     if ((tx->function != 16) || (tx->write.address != 0x01) || (tx->write.quantity != 2) ||
         (tx->write.count != 4) || (tx->data[0] != 0x000A) || (tx->data[1] != 0x0102)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
-        printf("expected write address %" PRIu8 ", got %" PRIu8 ": ", 0x01, tx->write.address);
-        printf("expected write quantity %" PRIu8 ", got %" PRIu8 ": ", 2, tx->write.quantity);
-        printf("expected write count %" PRIu8 ", got %" PRIu8 ": ", 4, tx->write.count);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x000A, tx->data[0]);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x0102, tx->data[1]);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
+        printf("expected write address %d, got %" PRIu16 ": ", 0x01, tx->write.address);
+        printf("expected write quantity %d, got %" PRIu16 ": ", 2, tx->write.quantity);
+        printf("expected write count %d, got %" PRIu8 ": ", 4, tx->write.count);
+        printf("expected data %d, got %" PRIu16 ": ", 0x000A, tx->data[0]);
+        printf("expected data %d, got %" PRIu16 ": ", 0x0102, tx->data[1]);
         goto end;
     }
 
@@ -1854,7 +1853,7 @@ static int ModbusParserTest02(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -1936,15 +1935,15 @@ static int ModbusParserTest03(void) {
     if ((tx->function != 23) || (tx->read.address != 0x03) || (tx->read.quantity != 6) ||
         (tx->write.address != 0x0E) || (tx->write.quantity != 3) || (tx->write.count != 6) ||
         (tx->data[0] != 0x1234) || (tx->data[1] != 0x5678) || (tx->data[2] != 0x9ABC)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 23, tx->function);
-        printf("expected read address %" PRIu8 ", got %" PRIu8 ": ", 0x03, tx->read.address);
-        printf("expected read quantity %" PRIu8 ", got %" PRIu8 ": ", 6, tx->read.quantity);
-        printf("expected write address %" PRIu8 ", got %" PRIu8 ": ", 0x0E, tx->write.address);
-        printf("expected write quantity %" PRIu8 ", got %" PRIu8 ": ", 3, tx->write.quantity);
-        printf("expected write count %" PRIu8 ", got %" PRIu8 ": ", 6, tx->write.count);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x1234, tx->data[0]);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x5678, tx->data[1]);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x9ABC, tx->data[2]);
+        printf("expected function %d, got %" PRIu8 ": ", 23, tx->function);
+        printf("expected read address %d, got %" PRIu16 ": ", 0x03, tx->read.address);
+        printf("expected read quantity %d, got %" PRIu16 ": ", 6, tx->read.quantity);
+        printf("expected write address %d, got %" PRIu16 ": ", 0x0E, tx->write.address);
+        printf("expected write quantity %d, got %" PRIu16 ": ", 3, tx->write.quantity);
+        printf("expected write count %d, got %" PRIu8 ": ", 6, tx->write.count);
+        printf("expected data %d, got %" PRIu16 ": ", 0x1234, tx->data[0]);
+        printf("expected data %d, got %" PRIu16 ": ", 0x5678, tx->data[1]);
+        printf("expected data %d, got %" PRIu16 ": ", 0x9ABC, tx->data[2]);
         goto end;
     }
 
@@ -1960,7 +1959,7 @@ static int ModbusParserTest03(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2025,8 +2024,8 @@ static int ModbusParserTest04(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 8) || (tx->subFunction != 4)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 8, tx->function);
-        printf("expected sub-function %" PRIu8 ", got %" PRIu8 ": ", 0x04, tx->subFunction);
+        printf("expected function %d, got %" PRIu8 ": ", 8, tx->function);
+        printf("expected sub-function %d, got %" PRIu16 ": ", 0x04, tx->subFunction);
         goto end;
     }
 
@@ -2367,9 +2366,9 @@ static int ModbusParserTest08(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 1) || (tx->read.address != 0x7890) || (tx->read.quantity != 19)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 1, tx->function);
-        printf("expected address %" PRIu8 ", got %" PRIu8 ": ", 0x7890, tx->read.address);
-        printf("expected quantity %" PRIu8 ", got %" PRIu8 ": ", 19, tx->read.quantity);
+        printf("expected function %d, got %" PRIu8 ": ", 1, tx->function);
+        printf("expected address %d, got %" PRIu16 ": ", 0x7890, tx->read.address);
+        printf("expected quantity %d, got %" PRIu16 ": ", 19, tx->read.quantity);
         goto end;
     }
 
@@ -2385,7 +2384,7 @@ static int ModbusParserTest08(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2460,9 +2459,9 @@ static int ModbusParserTest09(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 1) || (tx->read.address != 0x7890) || (tx->read.quantity != 19)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 1, tx->function);
-        printf("expected address %" PRIu8 ", got %" PRIu8 ": ", 0x7890, tx->read.address);
-        printf("expected quantity %" PRIu8 ", got %" PRIu8 ": ", 19, tx->read.quantity);
+        printf("expected function %d, got %" PRIu8 ": ", 1, tx->function);
+        printf("expected address %d, got %" PRIu16 ": ", 0x7890, tx->read.address);
+        printf("expected quantity %d, got %" PRIu16 ": ", 19, tx->read.quantity);
         goto end;
     }
 
@@ -2489,7 +2488,7 @@ static int ModbusParserTest09(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2546,7 +2545,7 @@ static int ModbusParserTest10(void) {
     }
 
     if (modbus_state->transaction_max !=2) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 2, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 2, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2554,12 +2553,12 @@ static int ModbusParserTest10(void) {
 
     if ((tx->function != 16) || (tx->write.address != 0x01) || (tx->write.quantity != 2) ||
         (tx->write.count != 4) || (tx->data[0] != 0x000A) || (tx->data[1] != 0x0102)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
-        printf("expected write address %" PRIu8 ", got %" PRIu8 ": ", 0x01, tx->write.address);
-        printf("expected write quantity %" PRIu8 ", got %" PRIu8 ": ", 2, tx->write.quantity);
-        printf("expected write count %" PRIu8 ", got %" PRIu8 ": ", 4, tx->write.count);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x000A, tx->data[0]);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x0102, tx->data[1]);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
+        printf("expected write address %d, got %" PRIu16 ": ", 0x01, tx->write.address);
+        printf("expected write quantity %d, got %" PRIu16 ": ", 2, tx->write.quantity);
+        printf("expected write count %d, got %" PRIu8 ": ", 4, tx->write.count);
+        printf("expected data %d, got %" PRIu16 ": ", 0x000A, tx->data[0]);
+        printf("expected data %d, got %" PRIu16 ": ", 0x0102, tx->data[1]);
         goto end;
     }
 
@@ -2807,9 +2806,9 @@ static int ModbusParserTest13(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 22) || (tx->data[0] != 0x00F2) || (tx->data[1] != 0x0025)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
-        printf("expected And_Mask %" PRIu8 ", got %" PRIu8 ": ", 0x00F2, tx->data[0]);
-        printf("expected Or_Mask %" PRIu8 ", got %" PRIu8 ": ", 0x0025, tx->data[1]);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
+        printf("expected And_Mask %d, got %" PRIu16 ": ", 0x00F2, tx->data[0]);
+        printf("expected Or_Mask %d, got %" PRIu16 ": ", 0x0025, tx->data[1]);
         goto end;
     }
 
@@ -2825,7 +2824,7 @@ static int ModbusParserTest13(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2875,9 +2874,9 @@ static int ModbusParserTest14(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 6) || (tx->write.address != 0x0001) || (tx->data[0] != 0x0003)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
-        printf("expected write address %" PRIu8 ", got %" PRIu8 ": ", 0x01, tx->write.address);
-        printf("expected data %" PRIu8 ", got %" PRIu8 ": ", 0x03, tx->data[0]);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
+        printf("expected write address %d, got %" PRIu16 ": ", 0x01, tx->write.address);
+        printf("expected data %d, got %" PRIu16 ": ", 0x03, tx->data[0]);
         goto end;
     }
 
@@ -2893,7 +2892,7 @@ static int ModbusParserTest14(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -2972,7 +2971,7 @@ static int ModbusParserTest15(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if (tx->function != 22) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
         goto end;
     }
 
@@ -2996,7 +2995,7 @@ static int ModbusParserTest15(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 
@@ -3083,8 +3082,8 @@ static int ModbusParserTest16(void) {
     ModbusTransaction *tx = ModbusGetTx(modbus_state, 0);
 
     if ((tx->function != 6) || (tx->write.address != 0x0001)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 16, tx->function);
-        printf("expected write address %" PRIu8 ", got %" PRIu8 ": ", 0x01, tx->write.address);
+        printf("expected function %d, got %" PRIu8 ": ", 16, tx->function);
+        printf("expected write address %d, got %" PRIu16 ": ", 0x01, tx->write.address);
         goto end;
     }
 
@@ -3108,7 +3107,7 @@ static int ModbusParserTest16(void) {
     FLOWLOCK_UNLOCK(&f);
 
     if (modbus_state->transaction_max !=1) {
-        printf("expected transaction_max %" PRIu8 ", got %" PRIu64 ": ", 1, modbus_state->transaction_max);
+        printf("expected transaction_max %d, got %" PRIu64 ": ", 1, modbus_state->transaction_max);
         goto end;
     }
 

--- a/src/detect-modbus.c
+++ b/src/detect-modbus.c
@@ -456,7 +456,7 @@ static int DetectModbusTest01(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_MODBUS_MATCH]->ctx;
 
     if (modbus->function != 1) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 1, modbus->function);
+        printf("expected function %d, got %" PRIu8 ": ", 1, modbus->function);
         goto end;
     }
 
@@ -500,8 +500,8 @@ static int DetectModbusTest02(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_MODBUS_MATCH]->ctx;
 
     if ((modbus->function != 8) || (*modbus->subfunction != 4)) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", 1, modbus->function);
-        printf("expected subfunction %" PRIu8 ", got %" PRIu16 ": ", 4, *modbus->subfunction);
+        printf("expected function %d, got %" PRIu8 ": ", 1, modbus->function);
+        printf("expected subfunction %d, got %" PRIu16 ": ", 4, *modbus->subfunction);
         goto end;
     }
 
@@ -545,7 +545,7 @@ static int DetectModbusTest03(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_MODBUS_MATCH]->ctx;
 
     if (modbus->category != MODBUS_CAT_RESERVED) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", MODBUS_CAT_RESERVED, modbus->category);
+        printf("expected function %d, got %" PRIu8 ": ", MODBUS_CAT_RESERVED, modbus->category);
         goto end;
     }
 
@@ -591,7 +591,7 @@ static int DetectModbusTest04(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_MODBUS_MATCH]->ctx;
 
     if (modbus->category != category) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", ~MODBUS_CAT_PUBLIC_ASSIGNED, modbus->category);
+        printf("expected function %u, got %" PRIu8 ": ", ~MODBUS_CAT_PUBLIC_ASSIGNED, modbus->category);
         goto end;
     }
 
@@ -635,7 +635,7 @@ static int DetectModbusTest05(void)
     modbus = (DetectModbus *) de_ctx->sig_list->sm_lists_tail[DETECT_SM_LIST_MODBUS_MATCH]->ctx;
 
     if (modbus->type != MODBUS_TYP_READ) {
-        printf("expected function %" PRIu8 ", got %" PRIu8 ": ", MODBUS_TYP_READ, modbus->type);
+        printf("expected function %d, got %" PRIu8 ": ", MODBUS_TYP_READ, modbus->type);
         goto end;
     }
 
@@ -730,8 +730,8 @@ static int DetectModbusTest07(void)
         ((*modbus->address).mode != mode) ||
         ((*modbus->address).min != 1000)) {
         printf("expected function %" PRIu8 ", got %" PRIu8 ": ", type, modbus->type);
-        printf("expected mode %" PRIu8 ", got %" PRIu16 ": ", mode, (*modbus->address).mode);
-        printf("expected address %" PRIu8 ", got %" PRIu16 ": ", 1000, (*modbus->address).min);
+        printf("expected mode %u, got %u: ", mode, (*modbus->address).mode);
+        printf("expected address %d, got %" PRIu16 ": ", 1000, (*modbus->address).min);
         goto end;
     }
 
@@ -780,8 +780,8 @@ static int DetectModbusTest08(void)
         ((*modbus->address).mode != mode) ||
         ((*modbus->address).min != 500)) {
         printf("expected function %" PRIu8 ", got %" PRIu8 ": ", type, modbus->type);
-        printf("expected mode %" PRIu8 ", got %" PRIu16 ": ", mode, (*modbus->address).mode);
-        printf("expected address %" PRIu8 ", got %" PRIu16 ": ", 500, (*modbus->address).min);
+        printf("expected mode %d, got %u: ", mode, (*modbus->address).mode);
+        printf("expected address %u, got %" PRIu16 ": ", 500, (*modbus->address).min);
         goto end;
     }
 
@@ -834,11 +834,11 @@ static int DetectModbusTest09(void)
         ((*modbus->data).min != 500)   ||
         ((*modbus->data).max != 1000)) {
         printf("expected function %" PRIu8 ", got %" PRIu8 ": ", type, modbus->type);
-        printf("expected address mode %" PRIu8 ", got %" PRIu16 ": ", addressMode, (*modbus->address).mode);
-        printf("expected address %" PRIu8 ", got %" PRIu16 ": ", 500, (*modbus->address).min);
-        printf("expected value mode %" PRIu8 ", got %" PRIu16 ": ", valueMode, (*modbus->data).mode);
-        printf("expected min value %" PRIu8 ", got %" PRIu16 ": ", 500, (*modbus->data).min);
-        printf("expected max value %" PRIu8 ", got %" PRIu16 ": ", 1000, (*modbus->data).max);
+        printf("expected address mode %u, got %u: ", addressMode, (*modbus->address).mode);
+        printf("expected address %d, got %" PRIu16 ": ", 500, (*modbus->address).min);
+        printf("expected value mode %u, got %u: ", valueMode, (*modbus->data).mode);
+        printf("expected min value %d, got %" PRIu16 ": ", 500, (*modbus->data).min);
+        printf("expected max value %d, got %" PRIu16 ": ", 1000, (*modbus->data).max);
         goto end;
     }
 

--- a/src/detect-stream_size.c
+++ b/src/detect-stream_size.c
@@ -354,7 +354,7 @@ static int DetectStreamSizeParseTest02 (void)
     DetectStreamSizeData *sd = NULL;
     sd = DetectStreamSizeParse("invalidoption,<,6");
     if (sd != NULL) {
-        printf("expected: NULL got 0x%02X %" PRId16 ": ",sd->flags, sd->ssize);
+        printf("expected: NULL got 0x%02X %" PRIu32 ": ",sd->flags, sd->ssize);
         result = 0;
         DetectStreamSizeFree(sd);
     }

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -7175,9 +7175,9 @@ static int StreamTcpTest14 (void)
         printf("failed in setting up OS policy, client.os_policy: %"PRIu8""
                 " should be %"PRIu8" and server.os_policy: %"PRIu8""
                 " should be %"PRIu8"\n", ((TcpSession *)
-                (p->flow->protoctx))->client.os_policy, OS_POLICY_WINDOWS,
+                (p->flow->protoctx))->client.os_policy, (uint8_t)OS_POLICY_WINDOWS,
                 ((TcpSession *)(p->flow->protoctx))->server.os_policy,
-                OS_POLICY_LINUX);
+                (uint8_t)OS_POLICY_LINUX);
         goto end;
     }
     StreamTcpSessionClear(p->flow->protoctx);
@@ -7589,9 +7589,9 @@ static int StreamTcpTest15 (void)
         printf("failed in setting up OS policy, client.os_policy: %"PRIu8""
                 " should be %"PRIu8" and server.os_policy: %"PRIu8""
                 " should be %"PRIu8"\n", ((TcpSession *)
-                (p->flow->protoctx))->client.os_policy, OS_POLICY_WINDOWS,
+                (p->flow->protoctx))->client.os_policy, (uint8_t)OS_POLICY_WINDOWS,
                 ((TcpSession *)(p->flow->protoctx))->server.os_policy,
-                OS_POLICY_LINUX);
+                (uint8_t)OS_POLICY_LINUX);
         goto end;
     }
     StreamTcpSessionPktFree(p);
@@ -7763,9 +7763,9 @@ static int StreamTcpTest16 (void)
         printf("failed in setting up OS policy, client.os_policy: %"PRIu8""
                 " should be %"PRIu8" and server.os_policy: %"PRIu8""
                 " should be %"PRIu8"\n", ((TcpSession *)
-                (p->flow->protoctx))->client.os_policy, OS_POLICY_LINUX,
+                (p->flow->protoctx))->client.os_policy, (uint8_t)OS_POLICY_LINUX,
                 ((TcpSession *)(p->flow->protoctx))->server.os_policy,
-                OS_POLICY_WINDOWS);
+                (uint8_t)OS_POLICY_WINDOWS);
         goto end;
     }
     StreamTcpSessionPktFree(p);
@@ -7938,9 +7938,9 @@ static int StreamTcpTest17 (void)
         printf("failed in setting up OS policy, client.os_policy: %"PRIu8""
                 " should be %"PRIu8" and server.os_policy: %"PRIu8""
                 " should be %"PRIu8"\n", ((TcpSession *)
-                (p->flow->protoctx))->client.os_policy, OS_POLICY_LINUX,
+                (p->flow->protoctx))->client.os_policy, (uint8_t)OS_POLICY_LINUX,
                 ((TcpSession *)(p->flow->protoctx))->server.os_policy,
-                OS_POLICY_DEFAULT);
+                (uint8_t)OS_POLICY_DEFAULT);
         goto end;
     }
     StreamTcpSessionPktFree(p);
@@ -8045,7 +8045,7 @@ static int StreamTcpTest19 (void)
 
     if (stream.os_policy != OS_POLICY_WINDOWS) {
         printf("expected os_policy: %"PRIu8" but received %"PRIu8": ",
-                OS_POLICY_WINDOWS, stream.os_policy);
+                (uint8_t)OS_POLICY_WINDOWS, stream.os_policy);
         goto end;
     }
 
@@ -8097,7 +8097,7 @@ static int StreamTcpTest20 (void)
 
     if (stream.os_policy != OS_POLICY_LINUX) {
         printf("expected os_policy: %"PRIu8" but received %"PRIu8"\n",
-                OS_POLICY_LINUX, stream.os_policy);
+                (uint8_t)OS_POLICY_LINUX, stream.os_policy);
         goto end;
     }
 
@@ -8149,7 +8149,7 @@ static int StreamTcpTest21 (void)
 
     if (stream.os_policy != OS_POLICY_LINUX) {
         printf("expected os_policy: %"PRIu8" but received %"PRIu8"\n",
-                OS_POLICY_LINUX, stream.os_policy);
+                (uint8_t)OS_POLICY_LINUX, stream.os_policy);
         goto end;
     }
 
@@ -8201,7 +8201,7 @@ static int StreamTcpTest22 (void)
 
     if (stream.os_policy != OS_POLICY_DEFAULT) {
         printf("expected os_policy: %"PRIu8" but received %"PRIu8"\n",
-                OS_POLICY_DEFAULT, stream.os_policy);
+                (uint8_t)OS_POLICY_DEFAULT, stream.os_policy);
         goto end;
     }
 

--- a/src/util-unittest-helper.c
+++ b/src/util-unittest-helper.c
@@ -570,7 +570,7 @@ int UTHCheckPacketMatchResults(Packet *p, uint32_t sids[],
     for (; i < numsids; i++) {
         uint16_t r = PacketAlertCheck(p, sids[i]);
         if (r != results[i]) {
-            SCLogInfo("Sid %"PRIu32" matched %"PRIu16" times, and not %"PRIu16
+            SCLogInfo("Sid %"PRIu32" matched %"PRIu16" times, and not %"PRIu32
                     " as expected", sids[i], r, results[i]);
             res = 0;
         } else {


### PR DESCRIPTION
I tried to make the best choice of casting the argument or changing the format string, but I suppose this could be a bit subjective.

Found running the OS X builds on Travis.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/52
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/404