### PR TITLE
tls-store: fix bug that causes Suricata to crash

### DIFF
--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -166,7 +166,6 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
             goto end_fwrite_fp;
     }
     fclose(fp);
-    SCFree(aft->enc_buf);
 
     //Logging certificate informations
     memcpy(filename + (strlen(filename) - 3), "meta", 4);
@@ -223,7 +222,6 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
 
 end_fwrite_fp:
     fclose(fp);
-    SCFree(aft->enc_buf);
     if (logging_dir_not_writable < LOGGING_WRITE_ISSUE_LIMIT) {
         SCLogWarning(SC_ERR_FWRITE, "Unable to write certificate");
         logging_dir_not_writable++;
@@ -337,6 +335,9 @@ static TmEcode LogTlsStoreLogThreadDeinit(ThreadVars *t, void *data)
     if (aft == NULL) {
         return TM_ECODE_OK;
     }
+
+    if (aft->enc_buf != NULL)
+        SCFree(aft->enc_buf);
 
     /* clear memory */
     memset(aft, 0, sizeof(LogTlsStoreLogThread));


### PR DESCRIPTION
Fix bug that causes Suricata to crash when the tls.store keyword is used.

```
*** Error in `/usr/bin/suricata': free(): invalid next size (fast): 0x00007fd4b4373180 ***
```

https://redmine.openinfosecfoundation.org/issues/1997

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/62
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/62