### PR TITLE
util-file: fix error logic in hash computation

### DIFF
--- a/src/util-file.c
+++ b/src/util-file.c
@@ -574,19 +574,23 @@ int FileAppendData(FileContainer *ffc, const uint8_t *data, uint32_t data_len)
 
     if (FileStoreNoStoreCheck(ffc->tail) == 1) {
 #ifdef HAVE_NSS
+        int hash_done = 0;
         /* no storage but forced hashing */
         if (ffc->tail->md5_ctx) {
             HASH_Update(ffc->tail->md5_ctx, data, data_len);
-            SCReturnInt(0);
+            hash_done = 1;
         }
         if (ffc->tail->sha1_ctx) {
             HASH_Update(ffc->tail->sha1_ctx, data, data_len);
-            SCReturnInt(0);
+            hash_done = 1;
         }
         if (ffc->tail->sha256_ctx) {
             HASH_Update(ffc->tail->sha256_ctx, data, data_len);
-            SCReturnInt(0);
+            hash_done = 1;
         }
+
+        if (hash_done)
+            SCReturnInt(0);
 #endif
         if (g_file_force_tracking || (!(ffc->tail->flags & FILE_NOTRACK)))
             SCReturnInt(0);


### PR DESCRIPTION
This patch fixes an issue with hash computation resulting in the
invalidity of at least one hash when at least two different hashes
functions were used.

Impact was setting as `force-hash: [md5, sha256]` not to be valid.
Also it could lead to false negative if too different hash functions
had to be used on a single file due to signatures.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/2004

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/234
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/16

