### PR TITLE
pcap-log: fix pcre_study error check - v1

### DIFF
--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -962,7 +962,7 @@ static OutputCtx *PcapLogInitCtx(ConfNode *conf)
             timestamp_pattern, pcre_erroffset, pcre_errbuf);
     }
     pcre_timestamp_extra = pcre_study(pcre_timestamp_code, 0, &pcre_errbuf);
-    if (pcre_timestamp_extra == NULL) {
+    if (pcre_errbuf != NULL) {
         FatalError(SC_ERR_PCRE_STUDY, "Fail to study pcre: %s", pcre_errbuf);
     }
 


### PR DESCRIPTION
Code was failing on a NULL return value which can be returned
when there was nothing todo instead of an error. Instead
check the errbuf for a non-NULL value to determine error.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/81
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/433
