### PR TITLE
travis: use a build matrix and add additional builds - v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,125 @@
-os:
-  - linux
-  - osx
-osx_image: xcode8.1
+# Default parameters, even this default build is excluded in the build
+# matrix below. We define so Travis doesn't think this is a Ruby
+# project.
+os: linux
 language: c
-env:
-  - CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
-compiler:
-  - gcc
-  - clang
+compiler: gcc
+
+# Define the default CFLAGS used by all builds as a YAML anchor.
+default-cflags: &default-cflags
+  CFLAGS="-Wall -Wextra -Werror -Wno-unused-parameter -Wno-unused-function"
+
+# The default build is Linux with gcc. Add additional builds to the
+# matrix here.
+matrix:
+  # Exclude the default build so any the builds in the matrix will be done.
+  exclude:
+    - os: linux
+      compiler: gcc
+  include:
+    # Linux, gcc, cocci tests enabled.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,cocci"
+        - *default-cflags
+        - ENABLE_COCCI="yes"
+    # Linux, clang. For this build we'll also enable -Wshadow.
+    - os: linux
+      compiler: clang
+      env:
+        - NAME="linux,clang"
+        - *default-cflags
+        - EXTRA_CFLAGS="-Wshadow"
+    # Linux, gcc, profiling.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,profiling"
+        - *default-cflags
+        - ARGS="--enable-profiling"
+    # Linux, gcc, debug.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,debug"
+        - *default-cflags
+        - ARGS="--enable-debug"
+        - ENABLE_DEBUG="yes"
+    # Linux, gcc, no json support.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,no-json"
+        - *default-cflags
+        - DISABLE_JSON="yes"
+    # OSX 10.12, XCode 8.1.
+    - os: osx
+      compiler: gcc
+      osx_image: xcode8.1
+      env:
+        - NAME="osx,gcc"
+        - *default-cflags
+
 # Change this to your needs
 script:
   - sh autogen.sh
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure --enable-nfqueue --enable-unittests --enable-hiredis; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./configure --enable-unittests --enable-hiredis --enable-ipfw --enable-lua --with-libpcre-includes=/usr/local/include --with-libpcre-includes=/usr/local/include --with-libpcre-libraries=/usr/local/lib --with-libnss-includes=/usr/local/opt/nss/include/nss --with-libnss-libraries=/usr/local/opt/nss/lib --with-libnspr-includes=/usr/local/opt/nspr/include/nspr --with-libnspr-libraries=/usr/local/opt/nspr/lib; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        ./configure --enable-nfqueue --enable-unittests --enable-hiredis ${ARGS}
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
+        ./configure --enable-unittests --enable-hiredis --enable-ipfw \
+            --enable-lua --with-libpcre-includes=/usr/local/include \
+            --with-libpcre-includes=/usr/local/include \
+            --with-libpcre-libraries=/usr/local/lib \
+            --with-libnss-includes=/usr/local/opt/nss/include/nss \
+            --with-libnss-libraries=/usr/local/opt/nss/lib \
+            --with-libnspr-includes=/usr/local/opt/nspr/include/nspr \
+            --with-libnspr-libraries=/usr/local/opt/nspr/lib
+    fi
   - make
-  - make check
+  # With debug enabled too much output is generated for Travis, so
+  # redirect stderr to a file.
+  - |
+    if [[ "$ENABLE_DEBUG" == "yes" ]]; then
+        make check 2> stderr.log
+    else
+        make check
+    fi
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "gcc" ]]; then sudo add-apt-repository -y ppa:npalix/coccinelle; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "gcc" ]]; then sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 coccinelle libjansson-dev libhiredis-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "clang" ]]; then sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev build-essential autoconf automake libtool libpcap-dev libnet1-dev libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 make libmagic-dev libnetfilter-queue-dev libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 libjansson-dev libhiredis-dev; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install pkg-config libmagic libyaml nss nspr jansson libnet lua pcre hiredis; fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+
+        if [[ "$ENABLE_COCCI" == "yes" ]]; then
+            sudo add-apt-repository -y ppa:npalix/coccinelle
+        fi
+
+        sudo apt-get update -qq
+        sudo apt-get install -y libpcre3 libpcre3-dbg libpcre3-dev \
+            build-essential autoconf automake libtool libpcap-dev libnet1-dev \
+            libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev \
+            libcap-ng0 make libmagic-dev libnetfilter-queue-dev \
+            libnetfilter-queue1 libnfnetlink-dev libnfnetlink0 \
+            libhiredis-dev
+
+
+        if [[ "$ENABLE_COCCI" == "yes" ]]; then
+            sudo apt-get install -y coccinelle
+        fi
+
+        if [[ "$DISABLE_JSON" != "yes" ]]; then
+            sudo apt-get install -y libjansson-dev
+        fi
+
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew update
+        brew install pkg-config libmagic libyaml nss nspr jansson libnet lua \
+            pcre hiredis
+    fi
   - ./qa/travis-libhtp.sh
 


### PR DESCRIPTION
The following builds were added:
- linux, clang with -Wshadow
- linux w/ profiling
- linux w/ debug
- linux w/ no-json support

Removes the extra OS X build.

Travis file was reworked signficantly for readabilty.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/56
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/408

Note that Travis was having issues with OS X builds and those builds are backlogged, so it might take a while for this to pass Travis CI.
