### PR TITLE
stream-tcp: separate stream config parsing and init

### DIFF
--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -303,18 +303,9 @@ static void StreamTcpSessionPoolCleanup(void *s)
     }
 }
 
-/** \brief          To initialize the stream global configuration data
- *
- *  \param  quiet   It tells the mode of operation, if it is TRUE nothing will
- *                  be get printed.
- */
-
-void StreamTcpInitConfig(char quiet)
-{
+void StreamTcpParseConfig(char quiet) {
     intmax_t value = 0;
     uint16_t rdrange = 10;
-
-    SCLogDebug("Initializing Stream");
 
     memset(&stream_config,  0, sizeof(stream_config));
 
@@ -475,7 +466,6 @@ void StreamTcpInitConfig(char quiet)
     } else {
         stream_config.reassembly_depth = 0;
     }
-
     if (!quiet) {
         SCLogConfig("stream.reassembly \"depth\": %"PRIu32"", stream_config.reassembly_depth);
     }
@@ -577,6 +567,21 @@ void StreamTcpInitConfig(char quiet)
     if (!quiet)
         SCLogConfig("stream.reassembly.raw: %s", enable_raw ? "enabled" : "disabled");
 
+}
+
+/** \brief          To initialize the stream global configuration data
+ *
+ *  \param  quiet   It tells the mode of operation, if it is TRUE nothing will
+ *                  be get printed.
+ */
+
+void StreamTcpInitConfig(char quiet)
+{
+    SCLogDebug("Initializing Stream");
+
+    if (RunmodeIsUnittests()) {
+        StreamTcpParseConfig(STREAM_VERBOSE);
+    }
     /* init the memcap/use tracking */
     SC_ATOMIC_INIT(st_memuse);
     StatsRegisterGlobalCounter("tcp.memuse", StreamTcpMemuseCounter);

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -107,6 +107,8 @@ typedef struct StreamTcpThread_ {
 } StreamTcpThread;
 
 TcpStreamCnf stream_config;
+void StreamTcpParseReassemblyDepth();
+void StreamTcpParseConfig(char);
 void StreamTcpInitConfig (char);
 void StreamTcpFreeConfig(char);
 void StreamTcpRegisterTests (void);

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2498,6 +2498,8 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    StreamTcpParseConfig(STREAM_VERBOSE);
+
     if (PostConfLoadedSetup(&suri) != TM_ECODE_OK) {
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Update of #2497 addressing the remark.

This patch separates the stream config parsing and init so we can
read the config before init the application layer as the stream
reassembly depth value is needed when doing it.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/238
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/20
