### PR TITLE
app-layer-tls: fix tls_cert_subject prefilter bug

### DIFF
--- a/src/detect-engine-tls.c
+++ b/src/detect-engine-tls.c
@@ -215,7 +215,7 @@ static void PrefilterTxTlsSubject(DetectEngineThreadCtx *det_ctx, const void *pe
     const MpmCtx *mpm_ctx = (MpmCtx *)pectx;
     SSLState *ssl_state = f->alstate;
 
-    if (ssl_state->server_connp.cert0_issuerdn == NULL)
+    if (ssl_state->server_connp.cert0_subject == NULL)
         return;
 
     const uint8_t *buffer = (const uint8_t *)ssl_state->server_connp.cert0_subject;


### PR DESCRIPTION
If check in prefilter was checking that issuer was non-NULL, when it in fact should be checking subject. This caused Suricata to segfault when encountering certificates with an empty subject field.

https://redmine.openinfosecfoundation.org/issues/1988

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/61
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/61