### PR TITLE
Bug 1780 v2

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -980,6 +980,14 @@ static inline int AFPParsePacketV3(AFPThreadVars *ptv, struct tpacket_block_desc
     p->livedev = ptv->livedev;
     p->datalink = ptv->datalink;
 
+    /* get vlan id from header */
+    if ((!(ptv->flags & AFP_VLAN_DISABLED)) &&
+            (ppd->tp_status & TP_STATUS_VLAN_VALID || ppd->hv1.tp_vlan_tci)) {
+        p->vlan_id[0] = ppd->hv1.tp_vlan_tci & 0x0fff;
+        p->vlan_idx = 1;
+        p->vlanh[0] = NULL;
+    }
+
     if (ptv->flags & AFP_ZERO_COPY) {
         if (PacketSetData(p, (unsigned char*)ppd + ppd->tp_mac, ppd->tp_snaplen) == -1) {
             TmqhOutputPacketpool(ptv->tv, p);

--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -662,10 +662,23 @@ int AFPRead(AFPThreadVars *ptv)
     SCReturnInt(AFP_READ_OK);
 }
 
-TmEcode AFPWritePacket(Packet *p)
+/**
+ * \brief AF packet write function.
+ *
+ * This function has to be called before the memory
+ * related to Packet in ring buffer is released.
+ *
+ * \param pointer to Packet
+ * \param version of capture: TPACKET_V2 or TPACKET_V3
+ * \retval TM_ECODE_FAILED on failure and TM_ECODE_OK on success
+ *
+ */
+static TmEcode AFPWritePacket(Packet *p, int version)
 {
     struct sockaddr_ll socket_address;
     int socket;
+    uint8_t *pstart;
+    size_t plen;
 
     if (p->afp_v.copy_mode == AFP_COPY_MODE_IPS) {
         if (PACKET_TEST_ACTION(p, ACTION_DROP)) {
@@ -691,7 +704,45 @@ TmEcode AFPWritePacket(Packet *p)
     if (p->afp_v.peer->flags & AFP_SOCK_PROTECT)
         SCMutexLock(&p->afp_v.peer->sock_protect);
     socket = SC_ATOMIC_GET(p->afp_v.peer->socket);
-    if (sendto(socket, GET_PKT_DATA(p), GET_PKT_LEN(p), 0,
+
+    if (version == TPACKET_V2) {
+        union thdr h;
+        h.raw = p->afp_v.relptr;
+        /* Copy VLAN header from ring memory */
+        if (h.h2->tp_status & TP_STATUS_VLAN_VALID || h.h2->tp_vlan_tci) {
+            pstart = GET_PKT_DATA(p) - VLAN_HEADER_LEN;
+            plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
+            /* move ethernet addresses */
+            memmove(pstart, GET_PKT_DATA(p), 2 * ETH_ALEN);
+            /* write vlan info */
+            *(uint16_t *)(pstart + 2 * ETH_ALEN) = htons(0x8100);
+            *(uint16_t *)(pstart + 2 * ETH_ALEN + 2) = htons(h.h2->tp_vlan_tci);
+        } else {
+            pstart = GET_PKT_DATA(p);
+            plen = GET_PKT_LEN(p);
+        }
+    } else if (version == TPACKET_V3) {
+        union thdr h;
+        h.raw = p->afp_v.relptr;
+        /* Copy VLAN header from ring memory */
+        if (h.h3->tp_status & TP_STATUS_VLAN_VALID || h.h3->hv1.tp_vlan_tci) {
+            pstart = GET_PKT_DATA(p) - VLAN_HEADER_LEN;
+            plen = GET_PKT_LEN(p) + VLAN_HEADER_LEN;
+            /* move ethernet addresses */
+            memmove(pstart, GET_PKT_DATA(p), 2 * ETH_ALEN);
+            /* write vlan info */
+            *(uint16_t *)(pstart + 2 * ETH_ALEN) = htons(0x8100);
+            *(uint16_t *)(pstart + 2 * ETH_ALEN + 2) = htons(h.h3->hv1.tp_vlan_tci);
+        } else {
+            pstart = GET_PKT_DATA(p);
+            plen = GET_PKT_LEN(p);
+        }
+    } else {
+        pstart = GET_PKT_DATA(p);
+        plen = GET_PKT_LEN(p);
+    }
+
+    if (sendto(socket, pstart, plen, 0,
                (struct sockaddr*) &socket_address,
                sizeof(struct sockaddr_ll)) < 0) {
         SCLogWarning(SC_ERR_SOCKET, "Sending packet failed on socket %d: %s",
@@ -712,7 +763,7 @@ void AFPReleaseDataFromRing(Packet *p)
     /* Need to be in copy mode and need to detect early release
        where Ethernet header could not be set (and pseudo packet) */
     if ((p->afp_v.copy_mode != AFP_COPY_MODE_NONE) && !PKT_IS_PSEUDOPKT(p)) {
-        AFPWritePacket(p);
+        AFPWritePacket(p, TPACKET_V2);
     }
 
     if (AFPDerefSocket(p->afp_v.mpeer) == 0)
@@ -733,7 +784,7 @@ void AFPReleasePacketV3(Packet *p)
     /* Need to be in copy mode and need to detect early release
        where Ethernet header could not be set (and pseudo packet) */
     if ((p->afp_v.copy_mode != AFP_COPY_MODE_NONE) && !PKT_IS_PSEUDOPKT(p)) {
-        AFPWritePacket(p);
+        AFPWritePacket(p, TPACKET_V3);
     }
     PacketFreeOrRelease(p);
 }
@@ -1685,6 +1736,20 @@ static int AFPSetupRing(AFPThreadVars *ptv, char *devname)
                 strerror(errno));
     }
 #endif
+
+    /* Let's reserve head room so we can add the VLAN header in IPS
+     * or TAP mode before write the packet */
+    if (ptv->copy_mode != AFP_COPY_MODE_NONE) {
+        /* Only one vlan is extracted from AFP header so
+         * one VLAN header length is enough. */
+        int reserve = VLAN_HEADER_LEN;
+        if (setsockopt(ptv->socket, SOL_PACKET, PACKET_RESERVE, (void *) &reserve,
+                    sizeof(reserve)) < 0) {
+            SCLogWarning(SC_ERR_AFP_CREATE,
+                    "Can't activate reserve on packet socket: %s",
+                    strerror(errno));
+        }
+    }
 
     /* Allocate RX ring */
 #ifdef HAVE_TPACKET_V3


### PR DESCRIPTION
Rework of #2405 that should copy the complete VLAN tag. Logic has been changed as I've discovered that we always have the ring buffer cell available when calling the write function. Which means we can use the vlan cell header to get the info at write time.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/246
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/28

@gozzy can you test this ? I've currently no setup I can use to do it.