### PR TITLE
travis and compiler warning fixes - v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ script:
   - sh autogen.sh
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
         ./configure --enable-nfqueue --enable-unittests --enable-hiredis ${ARGS}
     fi
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,13 @@ matrix:
         - NAME="linux,gcc,cocci"
         - *default-cflags
         - ENABLE_COCCI="yes"
+    # Linux, gcc, -DNDEBUG.
+    - os: linux
+      compiler: gcc
+      env:
+        - NAME="linux,gcc,ndebug"
+        - *default-cflags
+        - EXTRA_CFLAGS="-DNDEBUG"
     # Linux, clang. For this build we'll also enable -Wshadow.
     - os: linux
       compiler: clang

--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -127,7 +127,6 @@ int UnixNew(UnixCommand * this)
         struct stat stat_buf;
         /* coverity[toctou] */
         if (stat(SOCKET_PATH, &stat_buf) != 0) {
-            int ret;
             /* coverity[toctou] */
             ret = mkdir(SOCKET_PATH, S_IRWXU|S_IXGRP|S_IRGRP);
             if (ret != 0) {


### PR DESCRIPTION
Define a Travis build with -DNDEBUG.

Export EXTRA_CFLAGS on Travis Linux builds.

Fix a -Wshadow error.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/79
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/431
