### PR TITLE
dns - better response handling - v2

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -605,6 +605,7 @@ void DNSStoreAnswerInState(DNSState *dns_state, const int rtype, const uint8_t *
             return;
         TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
         dns_state->curr = tx;
+        dns_state->transaction_max++;
         tx->tx_num = dns_state->transaction_max;
     }
 

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -597,12 +597,12 @@ uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate)
     SCReturnCT((pstate == NULL) ? 0 : pstate->log_id, "uint64_t");
 }
 
-void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate)
+void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate, uint64_t tx_id)
 {
     SCEnter();
 
     if (pstate != NULL)
-        pstate->log_id++;
+        pstate->log_id = tx_id;
 
     SCReturn;
 }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -162,7 +162,7 @@ void AppLayerParserDestroyProtocolParserLocalStorage(uint8_t ipproto, AppProto a
 
 
 uint64_t AppLayerParserGetTransactionLogId(AppLayerParserState *pstate);
-void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate);
+void AppLayerParserSetTransactionLogId(AppLayerParserState *pstate, uint64_t tx_id);
 void AppLayerParserSetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,
                                void *tx, uint32_t logger);
 int AppLayerParserGetTxLogged(uint8_t ipproto, AppProto alproto, void *alstate,


### PR DESCRIPTION
Previous PR: #2479 

Changes from last PR:

Update the LogId to the maximum ID that has been logged where all earlier transactions have also been logged. For example, where "*" means that the request and response have been logged:

1*, 2*, 3*, 4*, 5* -> 5.

1*, 2, 3*, 4*, 5 -> 1.

1*, 2*, 3*, 4, 5* -> 4.

Redmine issue:
https://redmine.openinfosecfoundation.org/issues/2001

An output verification test exists here:
https://github.com/jasonish/suricata-verify/tree/master/dns-udp-unsolicited-response

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/72
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/424
