### PR TITLE
unified2 - nostamp and HUP rotation - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,7 @@
     AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h inttypes.h])
     AC_CHECK_HEADERS([getopt.h])
     AC_CHECK_HEADERS([limits.h netdb.h netinet/in.h poll.h sched.h signal.h])
-    AC_CHECK_HEADERS([stdarg.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h])
+    AC_CHECK_HEADERS([stdarg.h stdint.h stdio.h stdlib.h stdbool.h string.h strings.h sys/ioctl.h])
     AC_CHECK_HEADERS([syslog.h sys/prctl.h sys/socket.h sys/stat.h sys/syscall.h])
     AC_CHECK_HEADERS([sys/time.h time.h unistd.h])
     AC_CHECK_HEADERS([sys/ioctl.h linux/if_ether.h linux/if_packet.h linux/filter.h])

--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -359,66 +359,71 @@ For more advanced configuration options, see :ref:`Eve JSON Output <eve-json-out
 
 The format is documented in :ref:`Eve JSON Format <eve-json-format>`.
 
-Log output for use with Barnyard (unified.log)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This log only supports IPv4. Its information will be stored in the
-default logging directory.  This log is designed to be stored in a
-binary format on the hard disc, where it will be further processed by
-Barnyard. Barnyard can store the output in a database, so Suricata can
-work on other important tasks. Barnyard can add the files in the
-Mysql-database, send them to Sguil or several other output options.
-
-There is a size-limit to the log-file: If Suricata generates an alert,
-it stores this alert in a unified-file. Suricata keeps continuing
-doing that, until the file has reached its limit. Which in the default
-case is at 32 MB. At that point Suricata generates a new file and the
-process starts all over again. Barnyard keeps on processing these
-files. To prevent Suricata from filling up the hard disc, a size limit
-is enforced. When the limit is reached, the file will 'role-over',
-creating a new file. Barnyard removes old files. To every file,
-Suricata adds a time stamp, so it is easy to see which one came first
-and which one is the latter.
-
-::
-
-  -Unified-log:                     #The log-name.
-     enabled: no                    #This log is not enabled. Set 'yes' to enable.
-     filename: unified.log          #The name of the file in the default logging directory.
-     limit: 32                      #The file size limit in megabytes.
-
-This output option has been removed in Suricata 1.1rc1 (see ticket
-#353).
-
-Alert output for use with Barnyard (unified.alert)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-This log only supports IPv4. Its information will be stored in the
-default logging directory.  For further information read the above
-information about ( 2) unified.log)
-
-::
-
-  -Unified-alert:                 #The log-name.
-     enabled: no                  #This log is not enabled. Set 'yes' to enable.
-     filename: unified.alert      #The name of the file in the default logging directory.
-     limit: 32                    #The file size limit in megabytes.
-
-This output option has been removed in Suricata 1.1rc1 (see ticket #353).
-
 Alert output for use with Barnyard2 (unified2.alert)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This log also supports IPv6 in addition to IPv4. It's information will
-be stored in the default logging directory.  For further information
-read the above information about 2. unified.log.
+This log format is a binary format compatible with the unified2 output
+of another popular IDS format and is designed for use with Barnyard2
+or other tools that consume the unified2 log format.
+
+By default a file with the given filename and a timestamp (unix epoch
+format) will be created until the file hits the configured size limit,
+then a new file, with a new timestamp will be created. It is the job
+of other tools, such as Barnyard2 to cleanup old unified2 files.
+
+If the `nostamp` option is set the log file will not have a timestamp
+appended. The file will be re-opened on SIGHUP like other log files
+allowing external log rotation tools to work as expected. However, if
+the limit is reach the file will be deleted and re-opened.
+
+This output supports IPv6 and IPv4 events.
 
 ::
+      
+  - unified2-alert:
+      enabled: yes
 
-  - unified2-alert:               #The log-name.
-      enabled: yes                #This log is enabled. Set 'no' to disable.
-      filename: unified2.alert    #The name of the file in the default logging directory.
-      limit: 32                   #The file size limit in megabytes.
+      # The filename to log to in the default log directory. A
+      # timestamp in unix epoch time will be appended to the filename
+      # unless nostamp is set to yes.
+      filename: unified2.alert
+
+      # File size limit.  Can be specified in kb, mb, gb.  Just a number
+      # is parsed as bytes.
+      #limit: 32mb
+
+      # By default unified2 log files have the file creation time (in
+      # unix epoch format) appended to the filename. Set this to yes to
+      # disable this behaviour.
+      #nostamp: no
+
+      # Sensor ID field of unified2 alerts.
+      #sensor-id: 0
+
+      # Include payload of packets related to alerts. Defaults to true, set to
+      # false if payload is not required.
+      #payload: yes
+
+      # HTTP X-Forwarded-For support by adding the unified2 extra header or
+      # overwriting the source or destination IP address (depending on flow
+      # direction) with the one reported in the X-Forwarded-For HTTP header.
+      # This is helpful when reviewing alerts for traffic that is being reverse
+      # or forward proxied.
+      xff:
+        enabled: no
+        # Two operation modes are available, "extra-data" and "overwrite". Note
+        # that in the "overwrite" mode, if the reported IP address in the HTTP
+        # X-Forwarded-For header is of a different version of the packet
+        # received, it will fall-back to "extra-data" mode.
+        mode: extra-data
+        # Two proxy deployments are supported, "reverse" and "forward". In
+        # a "reverse" deployment the IP address used is the last one, in a
+        # "forward" deployment the first IP address is used.
+        deployment: reverse
+        # Header name where the actual IP address will be reported, if more
+        # than one IP address is present, the last IP address will be the
+        # one taken into consideration.
+        header: X-Forwarded-For
 
 This alert output needs Barnyard2.
 

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -225,7 +225,7 @@ static int Unified2IPv4TypeAlert(ThreadVars *, const Packet *, void *);
 static int Unified2IPv6TypeAlert(ThreadVars *, const Packet *, void *);
 static int Unified2PacketTypeAlert(Unified2AlertThread *, const Packet *, uint32_t, int);
 void Unified2RegisterTests(void);
-int Unified2AlertOpenFileCtx(LogFileCtx *, const char *);
+static int Unified2AlertOpenFileCtx(LogFileCtx *, const char *, bool);
 static void Unified2AlertDeInitCtx(OutputCtx *);
 
 int Unified2Condition(ThreadVars *tv, const Packet *p);
@@ -263,15 +263,15 @@ static int Unified2AlertCloseFile(Unified2AlertThread *aun)
  *  \retval 0 on succces
  *  \retval -1 on failure
  */
-static int Unified2AlertRotateFile(Unified2AlertThread *aun)
+static int Unified2AlertRotateFile(Unified2AlertThread *aun, bool truncate)
 {
     if (Unified2AlertCloseFile(aun) < 0) {
         SCLogError(SC_ERR_UNIFIED2_ALERT_GENERIC,
                    "Error: Unified2AlertCloseFile failed");
         return -1;
     }
-    if (Unified2AlertOpenFileCtx(aun->unified2alert_ctx->file_ctx,aun->unified2alert_ctx->
-            file_ctx->prefix) < 0) {
+    if (Unified2AlertOpenFileCtx(aun->unified2alert_ctx->file_ctx,
+            aun->unified2alert_ctx->file_ctx->prefix, truncate) < 0) {
         SCLogError(SC_ERR_UNIFIED2_ALERT_GENERIC,
                    "Error: Unified2AlertOpenFileCtx, open new log file failed");
         return -1;
@@ -787,6 +787,7 @@ static int Unified2PacketTypeAlert(Unified2AlertThread *aun, const Packet *p, ui
 static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
 {
     Unified2AlertThread *aun = (Unified2AlertThread *)data;
+    LogFileCtx *file_ctx = aun->unified2alert_ctx->file_ctx;
     Unified2AlertFileHeader hdr;
     AlertIPv6Unified2 *phdr;
     AlertIPv6Unified2 gphdr;
@@ -921,19 +922,22 @@ static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
         phdr->classification_id = htonl(pa->s->class);
         phdr->priority_id = htonl(pa->s->prio);
 
-        SCMutexLock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
-        if ((aun->unified2alert_ctx->file_ctx->size_current + length) >
-              aun->unified2alert_ctx->file_ctx->size_limit) {
-            if (Unified2AlertRotateFile(aun) < 0) {
+        SCMutexLock(&file_ctx->fp_mutex);
+
+        bool truncate = (file_ctx->size_current + length) > file_ctx->size_limit
+            ? true : false;
+        if (truncate || file_ctx->rotation_flag) {
+            if (Unified2AlertRotateFile(aun, truncate) < 0) {
                 aun->unified2alert_ctx->file_ctx->alerts += i;
-                SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+                SCMutexUnlock(&file_ctx->fp_mutex);
                 return -1;
             }
+            file_ctx->rotation_flag = 0;
         }
 
         if (Unified2Write(aun) != 1) {
-            aun->unified2alert_ctx->file_ctx->alerts += i;
-            SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+            file_ctx->alerts += i;
+            SCMutexUnlock(&file_ctx->fp_mutex);
             return -1;
         }
 
@@ -972,6 +976,7 @@ static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
 static int Unified2IPv4TypeAlert (ThreadVars *tv, const Packet *p, void *data)
 {
     Unified2AlertThread *aun = (Unified2AlertThread *)data;
+    LogFileCtx *file_ctx = aun->unified2alert_ctx->file_ctx;
     Unified2AlertFileHeader hdr;
     AlertIPv4Unified2 *phdr;
     AlertIPv4Unified2 gphdr;
@@ -1097,20 +1102,22 @@ static int Unified2IPv4TypeAlert (ThreadVars *tv, const Packet *p, void *data)
         phdr->priority_id = htonl(pa->s->prio);
 
         /* check and enforce the filesize limit */
-        SCMutexLock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+        SCMutexLock(&file_ctx->fp_mutex);
 
-        if ((aun->unified2alert_ctx->file_ctx->size_current + length) >
-              aun->unified2alert_ctx->file_ctx->size_limit) {
-            if (Unified2AlertRotateFile(aun) < 0) {
-                aun->unified2alert_ctx->file_ctx->alerts += i;
-                SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+        bool truncate = (file_ctx->size_current + length) > file_ctx->size_limit
+            ? true : false;
+        if (truncate || file_ctx->rotation_flag) {
+            if (Unified2AlertRotateFile(aun, truncate) < 0) {
+                file_ctx->alerts += i;
+                SCMutexUnlock(&file_ctx->fp_mutex);
                 return -1;
             }
+            file_ctx->rotation_flag = 0;
         }
 
         if (Unified2Write(aun) != 1) {
-            aun->unified2alert_ctx->file_ctx->alerts += i;
-            SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+            file_ctx->alerts += i;
+            SCMutexUnlock(&file_ctx->fp_mutex);
             return -1;
         }
 
@@ -1226,6 +1233,7 @@ OutputCtx *Unified2AlertInitCtx(ConfNode *conf)
     LogFileCtx* file_ctx = NULL;
     OutputCtx* output_ctx = NULL;
     HttpXFFCfg *xff_cfg = NULL;
+    int nostamp = 0;
 
     file_ctx = LogFileNewCtx();
     if (file_ctx == NULL) {
@@ -1279,6 +1287,13 @@ OutputCtx *Unified2AlertInitCtx(ConfNode *conf)
                 exit(EXIT_FAILURE);
             }
         }
+
+        if (ConfGetChildValueBool(conf, "nostamp", &nostamp)) {
+            if (nostamp) {
+                SCLogConfig("Disabling unified2 timestamp.");
+                file_ctx->nostamp = 1;
+            }
+        }
     }
 
     uint32_t flags = UNIFIED2_ALERT_FLAGS_EMIT_PACKET;
@@ -1295,9 +1310,14 @@ OutputCtx *Unified2AlertInitCtx(ConfNode *conf)
         }
     }
 
-    ret = Unified2AlertOpenFileCtx(file_ctx, filename);
+    ret = Unified2AlertOpenFileCtx(file_ctx, filename, false);
     if (ret < 0)
         goto error;
+
+    /* Only register for file rotation if theout is non-timestamped. */
+    if (nostamp) {
+        OutputRegisterFileRotationFlag(&file_ctx->rotation_flag);
+    }
 
     output_ctx = SCCalloc(1, sizeof(OutputCtx));
     if (unlikely(output_ctx == NULL))
@@ -1367,7 +1387,8 @@ static void Unified2AlertDeInitCtx(OutputCtx *output_ctx)
  *  \param prefix Prefix of the log file.
  *  \return -1 if failure, 0 if succesful
  * */
-int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix)
+static int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix,
+    bool truncate)
 {
     int ret = 0;
     char *filename = NULL;
@@ -1396,9 +1417,17 @@ int Unified2AlertOpenFileCtx(LogFileCtx *file_ctx, const char *prefix)
     char *log_dir;
     log_dir = ConfigGetLogDirectory();
 
-    snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32, log_dir, prefix, (uint32_t)ts.tv_sec);
+    if (file_ctx->nostamp) {
+        snprintf(filename, PATH_MAX, "%s/%s", log_dir, prefix);
+    } else {
+        snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32, log_dir, prefix, (uint32_t)ts.tv_sec);
+    }
 
-    file_ctx->fp = fopen(filename, "ab");
+    if (truncate) {
+        file_ctx->fp = fopen(filename, "wb");
+    } else {
+        file_ctx->fp = fopen(filename, "ab");
+    }
     if (file_ctx->fp == NULL) {
         SCLogError(SC_ERR_FOPEN, "failed to open %s: %s", filename,
             strerror(errno));
@@ -1916,7 +1945,7 @@ static int Unified2TestRotate01(void)
 
     TimeSetIncrementTime(1);
 
-    ret = Unified2AlertRotateFile(data);
+    ret = Unified2AlertRotateFile(data, false);
     if (ret == -1)
         goto error;
 

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -244,11 +244,9 @@ void Unified2AlertRegister(void)
 /**
  *  \brief Function to close unified2 file
  *
- *  \param t Thread Variable containing  input/output queue, cpu affinity etc.
  *  \param aun Unified2 thread variable.
  */
-
-int Unified2AlertCloseFile(ThreadVars *t, Unified2AlertThread *aun)
+static int Unified2AlertCloseFile(Unified2AlertThread *aun)
 {
     if (aun->unified2alert_ctx->file_ctx->fp != NULL) {
         fclose(aun->unified2alert_ctx->file_ctx->fp);
@@ -261,15 +259,13 @@ int Unified2AlertCloseFile(ThreadVars *t, Unified2AlertThread *aun)
 /**
  *  \brief Function to rotate unified2 file
  *
- *  \param t Thread Variable containing  input/output queue, cpu affinity etc.
  *  \param aun Unified2 thread variable.
  *  \retval 0 on succces
  *  \retval -1 on failure
  */
-
-int Unified2AlertRotateFile(ThreadVars *t, Unified2AlertThread *aun)
+static int Unified2AlertRotateFile(Unified2AlertThread *aun)
 {
-    if (Unified2AlertCloseFile(t,aun) < 0) {
+    if (Unified2AlertCloseFile(aun) < 0) {
         SCLogError(SC_ERR_UNIFIED2_ALERT_GENERIC,
                    "Error: Unified2AlertCloseFile failed");
         return -1;
@@ -928,7 +924,7 @@ static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
         SCMutexLock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
         if ((aun->unified2alert_ctx->file_ctx->size_current + length) >
               aun->unified2alert_ctx->file_ctx->size_limit) {
-            if (Unified2AlertRotateFile(t,aun) < 0) {
+            if (Unified2AlertRotateFile(aun) < 0) {
                 aun->unified2alert_ctx->file_ctx->alerts += i;
                 SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
                 return -1;
@@ -1105,7 +1101,7 @@ static int Unified2IPv4TypeAlert (ThreadVars *tv, const Packet *p, void *data)
 
         if ((aun->unified2alert_ctx->file_ctx->size_current + length) >
               aun->unified2alert_ctx->file_ctx->size_limit) {
-            if (Unified2AlertRotateFile(tv,aun) < 0) {
+            if (Unified2AlertRotateFile(aun) < 0) {
                 aun->unified2alert_ctx->file_ctx->alerts += i;
                 SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
                 return -1;
@@ -1920,7 +1916,7 @@ static int Unified2TestRotate01(void)
 
     TimeSetIncrementTime(1);
 
-    ret = Unified2AlertRotateFile(&tv, data);
+    ret = Unified2AlertRotateFile(data);
     if (ret == -1)
         goto error;
 

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -57,6 +57,10 @@
 #include <stdint.h>
 #endif
 
+#if HAVE_STDBOOL_H
+#include <stdbool.h>
+#endif
+
 #if HAVE_STDARG_H
 #include <stdarg.h>
 #endif

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -120,6 +120,9 @@ typedef struct LogFileCtx_ {
 
     /* Flag set when file rotation notification is received. */
     int rotation_flag;
+
+    /* Set to true if the filename should not be timestamped. */
+    bool nostamp;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -244,6 +244,11 @@ outputs:
       # is parsed as bytes.
       #limit: 32mb
 
+      # By default unified2 log files have the file creation time (in
+      # unix epoch format) appended to the filename. Set this to yes to
+      # disable this behaviour.
+      #nostamp: no
+
       # Sensor ID field of unified2 alerts.
       #sensor-id: 0
 


### PR DESCRIPTION
Redmine issue:
https://redmine.openinfosecfoundation.org/issues/1636

Adds nostamp option to remove the timestamp from the unified output file. Additionally, if nostamp is one, register for log file rotation on SIGHUP.

Of note, the limit is still enforced which will truncate the file (Snort behaviour).

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/77
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/429
