### PR TITLE
output-json: make JSON flags in eve-log user configurable

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -246,3 +246,27 @@ For most output types, you can add multiple:
 
 Except for ``drop`` for which only a single logger instance is supported.
 
+JSON flags
+~~~~~~~~~~
+
+Several flags can be specified to control the JSON output in EVE:
+
+::
+
+  outputs:
+    - eve-log:
+        json:
+          # Sort object keys in the same order as they were inserted
+          preserve-order: yes
+
+          # Make the output more compact
+          compact: yes
+
+          # Escape all unicode characters outside the ASCII range
+          ensure-ascii: yes
+
+          # Escape the '/' characters in string with '\/'
+          escape-slash: yes
+
+All these flags are enabled by default, and can be modified per EVE instance.
+

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -316,8 +316,7 @@ int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer)
     };
 
     int r = json_dump_callback(js, OutputJSONMemBufferCallback, &wrapper,
-            JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|
-            JSON_ESCAPE_SLASH);
+            file_ctx->json_flags);
     if (r != 0)
         return TM_ECODE_OK;
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -256,6 +256,35 @@ SCConfLogOpenGeneric(ConfNode *conf,
     if (append == NULL)
         append = DEFAULT_LOG_MODE_APPEND;
 
+    /* JSON flags */
+#ifdef HAVE_LIBJANSSON
+    log_ctx->json_flags = JSON_PRESERVE_ORDER|JSON_COMPACT|
+                          JSON_ENSURE_ASCII|JSON_ESCAPE_SLASH;
+
+    ConfNode *json_flags = ConfNodeLookupChild(conf, "json");
+
+    if (json_flags != 0) {
+        const char *preserve_order = ConfNodeLookupChildValue(json_flags,
+                                                              "preserve-order");
+        if (preserve_order != NULL && ConfValIsFalse(preserve_order))
+            log_ctx->json_flags &= ~(JSON_PRESERVE_ORDER);
+
+        const char *compact = ConfNodeLookupChildValue(json_flags, "compact");
+        if (compact != NULL && ConfValIsFalse(compact))
+            log_ctx->json_flags &= ~(JSON_COMPACT);
+
+        const char *ensure_ascii = ConfNodeLookupChildValue(json_flags,
+                                                            "ensure-ascii");
+        if (ensure_ascii != NULL && ConfValIsFalse(ensure_ascii))
+            log_ctx->json_flags &= ~(JSON_ENSURE_ASCII);
+
+        const char *escape_slash = ConfNodeLookupChildValue(json_flags,
+                                                            "escape-slash");
+        if (escape_slash != NULL && ConfValIsFalse(escape_slash))
+            log_ctx->json_flags &= ~(JSON_ESCAPE_SLASH);
+    }
+#endif /* HAVE_LIBJANSSON */
+
     // Now, what have we been asked to open?
     if (strcasecmp(filetype, "unix_stream") == 0) {
         /* Don't bail. May be able to connect later. */

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -118,6 +118,9 @@ typedef struct LogFileCtx_ {
      * allow for rotataion. */
     uint8_t is_regular;
 
+    /* JSON flags */
+    size_t json_flags;  /* passed to json_dump_callback() */
+
     /* Flag set when file rotation notification is received. */
     int rotation_flag;
 } LogFileCtx;


### PR DESCRIPTION
Make JSON flags user configurable per eve instance.

Fixes:
https://redmine.openinfosecfoundation.org/issues/1608

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/85
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/85