### PR TITLE
http: allow lower/mixed case in proto detect

### DIFF
--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2737,7 +2737,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
              * 3 is subtracted from the length since the spacing is hex typed as |xx|
              * but the pattern matching should only be one char
             */
-            register_result = AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP,
+            register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP,
                     ALPROTO_HTTP, method_buffer, strlen(method_buffer)-3, 0, STREAM_TOSERVER);
             if (register_result < 0) {
                 return -1;
@@ -2747,7 +2747,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
 
     /* Loop through all the http verions patterns that are TO_CLIENT */
     for (versions_pos = 0; versions[versions_pos]; versions_pos++) {
-        register_result = AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP,
+        register_result = AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP,
                 ALPROTO_HTTP, versions[versions_pos], strlen(versions[versions_pos]),
                 0, STREAM_TOCLIENT);
         if (register_result < 0) {


### PR DESCRIPTION
In HTTP detection registered patterns were upper case only. Since the
detection is based on both sides this would still work for sessions
where one of the talkers misbehaved. If both sides misbehave this
would fail however, so this patch introduces case insensitive matching.

PRscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/38
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/546

https://redmine.openinfosecfoundation.org/issues/1984