### PR TITLE
Stream depth fix

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -199,6 +199,9 @@ int AppLayerParserSetup(void)
         RegisterAppLayerGetActiveTxIdFunc(AppLayerTransactionGetActiveDetectLog);
     }
 
+    /* Make sure we have reassembly depth from config */
+    StreamTcpParseReassemblyDepth();
+
     /* lets set a default value for stream_depth */
     for (flow_proto = 0; flow_proto < FLOW_PROTO_DEFAULT; flow_proto++) {
         for (alproto = 0; alproto < ALPROTO_MAX; alproto++) {

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -303,6 +303,22 @@ static void StreamTcpSessionPoolCleanup(void *s)
     }
 }
 
+void StreamTcpParseReassemblyDepth() {
+    char *temp_stream_reassembly_depth_str;
+    if (ConfGet("stream.reassembly.depth", &temp_stream_reassembly_depth_str) == 1) {
+        if (ParseSizeStringU32(temp_stream_reassembly_depth_str,
+                               &stream_config.reassembly_depth) < 0) {
+            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing "
+                       "stream.reassembly.depth "
+                       "from conf file - %s.  Killing engine",
+                       temp_stream_reassembly_depth_str);
+            exit(EXIT_FAILURE);
+        }
+    } else {
+        stream_config.reassembly_depth = 0;
+    }
+}
+
 /** \brief          To initialize the stream global configuration data
  *
  *  \param  quiet   It tells the mode of operation, if it is TRUE nothing will
@@ -462,20 +478,7 @@ void StreamTcpInitConfig(char quiet)
         SCLogConfig("stream.reassembly \"memcap\": %"PRIu64"", stream_config.reassembly_memcap);
     }
 
-    char *temp_stream_reassembly_depth_str;
-    if (ConfGet("stream.reassembly.depth", &temp_stream_reassembly_depth_str) == 1) {
-        if (ParseSizeStringU32(temp_stream_reassembly_depth_str,
-                               &stream_config.reassembly_depth) < 0) {
-            SCLogError(SC_ERR_SIZE_PARSE, "Error parsing "
-                       "stream.reassembly.depth "
-                       "from conf file - %s.  Killing engine",
-                       temp_stream_reassembly_depth_str);
-            exit(EXIT_FAILURE);
-        }
-    } else {
-        stream_config.reassembly_depth = 0;
-    }
-
+    StreamTcpParseReassemblyDepth();
     if (!quiet) {
         SCLogConfig("stream.reassembly \"depth\": %"PRIu32"", stream_config.reassembly_depth);
     }

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -107,6 +107,7 @@ typedef struct StreamTcpThread_ {
 } StreamTcpThread;
 
 TcpStreamCnf stream_config;
+void StreamTcpParseReassemblyDepth();
 void StreamTcpInitConfig (char);
 void StreamTcpFreeConfig(char);
 void StreamTcpRegisterTests (void);


### PR DESCRIPTION
Stream config was initialized after the application layer causing the per application layer stream depth to be set to zero.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/235
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/17
