### PR TITLE
app-layer-tls: don't trigger decoder event when no CLIENT_HELLO extensions are present

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -275,8 +275,9 @@ static int TLSDecodeHandshakeHello(SSLState *ssl_state, uint8_t *input,
 
     input += compression_methods_length;
 
+    /* extensions are optional (RFC5246 section 7.4.1.2) */
     if (!(HAS_SPACE(2)))
-        goto invalid_length;
+        goto end;
 
     uint16_t extensions_len = input[0] << 8 | input[1];
     input += 2;


### PR DESCRIPTION
Extensions are optional, so don't trigger "SURICATA TLS handshake invalid length" decoder event when no extensions are present in CLIENT HELLO record.

Partially fixes the following issue:
https://redmine.openinfosecfoundation.org/issues/1982

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/59
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/59
