### PR TITLE
util-magic: fix build when magic is not available

### DIFF
--- a/src/util-magic.c
+++ b/src/util-magic.c
@@ -659,6 +659,7 @@ end:
 
 void MagicRegisterTests(void)
 {
+#ifdef HAVE_MAGIC
 #ifdef UNITTESTS
     UtRegisterTest("MagicInitTest01", MagicInitTest01);
     UtRegisterTest("MagicInitTest02", MagicInitTest02);
@@ -676,4 +677,6 @@ void MagicRegisterTests(void)
     UtRegisterTest("MagicDetectTest10ValgrindError",
                    MagicDetectTest10ValgrindError);
 #endif /* UNITTESTS */
+#endif /* HAVE_MAGIC */
 }
+


### PR DESCRIPTION
If HAVE_MAGIC is not defined then we don't have the test functions
so we can't register them.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/231
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/13
