### PR TITLE
Bug #2009: added CAP_NET_ADMIN for PCAP and af-packet modes.

### DIFF
--- a/src/util-privs.c
+++ b/src/util-privs.c
@@ -77,6 +77,7 @@ void SCDropMainThreadCaps(uint32_t userid, uint32_t groupid)
             capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED,
                     CAP_NET_RAW,            /* needed for pcap live mode */
                     CAP_SYS_NICE,
+                    CAP_NET_ADMIN,
                     -1);
             break;
         case RUNMODE_PFRING:


### PR DESCRIPTION
Without this capability suricata is unable to get network interface's settings.