### PR TITLE
output-json-tls: custom tls logging

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -202,6 +202,9 @@ outputs:
             #custom: [a, aaaa, cname, mx, ns, ptr, txt]
         - tls:
             extended: yes     # enable this for extended logging information
+            # custom allows to control which tls fields that are included
+            # in eve-log
+            #custom: [subject, issuer, fingerprint, sni, version, not_before, not_after]
         - files:
             force-magic: no   # force logging magic on all logged files
             # force logging of checksums, available hash functions are md5,


### PR DESCRIPTION
Add the possibility to specify in suricata.yaml which tls fields to log in eve-log.

```
- tls:
    extended: no
    custom: [subject, issuer, fingerprint, sni, version, not_before, not_after]
```

https://redmine.openinfosecfoundation.org/issues/1998

- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/63
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/63