### PR TITLE
log-pcap: use a snaplen of 262144 instead of -1 - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -82,6 +82,8 @@
 #define HONOR_PASS_RULES_DISABLED       0
 #define HONOR_PASS_RULES_ENABLED        1
 
+#define PCAP_SNAPLEN                    262144
+
 SC_ATOMIC_DECLARE(uint32_t, thread_cnt);
 
 typedef struct PcapFileName_ {
@@ -317,7 +319,7 @@ static int PcapLogOpenHandles(PcapLogData *pl, const Packet *p)
 
     if (pl->pcap_dead_handle == NULL) {
         if ((pl->pcap_dead_handle = pcap_open_dead(p->datalink,
-                        -1)) == NULL) {
+                        PCAP_SNAPLEN)) == NULL) {
             SCLogDebug("Error opening dead pcap handle");
             return TM_ECODE_FAILED;
         }


### PR DESCRIPTION
Newer versions of libpcap will not open pcap files with a
snaplen of -1, instead use the current maximum value of
262144.

Issue:
https://redmine.openinfosecfoundation.org/issues/1987

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/57
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/409
