### PR TITLE
dns - better response handling - v1

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -605,6 +605,7 @@ void DNSStoreAnswerInState(DNSState *dns_state, const int rtype, const uint8_t *
             return;
         TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
         dns_state->curr = tx;
+        dns_state->transaction_max++;
         tx->tx_num = dns_state->transaction_max;
     }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -597,12 +597,12 @@ uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate)
     SCReturnCT((pstate == NULL) ? 0 : pstate->log_id, "uint64_t");
 }
 
-void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate)
+void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate, uint64_t tx_id)
 {
     SCEnter();
 
     if (pstate != NULL)
-        pstate->log_id++;
+        pstate->log_id = tx_id;
 
     SCReturn;
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -162,7 +162,7 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
 
 
 uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate);
-void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate);
+void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate, uint64_t tx_id);
 void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
                                void *tx, uint32_t logger);
 int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,


### PR DESCRIPTION
The first commit simply updates the transaction id when a transaction is being allocated during a response. This can happen when a request is sent, and then an unexpected response is seen which allocates a new transaction. This commit gives this new transaction a new ID instead of re-using the previous one. Not doing so caused the real response to not be found properly.

The second commit fixes tx logging in the case where a newer transaction is complete but an old one isn't. Currently this will update the last logged ID causing the incomplete transaction from being logged.  Instead this commit will only update the last logged ID if every transaction was logged. This required the function to take the tx id as an argument instead of a simple increment.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2001

An output verification test exists here:
https://github.com/jasonish/suricata-verify/tree/master/dns-udp-unsolicited-response

Prscript:
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/421
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/69