### PR TITLE
Doc path fixes

### DIFF
--- a/doc/userguide/rules/tls-keywords.rst
+++ b/doc/userguide/rules/tls-keywords.rst
@@ -27,6 +27,18 @@ Examples::
 
 ``tls_cert_issuer`` is a 'Sticky buffer'.
 
+tls_sni
+-------
+
+Match TLS/SSL Server Name Indication field.
+
+Examples::
+
+  tls_sni; content:"oisf.net"; nocase; isdataat:!1,relative;
+  tls_sni; content:"oisf.net"; nocase; pcre:"/oisf.net$/";
+
+``tls_sni`` is a 'Sticky buffer'.
+
 tls_cert_notbefore
 ------------------
 

--- a/src/detect-tls-cert-issuer.c
+++ b/src/detect-tls-cert-issuer.c
@@ -63,6 +63,7 @@ void DetectTlsIssuerRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].name = "tls_cert_issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].desc = "content modifier to match specifically and only on the TLS cert issuer buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-issuer";
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].Match = NULL;
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].AppLayerMatch = NULL;
     sigmatch_table[DETECT_AL_TLS_CERT_ISSUER].Setup = DetectTlsIssuerSetup;

--- a/src/detect-tls-cert-subject.c
+++ b/src/detect-tls-cert-subject.c
@@ -63,6 +63,7 @@ void DetectTlsSubjectRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].name = "tls_cert_subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].desc = "content modifier to match specifically and only on the TLS cert subject buffer";
+    sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-cert-subject";
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].Match = NULL;
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].AppLayerMatch = NULL;
     sigmatch_table[DETECT_AL_TLS_CERT_SUBJECT].Setup = DetectTlsSubjectSetup;

--- a/src/detect-tls-sni.c
+++ b/src/detect-tls-sni.c
@@ -63,6 +63,7 @@ void DetectTlsSniRegister(void)
 {
     sigmatch_table[DETECT_AL_TLS_SNI].name = "tls_sni";
     sigmatch_table[DETECT_AL_TLS_SNI].desc = "content modifier to match specifically and only on the TLS SNI buffer";
+    sigmatch_table[DETECT_AL_TLS_SNI].url = DOC_URL DOC_VERSION "/rules/tls-keywords.html#tls-sni";
     sigmatch_table[DETECT_AL_TLS_SNI].Match = NULL;
     sigmatch_table[DETECT_AL_TLS_SNI].AppLayerMatch = NULL;
     sigmatch_table[DETECT_AL_TLS_SNI].Setup = DetectTlsSniSetup;

--- a/src/detect-xbits.c
+++ b/src/detect-xbits.c
@@ -66,7 +66,7 @@ void DetectXbitsRegister (void)
 {
     sigmatch_table[DETECT_XBITS].name = "xbits";
     sigmatch_table[DETECT_XBITS].desc = "operate on bits";
-//    sigmatch_table[DETECT_XBITS].url = DOC_URL DOC_VERSION "/rules/flow-keywords.html#flowbits";
+    sigmatch_table[DETECT_XBITS].url = DOC_URL DOC_VERSION "/rules/xbits.html";
     sigmatch_table[DETECT_XBITS].Match = DetectXbitMatch;
     sigmatch_table[DETECT_XBITS].Setup = DetectXbitSetup;
     sigmatch_table[DETECT_XBITS].Free  = DetectXbitFree;


### PR DESCRIPTION
Minor documentation effort mainly adding some missing URLs in keywords definition.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/245
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/27
