### PR TITLE
Bug 2005

### DIFF
--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -171,7 +171,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     if (ff->flags & FILE_STORED) {
         json_object_set_new(fjs, "file_id", json_integer(ff->file_id));
     }
-    json_object_set_new(fjs, "size", json_integer(FileSize(ff)));
+    json_object_set_new(fjs, "size", json_integer(ff->size));
     json_object_set_new(fjs, "tx_id", json_integer(ff->txid));
 
     /* originally just 'file', but due to bug 1127 naming it fileinfo */

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -565,6 +565,8 @@ int FileAppendData(FileContainer *ffc, const uint8_t *data, uint32_t data_len)
         SCReturnInt(-1);
     }
 
+    ffc->tail->size += data_len;
+
     if (ffc->tail->state != FILE_STATE_OPENED) {
         if (ffc->tail->flags & FILE_NOSTORE) {
             SCReturnInt(-2);
@@ -699,6 +701,7 @@ File *FileOpenFile(FileContainer *ffc, const StreamingBufferConfig *sbcfg,
     FileContainerAdd(ffc, ff);
 
     if (data != NULL) {
+        ff->size += data_len;
         if (AppendData(ff, data, data_len) != 0) {
             ff->state = FILE_STATE_ERROR;
             SCReturnPtr(NULL, "File");
@@ -723,6 +726,7 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
     }
 
     if (data != NULL) {
+        ff->size += data_len;
         if (ff->flags & FILE_NOSTORE) {
 #ifdef HAVE_NSS
             /* no storage but hashing */

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -82,6 +82,7 @@ typedef struct File_ {
     uint64_t content_inspected;     /**< used in pruning if FILE_USE_DETECT
                                      *   flag is set */
     uint64_t content_stored;
+    uint64_t size;
 } File;
 
 typedef struct FileContainer_ {


### PR DESCRIPTION
This patchset fixes file size computation by using a custom field instead of using the FileSize function which is dependant of storage.

Redmine issue: https://redmine.openinfosecfoundation.org/issues/2005

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/236
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/18
