### PR TITLE
detect-parse: simplify port prefiltering

### DIFF
--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -104,11 +104,7 @@ typedef struct SigDuplWrapper_ {
                            ")"
 
 /* if enclosed in [], spaces are allowed */
-#define CONFIG_PCRE_PORT   "(" \
-                            "[\\:A-z0-9_\\$\\!,]+"\
-                           "|"\
-                            "\\[[\\:A-z0-9_\\$\\!,\\s]+\\]"\
-                           ")"
+#define CONFIG_PCRE_PORT   "([\\[\\]\\:A-z0-9_\\$\\!,\\s]+)"
 
 /* format: action space(s) protocol spaces(s) src space(s) sp spaces(s) dir spaces(s) dst spaces(s) dp spaces(s) options */
 #define CONFIG_PCRE "^([A-z]+)\\s+([A-z0-9\\-]+)\\s+" \


### PR DESCRIPTION
Regular expression was not matching some authorized setting like
"![1234, 1235]". This patch simplify the regexp to match on
possible character and let the port parsing code handle the
complete verification.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/1991
 
PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/232
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/14