### PR TITLE
output-json-alert: print 'parent' JSON object if tunnel

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -277,7 +277,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* tls alert */
                 if (proto == ALPROTO_TLS)
                     AlertJsonTls(p->flow, js);
             }
@@ -287,7 +287,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* ssh alert */
                 if (proto == ALPROTO_SSH)
                     AlertJsonSsh(p->flow, js);
             }
@@ -297,7 +297,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* smtp alert */
                 if (proto == ALPROTO_SMTP) {
                     hjs = JsonSMTPAddMetadata(p->flow, pa->tx_id);
                     if (hjs)
@@ -313,6 +313,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         if (json_output_ctx->flags & LOG_JSON_DNP3) {
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
+
+                /* dnp3 alert */
                 if (proto == ALPROTO_DNP3) {
                     AlertJsonDnp3(p->flow, js);
                 }

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -41,6 +41,7 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
+void JsonFiveTuple(const Packet *, int, json_t *);
 json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type);
 json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);


### PR DESCRIPTION
Print "src_ip", "dst_ip" and "proto" for root packet (p->root) as JSON object 'parent' if packet is a tunnel. 

Without this, it is difficult to find the traffic that triggered if the match was done inside a tunnel (e.g. GRE tunnel), since far from all network solutions decode tunnels.

Example alert with 'parent' object:
```json
{
  "timestamp": "2008-06-21T14:06:06.578905+0200",
  "event_type": "alert",
  "src_ip": "1.1.1.1",
  "dest_ip": "2.2.2.2",
  "proto": "ICMP",
  "icmp_type": 8,
  "icmp_code": 0,
  "alert": {
    "severity": 3,
    "category": "",
    "signature": "ICMP something something",
    "rev": 0,
    "signature_id": 1230910,
    "gid": 1,
    "action": "allowed"
  },
  "parent": {
    "proto": "GRE",
    "dest_ip": "10.0.0.2",
    "src_ip": "10.0.0.1"
  }
}

```

https://redmine.openinfosecfoundation.org/issues/2011

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/86
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/86

