### PR TITLE
flow: add functionality to check if flow has alerts (v4)

### DIFF
--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -178,6 +178,22 @@ Example:
       end
   end
 
+SCFlowHasAlerts
+~~~~~~~~~~~~~~~
+
+Returns true if flow has alerts.
+
+Example:
+
+::
+
+  function log(args)
+      has_alerts = SCFlowHasAlerts()
+      if has_alerts then
+          -- do something
+      end
+  end
+
 SCFlowStats
 ~~~~~~~~~~~
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -327,6 +327,12 @@ void PacketAlertFinalize(DetectEngineCtx *de_ctx, DetectEngineThreadCtx *det_ctx
      * keyword context for sessions and hosts */
     if (!(p->flags & PKT_PSEUDO_STREAM_END))
         TagHandlePacket(de_ctx, det_ctx, p);
+
+    /* Set flag on flow to indicate that it has alerts */
+    if (p->flow != NULL && p->alerts.cnt > 0) {
+        FlowSetHasAlertsFlag(p->flow);
+    }
+
 }
 
 

--- a/src/flow.c
+++ b/src/flow.c
@@ -157,6 +157,30 @@ void FlowSetIPOnlyFlag(Flow *f, int direction)
     return;
 }
 
+/** \brief Set flag to indicate that flow has alerts
+ *
+ * \param f flow
+ */
+void FlowSetHasAlertsFlag(Flow *f)
+{
+    f->flags |= FLOW_HAS_ALERTS;
+}
+
+/** \brief Check if flow has alerts
+ *
+ * \param f flow
+ * \retval 1 has alerts
+ * \retval 0 has not alerts
+ */
+int FlowHasAlerts(const Flow *f)
+{
+    if (f->flags & FLOW_HAS_ALERTS) {
+        return 1;
+    }
+
+    return 0;
+}
+
 /**
  *  \brief determine the direction of the packet compared to the flow
  *  \retval 0 to_server

--- a/src/flow.h
+++ b/src/flow.h
@@ -72,7 +72,8 @@ typedef struct AppLayerParserState_ AppLayerParserState;
 /** packet to client direction has been logged in drop file (only in IPS mode) */
 #define FLOW_TOCLIENT_DROP_LOGGED       BIT_U32(11)
 
-// vacancy bit 12
+/** flow has alerts */
+#define FLOW_HAS_ALERTS                 BIT_U32(12)
 
 /** Pattern matcher alproto detection done */
 #define FLOW_TS_PM_ALPROTO_DETECT_DONE  BIT_U32(13)
@@ -458,6 +459,8 @@ void FlowInitConfig (char);
 void FlowPrintQueueInfo (void);
 void FlowShutdown(void);
 void FlowSetIPOnlyFlag(Flow *, int);
+void FlowSetHasAlertsFlag(Flow *);
+int FlowHasAlerts(const Flow *);
 
 void FlowRegisterTests (void);
 int FlowSetProtoTimeout(uint8_t ,uint32_t ,uint32_t ,uint32_t);

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -261,6 +261,12 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
     json_object_set_new(hjs, "reason",
             json_string(reason));
 
+    uint8_t has_alerts = 0;
+    if (FlowHasAlerts(f))
+        has_alerts = 1;
+
+    json_object_set_new(hjs, "has_alerts", json_boolean(has_alerts));
+
     json_object_set_new(js, "flow", hjs);
 
 

--- a/src/util-lua-common.c
+++ b/src/util-lua-common.c
@@ -248,6 +248,41 @@ static int LuaCallbackFlowTimeString(lua_State *luastate)
 }
 
 /** \internal
+ *  \brief fill lua stack with flow has alerts
+ *  \param luastate the lua state
+ *  \param flow flow
+ *  \retval cnt number of data items placed on the stack
+ *
+ *  Places alerts (bool)
+ */
+static int LuaCallbackHasAlertsPushToStackFromFlow(lua_State *luastate, const Flow *flow)
+{
+    if (FlowHasAlerts(flow)) {
+        lua_pushboolean(luastate, 1);
+    } else {
+        lua_pushboolean(luastate, 0);
+    }
+
+    return 1;
+}
+
+/** \internal
+ *  \brief Wrapper for getting flow has alerts info into a lua script
+ *  \retval cnt number of items placed on the stack
+ */
+static int LuaCallbackFlowHasAlerts(lua_State *luastate)
+{
+    int r = 0;
+    Flow *flow = LuaStateGetFlow(luastate);
+    if (flow == NULL)
+        return LuaCallbackError(luastate, "internal error: no flow");
+
+    r = LuaCallbackHasAlertsPushToStackFromFlow(luastate, flow);
+
+    return r;
+}
+
+/** \internal
  *  \brief fill lua stack with header info
  *  \param luastate the lua state
  *  \param p packet
@@ -768,6 +803,8 @@ int LuaRegisterFunctions(lua_State *luastate)
     lua_setglobal(luastate, "SCFlowAppLayerProto");
     lua_pushcfunction(luastate, LuaCallbackStatsFlow);
     lua_setglobal(luastate, "SCFlowStats");
+    lua_pushcfunction(luastate, LuaCallbackFlowHasAlerts);
+    lua_setglobal(luastate, "SCFlowHasAlerts");
 
     lua_pushcfunction(luastate, LuaCallbackStreamingBuffer);
     lua_setglobal(luastate, "SCStreamingBuffer");


### PR DESCRIPTION
Add function SCFlowHasAlerts to check if any of the packets in a flow has triggered an alert.

This makes it simple to e.g write a Lua script to signal a full capture solution to extract a session Suricata has triggered alerts on.

Changes:
- Use json_boolean instead of json_string

Example script:

``` lua
function init (args)
    local needs = {}
    needs["type"] = "flow"
    return needs
end

function setup (args)
    filename = SCLogPath() .. "/" .. "flows_with_alerts.log"
    file = assert(io.open(filename, "a"))
end

function log (args)
    ipver, srcip, dstip, proto, sp, dp = SCFlowTuple()
    has_alerts = SCFlowHasAlerts()

    if has_alerts then
        file:write(srcip .. ":" .. sp .. " -> " .. dstip  ..
                   ":" .. dp .. " (proto: " .. proto .. ")\n")
        file:flush()
    end
end

function deinit (args)
    file:close(file)
end
```

Also adds a "has_alerts" field to the flow eve-log.

prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/69
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/69