### PR TITLE
smtp: commands and replies are not case sensitive

### DIFF
--- a/src/app-layer-smtp.c
+++ b/src/app-layer-smtp.c
@@ -1490,17 +1490,17 @@ int SMTPStateGetEventInfo(const char *event_name,
 
 static int SMTPRegisterPatternsForProtocolDetection(void)
 {
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMTP,
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "EHLO", 4, 0, STREAM_TOSERVER) < 0)
     {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMTP,
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "HELO", 4, 0, STREAM_TOSERVER) < 0)
     {
         return -1;
     }
-    if (AppLayerProtoDetectPMRegisterPatternCS(IPPROTO_TCP, ALPROTO_SMTP,
+    if (AppLayerProtoDetectPMRegisterPatternCI(IPPROTO_TCP, ALPROTO_SMTP,
                                                "QUIT", 4, 0, STREAM_TOSERVER) < 0)
     {
         return -1;


### PR DESCRIPTION
RFC states that "Commands and replies are not case sensitive" and
patterns were registered to be case sensitive. So this patch fixes
a trivial evasion of SMTP signatures.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1989

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/230
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/12