### PR TITLE
log: TLS/SSL custom log

### DIFF
--- a/doc/userguide/output/custom-tls-logging.rst
+++ b/doc/userguide/output/custom-tls-logging.rst
@@ -1,0 +1,46 @@
+Custom tls logging
+===================
+
+As of Suricata 3.2.0 you can enable a custom tls logging option.
+
+In your Suricata.yaml, find the http-log section and edit as follows:
+
+
+::
+
+
+  - tls-log:
+      enabled: yes      # Log TLS connections.
+      filename: tls.log # File to store TLS logs.
+      append: yes
+      custom: yes       # enabled the custom logging format (defined by customformat)
+      customformat: "%{%D-%H:%M:%S}t.%z %a:%p -> %A:%P %n %n %d %D"
+
+And in your tls.log file you would get the following, for example:
+
+::
+
+ 12/03/16-19:20:14.85859 10.10.10.4:58274 -> 192.0.78.24:443 VERSION='TLS 1.2' suricata-ids.org NOTBEFORE='2016-10-27T20:36:00' NOTAFTER='2017-01-25T20:36:00'
+
+::
+ 12/03/16-19:20:20.36849 10.10.10.4:39472 -> 192.30.253.113:443 VERSION='TLS 1.2' github.com NOTBEFORE='2016-03-10T00:00:00' NOTAFTER='2018-05-17T12:00:00'
+
+
+The list of supported format strings is the following:
+
+* %n - client SNI
+* %v - TLS/SSL version
+* %d - certificate date not before
+* %D - certificate date not after
+* %f - certificate fingerprint SHA1
+* %s - certificate subject
+* %i - certificate issuer dn
+* %E - extended format
+* %{strftime_format]t - timestamp of the TLS transaction in the selected strftime format. ie: 08/28/12-22:14:30
+* %z - precision time in useconds. ie: 693856
+* %a - client IP address
+* %p - client port number
+* %A - server IP address
+* %P - server port number
+
+Any non printable character will be represented by its byte value in hexadecimal format (\|XX\|, where XX is the hex code)

--- a/doc/userguide/output/index.rst
+++ b/doc/userguide/output/index.rst
@@ -7,3 +7,4 @@ Output
    lua-output
    syslog-alerting-comp
    custom-http-logging
+   custom-tls-logging

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -260,6 +260,7 @@ log-dnslog.c log-dnslog.h \
 log-droplog.c log-droplog.h \
 log-file.c log-file.h \
 log-filestore.c log-filestore.h \
+log-cf-common.c log-cf-common.h \
 log-httplog.c log-httplog.h \
 log-pcap.c log-pcap.h \
 log-stats.c log-stats.h \

--- a/src/log-cf-common.c
+++ b/src/log-cf-common.c
@@ -1,0 +1,282 @@
+/* Copyright (C) 2007-2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Paulo Pacheco <fooinha@gmail.com>
+ * \author Victor Julien <victor@inliniac.net>
+ * \author Ignacio Sanchez <sanchezmartin.ji@gmail.com>
+ *
+ * Common custom loggging format
+ */
+
+#include "log-cf-common.h"
+#include "util-print.h"
+#include "util-unittest.h"
+
+/**
+ *  \brief Creates a custom format node
+ *  \retval LogCustomFormatNode * ptr if created
+ *  \retval NULL if failed to allocate
+ */
+LogCustomFormatNode * LogCustomFormatNodeAlloc()
+{
+    LogCustomFormatNode * node = SCMalloc(sizeof(LogCustomFormatNode));
+    if (unlikely(node == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to alloc custom format node");
+        return NULL;
+    }
+    memset(node, '\0', sizeof(LogCustomFormatNode));
+    memset(node->data, '\0', LOG_NODE_STRLEN);
+
+    return node;
+}
+
+/**
+ *  \brief Creates a custom format.
+ *  \retval LogCustomFormat * ptr if created
+ *  \retval NULL if failed to allocate
+ */
+LogCustomFormat * LogCustomFormatAlloc()
+{
+    LogCustomFormat * cf = SCMalloc(sizeof(LogCustomFormat));
+    if (unlikely(cf == NULL)) {
+        SCLogError(SC_ERR_MEM_ALLOC, "Failed to alloc custom format");
+        return NULL;
+    }
+    memset(cf, '\0', sizeof(LogCustomFormat));
+
+    return cf;
+}
+
+/**
+ *  \brief Frees memory held by a custom format node
+ *  \param LogCustomFormatNode * node - node to relaease
+ */
+void LogCustomFormatNodeFree(LogCustomFormatNode *node)
+{
+    if (node==NULL)
+        return;
+
+    SCFree(node);
+}
+
+/**
+ *  \brief Frees memory held by a custom format
+ *  \param LogCustomFormat * cf - format to relaease
+ */
+void LogCustomFormatFree(LogCustomFormat *cf)
+{
+    if (cf==NULL)
+        return;
+
+    for (size_t i = 0; i < cf->cf_n; ++i) {
+        LogCustomFormatNodeFree(cf->cf_nodes[i]);
+    }
+    SCFree(cf);
+}
+
+/**
+ *  \brief Parses and saves format nodes for custom format
+ *  \param LogCustomFormat * cf - custom format to build
+ *  \param const char * format - string with format specification
+ */
+int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
+{
+    const char *p, *np;
+    uint32_t n;
+    LogCustomFormatNode *node = NULL;
+
+    if (cf==NULL)
+        return 0;
+
+    if (format==NULL)
+        return 0;
+
+    p=format;
+
+    for (cf->cf_n = 0; cf->cf_n < LOG_MAXN_NODES-1 && p && *p != '\0';){
+
+        node = LogCustomFormatNodeAlloc();
+        if (node == NULL) {
+            goto parsererror;
+        }
+        node->maxlen = 0;
+
+        if (*p != '%'){
+            /* Literal found in format string */
+            node->type = LOG_CF_LITERAL;
+            np = strchr(p, '%');
+            if (np == NULL){
+                n = LOG_NODE_STRLEN-2;
+                np = NULL; /* End */
+            }else{
+                n = np-p;
+            }
+            strlcpy(node->data,p,n+1);
+            p = np;
+        } else {
+            /* Non Literal found in format string */
+            p++;
+            if (*p == '[') { /* Check if maxlength has been specified (ie: [25]) */
+                p++;
+                np = strchr(p, ']');
+                if (np != NULL) {
+                    if (np-p > 0 && np-p < 10){
+                        long maxlen = strtol(p,NULL,10);
+                        if (maxlen > 0 && maxlen < LOG_NODE_MAXOUTPUTLEN) {
+                            node->maxlen = (uint32_t) maxlen;
+                        }
+                    } else {
+                        goto parsererror;
+                    }
+                    p = np + 1;
+                } else {
+                    goto parsererror;
+                }
+            }
+            if (*p == '{') { /* Simple format char */
+                np = strchr(p, '}');
+                if (np != NULL && np-p > 1 && np-p < LOG_NODE_STRLEN-2) {
+                    p++;
+                    n = np-p;
+                    p = np;
+                } else {
+                    goto parsererror;
+                }
+                p++;
+            } else {
+                node->data[0] = '\0';
+            }
+            node->type = *p;
+            if (*p == '%'){
+                node->type = LOG_CF_LITERAL;
+                strlcpy(node->data, "%", 2);
+            }
+            p++;
+        }
+        LogCustomFormatAddNode(cf, node);
+
+    }
+    return 1;
+
+parsererror:
+    LogCustomFormatNodeFree(node);
+    return 0;
+
+}
+
+/**
+ *  \brief Adds a node to custom format
+ *  \param LogCustomFormat * cf - custom format
+ *  \param LogCustomFormatNode * node - node to add
+ */
+void LogCustomFormatAddNode(LogCustomFormat *cf, LogCustomFormatNode *node)
+{
+    if (cf == NULL || node == NULL)
+        return;
+
+    if (cf->cf_n == LOG_MAXN_NODES) {
+        SCLogWarning(SC_WARN_LOG_CF_TOO_MANY_NODES, "Too many options for custom format");
+        return;
+    }
+
+#ifdef DEBUG
+    SCLogDebug("%d-> n.type=[%d] n.maxlen=[%d] n.data=[%s]",
+            cf->cf_n, node->type, node->maxlen, node->data);
+#endif
+
+    cf->cf_nodes[cf->cf_n] = node;
+    cf->cf_n++;
+}
+
+/**
+ *  \brief Writes a timestamp with given format into a MemBuffer
+ *  \param MemBuffer * buffer - where to write
+ *  \param const char * fmt - format to be used write timestamp
+ *  \param const struct timeveal *ts  - the timetstamp
+ *
+ */
+void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const struct timeval *ts) {
+
+    time_t time = ts->tv_sec;
+    struct tm local_tm;
+    struct tm *timestamp = SCLocalTime(time, &local_tm);
+    char buf[128] = {0};
+    const char * fmt_to_use = TIMESTAMP_DEFAULT_FORMAT;
+
+    if (fmt && *fmt != '\0') {
+        fmt_to_use = fmt;
+    }
+
+    CreateFormattedTimeString (timestamp, fmt_to_use, buf, sizeof(buf));
+    PrintRawUriBuf((char *)buffer->buffer, &buffer->offset,
+                   buffer->size, (uint8_t *)buf,strlen(buf));
+}
+
+
+#ifdef UNITTESTS
+/**
+ * \internal
+ * \brief This test tests default timestamp format
+ */
+static int LogCustomFormatTest01(void)
+{
+
+    struct tm tm;
+    tm.tm_sec = 0;
+    tm.tm_min = 30;
+    tm.tm_hour = 4;
+    tm.tm_mday = 13;
+    tm.tm_mon = 0;
+    tm.tm_year = 114;
+    tm.tm_wday = 1;
+    tm.tm_yday = 13;
+    tm.tm_isdst = 0;
+    time_t secs = mktime(&tm);
+    struct timeval ts = {secs, 0};
+
+    MemBuffer *buffer = MemBufferCreateNew(62);
+    if (!buffer) {
+        return 0;
+    }
+
+    LogCustomFormatWriteTimestamp(buffer, "", &ts);
+    /*
+     * {buffer = "01/13/14-04:30:00", size = 62, offset = 17}
+     */
+    FAIL_IF_NOT( buffer->offset == 17);
+    FAIL_IF(strcmp((char *)buffer->buffer, "01/13/14-04:30:00") != 0);
+
+    MemBufferFree(buffer);
+
+    return 1;
+}
+
+void LogCustomFormatRegisterTests(void)
+{
+    UtRegisterTest("LogCustomFormatTest01", LogCustomFormatTest01);
+}
+#endif /* UNITTESTS */
+
+void LogCustomFormatRegister(void)
+{
+#ifdef UNITTESTS
+    LogCustomFormatRegisterTests();
+#endif /* UNITTESTS */
+}

--- a/src/log-cf-common.c
+++ b/src/log-cf-common.c
@@ -155,6 +155,7 @@ int LogCustomFormatParse(LogCustomFormat *cf, const char *format)
                 if (np != NULL && np-p > 1 && np-p < LOG_NODE_STRLEN-2) {
                     p++;
                     n = np-p;
+                    strlcpy(node->data, p, n+1);
                     p = np;
                 } else {
                     goto parsererror;

--- a/src/log-cf-common.h
+++ b/src/log-cf-common.h
@@ -47,8 +47,17 @@
 
 /* Line log common separators **/
 #define LOG_CF_STAR_SEPARATOR "[**]"
+#define LOG_CF_SPACE_SEPARATOR " "
+#define LOG_CF_UNKNOWN_VALUE "-"
+
 #define LOG_CF_WRITE_STAR_SEPATATOR(buffer) \
     MemBufferWriteString(buffer, LOG_CF_STAR_SEPARATOR);
+
+#define LOG_CF_WRITE_SPACE_SEPARATOR(buffer) \
+    MemBufferWriteString(buffer, LOG_CF_SPACE_SEPARATOR);
+
+#define LOG_CF_WRITE_UNKNOWN_VALUE(buffer) \
+    MemBufferWriteString(buffer, LOG_CF_UNKNOWN_VALUE);
 
 /* Include */
 #include "suricata-common.h"

--- a/src/log-cf-common.h
+++ b/src/log-cf-common.h
@@ -1,0 +1,81 @@
+/* Copyright (C) 2016 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ * \author Ignacio Sanchez <sanchezmartin.ji@gmail.com>
+ * \author Paulo Pacheco <fooinha@gmail.com>
+ *
+ * Common custom loggging format
+ */
+
+#ifndef __LOG_CF_COMMON_H__
+#define __LOG_CF_COMMON_H__
+
+#define LOG_MAXN_NODES 64
+#define LOG_NODE_STRLEN 256
+#define LOG_NODE_MAXOUTPUTLEN 8192
+
+#define TIMESTAMP_DEFAULT_FORMAT "%D-%H:%M:%S"
+#define TIMESTAMP_DEFAULT_FORMAT_LEN 62
+
+/* Common format nodes */
+#define LOG_CF_NONE "-"
+#define LOG_CF_LITERAL '%'
+#define LOG_CF_TIMESTAMP 't'
+#define LOG_CF_TIMESTAMP_U 'z'
+#define LOG_CF_CLIENT_IP 'a'
+#define LOG_CF_SERVER_IP 'A'
+#define LOG_CF_CLIENT_PORT 'p'
+#define LOG_CF_SERVER_PORT 'P'
+
+/* Line log common separators **/
+#define LOG_CF_STAR_SEPARATOR "[**]"
+#define LOG_CF_WRITE_STAR_SEPATATOR(buffer) \
+    MemBufferWriteString(buffer, LOG_CF_STAR_SEPARATOR);
+
+/* Include */
+#include "suricata-common.h"
+#include "util-buffer.h"
+
+typedef struct LogCustomFormatNode_ {
+    uint32_t type;              /**< Node format type. ie: LOG_CF_LITERAL, ... */
+    uint32_t maxlen;            /**< Maximun length of the data */
+    char data[LOG_NODE_STRLEN]; /**< optional data. ie: http header name */
+} LogCustomFormatNode;
+
+
+typedef struct LogCustomFormat_ {
+    uint32_t cf_n;                                  /**< Total number of custom string format nodes */
+    LogCustomFormatNode *cf_nodes[LOG_MAXN_NODES];  /**< Custom format string nodes */
+} LogCustomFormat;
+
+LogCustomFormatNode * LogCustomFormatNodeAlloc(void);
+LogCustomFormat * LogCustomFormatAlloc(void);
+
+void LogCustomFormatNodeFree(LogCustomFormatNode *node);
+void LogCustomFormatFree(LogCustomFormat *cf);
+
+void LogCustomFormatAddNode(LogCustomFormat *cf, LogCustomFormatNode *node);
+int LogCustomFormatParse(LogCustomFormat *cf, const char *format);
+
+void LogCustomFormatWriteTimestamp(MemBuffer *buffer, const char *fmt, const struct timeval *ts);
+void LogCustomFormatRegister(void);
+
+#endif /* __LOG_CF_COMMON_H__ */

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -49,6 +49,7 @@
 
 #include "util-logopenfile.h"
 #include "util-time.h"
+#include "log-cf-common.h"
 
 #define DEFAULT_LOG_FILENAME "http.log"
 
@@ -70,13 +71,6 @@ void LogHttpLogRegister (void)
         LogHttpLogThreadDeinit, LogHttpLogExitPrintStats);
 }
 
-#define LOG_HTTP_MAXN_NODES 64
-#define LOG_HTTP_NODE_STRLEN 256
-#define LOG_HTTP_NODE_MAXOUTPUTLEN 8192
-
-#define TIMESTAMP_DEFAULT_FORMAT "%b %d, %Y; %H:%M:%S"
-#define LOG_HTTP_CF_NONE "-"
-#define LOG_HTTP_CF_LITERAL '%'
 #define LOG_HTTP_CF_REQUEST_HOST 'h'
 #define LOG_HTTP_CF_REQUEST_PROTOCOL 'H'
 #define LOG_HTTP_CF_REQUEST_METHOD 'm'
@@ -88,24 +82,12 @@ void LogHttpLogRegister (void)
 #define LOG_HTTP_CF_RESPONSE_STATUS 's'
 #define LOG_HTTP_CF_RESPONSE_HEADER 'o'
 #define LOG_HTTP_CF_RESPONSE_LEN 'B'
-#define LOG_HTTP_CF_TIMESTAMP 't'
-#define LOG_HTTP_CF_TIMESTAMP_U 'z'
-#define LOG_HTTP_CF_CLIENT_IP 'a'
-#define LOG_HTTP_CF_SERVER_IP 'A'
-#define LOG_HTTP_CF_CLIENT_PORT 'p'
-#define LOG_HTTP_CF_SERVER_PORT 'P'
 
-typedef struct LogHttpCustomFormatNode_ {
-    uint32_t type; /** Node format type. ie: LOG_HTTP_CF_LITERAL, LOG_HTTP_CF_REQUEST_HEADER */
-    uint32_t maxlen; /** Maximun length of the data */
-    char data[LOG_HTTP_NODE_STRLEN]; /** optional data. ie: http header name */
-} LogHttpCustomFormatNode;
 
 typedef struct LogHttpFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
-    uint32_t cf_n; /** Total number of custom string format nodes */
-    LogHttpCustomFormatNode *cf_nodes[LOG_HTTP_MAXN_NODES]; /** Custom format string nodes */
+    LogCustomFormat *cf;
 } LogHttpFileCtx;
 
 #define LOG_HTTP_DEFAULT 0
@@ -161,49 +143,44 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
     htp_header_t *h_request_hdr;
     htp_header_t *h_response_hdr;
 
-    time_t time = ts->tv_sec;
-    struct tm local_tm;
-    struct tm *timestamp = SCLocalTime(time, &local_tm);
-
-    for (i = 0; i < httplog_ctx->cf_n; i++) {
+    for (i = 0; i < httplog_ctx->cf->cf_n; i++) {
         h_request_hdr = NULL;
         h_response_hdr = NULL;
-        switch (httplog_ctx->cf_nodes[i]->type){
-            case LOG_HTTP_CF_LITERAL:
+
+        LogCustomFormatNode * node = httplog_ctx->cf->cf_nodes[i];
+        if (! node) /* Should never happen */
+            continue;
+
+        switch (node->type){
+            case LOG_CF_LITERAL:
             /* LITERAL */
-                MemBufferWriteString(aft->buffer, "%s", httplog_ctx->cf_nodes[i]->data);
+                MemBufferWriteString(aft->buffer, "%s", node->data);
                 break;
-            case LOG_HTTP_CF_TIMESTAMP:
+            case LOG_CF_TIMESTAMP:
             /* TIMESTAMP */
-                if (httplog_ctx->cf_nodes[i]->data[0] == '\0') {
-                    strftime(buf, 62, TIMESTAMP_DEFAULT_FORMAT, timestamp);
-                } else {
-                    strftime(buf, 62, httplog_ctx->cf_nodes[i]->data, timestamp);
-                }
-                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                            aft->buffer->size, (uint8_t *)buf,strlen(buf));
+                LogCustomFormatWriteTimestamp(aft->buffer, node->data, ts);
                 break;
-            case LOG_HTTP_CF_TIMESTAMP_U:
+            case LOG_CF_TIMESTAMP_U:
             /* TIMESTAMP USECONDS */
-                snprintf(buf, 62, "%06u", (unsigned int) ts->tv_usec);
+                snprintf(buf, 6, "%06u", (unsigned int) ts->tv_usec);
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
                             aft->buffer->size, (uint8_t *)buf,strlen(buf));
                 break;
-            case LOG_HTTP_CF_CLIENT_IP:
+            case LOG_CF_CLIENT_IP:
             /* CLIENT IP ADDRESS */
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
                             aft->buffer->size, (uint8_t *)srcip,strlen(srcip));
                 break;
-            case LOG_HTTP_CF_SERVER_IP:
+            case LOG_CF_SERVER_IP:
             /* SERVER IP ADDRESS */
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
                             aft->buffer->size, (uint8_t *)dstip,strlen(dstip));
                 break;
-            case LOG_HTTP_CF_CLIENT_PORT:
+            case LOG_CF_CLIENT_PORT:
             /* CLIENT PORT */
                 MemBufferWriteString(aft->buffer, "%" PRIu16 "", sp);
                 break;
-            case LOG_HTTP_CF_SERVER_PORT:
+            case LOG_CF_SERVER_PORT:
             /* SERVER PORT */
                 MemBufferWriteString(aft->buffer, "%" PRIu16 "", dp);
                 break;
@@ -214,13 +191,13 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                 aft->buffer->size, (uint8_t *)bstr_ptr(tx->request_method),
                                 bstr_len(tx->request_method));
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_URI:
             /* URI */
                 if (tx->request_uri != NULL) {
-                    datalen = httplog_ctx->cf_nodes[i]->maxlen;
+                    datalen = node->maxlen;
                     if (datalen == 0 || datalen > bstr_len(tx->request_uri)) {
                         datalen = bstr_len(tx->request_uri);
                     }
@@ -228,14 +205,14 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                 aft->buffer->size, (uint8_t *)bstr_ptr(tx->request_uri),
                                 datalen);
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_HOST:
             /* HOSTNAME */
                 if (tx->request_hostname != NULL)
                 {
-                    datalen = httplog_ctx->cf_nodes[i]->maxlen;
+                    datalen = node->maxlen;
                     if (datalen == 0 || datalen > bstr_len(tx->request_hostname)) {
                         datalen = bstr_len(tx->request_hostname);
                     }
@@ -243,7 +220,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                 aft->buffer->size, (uint8_t *)bstr_ptr(tx->request_hostname),
                                 datalen);
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_PROTOCOL:
@@ -253,16 +230,16 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                     aft->buffer->size, (uint8_t *)bstr_ptr(tx->request_protocol),
                                     bstr_len(tx->request_protocol));
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_HEADER:
             /* REQUEST HEADER */
                 if (tx->request_headers != NULL) {
-                    h_request_hdr = htp_table_get_c(tx->request_headers, httplog_ctx->cf_nodes[i]->data);
+                    h_request_hdr = htp_table_get_c(tx->request_headers, node->data);
                 }
                 if (h_request_hdr != NULL) {
-                    datalen = httplog_ctx->cf_nodes[i]->maxlen;
+                    datalen = node->maxlen;
                     if (datalen == 0 || datalen > bstr_len(h_request_hdr->value)) {
                         datalen = bstr_len(h_request_hdr->value);
                     }
@@ -270,7 +247,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                     aft->buffer->size, (uint8_t *)bstr_ptr(h_request_hdr->value),
                                     datalen);
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_COOKIE:
@@ -279,19 +256,19 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                     h_request_hdr = htp_table_get_c(tx->request_headers, "Cookie");
                     if (h_request_hdr != NULL) {
                         cvalue_len = GetCookieValue((uint8_t *) bstr_ptr(h_request_hdr->value),
-                                    bstr_len(h_request_hdr->value), (char *) httplog_ctx->cf_nodes[i]->data,
+                                    bstr_len(h_request_hdr->value), (char *) node->data,
                                     &cvalue);
                     }
                 }
                 if (cvalue_len > 0 && cvalue != NULL) {
-                    datalen = httplog_ctx->cf_nodes[i]->maxlen;
+                    datalen = node->maxlen;
                     if (datalen == 0 || datalen > cvalue_len) {
                         datalen = cvalue_len;
                     }
                     PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
                                     aft->buffer->size, cvalue, datalen);
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_REQUEST_LEN:
@@ -305,17 +282,17 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                     aft->buffer->size, (uint8_t *)bstr_ptr(tx->response_status),
                                     bstr_len(tx->response_status));
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_RESPONSE_HEADER:
             /* RESPONSE HEADER */
                 if (tx->response_headers != NULL) {
                     h_response_hdr = htp_table_get_c(tx->response_headers,
-                                    httplog_ctx->cf_nodes[i]->data);
+                                    node->data);
                 }
                 if (h_response_hdr != NULL) {
-                    datalen = httplog_ctx->cf_nodes[i]->maxlen;
+                    datalen = node->maxlen;
                     if (datalen == 0 || datalen > bstr_len(h_response_hdr->value)) {
                         datalen = bstr_len(h_response_hdr->value);
                     }
@@ -323,7 +300,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                                     aft->buffer->size, (uint8_t *)bstr_ptr(h_response_hdr->value),
                                     datalen);
                 } else {
-                    MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
+                    MemBufferWriteString(aft->buffer, LOG_CF_NONE);
                 }
                 break;
             case LOG_HTTP_CF_RESPONSE_LEN:
@@ -332,8 +309,8 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                 break;
             default:
             /* NO MATCH */
-                MemBufferWriteString(aft->buffer, LOG_HTTP_CF_NONE);
-                SCLogDebug("No matching parameter %%%c for custom http log.", httplog_ctx->cf_nodes[i]->type);
+                MemBufferWriteString(aft->buffer, LOG_CF_NONE);
+                SCLogDebug("No matching parameter %%%c for custom http log.", node->type);
                 break;
         }
     }
@@ -342,7 +319,7 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
 
 static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
 {
-    MemBufferWriteString(aft->buffer, " [**] ");
+    LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
     /* referer */
     htp_header_t *h_referer = NULL;
@@ -356,7 +333,8 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
     } else {
         MemBufferWriteString(aft->buffer, "<no referer>");
     }
-    MemBufferWriteString(aft->buffer, " [**] ");
+
+    LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
     /* method */
     if (tx->request_method != NULL) {
@@ -364,7 +342,7 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
                        (uint8_t *)bstr_ptr(tx->request_method),
                        bstr_len(tx->request_method));
     }
-    MemBufferWriteString(aft->buffer, " [**] ");
+    LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
     /* protocol */
     if (tx->request_protocol != NULL) {
@@ -374,7 +352,7 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
     } else {
         MemBufferWriteString(aft->buffer, "<no protocol>");
     }
-    MemBufferWriteString(aft->buffer, " [**] ");
+    LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
     /* response status */
     if (tx->response_status != NULL) {
@@ -397,7 +375,8 @@ static void LogHttpLogExtended(LogHttpLogThread *aft, htp_tx_t *tx)
     }
 
     /* length */
-    MemBufferWriteString(aft->buffer, " [**] %"PRIuMAX" bytes", (uintmax_t)tx->response_message_len);
+    LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
+    MemBufferWriteString(aft->buffer, "%"PRIuMAX" bytes", (uintmax_t)tx->response_message_len);
 }
 
 static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, Flow *f, HtpState *htp_state, htp_tx_t *tx, uint64_t tx_id, int ipproto)
@@ -464,7 +443,7 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
         } else {
             MemBufferWriteString(aft->buffer, "<hostname unknown>");
         }
-        MemBufferWriteString(aft->buffer, " [**] ");
+        LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
         /* uri */
         if (tx->request_uri != NULL) {
@@ -472,7 +451,7 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
                     (uint8_t *)bstr_ptr(tx->request_uri),
                     bstr_len(tx->request_uri));
         }
-        MemBufferWriteString(aft->buffer, " [**] ");
+        LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
 
         /* user agent */
         htp_header_t *h_user_agent = NULL;
@@ -491,8 +470,9 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
         }
 
         /* ip/tcp header info */
+        LOG_CF_WRITE_STAR_SEPATATOR(aft->buffer);
         MemBufferWriteString(aft->buffer,
-                " [**] %s:%" PRIu16 " -> %s:%" PRIu16 "\n",
+                "%s:%" PRIu16 " -> %s:%" PRIu16 "\n",
                 srcip, sp, dstip, dp);
     }
 
@@ -585,8 +565,6 @@ void LogHttpLogExitPrintStats(ThreadVars *tv, void *data)
 OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
 {
     LogFileCtx* file_ctx = LogFileNewCtx();
-    const char *p, *np;
-    uint32_t n;
     if(file_ctx == NULL) {
         SCLogError(SC_ERR_HTTP_LOG_GENERIC, "couldn't create new file_ctx");
         return NULL;
@@ -605,7 +583,6 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
     memset(httplog_ctx, 0x00, sizeof(LogHttpFileCtx));
 
     httplog_ctx->file_ctx = file_ctx;
-    httplog_ctx->cf_n=0;
 
     const char *extended = ConfNodeLookupChildValue(conf, "extended");
     const char *custom = ConfNodeLookupChildValue(conf, "custom");
@@ -613,74 +590,17 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
 
     /* If custom logging format is selected, lets parse it */
     if (custom != NULL && customformat != NULL && ConfValIsTrue(custom)) {
-        p=customformat;
-        httplog_ctx->flags |= LOG_HTTP_CUSTOM;
-        for (httplog_ctx->cf_n = 0; httplog_ctx->cf_n < LOG_HTTP_MAXN_NODES-1 && p && *p != '\0';
-                                                    httplog_ctx->cf_n++){
-            httplog_ctx->cf_nodes[httplog_ctx->cf_n] = SCMalloc(sizeof(LogHttpCustomFormatNode));
-            if (httplog_ctx->cf_nodes[httplog_ctx->cf_n] == NULL) {
-                for (n = 0; n < httplog_ctx->cf_n; n++) {
-                    SCFree(httplog_ctx->cf_nodes[n]);
-                }
-                LogFileFreeCtx(file_ctx);
-                SCFree(httplog_ctx);
-                return NULL;
-            }
-            httplog_ctx->cf_nodes[httplog_ctx->cf_n]->maxlen = 0;
 
-            if (*p != '%'){
-                /* Literal found in format string */
-                httplog_ctx->cf_nodes[httplog_ctx->cf_n]->type = LOG_HTTP_CF_LITERAL;
-                np = strchr(p, '%');
-                if (np == NULL){
-                    n = LOG_HTTP_NODE_STRLEN-2;
-                    np = NULL; /* End */
-                }else{
-                    n = np-p;
-                }
-                strlcpy(httplog_ctx->cf_nodes[httplog_ctx->cf_n]->data,p,n+1);
-                p = np;
-            } else {
-                /* Non Literal found in format string */
-                p++;
-                if (*p == '[') { /* Check if maxlength has been specified (ie: [25]) */
-                    p++;
-                    np = strchr(p, ']');
-                    if (np != NULL) {
-                        if (np-p > 0 && np-p < 10){
-                            long maxlen = strtol(p,NULL,10);
-                            if (maxlen > 0 && maxlen < LOG_HTTP_NODE_MAXOUTPUTLEN) {
-                                httplog_ctx->cf_nodes[httplog_ctx->cf_n]->maxlen = (uint32_t) maxlen;
-                            }
-                        } else {
-                            goto parsererror;
-                        }
-                        p = np + 1;
-                    } else {
-                        goto parsererror;
-                    }
-                }
-                if (*p == '{') { /* Simple format char */
-                    np = strchr(p, '}');
-                    if (np != NULL && np-p > 1 && np-p < LOG_HTTP_NODE_STRLEN-2) {
-                        p++;
-                        n = np-p;
-                        strlcpy(httplog_ctx->cf_nodes[httplog_ctx->cf_n]->data, p, n+1);
-                        p = np;
-                    } else {
-                        goto parsererror;
-                    }
-                    p++;
-                } else {
-                    httplog_ctx->cf_nodes[httplog_ctx->cf_n]->data[0] = '\0';
-                }
-                httplog_ctx->cf_nodes[httplog_ctx->cf_n]->type = *p;
-                if (*p == '%'){
-                    httplog_ctx->cf_nodes[httplog_ctx->cf_n]->type = LOG_HTTP_CF_LITERAL;
-                    strlcpy(httplog_ctx->cf_nodes[httplog_ctx->cf_n]->data, "%", 2);
-                }
-                p++;
-            }
+        httplog_ctx->cf = LogCustomFormatAlloc();
+        if (!httplog_ctx->cf) {
+            goto errorfree;
+        }
+
+        httplog_ctx->flags |= LOG_HTTP_CUSTOM;
+
+        /* Parsing */
+        if ( ! LogCustomFormatParse(httplog_ctx->cf, customformat)) {
+            goto parsererror;
         }
     } else {
         if (extended == NULL) {
@@ -708,12 +628,11 @@ OutputCtx *LogHttpLogInitCtx(ConfNode *conf)
     return output_ctx;
 
 parsererror:
-    for (n = 0;n < httplog_ctx->cf_n;n++) {
-        SCFree(httplog_ctx->cf_nodes[n]);
-    }
+    SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom http log format string.");
+errorfree:
+    LogCustomFormatFree(httplog_ctx->cf);
     LogFileFreeCtx(file_ctx);
     SCFree(httplog_ctx);
-    SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom http log format string.");
     return NULL;
 
 }
@@ -721,10 +640,7 @@ parsererror:
 static void LogHttpLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogHttpFileCtx *httplog_ctx = (LogHttpFileCtx *)output_ctx->data;
-    uint32_t i;
-    for (i = 0; i < httplog_ctx->cf_n; i++) {
-        SCFree(httplog_ctx->cf_nodes[i]);
-    }
+    LogCustomFormatFree(httplog_ctx->cf);
     LogFileFreeCtx(httplog_ctx->file_ctx);
     SCFree(httplog_ctx);
     SCFree(output_ctx);

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -21,6 +21,7 @@
  * \author Roliers Jean-Paul <popof.fpn@gmail.co>
  * \author Eric Leblond <eric@regit.org>
  * \author Victor Julien <victor@inliniac.net>
+ * \author Paulo Pacheco <fooinha@gmail.com>
  *
  * Implements TLS logging portion of the engine. The TLS logger is
  * implemented as a packet logger, as the TLS parser is not transaction
@@ -53,6 +54,7 @@
 #include "util-logopenfile.h"
 #include "util-crypt.h"
 #include "util-time.h"
+#include "log-cf-common.h"
 
 #define DEFAULT_LOG_FILENAME "tls.log"
 
@@ -63,10 +65,21 @@
 
 #define LOG_TLS_DEFAULT     0
 #define LOG_TLS_EXTENDED    1
+#define LOG_TLS_CUSTOM      2
+
+#define LOG_TLS_CF_VERSION 'v'
+#define LOG_TLS_CF_DATE_NOT_BEFORE 'd'
+#define LOG_TLS_CF_DATE_NOT_AFTER 'D'
+#define LOG_TLS_CF_SHA1 'f'
+#define LOG_TLS_CF_SNI 'n'
+#define LOG_TLS_CF_SUBJECT 's'
+#define LOG_TLS_CF_ISSUER 'i'
+#define LOG_TLS_CF_EXTENDED 'E'
 
 typedef struct LogTlsFileCtx_ {
     LogFileCtx *file_ctx;
     uint32_t flags; /** Store mode */
+    LogCustomFormat *cf;
 } LogTlsFileCtx;
 
 typedef struct LogTlsLogThread_ {
@@ -78,55 +91,70 @@ typedef struct LogTlsLogThread_ {
     MemBuffer *buffer;
 } LogTlsLogThread;
 
+static void LogTlsLogVersion(MemBuffer *buffer, uint16_t version)
+{
+    switch (version) {
+        case TLS_VERSION_UNKNOWN:
+            MemBufferWriteString(buffer, "VERSION='UNDETERMINED'");
+            break;
+        case SSL_VERSION_2:
+            MemBufferWriteString(buffer, "VERSION='SSLv2'");
+            break;
+        case SSL_VERSION_3:
+            MemBufferWriteString(buffer, "VERSION='SSLv3'");
+            break;
+        case TLS_VERSION_10:
+            MemBufferWriteString(buffer, "VERSION='TLSv1'");
+            break;
+        case TLS_VERSION_11:
+            MemBufferWriteString(buffer, "VERSION='TLS 1.1'");
+            break;
+        case TLS_VERSION_12:
+            MemBufferWriteString(buffer, "VERSION='TLS 1.2'");
+            break;
+        default:
+            MemBufferWriteString(buffer, "VERSION='0x%04x'", version);
+            break;
+    }
+}
+
+static void LogTlsLogDate(MemBuffer *buffer, const char *title, time_t *date)
+{
+    char timebuf[64] = {0};
+    struct timeval tv;
+    tv.tv_sec = *date;
+    tv.tv_usec = 0;
+    CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
+    MemBufferWriteString(buffer, "%s='%s'", title, timebuf);
+}
+
+static void LogTlsLogString(MemBuffer *buffer, const char *title, const char *value)
+{
+    MemBufferWriteString(buffer, "%s='%s'", title, value);
+}
+
 static void LogTlsLogExtended(LogTlsLogThread *aft, SSLState * state)
 {
     if (state->server_connp.cert0_fingerprint != NULL) {
-        MemBufferWriteString(aft->buffer, " SHA1='%s'", state->server_connp.cert0_fingerprint);
+        LOG_CF_WRITE_SPACE_SEPARATOR(aft->buffer);
+        LogTlsLogString(aft->buffer, "SHA1", state->server_connp.cert0_fingerprint);
     }
     if (state->client_connp.sni != NULL) {
-        MemBufferWriteString(aft->buffer, " SNI='%s'", state->client_connp.sni);
+        LOG_CF_WRITE_SPACE_SEPARATOR(aft->buffer);
+        LogTlsLogString(aft->buffer, "SNI", state->client_connp.sni);
     }
-    switch (state->server_connp.version) {
-        case TLS_VERSION_UNKNOWN:
-            MemBufferWriteString(aft->buffer, " VERSION='UNDETERMINED'");
-            break;
-        case SSL_VERSION_2:
-            MemBufferWriteString(aft->buffer, " VERSION='SSLv2'");
-            break;
-        case SSL_VERSION_3:
-            MemBufferWriteString(aft->buffer, " VERSION='SSLv3'");
-            break;
-        case TLS_VERSION_10:
-            MemBufferWriteString(aft->buffer, " VERSION='TLSv1'");
-            break;
-        case TLS_VERSION_11:
-            MemBufferWriteString(aft->buffer, " VERSION='TLS 1.1'");
-            break;
-        case TLS_VERSION_12:
-            MemBufferWriteString(aft->buffer, " VERSION='TLS 1.2'");
-            break;
-        default:
-            MemBufferWriteString(aft->buffer, " VERSION='0x%04x'",
-                                 state->server_connp.version);
-            break;
-    }
+
+    LOG_CF_WRITE_SPACE_SEPARATOR(aft->buffer);
+    LogTlsLogVersion(aft->buffer, state->server_connp.version);
+
     if (state->server_connp.cert0_not_before != 0) {
-        char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = state->server_connp.cert0_not_before;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
-        MemBufferWriteString(aft->buffer, " NOTBEFORE='%s'", timebuf);
+        LOG_CF_WRITE_SPACE_SEPARATOR(aft->buffer);
+        LogTlsLogDate(aft->buffer, "NOTBEFORE", &state->server_connp.cert0_not_before);
     }
     if (state->server_connp.cert0_not_after != 0) {
-        char timebuf[64];
-        struct timeval tv;
-        tv.tv_sec = state->server_connp.cert0_not_after;
-        tv.tv_usec = 0;
-        CreateUtcIsoTimeString(&tv, timebuf, sizeof(timebuf));
-        MemBufferWriteString(aft->buffer, " NOTAFTER='%s'", timebuf);
+        LOG_CF_WRITE_SPACE_SEPARATOR(aft->buffer);
+        LogTlsLogDate(aft->buffer, "NOTAFTER", &state->server_connp.cert0_not_after);
     }
-    MemBufferWriteString(aft->buffer, "\n");
 }
 
 int TLSGetIPInformations(const Packet *p, char* srcip, size_t srcip_len,
@@ -212,6 +240,7 @@ static void LogTlsLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogTlsFileCtx *tlslog_ctx = (LogTlsFileCtx *) output_ctx->data;
     LogFileFreeCtx(tlslog_ctx->file_ctx);
+    LogCustomFormatFree(tlslog_ctx->cf);
     SCFree(tlslog_ctx);
     SCFree(output_ctx);
 }
@@ -250,11 +279,28 @@ static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
     tlslog_ctx->file_ctx = file_ctx;
 
     const char *extended = ConfNodeLookupChildValue(conf, "extended");
-    if (extended == NULL) {
-        tlslog_ctx->flags |= LOG_TLS_DEFAULT;
+    const char *custom = ConfNodeLookupChildValue(conf, "custom");
+    const char *customformat = ConfNodeLookupChildValue(conf, "customformat");
+
+    /* If custom logging format is selected, lets parse it */
+    if (custom != NULL && customformat != NULL && ConfValIsTrue(custom)) {
+        tlslog_ctx->cf = LogCustomFormatAlloc();
+        if (!tlslog_ctx->cf) {
+            goto tlslog_error;
+        }
+
+        tlslog_ctx->flags |= LOG_TLS_CUSTOM;
+        /* Parsing */
+        if ( ! LogCustomFormatParse(tlslog_ctx->cf, customformat)) {
+            goto parser_error;
+        }
     } else {
-        if (ConfValIsTrue(extended)) {
-            tlslog_ctx->flags |= LOG_TLS_EXTENDED;
+        if (extended == NULL) {
+            tlslog_ctx->flags |= LOG_TLS_DEFAULT;
+        } else {
+            if (ConfValIsTrue(extended)) {
+                tlslog_ctx->flags |= LOG_TLS_EXTENDED;
+            }
         }
     }
 
@@ -270,13 +316,118 @@ static OutputCtx *LogTlsLogInitCtx(ConfNode *conf)
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_TLS);
 
     return output_ctx;
-
+parser_error:
+    SCLogError(SC_ERR_INVALID_ARGUMENT,"Syntax error in custom tls log format string.");
 tlslog_error:
+    LogCustomFormatFree(tlslog_ctx->cf);
     SCFree(tlslog_ctx);
 filectx_error:
     LogFileFreeCtx(file_ctx);
     return NULL;
 }
+
+/* Custom format logging */
+static void LogTlsLogCustom(LogTlsLogThread *aft, SSLState *ssl_state, const struct timeval *ts,
+                            char *srcip, Port sp, char *dstip, Port dp)
+{
+    LogTlsFileCtx *tlslog_ctx = aft->tlslog_ctx;
+    uint32_t i;
+    char buf[6];
+
+    for (i = 0; i < tlslog_ctx->cf->cf_n; i++) {
+
+        LogCustomFormatNode * node = tlslog_ctx->cf->cf_nodes[i];
+        if (! node) /* Should never happen */
+            continue;
+
+        switch (node->type){
+            case LOG_CF_LITERAL:
+            /* LITERAL */
+                MemBufferWriteString(aft->buffer, "%s", node->data);
+                break;
+            case LOG_CF_TIMESTAMP:
+            /* TIMESTAMP */
+                LogCustomFormatWriteTimestamp(aft->buffer, node->data, ts);
+                break;
+            case LOG_CF_TIMESTAMP_U:
+            /* TIMESTAMP USECONDS */
+                snprintf(buf, 6, "%06u", (unsigned int) ts->tv_usec);
+                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
+                            aft->buffer->size, (uint8_t *)buf,strlen(buf));
+                break;
+            case LOG_CF_CLIENT_IP:
+            /* CLIENT IP ADDRESS */
+                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
+                            aft->buffer->size, (uint8_t *)srcip,strlen(srcip));
+                break;
+            case LOG_CF_SERVER_IP:
+            /* SERVER IP ADDRESS */
+                PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
+                            aft->buffer->size, (uint8_t *)dstip,strlen(dstip));
+                break;
+            case LOG_CF_CLIENT_PORT:
+            /* CLIENT PORT */
+                MemBufferWriteString(aft->buffer, "%" PRIu16 "", sp);
+                break;
+            case LOG_CF_SERVER_PORT:
+            /* SERVER PORT */
+                MemBufferWriteString(aft->buffer, "%" PRIu16 "", dp);
+                break;
+            case LOG_TLS_CF_VERSION:
+                LogTlsLogVersion(aft->buffer, ssl_state->server_connp.version);
+                break;
+            case LOG_TLS_CF_DATE_NOT_BEFORE:
+                LogTlsLogDate(aft->buffer, "NOTBEFORE", &ssl_state->server_connp.cert0_not_before);
+                break;
+            case LOG_TLS_CF_DATE_NOT_AFTER:
+                LogTlsLogDate(aft->buffer, "NOTAFTER", &ssl_state->server_connp.cert0_not_after);
+                break;
+            case LOG_TLS_CF_SHA1:
+                if (ssl_state->server_connp.cert0_fingerprint != NULL) {
+                    MemBufferWriteString(aft->buffer, "%s",
+                                         ssl_state->server_connp.cert0_fingerprint);
+                } else {
+                    LOG_CF_WRITE_UNKNOWN_VALUE(aft->buffer);
+                }
+                break;
+            case LOG_TLS_CF_SNI:
+                if (ssl_state->client_connp.sni != NULL) {
+                    MemBufferWriteString(aft->buffer, "%s",
+                                         ssl_state->client_connp.sni);
+                } else {
+                    LOG_CF_WRITE_UNKNOWN_VALUE(aft->buffer);
+                }
+                break;
+            case LOG_TLS_CF_SUBJECT:
+                if (ssl_state->server_connp.cert0_subject != NULL) {
+                    MemBufferWriteString(aft->buffer, "%s",
+                                         ssl_state->server_connp.cert0_subject);
+                } else {
+                    LOG_CF_WRITE_UNKNOWN_VALUE(aft->buffer);
+                }
+                break;
+            case LOG_TLS_CF_ISSUER:
+                if (ssl_state->server_connp.cert0_issuerdn != NULL) {
+                    MemBufferWriteString(aft->buffer, "%s",
+                                         ssl_state->server_connp.cert0_issuerdn);
+                } else {
+                    LOG_CF_WRITE_UNKNOWN_VALUE(aft->buffer);
+                }
+                break;
+            case LOG_TLS_CF_EXTENDED:
+            /* Extended format  */
+                LogTlsLogExtended(aft, ssl_state);
+                break;
+            default:
+            /* NO MATCH */
+                MemBufferWriteString(aft->buffer, LOG_CF_NONE);
+                SCLogDebug("No matching parameter %%%c for custom http log.", node->type);
+                break;
+        }
+    }
+    MemBufferWriteString(aft->buffer, "\n");
+}
+
 
 static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
                         Flow *f, void *state, void *tx, uint64_t tx_id)
@@ -296,7 +447,6 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
 #define PRINT_BUF_LEN 46
     char srcip[PRINT_BUF_LEN], dstip[PRINT_BUF_LEN];
     Port sp, dp;
@@ -305,17 +455,25 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    MemBufferReset(aft->buffer);
-    MemBufferWriteString(aft->buffer,
-                         "%s %s:%d -> %s:%d  TLS: Subject='%s' Issuerdn='%s'",
-                         timebuf, srcip, sp, dstip, dp,
-                         ssl_state->server_connp.cert0_subject,
-                         ssl_state->server_connp.cert0_issuerdn);
-
-    if (hlog->flags & LOG_TLS_EXTENDED) {
-        LogTlsLogExtended(aft, ssl_state);
+    /* Custom format */
+    if (hlog->flags & LOG_TLS_CUSTOM) {
+        LogTlsLogCustom(aft, ssl_state, &p->ts, srcip, sp, dstip, dp);
     } else {
-        MemBufferWriteString(aft->buffer, "\n");
+
+        MemBufferReset(aft->buffer);
+        CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
+        MemBufferWriteString(aft->buffer,
+                "%s %s:%d -> %s:%d  TLS: Subject='%s' Issuerdn='%s'",
+                timebuf, srcip, sp, dstip, dp,
+                ssl_state->server_connp.cert0_subject,
+                ssl_state->server_connp.cert0_issuerdn);
+
+        if (hlog->flags & LOG_TLS_EXTENDED) {
+            LogTlsLogExtended(aft, ssl_state);
+            MemBufferWriteString(aft->buffer, "\n");
+        } else {
+            MemBufferWriteString(aft->buffer, "\n");
+        }
     }
 
     aft->tls_cnt++;

--- a/src/output.c
+++ b/src/output.c
@@ -48,6 +48,7 @@
 #include "output-json-alert.h"
 #include "output-json-flow.h"
 #include "output-json-netflow.h"
+#include "log-cf-common.h"
 #include "log-droplog.h"
 #include "output-json-drop.h"
 #include "log-httplog.h"
@@ -1025,6 +1026,9 @@ void OutputRegisterRootLoggers(void)
  */
 void OutputRegisterLoggers(void)
 {
+    /* custom format log*/
+    LogCustomFormatRegister();
+
     LuaLogRegister();
     /* fast log */
     AlertFastLogRegister();

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -336,6 +336,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_NO_MAGIC_SUPPORT);
         CASE_CODE (SC_ERR_REDIS);
         CASE_CODE (SC_ERR_VAR_LIMIT);
+        CASE_CODE(SC_WARN_LOG_CF_TOO_MANY_NODES);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -326,6 +326,7 @@ typedef enum {
     SC_ERR_NO_MAGIC_SUPPORT,
     SC_ERR_REDIS,
     SC_ERR_VAR_LIMIT,
+    SC_WARN_LOG_CF_TOO_MANY_NODES,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -208,6 +208,15 @@ void CreateUtcIsoTimeString (const struct timeval *ts, char *str, size_t size)
     }
 }
 
+void CreateFormattedTimeString (const struct tm *t, const char *fmt, char *str, size_t size)
+{
+    if (likely(t != NULL) && likely(fmt != NULL) && likely(str != NULL) ) {
+        strftime(str, size, fmt, t);
+    } else {
+        snprintf(str, size, "ts-error");
+    }
+}
+
 struct tm *SCUtcTime(time_t timep, struct tm *result)
 {
     return gmtime_r(&timep, result);

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -51,11 +51,12 @@ void TimeModeSetOffline (void);
 int TimeModeIsLive(void);
 
 struct tm *SCLocalTime(time_t timep, struct tm *result);
-void CreateTimeString (const struct timeval *ts, char *str, size_t size);
-void CreateIsoTimeString (const struct timeval *ts, char *str, size_t size);
-void CreateUtcIsoTimeString (const struct timeval *ts, char *str, size_t size);
-time_t SCMkTimeUtc (struct tm *tp);
-int SCStringPatternToTime (char *string, char **patterns,
+void CreateTimeString(const struct timeval *ts, char *str, size_t size);
+void CreateIsoTimeString(const struct timeval *ts, char *str, size_t size);
+void CreateUtcIsoTimeString(const struct timeval *ts, char *str, size_t size);
+void CreateFormattedTimeString(const struct tm *t, const char * fmt, char *str, size_t size);
+time_t SCMkTimeUtc(struct tm *tp);
+int SCStringPatternToTime(char *string, char **patterns,
                            int num_patterns, struct tm *time);
 
 #endif /* __UTIL_TIME_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -298,8 +298,10 @@ outputs:
       enabled: no  # Log TLS connections.
       filename: tls.log # File to store TLS logs.
       append: yes
+      #extended: yes     # Log extended information like fingerprint
+      #custom: yes       # enabled the custom logging format (defined by customformat)
+      #customformat: "%{%D-%H:%M:%S}t.%z %a:%p -> %A:%P %v %n %d %D"
       #filetype: regular # 'regular', 'unix_stream' or 'unix_dgram'
-      #extended: yes # Log extended information like fingerprint
 
   # output module to store certificates chain to disk
   - tls-store:


### PR DESCRIPTION
Custom format output for TLS/SSL

Work in progress for review and comments.

Requires #2448.
Useful for #2427 ( @thus ) and future output loggers.
