### PR TITLE
pcap-log: fix memory leak during initialization of ring buffer - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -671,6 +671,7 @@ static TmEcode PcapLogInitRingBuffer(PcapLogData *pl)
                     strerror(errno));
             }
             TAILQ_REMOVE(&pl->pcap_file_list, pf, next);
+            PcapFileNameFree(pf);
             pf = TAILQ_FIRST(&pl->pcap_file_list);
             pl->file_cnt--;
         }


### PR DESCRIPTION
A free was missing when files are removed during initialization
of the ring buffer.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1985

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/58
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/410
