### PR TITLE
Preview: DNS app-layer in Rust - v8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,9 @@ script:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         export CFLAGS="${CFLAGS} ${EXTRA_CFLAGS}"
-        ./configure --enable-nfqueue --enable-unittests --enable-hiredis ${ARGS}
+        export LDFLAGS="-lrt"
+        ./configure --enable-nfqueue --enable-unittests \
+            --enable-hiredis ${ARGS}
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -122,6 +124,7 @@ before_install:
             sudo apt-get install -y libjansson-dev
         fi
 
+        curl https://sh.rustup.rs -sSf | sh -s -- -y
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -129,5 +132,6 @@ before_install:
         brew install pkg-config libmagic libyaml nss nspr jansson libnet lua \
             pcre hiredis
     fi
+  - export PATH=$PATH:$HOME/.cargo/bin
   - ./qa/travis-libhtp.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              classification.config threshold.config \
              reference.config
-SUBDIRS = $(HTP_DIR) src qa rules doc contrib scripts
+SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -1992,7 +1992,7 @@ AC_SUBST(CONFIGURE_PREFIX)
 AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 
-AC_OUTPUT(Makefile src/Makefile qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,0 +1,21 @@
+[root]
+name = "suricata"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
+"checksum nom 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d4598834859fedb9a0a69d5b862a970e77982a92f544d547257a4d49469067"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,3 +9,6 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2.0"
 nom = "^2.0.1"
+
+[profile.release]
+debug = true

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "suricata"
+version = "0.1.0"
+authors = ["Jason Ish <ish@unx.ca>"]
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+libc = "0.2.0"
+nom = "^2.0.1"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,0 +1,8 @@
+all:
+	cargo build --release
+
+clean:
+	cargo clean
+
+check:
+	cargo test

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -25,16 +25,15 @@ pub const TO_CLIENT: u8 = 1;
 /// The Rust place holder for DetectEngineState *.
 pub enum DetectEngineState {}
 
-extern {
-    pub fn DetectEngineStateFree(state: *mut DetectEngineState);
-}
-
 /// The Rust place holder for AppLayerDecoderEvents *.
 pub enum AppLayerDecoderEvents {}
 
-extern {
-    pub fn AppLayerDecoderEventsSetEventRaw(
-        events: *mut *mut AppLayerDecoderEvents, event: libc::uint8_t);
-    pub fn AppLayerDecoderEventsFreeEvents(
-        events: *mut *mut AppLayerDecoderEvents);
-}
+pub type AppLayerDecoderEventsSetEventRawFunc =
+    Option<extern "C" fn (events: *mut *mut AppLayerDecoderEvents,
+                          event: libc::uint8_t)>;
+
+pub type AppLayerDecoderEventsFreeEventsFunc =
+    Option<extern "C" fn (events: *mut *mut AppLayerDecoderEvents)>;
+
+pub type DetectEngineStateFreeFunc =
+    Option<extern "C" fn(state: *mut DetectEngineState)>;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -1,0 +1,37 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Definition from Suricata core.
+
+extern crate libc;
+
+pub const STREAM_TOSERVER: u8 = 0x04;
+pub const STREAM_TOCLIENT: u8 = 0x08;
+
+// Callbacks into Suricata core.
+extern {
+    pub fn DetectEngineContentInspection(de_ctx: *mut libc::c_void,
+                                         det_ctx: *mut libc::c_void,
+                                         s: *mut libc::c_void,
+                                         sm: *mut libc::c_void,
+                                         f: *mut libc::c_void,
+                                         buffer: *const libc::uint8_t,
+                                         buffer_len: libc::uint32_t,
+                                         stream_start_offset: libc::uint32_t,
+                                         inspection_mode: libc::uint8_t,
+                                         data: *mut libc::c_void) -> u32;
+}

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -17,21 +17,5 @@
 
 //! Definition from Suricata core.
 
-extern crate libc;
-
 pub const STREAM_TOSERVER: u8 = 0x04;
 pub const STREAM_TOCLIENT: u8 = 0x08;
-
-// Callbacks into Suricata core.
-extern {
-    pub fn DetectEngineContentInspection(de_ctx: *mut libc::c_void,
-                                         det_ctx: *mut libc::c_void,
-                                         s: *mut libc::c_void,
-                                         sm: *mut libc::c_void,
-                                         f: *mut libc::c_void,
-                                         buffer: *const libc::uint8_t,
-                                         buffer_len: libc::uint32_t,
-                                         stream_start_offset: libc::uint32_t,
-                                         inspection_mode: libc::uint8_t,
-                                         data: *mut libc::c_void) -> u32;
-}

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -17,6 +17,24 @@
 
 //! Definitions from Suricata core.
 
+extern crate libc;
+
 pub const TO_SERVER: u8 = 0;
 pub const TO_CLIENT: u8 = 1;
 
+/// The Rust place holder for DetectEngineState *.
+pub enum DetectEngineState {}
+
+extern {
+    pub fn DetectEngineStateFree(state: *mut DetectEngineState);
+}
+
+/// The Rust place holder for AppLayerDecoderEvents *.
+pub enum AppLayerDecoderEvents {}
+
+extern {
+    pub fn AppLayerDecoderEventsSetEventRaw(
+        events: *mut *mut AppLayerDecoderEvents, event: libc::uint8_t);
+    pub fn AppLayerDecoderEventsFreeEvents(
+        events: *mut *mut AppLayerDecoderEvents);
+}

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -15,7 +15,7 @@
  * 02110-1301, USA.
  */
 
-//! Definition from Suricata core.
+//! Definitions from Suricata core.
 
 pub const TO_SERVER: u8 = 0;
 pub const TO_CLIENT: u8 = 1;

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -17,5 +17,6 @@
 
 //! Definition from Suricata core.
 
-pub const STREAM_TOSERVER: u8 = 0x04;
-pub const STREAM_TOCLIENT: u8 = 0x08;
+pub const TO_SERVER: u8 = 0;
+pub const TO_CLIENT: u8 = 1;
+

--- a/rust/src/dns/bindings.rs
+++ b/rust/src/dns/bindings.rs
@@ -1,0 +1,18 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! C bindings.

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -75,8 +75,7 @@ macro_rules!export_state_free {
     ($name: ident, $parser: ident) => {
         #[no_mangle]
         pub extern "C" fn $name(state: *mut $parser) {
-            let mut _drop: Box<$parser> = unsafe{transmute(state)};
-            &_drop.free();
+            let _drop: Box<$parser> = unsafe{transmute(state)};
         }
     }
 }
@@ -358,6 +357,15 @@ impl DNSState {
         }
     }
 
+}
+
+/// Implement Drop for DNSState as transactions need to do some
+/// explicit cleanup.
+impl Drop for DNSState {
+
+    fn drop(&mut self) {
+        self.free();
+    }
 }
 
 /// Expose DNSState::new.

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -381,7 +381,7 @@ impl DNSTransaction {
 pub extern fn rs_dns_tx_get_alstate_progress(tx: &mut DNSTransaction,
                                              direction: libc::uint8_t)
                                              -> libc::uint8_t {
-    if direction & core::STREAM_TOCLIENT > 0 {
+    if direction == core::TO_CLIENT {
         if tx.replied {
             return 1;
         }

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -96,6 +96,7 @@ pub struct DNSTransaction {
     pub request: Option<DNSRequest>,
     pub response: Option<DNSResponse>,
     pub replied: bool,
+    pub logged: u32,
 }
 
 #[derive(Debug)]
@@ -372,9 +373,30 @@ impl DNSTransaction {
             request: None,
             response: None,
             replied: false,
+            logged: 0,
         }
     }
 
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_set_logged(state: &mut DNSState,
+                                   tx: &mut DNSTransaction,
+                                   logger: libc::uint32_t)
+{
+    tx.logged |= logger;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_get_logged(state: &mut DNSState,
+                                   tx: &mut DNSTransaction,
+                                   logger: libc::uint32_t)
+                                   -> i8
+{
+    if tx.logged & logger != 0 {
+        return 1;
+    }
+    return 0;
 }
 
 #[no_mangle]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -460,24 +460,6 @@ mod tests {
     use nom::IResult;
 
     #[test]
-    fn test_dns_parse_label() {
-        let buf: &[u8] = &[
-            // www
-            0x03, 0x77, 0x77, 0x77,
-
-            // suricata-ids
-            0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, 0x61, 0x74,
-            0x61, 0x2d, 0x69, 0x64, 0x73,
-
-            // org
-            0x03, 0x72, 0x67, 0x00];
-
-        let res = dns_parse_label(buf);
-        let expected = IResult::Done(&buf[4..], "www".as_bytes());
-        assert_eq!(res, expected);
-    }
-
-    #[test]
     fn test_dns_parse_name_simple() {
         let buf: &[u8] = &[
                                                 0x09, 0x63, /* .......c */

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -412,46 +412,6 @@ pub extern fn rs_dns_tx_get_query_buffer(tx: &mut DNSTransaction,
     return 0;
 }
 
-#[no_mangle]
-pub extern fn rs_dns_tx_inspect_query_name(
-    txp: *mut DNSTransaction,
-    de_ctx: *mut libc::c_void,
-    det_ctx: *mut libc::c_void,
-    s: *mut libc::c_void,
-    sm: *mut libc::c_void,
-    f: *mut libc::c_void,
-    stream_start_offset: libc::uint32_t,
-    inspection_mode: libc::uint8_t,
-    data: *mut libc::c_void) -> u32
-{
-    let tx = unsafe{&mut *txp};
-
-    for request in &tx.request {
-        for query in &request.queries {
-            let len = query.name.len();
-            unsafe {
-                let buf = &query.name[..];
-                let r = core::DetectEngineContentInspection(
-                    de_ctx,
-                    det_ctx,
-                    s,
-                    sm,
-                    f,
-                    buf.as_ptr(),
-                    len as u32,
-                    stream_start_offset,
-                    inspection_mode,
-                    data);
-                if r == 1 {
-                    return 1;
-                }
-            }
-        }
-    }
-
-    return 0;
-}
-
 /// Probe a buffer to see if it looks like a DNS request or response.
 pub fn dns_probe(input: &[u8]) -> bool {
     match dns_parse_request(input) {

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -90,6 +90,9 @@ pub struct DNSHeader {
     pub additional_rr: u16,
 }
 
+/// The Rust place holder for DetectEngineState *.
+pub enum DetectEngineState {}
+
 #[derive(Debug)]
 pub struct DNSTransaction {
     pub id: u64,
@@ -97,6 +100,7 @@ pub struct DNSTransaction {
     pub response: Option<DNSResponse>,
     pub replied: bool,
     pub logged: u32,
+    pub de_state: Option<*mut DetectEngineState>,
 }
 
 #[derive(Debug)]
@@ -374,6 +378,7 @@ impl DNSTransaction {
             response: None,
             replied: false,
             logged: 0,
+            de_state: None,
         }
     }
 
@@ -397,6 +402,28 @@ pub extern fn rs_dns_tx_get_logged(state: &mut DNSState,
         return 1;
     }
     return 0;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_set_detect_state(state: &mut DNSState,
+                                         tx: &mut DNSTransaction,
+                                         ds: *mut DetectEngineState)
+{
+    tx.de_state = Some(ds);
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_get_detect_state(tx: &mut DNSTransaction)
+                                         -> *mut DetectEngineState
+{
+    match tx.de_state {
+        Some(ds) => {
+            return ds;
+        },
+        None => {
+            return std::ptr::null_mut();
+        }
+    }
 }
 
 #[no_mangle]

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -1,0 +1,907 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// TODO: Log reply handling (windowed).
+// TODO: Flood handling.
+
+extern crate std;
+extern crate libc;
+extern crate nom;
+
+use std::slice;
+use std::mem::transmute;
+use std::panic;
+use std::ptr;
+
+use core;
+
+use dns::*;
+
+/// DNS error codes.
+pub const DNS_RCODE_NOERROR:  u16 = 0;
+pub const DNS_RCODE_FORMERR:  u16 = 1;
+pub const DNS_RCODE_NXDOMAIN: u16 = 3;
+
+/// DNS record types.
+pub const DNS_RTYPE_A:     u16 = 1;
+pub const DNS_RTYPE_CNAME: u16 = 5;
+pub const DNS_RTYPE_SOA:   u16 = 6;
+pub const DNS_RTYPE_PTR:   u16 = 12;
+pub const DNS_RTYPE_MX:    u16 = 15;
+pub const DNS_RTYPE_SSHFP: u16 = 44;
+pub const DNS_RTYPE_RRSIG: u16 = 46;
+
+#[repr(u32)]
+pub enum DNSEvents {
+    UnsolicitedResponse = 1,
+    MalformedData,
+    NotRequest,
+    NotResponse,
+    ZFlagSet,
+    Flooded,
+    StateMemCapReached,
+}
+
+/// Expose a parsers state ::new to C.
+/// TODO: Move out into some common module.
+macro_rules!export_state_new {
+    ($name: ident, $parser: ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name() -> *mut $parser {
+            let state = $parser::new();
+            let boxed = Box::new(state);
+            return unsafe{transmute(boxed)};
+        }
+    }
+}
+
+/// Expose a function to free a parser state to C.
+/// TODO: Move out into some common module.
+macro_rules!export_state_free {
+    ($name: ident, $parser: ident) => {
+        #[no_mangle]
+        pub extern "C" fn $name(state: *mut $parser) {
+            let _drop: Box<$parser> = unsafe{transmute(state)};
+        }
+    }
+}
+
+#[derive(Debug,PartialEq)]
+pub struct DNSHeader {
+    pub tx_id: u16,
+    pub flags: u16,
+    pub questions: u16,
+    pub answer_rr: u16,
+    pub authority_rr: u16,
+    pub additional_rr: u16,
+}
+
+#[derive(Debug)]
+pub struct DNSTransaction {
+    pub id: u64,
+    pub request: Option<DNSRequest>,
+    pub response: Option<DNSResponse>,
+    pub replied: bool,
+}
+
+#[derive(Debug)]
+pub struct DNSRequest {
+    pub header: DNSHeader,
+    pub queries: Vec<DNSQueryEntry>,
+}
+
+#[derive(Debug)]
+pub struct DNSResponse {
+    pub header: DNSHeader,
+    pub queries: Vec<DNSQueryEntry>,
+    pub answers: Vec<DNSAnswerEntry>,
+    pub authorities: Vec<DNSAnswerEntry>,
+}
+
+#[derive(Debug)]
+pub struct DNSQueryEntry {
+    pub name: Vec<u8>,
+    pub rrtype: u16,
+    pub rrclass: u16,
+}
+
+#[derive(Debug)]
+pub struct DNSAnswerEntry {
+    pub name: Vec<u8>,
+    pub rrtype: u16,
+    pub rrclass: u16,
+    pub ttl: u32,
+    pub data_len: u16,
+    pub data: Vec<u8>,
+}
+
+pub struct DNSState {
+
+    pub events: Vec<DNSEvents>,
+
+    // Vector of transactions.
+    pub transactions: Vec<Box<DNSTransaction>>,
+
+    // Internal transaction ID tracker.
+    pub tx_id: u64,
+
+    pub unreplied: u64,
+}
+
+impl DNSState {
+
+    pub fn new() -> DNSState {
+        return DNSState{
+            events: Vec::new(),
+            transactions: Vec::new(),
+            tx_id: 0,
+            unreplied: 0,
+        }
+    }
+
+    pub fn new_tx(&mut self) -> DNSTransaction {
+        self.tx_id = self.tx_id + 1;
+        let mut tx = DNSTransaction::new();
+        tx.id = self.tx_id;
+        return tx;
+    }
+
+    pub fn tx_free(&mut self, tx_id: u64) {
+        for i in 0..self.transactions.len() {
+            if self.transactions[i].id == tx_id + 1 {
+                self.transactions.remove(i);
+                return;
+            }
+        }
+    }
+
+    pub fn tx_get(&self, tx_id: u64) -> Option<&DNSTransaction> {
+        // Loops through the transactions in reverse as we are most
+        // likely getting the most recent. Its a bit of a
+        // micro-optimization, but was visible in profiling.
+        let mut len = self.transactions.len();
+        loop {
+            len = len - 1;
+            if self.transactions[len].id == tx_id + 1 {
+                return Some(&self.transactions[len]);
+            }
+            if len == 0 {
+                break;
+            }
+        }
+
+        return None;
+    }
+
+    pub fn validate_request_header(&mut self, request: &DNSRequest) -> bool {
+        // XXX In the C version the header was validated prior to
+        // parsing. In this Rust version the header is parsed with the
+        // request so we validate it after successful parsing. We
+        // could go back to the C behaviour by parsing the header,
+        // validating then parsing the full request.
+
+        if request.header.flags & 0x8000 != 0 {
+            self.events.push(DNSEvents::NotRequest);
+            return false;
+        }
+
+        if request.header.flags & 0x0040 != 0 {
+            self.events.push(DNSEvents::ZFlagSet);
+            return false;
+        }
+
+        return true;
+    }
+
+    pub fn validate_response_header(&mut self, response: &DNSResponse) -> bool {
+        // XXX In the C version the header was validated prior to
+        // parsing. In this Rust version the header is parsed with the
+        // request so we validate it after successful parsing. We
+        // could go back to the C behaviour by parsing the header,
+        // validating then parsing the full request.
+
+        if response.header.flags & 0x8000 == 0 {
+            self.events.push(DNSEvents::NotResponse);
+            return false;
+        }
+
+        if response.header.flags & 0x0040 != 0 {
+            self.events.push(DNSEvents::ZFlagSet);
+            return false;
+        }
+
+        return true;
+    }
+
+    /// Returns the ID of the new transaction.
+    pub fn handle_request(&mut self, request: DNSRequest) -> u64 {
+
+        if !self.validate_request_header(&request) {
+            return 0;
+        }
+
+        let mut tx = self.new_tx();
+        let id = tx.id;
+        tx.request = Some(request);
+        self.transactions.push(Box::new(tx));
+        self.unreplied += 1;
+
+        return id;
+    }
+
+    /// Returns the transaction ID this response belongs to, or was
+    /// given in the case of an unsolicited response.
+    pub fn handle_response(&mut self, response: DNSResponse) -> u64 {
+
+        if !self.validate_response_header(&response) {
+            return 0;
+        }
+
+        for tx in &mut self.transactions {
+            let tx = &mut **tx;
+            for request in &tx.request {
+                if request.header.tx_id == response.header.tx_id {
+                    tx.response = Some(response);
+                    tx.replied = true;
+                    self.unreplied -= 1;
+                    return tx.id;
+                }
+            }
+        }
+
+        self.events.push(DNSEvents::UnsolicitedResponse);
+
+        // Create a response only transaction.
+        let mut tx = self.new_tx();
+        let id = tx.id;
+        tx.response = Some(response);
+        tx.replied = true;
+        self.transactions.push(Box::new(tx));
+
+        return id;
+    }
+
+    /// Parse and handle a DNS request.
+    pub fn parse_request(&mut self, input: &[u8]) -> u64 {
+        match dns_parse_request(input) {
+            nom::IResult::Done(_, request) => {
+                return self.handle_request(request);
+            },
+            _ => {
+                self.events.push(DNSEvents::MalformedData);
+                return 0;
+            }
+        }
+    }
+
+    /// Parse and handle a DNS response.
+    pub fn parse_response(&mut self, input: &[u8]) -> u64 {
+        match dns_parse_response(input) {
+            nom::IResult::Done(_, response) => {
+                return self.handle_response(response);
+            },
+            _ => {
+                self.events.push(DNSEvents::MalformedData);
+                return 0;
+            }
+        }
+    }
+
+}
+
+/// Expose DNSState::new.
+export_state_new!(rs_dns_state_new, DNSState);
+
+/// Expose a function to free DNSState.
+export_state_free!(rs_dns_state_free, DNSState);
+
+#[no_mangle]
+pub extern fn rs_dns_state_tx_free(this: &mut DNSState, tx_id: libc::uint64_t) {
+   this.tx_free(tx_id);
+}
+
+#[no_mangle]
+pub extern fn rs_dns_state_tx_get(this: &mut DNSState, tx_id: libc::uint64_t)
+                                  -> *mut DNSTransaction {
+    match this.tx_get(tx_id) {
+        Some(tx) => {
+            return unsafe{transmute(tx)};
+        },
+        _ => {
+            return ptr::null_mut();
+        }
+    }
+}
+
+#[no_mangle]
+pub extern fn rs_dns_state_get_next_event(this: &mut DNSState) -> u32 {
+    match this.events.pop() {
+        Some(ev) => {
+            return ev as u32;
+        },
+        _ => {
+            return 0;
+        }
+    }
+}
+
+#[no_mangle]
+pub extern fn rs_dns_state_get_tx_count(this: &mut DNSState) -> u64 {
+    return this.tx_id;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_state_parse_request(state: &mut DNSState,
+                                         input: *const libc::uint8_t,
+                                         len: libc::uint32_t) -> libc::uint64_t
+{
+    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+    let tx_id = state.parse_request(buf);
+    return tx_id as libc::uint64_t;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_state_parse_response(state: &mut DNSState,
+                                          input: *const libc::uint8_t,
+                                          len: libc::uint32_t) -> libc::uint64_t
+{
+    let buf = unsafe{std::slice::from_raw_parts(input, len as usize)};
+    let tx_id = state.parse_response(buf);
+    return tx_id as libc::uint64_t;
+}
+
+impl DNSTransaction {
+
+    pub fn new() -> DNSTransaction {
+        return DNSTransaction{
+            id: 0,
+            request: None,
+            response: None,
+            replied: false,
+        }
+    }
+
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_get_alstate_progress(tx: &mut DNSTransaction,
+                                             direction: libc::uint8_t)
+                                             -> libc::uint8_t {
+    if direction & core::STREAM_TOCLIENT > 0 {
+        if tx.replied {
+            return 1;
+        }
+        return 0;
+    }
+    return 1;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_get_query_buffer(tx: &mut DNSTransaction,
+                                         i: libc::uint16_t,
+                                         buf: *mut *const libc::uint8_t,
+                                         len: *mut libc::uint32_t)
+                                         -> libc::uint8_t
+{
+    for request in &tx.request {
+        if (i as usize) < request.queries.len() {
+            let query = &request.queries[i as usize];
+            if query.name.len() > 0 {
+                unsafe {
+                    *len = query.name.len() as libc::uint32_t;
+                    *buf = query.name.as_ptr();
+                }
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+#[no_mangle]
+pub extern fn rs_dns_tx_inspect_query_name(
+    txp: *mut DNSTransaction,
+    de_ctx: *mut libc::c_void,
+    det_ctx: *mut libc::c_void,
+    s: *mut libc::c_void,
+    sm: *mut libc::c_void,
+    f: *mut libc::c_void,
+    stream_start_offset: libc::uint32_t,
+    inspection_mode: libc::uint8_t,
+    data: *mut libc::c_void) -> u32
+{
+    let tx = unsafe{&mut *txp};
+
+    for request in &tx.request {
+        for query in &request.queries {
+            let len = query.name.len();
+            unsafe {
+                let buf = &query.name[..];
+                let r = core::DetectEngineContentInspection(
+                    de_ctx,
+                    det_ctx,
+                    s,
+                    sm,
+                    f,
+                    buf.as_ptr(),
+                    len as u32,
+                    stream_start_offset,
+                    inspection_mode,
+                    data);
+                if r == 1 {
+                    return 1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+/// Probe a buffer to see if it looks like a DNS request or response.
+pub fn dns_probe(input: &[u8]) -> bool {
+    match dns_parse_request(input) {
+        nom::IResult::Done(_, _) => {
+            return true;
+        },
+        _ => {
+            return false;
+        }
+    }
+}
+
+/// Expose dns_probe to C. This wrapper is an example of how to catch
+/// panic's and unwind so an error code can be returned.
+#[no_mangle]
+pub extern "C" fn rs_dns_probe(input: *const libc::uint8_t, len: libc::uint32_t)
+                               -> libc::uint8_t {
+    let res = panic::catch_unwind(|| {
+        let slice: &[u8] = unsafe {
+            slice::from_raw_parts(input as *mut u8, len as usize)};
+        match dns_probe(slice) {
+            true => {
+                return 1;
+            },
+            false => {
+                return 0;
+            }
+        }
+    });
+
+    match res {
+        Ok(rc) => {
+            return rc;
+        },
+        _ => {
+            return 0;
+        },
+    };
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::str;
+    use dns::*;
+    use nom::IResult;
+
+    #[test]
+    fn test_dns_parse_label() {
+        let buf: &[u8] = &[
+            // www
+            0x03, 0x77, 0x77, 0x77,
+
+            // suricata-ids
+            0x0c, 0x73, 0x75, 0x72, 0x69, 0x63, 0x61, 0x74,
+            0x61, 0x2d, 0x69, 0x64, 0x73,
+
+            // org
+            0x03, 0x72, 0x67, 0x00];
+
+        let res = dns_parse_label(buf);
+        let expected = IResult::Done(&buf[4..], "www".as_bytes());
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_dns_parse_name_simple() {
+        let buf: &[u8] = &[
+                                                0x09, 0x63, /* .......c */
+            0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x63, 0x66, /* lient-cf */
+            0x07, 0x64, 0x72, 0x6f, 0x70, 0x62, 0x6f, 0x78, /* .dropbox */
+            0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, /* .com.... */
+        ];
+        let expected_remainder: &[u8] = &[0x00, 0x01, 0x00];
+        let res = dns_parse_name(buf, buf);
+        match res {
+            IResult::Done(remainder, name) => {
+                assert_eq!("client-cf.dropbox.com".as_bytes(), &name[..]);
+                assert_eq!(remainder, expected_remainder);
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dns_parse_name_pointer() {
+        let buf: &[u8] = &[
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* .....F.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x00, 0x7b, 0x71, 0x6e, 0x00, 0x00, 0x39, 0x11 /* .{qn..9. */,
+            0xf4, 0xd9, 0x08, 0x08, 0x08, 0x08, 0x0a, 0x10 /* ........ */,
+            0x01, 0x0b, 0x00, 0x35, 0xe1, 0x8e, 0x00, 0x67 /* ...5...g */,
+            0x60, 0x00, 0xef, 0x08, 0x81, 0x80, 0x00, 0x01 /* `....... */,
+            0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x03, 0x77 /* .......w */,
+            0x77, 0x77, 0x0c, 0x73, 0x75, 0x72, 0x69, 0x63 /* ww.suric */,
+            0x61, 0x74, 0x61, 0x2d, 0x69, 0x64, 0x73, 0x03 /* ata-ids. */,
+            0x6f, 0x72, 0x67, 0x00, 0x00, 0x01, 0x00, 0x01 /* org..... */,
+            0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00 /* ........ */,
+            0x0e, 0x0f, 0x00, 0x02, 0xc0, 0x10, 0xc0, 0x10 /* ........ */,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2b /* .......+ */,
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x19, 0xc0, 0x10 /* ....N... */,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x01, 0x2b /* .......+ */,
+            0x00, 0x04, 0xc0, 0x00, 0x4e, 0x18, 0x00, 0x00 /* ....N... */,
+            0x29, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 /* )....... */,
+            0x00,                                          /* . */
+        ];
+        let message = &buf[42..];
+
+        let start = &buf[0x36..];
+        let res = dns_parse_name(start, message);
+        assert_eq!(res,
+                   IResult::Done(&start[22..], "www.suricata-ids.org".as_bytes().to_vec()));
+
+        let start1 = &buf[0x50..];
+        let res1 = dns_parse_name(start1, message);
+        assert_eq!(res1,
+                   IResult::Done(&start1[2..], "www.suricata-ids.org".as_bytes().to_vec()));
+
+        let start2 = &buf[0x5e..];
+        let res2 = dns_parse_name(start2, message);
+        assert_eq!(res2,
+                   IResult::Done(&start2[2..], "suricata-ids.org".as_bytes().to_vec()));
+
+        let start3 = &buf[0x6e..];
+        let res3 = dns_parse_name(start3, message);
+        assert_eq!(res3,
+                   IResult::Done(&start3[2..], "suricata-ids.org".as_bytes().to_vec()));
+    }
+
+    #[test]
+    fn test_dns_parse_name_double_pointer() {
+        let buf: &[u8] = &[
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* .....F.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x00, 0x66, 0x5e, 0x20, 0x40, 0x00, 0x40, 0x11 /* .f^ @.@. */,
+            0xc6, 0x3b, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* .;...... */,
+            0x01, 0x0b, 0x00, 0x35, 0xc2, 0x21, 0x00, 0x52 /* ...5.!.R */,
+            0x35, 0xc5, 0x0d, 0x4f, 0x81, 0x80, 0x00, 0x01 /* 5..O.... */,
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x05, 0x62 /* .......b */,
+            0x6c, 0x6f, 0x63, 0x6b, 0x07, 0x64, 0x72, 0x6f /* lock.dro */,
+            0x70, 0x62, 0x6f, 0x78, 0x03, 0x63, 0x6f, 0x6d /* pbox.com */,
+            0x00, 0x00, 0x01, 0x00, 0x01, 0xc0, 0x0c, 0x00 /* ........ */,
+            0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00 /* ........ */,
+            0x0b, 0x05, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x02 /* ..block. */,
+            0x67, 0x31, 0xc0, 0x12, 0xc0, 0x2f, 0x00, 0x01 /* g1.../.. */,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x04 /* ........ */,
+            0x2d, 0x3a, 0x46, 0x21 /* -:F! */];
+
+        // The start of the DNS message in the above packet.
+        let message: &[u8] = &buf[42..];
+
+        // The start of the name we want to parse.
+        let start: &[u8] = &buf[0x64..];
+
+        let res = dns_parse_name(start, message);
+        assert_eq!(res,
+                   IResult::Done(&start[2..], "block.g1.dropbox.com".as_bytes().to_vec()));
+    }
+
+    #[test]
+    fn test_dns_parse_simple_request() {
+        let input: &[u8] = &[
+            0x00, 0x15, 0x17, 0x0d, 0x06, 0xf7, 0xd8, 0xcb /* ........ */,
+            0x8a, 0xed, 0xa1, 0x46, 0x08, 0x00, 0x45, 0x00 /* ...F..E. */,
+            0x00, 0x43, 0x9c, 0x8a, 0x40, 0x00, 0x40, 0x11 /* .C..@.@. */,
+            0x87, 0xf4, 0x0a, 0x10, 0x01, 0x0b, 0x0a, 0x10 /* ........ */,
+            0x01, 0x01, 0xd1, 0xaf, 0x00, 0x35, 0x00, 0x2f /* .....5./ */,
+            0x16, 0x6c, 0x99, 0xab, 0x01, 0x00, 0x00, 0x01 /* .l...... */,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x63 /* .......c */,
+            0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x63, 0x66 /* lient-cf */,
+            0x07, 0x64, 0x72, 0x6f, 0x70, 0x62, 0x6f, 0x78 /* .dropbox */,
+            0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00 /* .com.... */,
+            0x01,                                          /* . */
+        ];
+        let offset = 42;
+
+        let res = dns_parse_request(&input[offset..]);
+        match res {
+            IResult::Done(rem, request) => {
+
+                // Check how much data is remaining.
+                assert_eq!(rem.len(), 0);
+
+                // Check the header.
+                let header = request.header;
+                assert_eq!(header,
+                           DNSHeader {
+                               tx_id: 0x99ab,
+                               flags: 0x0100,
+                               questions: 1,
+                               answer_rr: 0,
+                               authority_rr: 0,
+                               additional_rr: 0,
+                           });
+
+                // Check the query/question section.
+                assert_eq!(request.queries.len(), 1);
+                let query0 = &request.queries[0];
+                assert_eq!(query0.name, "client-cf.dropbox.com".as_bytes().to_vec());
+                assert_eq!(query0.rrtype, 1);
+                assert_eq!(query0.rrclass, 1);
+            }
+            IResult::Incomplete(_) => {
+                assert!(false);
+            }
+            IResult::Error(_) => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dns_parse_simple_response() {
+        let buf: &[u8] = &[
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* .....F.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x00, 0x53, 0x5e, 0x1f, 0x40, 0x00, 0x40, 0x11 /* .S^.@.@. */,
+            0xc6, 0x4f, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* .O...... */,
+            0x01, 0x0b, 0x00, 0x35, 0xd1, 0xaf, 0x00, 0x3f /* ...5...? */,
+            0xce, 0x7f, 0x99, 0xab, 0x81, 0x80, 0x00, 0x01 /* ........ */,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x09, 0x63 /* .......c */,
+            0x6c, 0x69, 0x65, 0x6e, 0x74, 0x2d, 0x63, 0x66 /* lient-cf */,
+            0x07, 0x64, 0x72, 0x6f, 0x70, 0x62, 0x6f, 0x78 /* .dropbox */,
+            0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00 /* .com.... */,
+            0x01, 0xc0, 0x0c, 0x00, 0x01, 0x00, 0x01, 0x00 /* ........ */,
+            0x00, 0x00, 0x2f, 0x00, 0x04, 0x34, 0x55, 0x70 /* ../..4Up */,
+            0x15,                                          /* . */
+        ];
+        let offset = 42;
+        let expected_addr: &[u8] = &[0x34, 0x55, 0x70, 0x15];
+
+        let res = dns_parse_response(&buf[offset..]);
+        match res {
+            IResult::Done(rem, response) => {
+
+                // Check how much data is remaining.
+                assert_eq!(rem.len(), 0);
+
+                // Check the header.
+                let header = response.header;
+                assert_eq!(header,
+                           DNSHeader {
+                               tx_id: 0x99ab,
+                               flags: 0x8180,
+                               questions: 1,
+                               answer_rr: 1,
+                               authority_rr: 0,
+                               additional_rr: 0,
+                           });
+
+                // Check the query/question section.
+                assert_eq!(response.queries.len(), 1);
+                let query0 = &response.queries[0];
+                assert_eq!(query0.name, "client-cf.dropbox.com".as_bytes().to_vec());
+                assert_eq!(query0.rrtype, 1);
+                assert_eq!(query0.rrclass, 1);
+
+                // Check the answer section.
+                assert_eq!(response.answers.len(), 1);
+                let answer0 = &response.answers[0];
+                assert_eq!(answer0.name, "client-cf.dropbox.com".as_bytes().to_vec());
+                assert_eq!(answer0.rrtype, 1);
+                assert_eq!(answer0.rrclass, 1);
+                assert_eq!(answer0.ttl, 47);
+                assert_eq!(answer0.data_len, 4);
+                assert_eq!(answer0.data, expected_addr);
+            }
+            IResult::Incomplete(_) => {
+                assert!(false);
+            }
+            IResult::Error(_) => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dns_parse_2answer_response() {
+        let buf: &[u8] = &[
+            0xd8, 0xcb, 0x8a, 0xed, 0xa1, 0x46, 0x00, 0x15 /* .....F.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x00, 0x66, 0x5e, 0x20, 0x40, 0x00, 0x40, 0x11 /* .f^ @.@. */,
+            0xc6, 0x3b, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* .;...... */,
+            0x01, 0x0b, 0x00, 0x35, 0xc2, 0x21, 0x00, 0x52 /* ...5.!.R */,
+            0x35, 0xc5, 0x0d, 0x4f, 0x81, 0x80, 0x00, 0x01 /* 5..O.... */,
+            0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x05, 0x62 /* .......b */,
+            0x6c, 0x6f, 0x63, 0x6b, 0x07, 0x64, 0x72, 0x6f /* lock.dro */,
+            0x70, 0x62, 0x6f, 0x78, 0x03, 0x63, 0x6f, 0x6d /* pbox.com */,
+            0x00, 0x00, 0x01, 0x00, 0x01, 0xc0, 0x0c, 0x00 /* ........ */,
+            0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00 /* ........ */,
+            0x0b, 0x05, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x02 /* ..block. */,
+            0x67, 0x31, 0xc0, 0x12, 0xc0, 0x2f, 0x00, 0x01 /* g1.../.. */,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x04 /* ........ */,
+            0x2d, 0x3a, 0x46, 0x21                         /* -:F! */
+        ];
+        let offset = 42;
+
+        let res = dns_parse_response(&buf[offset..]);
+        match res {
+            IResult::Done(rem, response) => {
+
+                // Check how much data is remaining.
+                assert_eq!(rem.len(), 0);
+
+                // Check the header.
+                let header = response.header;
+                assert_eq!(header,
+                           DNSHeader {
+                               tx_id: 0x0d4f,
+                               flags: 0x8180,
+                               questions: 1,
+                               answer_rr: 2,
+                               authority_rr: 0,
+                               additional_rr: 0,
+                           });
+
+                // Check the query/question section.
+                assert_eq!(response.queries.len(), 1);
+                let query0 = &response.queries[0];
+                assert_eq!(query0.name,
+                           "block.dropbox.com".as_bytes().to_vec());
+                assert_eq!(query0.rrtype, 1);
+                assert_eq!(query0.rrclass, 1);
+
+                // Check the answer section.
+                assert_eq!(response.answers.len(), 2);
+
+                let answer0 = &response.answers[0];
+                assert_eq!(answer0.name,
+                           "block.dropbox.com".as_bytes().to_vec());
+                assert_eq!(answer0.rrtype, 5);
+                assert_eq!(answer0.rrclass, 1);
+                assert_eq!(answer0.ttl, 9);
+                assert_eq!(answer0.data_len, 11);
+                assert_eq!(answer0.data,
+                           "block.g1.dropbox.com".as_bytes().to_vec());
+
+                let answer1 = &response.answers[1];
+                assert_eq!(answer1.name,
+                           "block.g1.dropbox.com".as_bytes().to_vec());
+                assert_eq!(answer1.rrtype, 1);
+                assert_eq!(answer1.rrclass, 1);
+                assert_eq!(answer1.ttl, 8);
+                assert_eq!(answer1.data_len, 4);
+                assert_eq!(answer1.data, &[0x2d, 0x3a, 0x46, 0x21]);
+
+            }
+            IResult::Incomplete(_) => {
+                assert!(false);
+            }
+            IResult::Error(_) => {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dns_parse_5answer_response() {
+        let buf: &[u8] = &[
+            0x00, 0x24, 0x8c, 0x0e, 0x31, 0x54, 0x00, 0x15 /* .$..1T.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x00, 0xbf, 0x70, 0x65, 0x40, 0x00, 0x40, 0x11 /* ..pe@.@. */,
+            0xb2, 0xc1, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* ........ */,
+            0x01, 0xe7, 0x00, 0x35, 0xea, 0x32, 0x00, 0xab /* ...5.2.. */,
+            0x17, 0xc4, 0x55, 0x96, 0x81, 0x80, 0x00, 0x01 /* ..U..... */,
+            0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x02, 0x63 /* .......c */,
+            0x37, 0x06, 0x72, 0x62, 0x78, 0x63, 0x64, 0x6e /* 7.rbxcdn */,
+            0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00 /* .com.... */,
+            0x01, 0xc0, 0x0c, 0x00, 0x05, 0x00, 0x01, 0x00 /* ........ */,
+            0x00, 0x31, 0x11, 0x00, 0x08, 0x05, 0x63, 0x37 /* .1....c7 */,
+            0x63, 0x78, 0x73, 0xc0, 0x0f, 0xc0, 0x2b, 0x00 /* cxs...+. */,
+            0x05, 0x00, 0x01, 0x00, 0x00, 0x31, 0x44, 0x00 /* .....1D. */,
+            0x20, 0x0e, 0x32, 0x2d, 0x30, 0x31, 0x2d, 0x34 /*  .2-01-4 */,
+            0x38, 0x37, 0x37, 0x2d, 0x30, 0x30, 0x30, 0x64 /* 877-000d */,
+            0x03, 0x63, 0x64, 0x78, 0x07, 0x63, 0x65, 0x64 /* .cdx.ced */,
+            0x65, 0x78, 0x69, 0x73, 0x03, 0x6e, 0x65, 0x74 /* exis.net */,
+            0x00, 0xc0, 0x3f, 0x00, 0x05, 0x00, 0x01, 0x00 /* ..?..... */,
+            0x00, 0x00, 0x17, 0x00, 0x07, 0x04, 0x63, 0x37 /* ......c7 */,
+            0x6c, 0x6c, 0xc0, 0x0f, 0xc0, 0x6b, 0x00, 0x05 /* ll...k.. */,
+            0x00, 0x01, 0x00, 0x00, 0x01, 0x26, 0x00, 0x15 /* .....&.. */,
+            0x09, 0x72, 0x6f, 0x62, 0x6c, 0x6f, 0x78, 0x69 /* .robloxi */,
+            0x6e, 0x63, 0x02, 0x68, 0x73, 0x05, 0x6c, 0x6c /* nc.hs.ll */,
+            0x6e, 0x77, 0x64, 0xc0, 0x5a, 0xc0, 0x7e, 0x00 /* nwd.Z.~. */,
+            0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0xe1, 0x00 /* ........ */,
+            0x04, 0x45, 0x1c, 0xbc, 0x1e /* .E... */];
+        let message = &buf[0x2a..];
+        dns_parse_response(message);
+    }
+
+    #[test]
+    fn test_dns_parse_6answer_response() {
+        let buf: &[u8] = &[
+            0x00, 0x24, 0x8c, 0x0e, 0x31, 0x54, 0x00, 0x15 /* .$..1T.. */,
+            0x17, 0x0d, 0x06, 0xf7, 0x08, 0x00, 0x45, 0x00 /* ......E. */,
+            0x01, 0x54, 0x70, 0xed, 0x40, 0x00, 0x40, 0x11 /* .Tp.@.@. */,
+            0xb1, 0xa4, 0x0a, 0x10, 0x01, 0x01, 0x0a, 0x10 /* ........ */,
+            0x01, 0xe7, 0x00, 0x35, 0xc8, 0x0a, 0x01, 0x40 /* ...5...@ */,
+            0x18, 0x59, 0xa2, 0xf2, 0x81, 0x80, 0x00, 0x01 /* .Y...... */,
+            0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x73 /* .......s */,
+            0x74, 0x6f, 0x72, 0x65, 0x2d, 0x69, 0x6d, 0x61 /* tore-ima */,
+            0x67, 0x65, 0x73, 0x09, 0x6d, 0x69, 0x63, 0x72 /* ges.micr */,
+            0x6f, 0x73, 0x6f, 0x66, 0x74, 0x03, 0x63, 0x6f /* osoft.co */,
+            0x6d, 0x00, 0x00, 0x01, 0x00, 0x01, 0xc0, 0x0c /* m....... */,
+            0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x02, 0x7a /* .......z */,
+            0x00, 0x26, 0x09, 0x6d, 0x69, 0x63, 0x72, 0x6f /* .&.micro */,
+            0x73, 0x6f, 0x66, 0x74, 0x03, 0x63, 0x6f, 0x6d /* soft.com */,
+            0x0b, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x69, 0x6d /* .storeim */,
+            0x61, 0x67, 0x65, 0x73, 0x06, 0x61, 0x6b, 0x61 /* ages.aka */,
+            0x64, 0x6e, 0x73, 0x03, 0x6e, 0x65, 0x74, 0x00 /* dns.net. */,
+            0xc0, 0x38, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00 /* .8...... */,
+            0x00, 0x6e, 0x00, 0x23, 0x0c, 0x73, 0x74, 0x6f /* .n.#.sto */,
+            0x72, 0x65, 0x2d, 0x69, 0x6d, 0x61, 0x67, 0x65 /* re-image */,
+            0x73, 0x09, 0x6d, 0x69, 0x63, 0x72, 0x6f, 0x73 /* s.micros */,
+            0x6f, 0x66, 0x74, 0x03, 0x63, 0x6f, 0x6d, 0x05 /* oft.com. */,
+            0x6e, 0x73, 0x61, 0x74, 0x63, 0xc0, 0x59, 0xc0 /* nsatc.Y. */,
+            0x6a, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00 /* j....... */,
+            0x7b, 0x00, 0x27, 0x0c, 0x73, 0x74, 0x6f, 0x72 /* {.'.stor */,
+            0x65, 0x2d, 0x69, 0x6d, 0x61, 0x67, 0x65, 0x73 /* e-images */,
+            0x09, 0x6d, 0x69, 0x63, 0x72, 0x6f, 0x73, 0x6f /* .microso */,
+            0x66, 0x74, 0x05, 0x63, 0x6f, 0x6d, 0x2d, 0x63 /* ft.com-c */,
+            0x07, 0x65, 0x64, 0x67, 0x65, 0x6b, 0x65, 0x79 /* .edgekey */,
+            0xc0, 0x59, 0xc0, 0x99, 0x00, 0x05, 0x00, 0x01 /* .Y...... */,
+            0x00, 0x00, 0x17, 0x0b, 0x00, 0x37, 0x0c, 0x73 /* .....7.s */,
+            0x74, 0x6f, 0x72, 0x65, 0x2d, 0x69, 0x6d, 0x61 /* tore-ima */,
+            0x67, 0x65, 0x73, 0x09, 0x6d, 0x69, 0x63, 0x72 /* ges.micr */,
+            0x6f, 0x73, 0x6f, 0x66, 0x74, 0x05, 0x63, 0x6f /* osoft.co */,
+            0x6d, 0x2d, 0x63, 0x07, 0x65, 0x64, 0x67, 0x65 /* m-c.edge */,
+            0x6b, 0x65, 0x79, 0x03, 0x6e, 0x65, 0x74, 0x0b /* key.net. */,
+            0x67, 0x6c, 0x6f, 0x62, 0x61, 0x6c, 0x72, 0x65 /* globalre */,
+            0x64, 0x69, 0x72, 0xc0, 0x52, 0xc0, 0xcc, 0x00 /* dir.R... */,
+            0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x19, 0x00 /* ........ */,
+            0x19, 0x06, 0x65, 0x31, 0x32, 0x35, 0x36, 0x34 /* ..e12564 */,
+            0x04, 0x64, 0x73, 0x70, 0x67, 0x0a, 0x61, 0x6b /* .dspg.ak */,
+            0x61, 0x6d, 0x61, 0x69, 0x65, 0x64, 0x67, 0x65 /* amaiedge */,
+            0xc0, 0x59, 0xc1, 0x0f, 0x00, 0x01, 0x00, 0x01 /* .Y...... */,
+            0x00, 0x00, 0x00, 0x12, 0x00, 0x04, 0x17, 0x3a /* .......: */,
+            0xa1, 0xdd,                                    /* .. */];
+        let message = &buf[0x2a..];
+        dns_parse_response(message);
+    }
+
+    #[test]
+    fn test_dns_state_tx_alloc_free() {
+        let mut state = DNSState::new();
+        let tx = state.new_tx();
+        let tx_id = tx.id;
+        state.transactions.push(Box::new(tx));
+        state.tx_free(tx_id);
+    }
+
+}

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -1,0 +1,340 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+// TODO: log-dnslog "fast" style logging.
+// TODO: rtype log filtering.
+
+extern crate libc;
+
+use std;
+use std::ffi::CString;
+
+use dns::*;
+use json::*;
+
+fn dns_type_string(rrtype: u16) -> std::string::String {
+    match rrtype {
+        DNS_RTYPE_A => "A",
+        DNS_RTYPE_CNAME => "CNAME",
+        DNS_RTYPE_SOA => "SOA",
+        DNS_RTYPE_PTR => "PTR",
+        DNS_RTYPE_MX => "MX",
+        DNS_RTYPE_SSHFP => "SSHFP",
+        DNS_RTYPE_RRSIG => "RRSIG",
+        _ => "?",
+    }.to_string()
+}
+
+fn dns_rcode_string(flags: u16) -> std::string::String {
+    match flags & 0x000f {
+        DNS_RCODE_NOERROR => "NOERROR",
+        DNS_RCODE_FORMERR => "FORMERR",
+        DNS_RCODE_NXDOMAIN => "NXDOMAIN",
+        _ => "?",
+    }.to_string()
+}
+
+/// Format bytes as an IP address string.
+///
+/// TODO: IPv6.
+fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
+    if addr.len() == 4 {
+        return format!("{}.{}.{}.{}", addr[0], addr[1], addr[2], addr[3]);
+    }
+    else {
+        println!("Unsupported address length {}", addr.len());
+        return "unknown".to_string();
+    }
+}
+
+pub fn dns_get_request_query(request: &DNSRequest, i: u16)
+                             -> Option<&DNSQueryEntry>
+{
+    if (i as usize) < request.queries.len() {
+        return Some(&request.queries[i as usize]);
+    }
+    return None
+}
+
+pub fn dns_get_response_answer(response: &DNSResponse, i: u16)
+                               -> Option<&DNSAnswerEntry>
+{
+    if (i as usize) < response.answers.len() {
+        return Some(&response.answers[i as usize]);
+    }
+    return None
+}
+
+pub fn dns_get_response_authority(response: &DNSResponse, i: u16)
+                                  -> Option<&DNSAnswerEntry>
+{
+    if (i as usize) < response.authorities.len() {
+        return Some(&response.authorities[i as usize]);
+    }
+    return None
+}
+
+#[no_mangle]
+pub extern fn rs_dns_log_query(txp: *mut DNSTransaction, i: libc::uint16_t)
+                               -> *mut JsonT {
+
+    let tx = unsafe{&mut *txp};
+
+    for request in &tx.request {
+
+        if (i as usize) < request.queries.len() {
+
+            let query = &request.queries[i as usize];
+
+            let js = Json::object();
+
+            js.set_string("type", "query");
+            js.set_integer("id", request.header.tx_id as u64);
+
+            js.set_string("rrname",
+                          std::str::from_utf8(&query.name[..]).unwrap());
+            js.set_string("rrtype", &dns_type_string(query.rrtype));
+            //js.set_integer("rrclass", query.rrclass as u64);
+
+            // This is - 1 as the ID stored in the transaction is one
+            // greater than Suricata's app-layer idea of the ID.
+            js.set_integer("tx_id", tx.id - 1);
+
+            return js.unwrap();
+        }
+
+    }
+
+    return std::ptr::null_mut();
+}
+
+fn dns_log_response_failure(r: &DNSResponse, i: u16) -> * mut JsonT {
+    if (i as usize) >= r.queries.len() {
+        return std::ptr::null_mut();
+    }
+
+    let ref query = r.queries[i as usize];
+
+    let js = Json::object();
+
+    js.set_string("type", "answer");
+    js.set_integer("id", r.header.tx_id as u64);
+    js.set_string("rcode", &dns_rcode_string(r.header.flags));
+    js.set_string("rrname", std::str::from_utf8(&query.name[..]).unwrap());
+
+    return js.unwrap();
+}
+
+fn dns_log_sshfp(js: &Json, answer: &DNSAnswerEntry)
+{
+    // Need at least 3 bytes - TODO: log something if we don't?
+    if answer.data_len < 3 {
+        return;
+    }
+
+    let sshfp = Json::object();
+
+    let mut hex = Vec::new();
+    for byte in &answer.data[2..] {
+        hex.push(format!("{:02x}", byte));
+    }
+    sshfp.set_string("fingerprint", &hex.join(":"));
+
+    sshfp.set_integer("algo", answer.data[0] as u64);
+    sshfp.set_integer("type", answer.data[1] as u64);
+
+    js.set("sshfp", sshfp);
+}
+
+fn dns_log_answer_entry(header: &DNSHeader, answer: &DNSAnswerEntry)
+                        -> *mut JsonT {
+    let js = Json::object();
+
+    js.set_string("type", "answer");
+    js.set_integer("id", header.tx_id as u64);
+    js.set_string("rcode", &dns_rcode_string(header.flags));
+    js.set_string("rrname",
+                  std::str::from_utf8(&answer.name[..]).unwrap());
+    js.set_string("rrtype", &dns_type_string(answer.rrtype));
+    js.set_integer("ttl", answer.ttl as u64);
+
+    match answer.rrtype {
+        DNS_RTYPE_A => {
+            js.set_string("rdata", &dns_print_addr(&answer.data));
+        },
+        DNS_RTYPE_CNAME |
+        DNS_RTYPE_MX |
+        DNS_RTYPE_PTR => {
+            js.set_string("rdata",
+                          std::str::from_utf8(&answer.data[..]).unwrap());
+        },
+        DNS_RTYPE_SOA => {},
+        DNS_RTYPE_SSHFP => {
+            dns_log_sshfp(&js, &answer);
+        },
+        _ => {
+        }
+    }
+
+    return js.unwrap();
+}
+
+#[no_mangle]
+pub extern fn rs_dns_log_answers(tx: &mut DNSTransaction, i: libc::uint16_t)
+                                -> *mut JsonT
+{
+    for response in &tx.response {
+        if response.header.flags & 0x000f > 0 {
+            return dns_log_response_failure(response, i);
+        }
+
+        if (i as usize) >= response.answers.len() {
+            return std::ptr::null_mut();
+        }
+
+        let answer = &response.answers[i as usize];
+        return dns_log_answer_entry(&response.header, answer);
+    }
+
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub extern fn rs_dns_log_authorities(tx: &mut DNSTransaction, i: libc::uint16_t)
+                                     -> *mut JsonT
+{
+    for response in &tx.response {
+        if (i as usize) >= response.authorities.len() {
+            return std::ptr::null_mut();
+        }
+
+        let answer = &response.authorities[i as usize];
+        return dns_log_answer_entry(&response.header, answer);
+    }
+
+    return std::ptr::null_mut();
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_log_txt_query(tx: &mut DNSTransaction,
+                                       i: libc::uint16_t)
+                                       -> CString
+{
+    for request in &tx.request {
+        for query in dns_get_request_query(request, i) {
+            let log = format!("Query TX {:04x} [**] {} [**] {}",
+                              request.header.tx_id,
+                              std::str::from_utf8(&query.name[..]).unwrap(),
+                              dns_type_string(query.rrtype));
+            return CString::new(log).unwrap();
+        }
+    }
+    return CString::default();
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_log_txt_response_rcode(tx: &mut DNSTransaction)
+                                                -> CString
+{
+    for response in &tx.response {
+        if response.header.flags & 0x000f > 0 {
+            let log = format!("Response TX {:04x} [**] {}",
+                              response.header.tx_id,
+                              dns_rcode_string(response.header.flags));
+            return CString::new(log).unwrap();
+        }
+    }
+    return CString::default();
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_log_txt_response_recursion(tx: &mut DNSTransaction)
+                                                    -> CString
+{
+    for response in &tx.response {
+        if response.header.flags & 0x0080 > 0 {
+            let log = format!("Response TX {:04x} [**] Recursion Desired",
+                              response.header.tx_id);
+            return CString::new(log).unwrap();
+        }
+    }
+    return CString::default();
+}
+
+/// Check if a byte is a printable character or not.
+fn isprint(byte: u8) -> bool {
+    return byte >= 32 && byte <= 127;
+}
+
+pub fn dns_log_txt_format_data(answer: &DNSAnswerEntry) -> String {
+    match answer.rrtype {
+        _ => {
+            if answer.data.len() == 0 {
+                return "<no data>".to_string();
+            }
+            let mut raw = Vec::new();
+            for byte in &answer.data[..] {
+                if isprint(*byte) {
+                    raw.push(format!("{}", *byte as char));
+                } else {
+                    raw.push(format!("\\x{:02X}", byte));
+                }
+            }
+            return raw.join("");
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_log_txt_response_answer(tx: &mut DNSTransaction,
+                                                 i: libc::uint16_t)
+                                                 -> CString
+{
+    for response in &tx.response {
+        for answer in dns_get_response_answer(response, i) {
+            let log = format!(
+                "Response TX {:04x} [**] {} [**] {} [**] TTL {} [**] {}",
+                response.header.tx_id,
+                std::str::from_utf8(&answer.name[..]).unwrap(),
+                dns_type_string(answer.rrtype),
+                answer.ttl,
+                dns_log_txt_format_data(answer));
+            return CString::new(log).unwrap();
+        }
+    }
+    return CString::default();
+}
+
+#[no_mangle]
+pub extern "C" fn rs_dns_log_txt_response_authority(tx: &mut DNSTransaction,
+                                                 i: libc::uint16_t)
+                                                 -> CString
+{
+    for response in &tx.response {
+        for answer in dns_get_response_authority(response, i) {
+            let log = format!(
+                "Response TX {:04x} [**] {} [**] {} [**] TTL {} [**] {}",
+                response.header.tx_id,
+                std::str::from_utf8(&answer.name[..]).unwrap(),
+                dns_type_string(answer.rrtype),
+                answer.ttl,
+                dns_log_txt_format_data(answer));
+            return CString::new(log).unwrap();
+        }
+    }
+    return CString::default();
+}

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -1,0 +1,27 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+pub mod log;
+pub use self::log::*;
+
+pub mod dns;
+pub use self::dns::*;
+
+pub mod parsers;
+pub use self::parsers::*;
+
+pub mod bindings;

--- a/rust/src/dns/parsers.rs
+++ b/rust/src/dns/parsers.rs
@@ -1,0 +1,223 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Nom parsers for DNS.
+
+use nom::{be_u8, be_u16, be_u32};
+use nom::Offset;
+use nom;
+
+use dns::*;
+
+/// Parse a DNS header.
+named!(pub dns_parse_header<DNSHeader>,
+       do_parse!(
+           tx_id: be_u16 >>
+           flags: be_u16 >>
+           questions: be_u16 >>
+           answer_rr: be_u16 >>
+           authority_rr: be_u16 >>
+           additional_rr: be_u16 >>
+           (
+               DNSHeader{
+                   tx_id: tx_id,
+                   flags: flags,
+                   questions: questions,
+                   answer_rr: answer_rr,
+                   authority_rr: authority_rr,
+                   additional_rr: additional_rr,
+               }
+           )
+       )
+);
+
+/// Parse a DNS label returning the result as a u8 slice. The label
+/// must first be checked that its an actual label and not a pointer.
+named!(pub dns_parse_label<&[u8]>, do_parse!(
+    length: be_u8 >>
+    label: take!(length) >> (label)
+));
+
+pub fn dns_parse_name<'a, 'b>(start: &'b [u8],
+                              message: &'b [u8])
+                              -> nom::IResult<&'b [u8], Vec<u8>> {
+    let mut pos = start;
+    let mut pivot = start;
+    let mut name: Vec<u8> = Vec::with_capacity(32);
+    let mut count = 0;
+
+    loop {
+        if pos.len() == 0 {
+            break;
+        } else if pos[0] == 0x00 {
+            pos = &pos[1..];
+            break;
+        } else if pos[0] >> 6 == 0 {
+            match dns_parse_label(pos) {
+                nom::IResult::Done(rem, label) => {
+                    if name.len() > 0 {
+                        name.push('.' as u8);
+                    }
+                    name.extend(label);
+                    pos = rem;
+                }
+                _ => {
+                    return nom::IResult::Error(
+                        error_position!(nom::ErrorKind::OctDigit, input));
+                }
+            }
+        } else if pos[0] >> 6 != 0 {
+            match closure!(do_parse!(leader: be_u16 >> (leader)))(pos) {
+                nom::IResult::Done(rem, leader) => {
+                    let offset = leader & 0x3fff;
+                    if offset as usize > message.len() {
+                        return nom::IResult::Error(
+                            error_position!(nom::ErrorKind::OctDigit, input));
+                    }
+                    pos = &message[offset as usize..];
+                    if pivot == start {
+                        pivot = rem;
+                    }
+                }
+                _ => {
+                    return nom::IResult::Error(
+                        error_position!(nom::ErrorKind::OctDigit, input));
+                }
+            }
+        } else {
+            return nom::IResult::Error(
+                error_position!(nom::ErrorKind::OctDigit, input));
+        }
+
+        // Return error if we've looped a certain number of times.
+        count += 1;
+        if count > 255 {
+            return nom::IResult::Error(
+                error_position!(nom::ErrorKind::OctDigit, input));
+        }
+
+    }
+
+    // If we followed a pointer we return the position after the first
+    // pointer followed.
+    if message.offset(pivot) != message.offset(start) {
+        return nom::IResult::Done(pivot, name);
+    }
+    return nom::IResult::Done(pos, name);
+
+}
+
+/// Parse a DNS response.
+pub fn dns_parse_response<'a>(slice: &'a [u8])
+                              -> nom::IResult<&[u8], DNSResponse> {
+    let answer_parser = closure!(&'a [u8], do_parse!(
+        name: apply!(dns_parse_name, slice) >>
+        rrtype: be_u16 >>
+        rrclass: be_u16 >>
+        ttl: be_u32 >>
+        data_len: be_u16 >>
+        data: flat_map!(take!(data_len),
+                        apply!(dns_parse_rdata, slice, rrtype)) >>
+            (
+                DNSAnswerEntry{
+                    name: name,
+                    rrtype: rrtype,
+                    rrclass: rrclass,
+                    ttl: ttl,
+                    data_len: data_len,
+                    data: data.to_vec(),
+                }
+            )
+    ));
+
+    let response = closure!(&'a [u8], do_parse!(
+        header: dns_parse_header >>
+        queries: count!(apply!(dns_parse_query, slice),
+                        header.questions as usize) >>
+        answers: count!(answer_parser, header.answer_rr as usize) >>
+        authorities: count!(answer_parser, header.authority_rr as usize) >>
+        (
+            DNSResponse{
+                header: header,
+                queries: queries,
+                answers: answers,
+                authorities: authorities,
+            }
+        )
+    ))(slice);
+
+    return response;
+}
+
+/// Parse a single DNS query.
+///
+/// Arguments are suitable for using with apply!:
+///
+///    apply!(complete_dns_message_buffer)
+pub fn dns_parse_query<'a>(input: &'a [u8],
+                           message: &'a [u8])
+                           -> nom::IResult<&'a [u8], DNSQueryEntry> {
+    return closure!(&'a [u8], do_parse!(
+        name: apply!(dns_parse_name, message) >>
+        rrtype: be_u16 >>
+        rrclass: be_u16 >>
+            (
+                DNSQueryEntry{
+                    name: name,
+                    rrtype: rrtype,
+                    rrclass: rrclass,
+                }
+            )
+    ))(input);
+}
+
+pub fn dns_parse_rdata<'a>(data: &'a [u8], message: &'a [u8], rrtype: u16)
+    -> nom::IResult<&'a [u8], Vec<u8>>
+{
+    match rrtype {
+        DNS_RTYPE_CNAME |
+        DNS_RTYPE_PTR |
+        DNS_RTYPE_SOA => {
+            dns_parse_name(data, message)
+        },
+        DNS_RTYPE_MX => {
+            // For MX we we skip over the preference field before
+            // parsing out the name.
+            closure!(do_parse!(
+                be_u16 >>
+                name: apply!(dns_parse_name, message) >>
+                    (name)
+            ))(data)
+        },
+        _ => nom::IResult::Done(data, data.to_vec())
+    }
+}
+
+/// Parse a DNS request.
+pub fn dns_parse_request<'a>(input: &'a [u8]) -> nom::IResult<&[u8], DNSRequest> {
+    return closure!(&'a [u8], do_parse!(
+        header: dns_parse_header >>
+        queries: count!(apply!(dns_parse_query, input),
+                        header.questions as usize) >>
+            (
+                DNSRequest{
+                    header: header,
+                    queries: queries,
+                }
+            )
+    ))(input);
+}

--- a/rust/src/json.rs
+++ b/rust/src/json.rs
@@ -1,0 +1,91 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Expose portions of the libjansson API to Rust so Rust code can
+//! populate a json_t and return it for logging by Suricata.
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+/// The Rust place holder for the json_t pointer.
+pub enum JsonT {}
+
+/// Expose the json functions we need.
+extern {
+    fn json_object() -> *mut JsonT;
+    fn json_object_set_new(js: *mut JsonT, key: *const c_char,
+                           val: *mut JsonT) -> u32;
+
+    fn json_array() -> *mut JsonT;
+    fn json_array_append_new(array: *mut JsonT, value: *mut JsonT);
+
+    fn json_string(value: *const c_char) -> *mut JsonT;
+    fn json_integer(val: u64) -> *mut JsonT;
+}
+
+pub struct Json {
+    pub js: *mut JsonT,
+}
+
+impl Json {
+
+    pub fn object() -> Json {
+        return Json{
+            js: unsafe{json_object()},
+        }
+    }
+
+    pub fn array() -> Json {
+        return Json{
+            js: unsafe{json_array()},
+        }
+    }
+
+    pub fn unwrap(&self) -> *mut JsonT {
+        return self.js;
+    }
+
+    pub fn set(&self, key: &str, val: Json) {
+        unsafe {
+            json_object_set_new(self.js,
+                                CString::new(key).unwrap().as_ptr(),
+                                val.js);
+        }
+    }
+
+    pub fn set_string(&self, key: &str, val: &str) {
+        unsafe{
+            json_object_set_new(self.js,
+                                CString::new(key).unwrap().as_ptr(),
+                                json_string(CString::new(val).unwrap().as_ptr()));
+        }
+    }
+
+    pub fn set_integer(&self, key: &str, val: u64) {
+        unsafe {
+            json_object_set_new(self.js,
+                                CString::new(key).unwrap().as_ptr(),
+                                json_integer(val));
+        }
+    }
+
+    pub fn array_append(&self, val: Json) {
+        unsafe {
+            json_array_append_new(self.js, val.js);
+        }
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,25 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#[macro_use]
+extern crate nom;
+
+pub mod dns;
+pub mod json;
+
+#[macro_use]
+pub mod core;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-// #![feature(alloc_jemalloc)]
-// #![crate_type = "staticlib"]
-// extern crate alloc_jemalloc;
+#![feature(alloc_jemalloc)]
+#![crate_type = "staticlib"]
+extern crate alloc_jemalloc;
 
 #[macro_use]
 extern crate nom;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,9 +15,9 @@
  * 02110-1301, USA.
  */
 
-#![feature(alloc_jemalloc)]
-#![crate_type = "staticlib"]
-extern crate alloc_jemalloc;
+// #![feature(alloc_jemalloc)]
+// #![crate_type = "staticlib"]
+// extern crate alloc_jemalloc;
 
 #[macro_use]
 extern crate nom;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,6 +15,10 @@
  * 02110-1301, USA.
  */
 
+// #![feature(alloc_jemalloc)]
+// #![crate_type = "staticlib"]
+// extern crate alloc_jemalloc;
+
 #[macro_use]
 extern crate nom;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -451,7 +451,8 @@ EXTRA_DIST = util-mpm-ac-cuda-kernel.cu ptxdump.py
 AM_CPPFLAGS = $(all_includes)
 
 # the library search path.
-suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
+suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS} \
+	../rust/target/release/libsuricata.a -ldl
 suricata_LDADD = $(HTP_LDADD)
 
 # Rules to build CUDA ptx modules

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -22,68 +22,7 @@
  */
 
 #include "suricata-common.h"
-#include "stream.h"
-#include "app-layer-parser.h"
 #include "app-layer-dns-common.h"
-#ifdef DEBUG
-#include "util-print.h"
-#endif
-#include "util-memcmp.h"
-#include "util-atomic.h"
-
-typedef struct DNSConfig_ {
-    uint32_t request_flood;
-    uint32_t state_memcap;  /**< memcap in bytes per state */
-    uint64_t global_memcap; /**< memcap in bytes globally for parser */
-} DNSConfig;
-static DNSConfig dns_config;
-
-void DNSConfigInit(void)
-{
-    memset(&dns_config, 0x00, sizeof(dns_config));
-}
-
-void DNSConfigSetRequestFlood(uint32_t value)
-{
-    dns_config.request_flood = value;
-}
-
-void DNSConfigSetStateMemcap(uint32_t value)
-{
-    dns_config.state_memcap = value;
-}
-
-void DNSConfigSetGlobalMemcap(uint64_t value)
-{
-    dns_config.global_memcap = value;
-}
-
-uint64_t DNSMemcapGetMemuseCounter(void)
-{
-#if 0
-    uint64_t x = SC_ATOMIC_GET(dns_memuse);
-    return x;
-#endif
-    return 0;
-}
-
-uint64_t DNSMemcapGetMemcapStateCounter(void)
-{
-#if 0
-    uint64_t x = SC_ATOMIC_GET(dns_memcap_state);
-    return x;
-#endif
-    return 0;
-}
-
-uint64_t DNSMemcapGetMemcapGlobalCounter(void)
-{
-#if 0
-    uint64_t x = SC_ATOMIC_GET(dns_memcap_global);
-    return x;
-#endif
-    return 0;
-}
 
 SCEnumCharMap dns_decoder_event_table[ ] = {
     { "UNSOLLICITED_RESPONSE",      DNS_DECODER_EVENT_UNSOLLICITED_RESPONSE, },
@@ -193,7 +132,6 @@ int DNSStateHasTxDetectState(void *alstate)
 DetectEngineState *DNSGetTxDetectState(void *vtx)
 {
     return rs_dns_tx_get_detect_state(vtx);
-    return NULL;
 }
 
 int DNSSetTxDetectState(void *alstate, void *vtx, DetectEngineState *s)

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -217,23 +217,16 @@ void *DNSGetTx(void *alstate, uint64_t tx_id)
 uint64_t DNSGetTxCnt(void *alstate)
 {
     DNSState *dns_state = (DNSState *)alstate;
-    return (uint64_t)dns_state->transaction_max;
+    return rs_dns_state_get_tx_count(dns_state->rs_state);
 }
 
 int DNSGetAlstateProgress(void *tx, uint8_t direction)
 {
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
-    if (direction & STREAM_TOCLIENT) {
-        /* response side of the tx is done if we parsed a reply
-         * or if we tagged this tx as 'reply lost'. */
-        return (dns_tx->replied|dns_tx->reply_lost) ? 1 : 0;
-    }
-    else {
-        /* tx is only created if we have a complete request,
-         * or if we lost the request. Either way, if we have
-         * a tx it we consider the request complete. */
-        return 1;
-    }
+    BUG_ON(dns_tx == NULL);
+    BUG_ON(dns_tx->rs_tx == NULL);
+
+    return rs_dns_tx_get_alstate_progress(dns_tx->rs_tx, direction);
 }
 
 void DNSSetTxLogged(void *alstate, void *tx, uint32_t logger)
@@ -275,23 +268,16 @@ void DNSSetEvent(DNSState *s, uint8_t e)
 /** \internal
  *  \brief Allocate a DNS TX
  *  \retval tx or NULL */
-static DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id)
+DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id)
 {
     if (DNSCheckMemcap(sizeof(DNSTransaction), state) < 0)
         return NULL;
 
-    DNSTransaction *tx = SCMalloc(sizeof(DNSTransaction));
+    DNSTransaction *tx = SCCalloc(1, sizeof(DNSTransaction));
     if (unlikely(tx == NULL))
         return NULL;
     DNSIncrMemcap(sizeof(DNSTransaction), state);
 
-    memset(tx, 0x00, sizeof(DNSTransaction));
-
-    TAILQ_INIT(&tx->query_list);
-    TAILQ_INIT(&tx->answer_list);
-    TAILQ_INIT(&tx->authority_list);
-
-    tx->tx_id = tx_id;
     return tx;
 }
 
@@ -301,25 +287,6 @@ static DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id
 static void DNSTransactionFree(DNSTransaction *tx, DNSState *state)
 {
     SCEnter();
-
-    DNSQueryEntry *q = NULL;
-    while ((q = TAILQ_FIRST(&tx->query_list))) {
-        TAILQ_REMOVE(&tx->query_list, q, next);
-        DNSDecrMemcap((sizeof(DNSQueryEntry) + q->len), state);
-        SCFree(q);
-    }
-
-    DNSAnswerEntry *a = NULL;
-    while ((a = TAILQ_FIRST(&tx->answer_list))) {
-        TAILQ_REMOVE(&tx->answer_list, a, next);
-        DNSDecrMemcap((sizeof(DNSAnswerEntry) + a->fqdn_len + a->data_len), state);
-        SCFree(a);
-    }
-    while ((a = TAILQ_FIRST(&tx->authority_list))) {
-        TAILQ_REMOVE(&tx->authority_list, a, next);
-        DNSDecrMemcap((sizeof(DNSAnswerEntry) + a->fqdn_len + a->data_len), state);
-        SCFree(a);
-    }
 
     AppLayerDecoderEventsFreeEvents(&tx->decoder_events);
 
@@ -349,6 +316,8 @@ void DNSStateTransactionFree(void *state, uint64_t tx_id)
 
     SCLogDebug("state %p, id %"PRIu64, dns_state, tx_id);
 
+    rs_dns_state_tx_free(dns_state->rs_state, tx_id);
+
     TAILQ_FOREACH(tx, &dns_state->tx_list, next) {
         SCLogDebug("tx %p tx->tx_num %u, tx_id %"PRIu64, tx, tx->tx_num, (tx_id+1));
         if ((tx_id+1) < tx->tx_num)
@@ -370,36 +339,8 @@ void DNSStateTransactionFree(void *state, uint64_t tx_id)
         DNSTransactionFree(tx, state);
         break;
     }
+
     SCReturn;
-}
-
-/** \internal
- *  \brief Find the DNS Tx in the state
- *  \param tx_id id of the tx
- *  \retval tx or NULL if not found */
-DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id)
-{
-    if (dns_state->curr == NULL)
-        return NULL;
-
-    /* fast path */
-    if (dns_state->curr->tx_id == tx_id) {
-        return dns_state->curr;
-
-    /* slow path, iterate list */
-    } else {
-        DNSTransaction *tx = NULL;
-        TAILQ_FOREACH(tx, &dns_state->tx_list, next) {
-            if (tx->tx_id == tx_id) {
-                return tx;
-            } else if ((dns_state->transaction_max - tx->tx_num) >
-                (dns_state->window - 1U)) {
-                tx->reply_lost = 1;
-            }
-        }
-    }
-    /* not found */
-    return NULL;
 }
 
 int DNSStateHasTxDetectState(void *alstate)
@@ -425,18 +366,16 @@ int DNSSetTxDetectState(void *alstate, void *vtx, DetectEngineState *s)
 
 void *DNSStateAlloc(void)
 {
-    void *s = SCMalloc(sizeof(DNSState));
-    if (unlikely(s == NULL))
+    DNSState *state  = SCCalloc(1, sizeof(*state));
+    if (unlikely(state == NULL)) {
         return NULL;
+    }
 
-    memset(s, 0, sizeof(DNSState));
+    DNSIncrMemcap(sizeof(*state), state);
+    state->rs_state = rs_dns_state_new(); /* TODO: memcap, null check? */
+    TAILQ_INIT(&state->tx_list);
 
-    DNSState *dns_state = (DNSState *)s;
-
-    DNSIncrMemcap(sizeof(DNSState), dns_state);
-
-    TAILQ_INIT(&dns_state->tx_list);
-    return s;
+    return (void *)state;
 }
 
 void DNSStateFree(void *s)
@@ -445,16 +384,16 @@ void DNSStateFree(void *s)
     if (s) {
         DNSState *dns_state = (DNSState *) s;
 
+        rs_dns_state_free(dns_state->rs_state);
+
         DNSTransaction *tx = NULL;
         while ((tx = TAILQ_FIRST(&dns_state->tx_list))) {
             TAILQ_REMOVE(&dns_state->tx_list, tx, next);
             DNSTransactionFree(tx, dns_state);
         }
 
-        if (dns_state->buffer != NULL) {
-            DNSDecrMemcap(0xffff, dns_state); /** TODO update if/once we alloc
-                                               *  in a smarter way */
-            SCFree(dns_state->buffer);
+        if (dns_state->buffer.size > 0) {
+            SCFree(dns_state->buffer.buffer);
         }
 
         BUG_ON(dns_state->tx_with_detect_state_cnt > 0);
@@ -464,582 +403,6 @@ void DNSStateFree(void *s)
         SCFree(s);
     }
     SCReturn;
-}
-
-/** \brief Validation checks for DNS request header
- *
- *  Will set decoder events if anomalies are found.
- *
- *  \retval 0 ok
- *  \retval -1 error
- */
-int DNSValidateRequestHeader(DNSState *dns_state, const DNSHeader *dns_header)
-{
-    uint16_t flags = ntohs(dns_header->flags);
-
-    if ((flags & 0x8000) != 0) {
-        SCLogDebug("not a request 0x%04x", flags);
-        DNSSetEvent(dns_state, DNS_DECODER_EVENT_NOT_A_REQUEST);
-        goto bad_data;
-    }
-
-    if ((flags & 0x0040) != 0) {
-        SCLogDebug("Z flag not 0, 0x%04x", flags);
-        DNSSetEvent(dns_state, DNS_DECODER_EVENT_Z_FLAG_SET);
-        goto bad_data;
-    }
-
-    return 0;
-bad_data:
-    return -1;
-}
-
-/** \brief Validation checks for DNS response header
- *
- *  Will set decoder events if anomalies are found.
- *
- *  \retval 0 ok
- *  \retval -1 error
- */
-int DNSValidateResponseHeader(DNSState *dns_state, const DNSHeader *dns_header)
-{
-    uint16_t flags = ntohs(dns_header->flags);
-
-    if ((flags & 0x8000) == 0) {
-        SCLogDebug("not a response 0x%04x", flags);
-        DNSSetEvent(dns_state, DNS_DECODER_EVENT_NOT_A_RESPONSE);
-        goto bad_data;
-    }
-
-    if ((flags & 0x0040) != 0) {
-        SCLogDebug("Z flag not 0, 0x%04x", flags);
-        DNSSetEvent(dns_state, DNS_DECODER_EVENT_Z_FLAG_SET);
-        goto bad_data;
-    }
-
-    return 0;
-bad_data:
-    return -1;
-}
-
-/** \internal
- *  \brief check the query list to see if we already have this exact query
- *  \retval bool true or false
- */
-static int QueryIsDuplicate(DNSTransaction *tx, const uint8_t *fqdn, const uint16_t fqdn_len,
-        const uint16_t type, const uint16_t class)
-{
-    DNSQueryEntry *q = NULL;
-
-    TAILQ_FOREACH(q, &tx->query_list, next) {
-        uint8_t *qfqdn = (uint8_t *)q + sizeof(DNSQueryEntry);
-
-        if (q->len == fqdn_len && q->type == type &&
-            q->class == class &&
-            SCMemcmp(qfqdn, fqdn, fqdn_len) == 0) {
-            return TRUE;
-        }
-    }
-    return FALSE;
-}
-
-void DNSStoreQueryInState(DNSState *dns_state, const uint8_t *fqdn, const uint16_t fqdn_len,
-        const uint16_t type, const uint16_t class, const uint16_t tx_id)
-{
-    /* flood protection */
-    if (dns_state->givenup)
-        return;
-
-    /* find the tx and see if this is an exact duplicate */
-    DNSTransaction *tx = DNSTransactionFindByTxId(dns_state, tx_id);
-    if ((tx != NULL) && (QueryIsDuplicate(tx, fqdn, fqdn_len, type, class) == TRUE)) {
-        SCLogDebug("query is duplicate");
-        return;
-    }
-
-    /* check flood limit */
-    if (dns_config.request_flood != 0 &&
-        dns_state->unreplied_cnt > dns_config.request_flood) {
-        DNSSetEvent(dns_state, DNS_DECODER_EVENT_FLOODED);
-        dns_state->givenup = 1;
-    }
-
-    if (tx == NULL) {
-        tx = DNSTransactionAlloc(dns_state, tx_id);
-        if (tx == NULL)
-            return;
-        dns_state->transaction_max++;
-        SCLogDebug("dns_state->transaction_max updated to %"PRIu64, dns_state->transaction_max);
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-        dns_state->curr = tx;
-        tx->tx_num = dns_state->transaction_max;
-        SCLogDebug("new tx %u with internal id %u", tx->tx_id, tx->tx_num);
-        dns_state->unreplied_cnt++;
-    }
-
-    if (DNSCheckMemcap((sizeof(DNSQueryEntry) + fqdn_len), dns_state) < 0)
-        return;
-    DNSQueryEntry *q = SCMalloc(sizeof(DNSQueryEntry) + fqdn_len);
-    if (unlikely(q == NULL))
-        return;
-    DNSIncrMemcap((sizeof(DNSQueryEntry) + fqdn_len), dns_state);
-
-    q->type = type;
-    q->class = class;
-    q->len = fqdn_len;
-    memcpy((uint8_t *)q + sizeof(DNSQueryEntry), fqdn, fqdn_len);
-
-    TAILQ_INSERT_TAIL(&tx->query_list, q, next);
-
-    SCLogDebug("Query for TX %04x stored", tx_id);
-}
-
-void DNSStoreAnswerInState(DNSState *dns_state, const int rtype, const uint8_t *fqdn,
-        const uint16_t fqdn_len, const uint16_t type, const uint16_t class, const uint16_t ttl,
-        const uint8_t *data, const uint16_t data_len, const uint16_t tx_id)
-{
-    DNSTransaction *tx = DNSTransactionFindByTxId(dns_state, tx_id);
-    if (tx == NULL) {
-        tx = DNSTransactionAlloc(dns_state, tx_id);
-        if (tx == NULL)
-            return;
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-        dns_state->curr = tx;
-        dns_state->transaction_max++;
-        tx->tx_num = dns_state->transaction_max;
-    }
-
-    if (DNSCheckMemcap((sizeof(DNSAnswerEntry) + fqdn_len + data_len), dns_state) < 0)
-        return;
-    DNSAnswerEntry *q = SCMalloc(sizeof(DNSAnswerEntry) + fqdn_len + data_len);
-    if (unlikely(q == NULL))
-        return;
-    DNSIncrMemcap((sizeof(DNSAnswerEntry) + fqdn_len + data_len), dns_state);
-
-    q->type = type;
-    q->class = class;
-    q->ttl = ttl;
-    q->fqdn_len = fqdn_len;
-    q->data_len = data_len;
-
-    uint8_t *ptr = (uint8_t *)q + sizeof(DNSAnswerEntry);
-    if (fqdn != NULL && fqdn_len > 0) {
-        memcpy(ptr, fqdn, fqdn_len);
-        ptr += fqdn_len;
-    }
-    if (data != NULL && data_len > 0) {
-        memcpy(ptr, data, data_len);
-    }
-
-    if (rtype == DNS_LIST_ANSWER)
-        TAILQ_INSERT_TAIL(&tx->answer_list, q, next);
-    else if (rtype == DNS_LIST_AUTHORITY)
-        TAILQ_INSERT_TAIL(&tx->authority_list, q, next);
-    else
-        BUG_ON(1);
-
-    SCLogDebug("Answer for TX %04x stored", tx_id);
-
-    /* mark tx is as replied so we can log it */
-    tx->replied = 1;
-}
-
-/** \internal
- *  \brief get domain name from dns packet
- *
- *  In case of compressed name storage this function follows the ptrs to
- *  create the full domain name.
- *
- *  The length bytes are converted into dots, e.g. |03|com|00| becomes
- *  .com
- *  The trailing . is not stored.
- *
- *  \param input input buffer (complete dns record)
- *  \param input_len lenght of input buffer
- *  \param offset offset into @input where dns name starts
- *  \param fqdn buffer to store result
- *  \param fqdn_size size of @fqdn buffer
- *  \retval 0 on error/no buffer
- *  \retval size size of fqdn
- */
-static uint16_t DNSResponseGetNameByOffset(const uint8_t * const input, const uint32_t input_len,
-        const uint16_t offset, uint8_t *fqdn, const size_t fqdn_size)
-{
-    if (offset >= input_len) {
-        SCLogDebug("input buffer too small for domain of len %u", offset);
-        goto insufficient_data;
-    }
-
-    int steps = 0;
-    uint16_t fqdn_offset = 0;
-    uint8_t length = *(input + offset);
-    const uint8_t *qdata = input + offset;
-    SCLogDebug("qry length %u", length);
-
-    if (length == 0) {
-        memcpy(fqdn, "<root>", 6);
-        SCReturnUInt(6U);
-    }
-
-    if ((uint64_t)((qdata + 1) - input) >= (uint64_t)input_len) {
-        SCLogDebug("input buffer too small");
-        goto insufficient_data;
-    }
-
-    while (length != 0) {
-        int cnt = 0;
-        while (length & 0xc0) {
-            uint16_t off = ((length & 0x3f) << 8) + *(qdata+1);
-            qdata = (const uint8_t *)input + off;
-
-            if ((uint64_t)((qdata + 1) - input) >= (uint64_t)input_len) {
-                SCLogDebug("input buffer too small");
-                goto insufficient_data;
-            }
-
-            length = *qdata;
-            SCLogDebug("qry length %u", length);
-
-            if (cnt++ == 100) {
-                SCLogDebug("too many pointer iterations, loop?");
-                goto bad_data;
-            }
-        }
-        qdata++;
-
-        if (length == 0) {
-            break;
-        }
-
-        if (input + input_len < qdata + length) {
-            SCLogDebug("input buffer too small for domain of len %u", length);
-            goto insufficient_data;
-        }
-        //PrintRawDataFp(stdout, qdata, length);
-
-        if ((size_t)(fqdn_offset + length + 1) < fqdn_size) {
-            memcpy(fqdn + fqdn_offset, qdata, length);
-            fqdn_offset += length;
-            fqdn[fqdn_offset++] = '.';
-        }
-        qdata += length;
-
-        /* if we're at the end of the input data, we're done */
-        if ((uint64_t)((qdata + 1) - input) == (uint64_t)input_len) {
-            break;
-        }
-        else if ((uint64_t)((qdata + 1) - input) > (uint64_t)input_len) {
-            SCLogDebug("input buffer too small");
-            goto insufficient_data;
-        }
-
-        length = *qdata;
-        SCLogDebug("qry length %u", length);
-        steps++;
-        if (steps >= 255)
-            goto bad_data;
-    }
-    if (fqdn_offset) {
-        fqdn_offset--;
-    }
-    //PrintRawDataFp(stdout, fqdn, fqdn_offset);
-    SCReturnUInt(fqdn_offset);
-bad_data:
-insufficient_data:
-    SCReturnUInt(0U);
-}
-
-/** \internal
- *  \brief skip past domain name field
- *
- *  Skip the domain at position data. We don't care about following compressed names
- *  as we only want to know when the next part of the buffer starts
- *
- *  \param input input buffer (complete dns record)
- *  \param input_len lenght of input buffer
- *  \param data current position
- *
- *  \retval NULL on out of bounds data
- *  \retval sdata ptr to position in buffer past the name
- */
-static const uint8_t *SkipDomain(const uint8_t * const input,
-        const uint32_t input_len, const uint8_t *data)
-{
-    const uint8_t *sdata = data;
-    while (*sdata != 0x00) {
-        if (*sdata & 0xc0) {
-            sdata++;
-            break;
-        } else {
-            sdata += ((*sdata) + 1);
-        }
-        if (input + input_len < sdata) {
-            SCLogDebug("input buffer too small for data of len");
-            goto insufficient_data;
-        }
-    }
-    sdata++;
-    if (input + input_len < sdata) {
-        SCLogDebug("input buffer too small for data of len");
-        goto insufficient_data;
-    }
-    return sdata;
-insufficient_data:
-    return NULL;
-}
-
-const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_header,
-        const uint16_t num, const DnsListEnum list, const uint8_t * const input,
-        const uint32_t input_len, const uint8_t *data)
-{
-    if (input + input_len < data + 2) {
-        SCLogDebug("input buffer too small for record 'name' field, record %u, "
-                "total answer_rr %u", num, ntohs(dns_header->answer_rr));
-        goto insufficient_data;
-    }
-
-    uint8_t fqdn[DNS_MAX_SIZE];
-    uint16_t fqdn_len = 0;
-
-    /* see if name is compressed */
-    if (!(data[0] & 0xc0)) {
-        if ((fqdn_len = DNSResponseGetNameByOffset(input, input_len,
-                        data - input, fqdn, sizeof(fqdn))) == 0)
-        {
-            DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-            goto insufficient_data;
-        }
-        //PrintRawDataFp(stdout, fqdn, fqdn_len);
-        const uint8_t *tdata = SkipDomain(input, input_len, data);
-        if (tdata == NULL) {
-            goto insufficient_data;
-        }
-        data = tdata;
-    } else {
-        uint16_t offset = (data[0] & 0x3f) << 8 | data[1];
-
-        if ((fqdn_len = DNSResponseGetNameByOffset(input, input_len,
-                        offset, fqdn, sizeof(fqdn))) == 0)
-        {
-            DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-            goto insufficient_data;
-        }
-        //PrintRawDataFp(stdout, fqdn, fqdn_len);
-        data += 2;
-    }
-
-    if (input + input_len < data + sizeof(DNSAnswerHeader)) {
-        SCLogDebug("input buffer too small for DNSAnswerHeader");
-        goto insufficient_data;
-    }
-
-    const DNSAnswerHeader *head = (DNSAnswerHeader *)data;
-    const uint16_t datalen = ntohs(head->len);
-
-    data += sizeof(DNSAnswerHeader);
-
-    SCLogDebug("head->len %u", ntohs(head->len));
-
-    if (input + input_len < data + ntohs(head->len)) {
-        SCLogDebug("input buffer too small for data of len %u", ntohs(head->len));
-        goto insufficient_data;
-    }
-
-    SCLogDebug("TTL %u", ntohl(head->ttl));
-
-    switch (ntohs(head->type)) {
-        case DNS_RECORD_TYPE_A:
-        {
-            if (datalen == 0 || datalen == 4) {
-                //PrintRawDataFp(stdout, data, ntohs(head->len));
-                //char a[16];
-                //PrintInet(AF_INET, (const void *)data, a, sizeof(a));
-                //SCLogInfo("A %s TTL %u", a, ntohl(head->ttl));
-
-                DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                        ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                        data, 4, ntohs(dns_header->tx_id));
-            } else {
-                SCLogDebug("invalid length for A response data: %u", ntohs(head->len));
-                goto bad_data;
-            }
-
-            data += datalen;
-            break;
-        }
-        case DNS_RECORD_TYPE_AAAA:
-        {
-            if (datalen == 0 || datalen == 16) {
-                //char a[46];
-                //PrintInet(AF_INET6, (const void *)data, a, sizeof(a));
-                //SCLogInfo("AAAA %s TTL %u", a, ntohl(head->ttl));
-
-                DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                        ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                        data, 16, ntohs(dns_header->tx_id));
-            } else {
-                SCLogDebug("invalid length for AAAA response data: %u", ntohs(head->len));
-                goto bad_data;
-            }
-
-            data += datalen;
-            break;
-        }
-        case DNS_RECORD_TYPE_MX:
-        case DNS_RECORD_TYPE_CNAME:
-        case DNS_RECORD_TYPE_PTR:
-        {
-            uint8_t name[DNS_MAX_SIZE];
-            uint16_t name_len = 0;
-            uint8_t skip = 0;
-
-            if (ntohs(head->type) == DNS_RECORD_TYPE_MX) {
-                // Skip the preference header
-                skip = 2;
-            }
-
-            if ((name_len = DNSResponseGetNameByOffset(input, input_len,
-                            data - input + skip, name, sizeof(name))) == 0)
-            {
-                DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-                goto insufficient_data;
-            }
-
-            DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                    ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                    name, name_len, ntohs(dns_header->tx_id));
-
-            data += ntohs(head->len);
-            break;
-        }
-        case DNS_RECORD_TYPE_NS:
-        case DNS_RECORD_TYPE_SOA:
-        {
-            uint8_t pname[DNS_MAX_SIZE];
-            uint16_t pname_len = 0;
-
-            if ((pname_len = DNSResponseGetNameByOffset(input, input_len,
-                            data - input, pname, sizeof(pname))) == 0)
-            {
-                DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-                goto insufficient_data;
-            }
-
-            if (ntohs(head->type) == DNS_RECORD_TYPE_SOA) {
-                const uint8_t *sdata = SkipDomain(input, input_len, data);
-                if (sdata == NULL) {
-                    goto insufficient_data;
-                }
-
-                uint8_t pmail[DNS_MAX_SIZE];
-                uint16_t pmail_len = 0;
-                SCLogDebug("getting pmail");
-                if ((pmail_len = DNSResponseGetNameByOffset(input, input_len,
-                                sdata - input, pmail, sizeof(pmail))) == 0)
-                {
-                    DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-                    goto insufficient_data;
-                }
-                SCLogDebug("pmail_len %u", pmail_len);
-                //PrintRawDataFp(stdout, (uint8_t *)pmail, pmail_len);
-
-                const uint8_t *tdata = SkipDomain(input, input_len, sdata);
-                if (tdata == NULL) {
-                    goto insufficient_data;
-                }
-#if DEBUG
-                struct Trailer {
-                    uint32_t serial;
-                    uint32_t refresh;
-                    uint32_t retry;
-                    uint32_t experiation;
-                    uint32_t minttl;
-                } *tail = (struct Trailer *)tdata;
-
-                if (input + input_len < tdata + sizeof(struct Trailer)) {
-                    SCLogDebug("input buffer too small for data of len");
-                    goto insufficient_data;
-                }
-
-                SCLogDebug("serial %u refresh %u retry %u exp %u min ttl %u",
-                        ntohl(tail->serial), ntohl(tail->refresh),
-                        ntohl(tail->retry), ntohl(tail->experiation),
-                        ntohl(tail->minttl));
-#endif
-            }
-
-            DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                    ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                    pname, pname_len, ntohs(dns_header->tx_id));
-
-            data += ntohs(head->len);
-            break;
-        }
-        case DNS_RECORD_TYPE_TXT:
-        {
-            uint16_t txtdatalen = datalen;
-
-            if (txtdatalen == 0) {
-                DNSSetEvent(dns_state, DNS_DECODER_EVENT_MALFORMED_DATA);
-                goto bad_data;
-            }
-
-            uint8_t txtlen = *data;
-            const uint8_t *tdata = data + 1;
-
-            do {
-                //PrintRawDataFp(stdout, (uint8_t*)tdata, txtlen);
-
-                if (txtlen >= txtdatalen)
-                    goto bad_data;
-
-                DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                        ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                        (uint8_t*)tdata, (uint16_t)txtlen, ntohs(dns_header->tx_id));
-
-                txtdatalen -= txtlen;
-                tdata += txtlen;
-                txtlen = *tdata;
-
-                tdata++;
-                txtdatalen--;
-
-                SCLogDebug("datalen %u, txtlen %u", txtdatalen, txtlen);
-            } while (txtdatalen > 1);
-
-            data += datalen;
-            break;
-        }
-        case DNS_RECORD_TYPE_SSHFP:
-        {
-            /* data here should be:
-             * [1 byte algo][1 byte type][var bytes fingerprint]
-             * As we currently can't store each of those in the state,
-             * we just store the raw data an let the output/detect
-             * code figure out what to do with it. */
-
-            DNSStoreAnswerInState(dns_state, list, fqdn, fqdn_len,
-                    ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                    data, ntohs(head->len), ntohs(dns_header->tx_id));
-
-            data += datalen;
-            break;
-        }
-        default:    /* unsupported record */
-        {
-            DNSStoreAnswerInState(dns_state, list, NULL, 0,
-                    ntohs(head->type), ntohs(head->class), ntohl(head->ttl),
-                    NULL, 0, ntohs(dns_header->tx_id));
-
-            //PrintRawDataFp(stdout, data, ntohs(head->len));
-            data += datalen;
-            break;
-        }
-    }
-    return data;
-bad_data:
-insufficient_data:
-    return NULL;
 }
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size)

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -232,16 +232,13 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction)
 void DNSSetTxLogged(void *alstate, void *tx, uint32_t logger)
 {
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
-    dns_tx->logged |= logger;
+    rs_dns_tx_set_logged(alstate, dns_tx->rs_tx, logger);
 }
 
 int DNSGetTxLogged(void *alstate, void *tx, uint32_t logger)
 {
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
-    if (dns_tx->logged & logger)
-        return 1;
-
-    return 0;
+    return rs_dns_tx_get_logged(alstate, dns_tx->rs_tx, logger);
 }
 
 /** \brief get value for 'complete' status in DNS

--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -225,8 +225,8 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction)
     DNSTransaction *dns_tx = (DNSTransaction *)tx;
     BUG_ON(dns_tx == NULL);
     BUG_ON(dns_tx->rs_tx == NULL);
-
-    return rs_dns_tx_get_alstate_progress(dns_tx->rs_tx, direction);
+    return rs_dns_tx_get_alstate_progress(dns_tx->rs_tx,
+        direction & STREAM_TOCLIENT ? 1 : 0);
 }
 
 void DNSSetTxLogged(void *alstate, void *tx, uint32_t logger)

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -151,10 +151,9 @@ typedef struct DNSTransaction_ {
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
 
-    TAILQ_ENTRY(DNSTransaction_) next;
-    DetectEngineState *de_state;
-
     RSDNSTransaction *rs_tx;
+
+    TAILQ_ENTRY(DNSTransaction_) next;
 
 } DNSTransaction;
 
@@ -245,5 +244,9 @@ extern uint16_t rs_dns_request_get_id(RSDNSRequest *);
 
 extern void rs_dns_tx_set_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
 extern int8_t rs_dns_tx_get_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
+
+extern void rs_dns_tx_set_detect_state(RSDNSState *, RSDNSTransaction *,
+    DetectEngineState *);
+extern DetectEngineState *rs_dns_tx_get_detect_state(RSDNSTransaction *);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -148,7 +148,6 @@ typedef struct ParserBuffer_ {
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
-    uint32_t logged;                                /**< flags for loggers done logging */
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
 
@@ -243,5 +242,8 @@ extern uint64_t rs_dns_state_get_tx_count(RSDNSState *);
 extern int8_t rs_dns_tx_get_alstate_progress(RSDNSTransaction *, uint8_t);
 extern uint8_t rs_dns_probe(const uint8_t *, uint32_t);
 extern uint16_t rs_dns_request_get_id(RSDNSRequest *);
+
+extern void rs_dns_tx_set_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
+extern int8_t rs_dns_tx_get_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -148,13 +148,9 @@ typedef struct ParserBuffer_ {
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
-
-    AppLayerDecoderEvents *decoder_events;          /**< per tx events */
-
     RSDNSTransaction *rs_tx;
 
     TAILQ_ENTRY(DNSTransaction_) next;
-
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */
@@ -167,7 +163,6 @@ typedef struct DNSState_ {
                                                  state-memcap settings */
     uint64_t tx_with_detect_state_cnt;
 
-    uint16_t events;
     uint16_t givenup;
 
     ParserBuffer buffer;
@@ -236,7 +231,6 @@ extern uint64_t rs_dns_state_parse_response(RSDNSState *, const uint8_t *,
     uint32_t);
 extern void rs_dns_state_tx_free(RSDNSState *, uint64_t);
 extern RSDNSTransaction *rs_dns_state_tx_get(RSDNSState *, uint64_t);
-extern uint32_t rs_dns_state_get_next_event(RSDNSState *);
 extern uint64_t rs_dns_state_get_tx_count(RSDNSState *);
 extern int8_t rs_dns_tx_get_alstate_progress(RSDNSTransaction *, uint8_t);
 extern uint8_t rs_dns_probe(const uint8_t *, uint32_t);
@@ -244,6 +238,9 @@ extern uint16_t rs_dns_request_get_id(RSDNSRequest *);
 
 extern void rs_dns_tx_set_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
 extern int8_t rs_dns_tx_get_logged(RSDNSState *, RSDNSTransaction *, uint32_t);
+
+extern int8_t rs_dns_state_has_events(RSDNSState *);
+extern AppLayerDecoderEvents *rs_dns_state_get_events(RSDNSState *, uint32_t);
 
 extern void rs_dns_tx_set_detect_state(RSDNSState *, RSDNSTransaction *,
     DetectEngineState *);

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -217,6 +217,10 @@ typedef struct DNSAnswer_ {
     uint32_t data_len;
 } DNSAnswer;
 
+struct DNSContext;
+
+extern void rs_dns_set_context(struct DNSContext *);
+
 extern RSDNSState *rs_dns_state_new(void);
 extern void rs_dns_state_free(RSDNSState *);
 extern uint64_t rs_dns_state_parse_request(RSDNSState *, const uint8_t *,

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -258,4 +258,8 @@ extern uint8_t rs_dns_tx_get_response_answer(RSDNSTransaction *tx, uint16_t i,
 extern uint8_t rs_dns_tx_get_response_authority(RSDNSTransaction *tx,
     uint16_t i, DNSAnswer *answer);
 
+extern uint64_t rs_dns_get_memuse(void);
+extern uint64_t rs_dns_get_memcap_state_hit_counter(void);
+extern uint64_t rs_dns_get_memcap_global_hit_counter(void);
+
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -206,6 +206,17 @@ void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
  * Rust implementation.
  */
 
+/* Redefinition of struct CDNSAnswer. */
+typedef struct DNSAnswer_ {
+    uint8_t *name;
+    uint32_t name_len;
+    uint16_t rrtype;
+    uint16_t rrclass;
+    uint32_t ttl;
+    uint8_t *data;
+    uint32_t data_len;
+} DNSAnswer;
+
 extern RSDNSState *rs_dns_state_new(void);
 extern void rs_dns_state_free(RSDNSState *);
 extern uint64_t rs_dns_state_parse_request(RSDNSState *, const uint8_t *,
@@ -229,5 +240,18 @@ extern void rs_dns_tx_set_detect_state(RSDNSState *, RSDNSTransaction *,
     DetectEngineState *);
 extern DetectEngineState *rs_dns_tx_get_detect_state(RSDNSTransaction *);
 extern uint8_t rs_dns_state_has_detect_state(RSDNSState *);
+
+extern uint8_t rs_dns_tx_get_query_name(RSDNSTransaction *tx, uint16_t i,
+    uint8_t **buf, uint32_t *buf_len);
+extern uint8_t rs_dns_tx_get_query_rrtype(RSDNSTransaction *tx, uint16_t i,
+    uint16_t *rrtype);
+
+extern uint16_t rs_dns_tx_get_tx_id(RSDNSTransaction *tx);
+extern uint16_t rs_dns_tx_get_response_flags(RSDNSTransaction *tx);
+
+extern uint8_t rs_dns_tx_get_response_answer(RSDNSTransaction *tx, uint16_t i,
+    DNSAnswer *answer);
+extern uint8_t rs_dns_tx_get_response_authority(RSDNSTransaction *tx,
+    uint16_t i, DNSAnswer *answer);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -145,9 +145,11 @@ typedef struct ParserBuffer_ {
     uint32_t  offset;
 } ParserBuffer;
 
+#if 0
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
 } DNSTransaction;
+#endif
 
 /** \brief Per flow DNS state container */
 typedef struct DNSState_ {
@@ -194,7 +196,6 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction);
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 
 void DNSStateTransactionFree(void *state, uint64_t tx_id);
-DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id);
 
 int DNSStateHasTxDetectState(void *alstate);
 DetectEngineState *DNSGetTxDetectState(void *vtx);
@@ -208,8 +209,6 @@ int DNSHasEvents(void *state);
 
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
-
-DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id);
 
 /*
  * Rust implementation.

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -145,16 +145,8 @@ typedef struct ParserBuffer_ {
     uint32_t  offset;
 } ParserBuffer;
 
-#if 0
-/** \brief DNS Transaction, request/reply with same TX id. */
-typedef struct DNSTransaction_ {
-} DNSTransaction;
-#endif
-
 /** \brief Per flow DNS state container */
 typedef struct DNSState_ {
-    uint32_t memuse;                        /**< state memuse, for comparing with
-                                                 state-memcap settings */
     uint64_t tx_with_detect_state_cnt;
 
     uint16_t givenup;
@@ -236,5 +228,6 @@ extern AppLayerDecoderEvents *rs_dns_state_get_events(RSDNSState *, uint32_t);
 extern void rs_dns_tx_set_detect_state(RSDNSState *, RSDNSTransaction *,
     DetectEngineState *);
 extern DetectEngineState *rs_dns_tx_get_detect_state(RSDNSTransaction *);
+extern uint8_t rs_dns_state_has_detect_state(RSDNSState *);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -147,18 +147,10 @@ typedef struct ParserBuffer_ {
 
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
-    uint16_t tx_num;                                /**< internal: id */
-    RSDNSTransaction *rs_tx;
-
-    TAILQ_ENTRY(DNSTransaction_) next;
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */
 typedef struct DNSState_ {
-    TAILQ_HEAD(, DNSTransaction_) tx_list;  /**< transaction list */
-    DNSTransaction *curr;                   /**< ptr to current tx */
-    DNSTransaction *iter;
-    uint64_t transaction_max;
     uint32_t memuse;                        /**< state memuse, for comparing with
                                                  state-memcap settings */
     uint64_t tx_with_detect_state_cnt;

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -32,7 +32,6 @@
 
 #define DNS_MAX_SIZE 256
 
-
 #define DNS_RECORD_TYPE_A           1
 #define DNS_RECORD_TYPE_NS          2
 #define DNS_RECORD_TYPE_MD          3   // Obsolete
@@ -115,7 +114,7 @@
 #define DNS_RCODE_BADTRUNC      22
 
 enum {
-    DNS_DECODER_EVENT_UNSOLLICITED_RESPONSE,
+    DNS_DECODER_EVENT_UNSOLLICITED_RESPONSE = 1,
     DNS_DECODER_EVENT_MALFORMED_DATA,
     DNS_DECODER_EVENT_NOT_A_REQUEST,
     DNS_DECODER_EVENT_NOT_A_RESPONSE,
@@ -123,6 +122,11 @@ enum {
     DNS_DECODER_EVENT_FLOODED,
     DNS_DECODER_EVENT_STATE_MEMCAP_REACHED,
 };
+
+typedef struct RSDNSState_ RSDNSState;
+typedef struct RSDNSRequest_ RSDNSRequest;
+typedef struct RSDNSResponse_ RSDNSResponse;
+typedef struct RSDNSTransaction_ RSDNSTransaction;
 
 /** \brief DNS packet header */
 typedef struct DNSHeader_ {
@@ -134,77 +138,25 @@ typedef struct DNSHeader_ {
     uint16_t additional_rr;
 } __attribute__((__packed__)) DNSHeader;
 
-typedef struct DNSQueryTrailer_ {
-    uint16_t type;
-    uint16_t class;
-} __attribute__((__packed__)) DNSQueryTrailer;
-
-/** \brief DNS answer header
- *  packed as we don't want alignment to mess up sizeof() */
-struct DNSAnswerHeader_ {
-    uint16_t type;
-    uint16_t class;
-    uint32_t ttl;
-    uint16_t len;
-} __attribute__((__packed__));
-typedef struct DNSAnswerHeader_ DNSAnswerHeader;
-
-/** \brief List types in the TX.
- *  Used when storing answers from "Answer" or "Authority" */
-typedef enum {
-    DNS_LIST_ANSWER = 0,
-    DNS_LIST_AUTHORITY,
-} DnsListEnum;
-
-/** \brief DNS Query storage. Stored in TX list.
- *
- *  Layout is:
- *  [list ptr][2 byte type][2 byte class][2 byte len][...data...]
- */
-typedef struct DNSQueryEntry_ {
-    TAILQ_ENTRY(DNSQueryEntry_) next;
-    uint16_t type;
-    uint16_t class;
-    uint16_t len;
-} DNSQueryEntry;
-
-/** \brief DNS Answer storage. Stored in TX list.
- *
- *  Layout is:
- *  [list ptr][2 byte type][2 byte class][2 byte ttl] \
- *      [2 byte fqdn len][2 byte data len][...fqdn...][...data...]
- */
-typedef struct DNSAnswerEntry_ {
-    TAILQ_ENTRY(DNSAnswerEntry_) next;
-
-    uint16_t type;
-    uint16_t class;
-
-    uint32_t ttl;
-
-    uint16_t fqdn_len;
-    uint16_t data_len;
-} DNSAnswerEntry;
+typedef struct ParserBuffer_ {
+    uint8_t  *buffer;
+    uint32_t  size;
+    uint32_t  len;
+    uint32_t  offset;
+} ParserBuffer;
 
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
     uint16_t tx_num;                                /**< internal: id */
-    uint16_t tx_id;                                 /**< transaction id */
     uint32_t logged;                                /**< flags for loggers done logging */
-    uint8_t replied;                                /**< bool indicating request is
-                                                         replied to. */
-    uint8_t reply_lost;
-    uint8_t rcode;                                  /**< response code (e.g. "no error" / "no such name") */
-    uint8_t recursion_desired;                      /**< server said "recursion desired" */
-
-    TAILQ_HEAD(, DNSQueryEntry_) query_list;        /**< list for query/queries */
-    TAILQ_HEAD(, DNSAnswerEntry_) answer_list;      /**< list for answers */
-    TAILQ_HEAD(, DNSAnswerEntry_) authority_list;   /**< list for authority records */
 
     AppLayerDecoderEvents *decoder_events;          /**< per tx events */
 
     TAILQ_ENTRY(DNSTransaction_) next;
     DetectEngineState *de_state;
+
+    RSDNSTransaction *rs_tx;
+
 } DNSTransaction;
 
 /** \brief Per flow DNS state container */
@@ -213,25 +165,16 @@ typedef struct DNSState_ {
     DNSTransaction *curr;                   /**< ptr to current tx */
     DNSTransaction *iter;
     uint64_t transaction_max;
-    uint32_t unreplied_cnt;                 /**< number of unreplied requests in a row */
     uint32_t memuse;                        /**< state memuse, for comparing with
                                                  state-memcap settings */
     uint64_t tx_with_detect_state_cnt;
 
-    struct timeval last_req;      /**< Timestamp of last request. */
-    struct timeval last_resp;     /**< Timestamp of last response. */
-
-    uint16_t window;              /**< Window of allowed unreplied
-                                   * requests. Set by the maximum
-                                   * number of subsequent requests
-                                   * without a response. */
     uint16_t events;
     uint16_t givenup;
 
-    /* used by TCP only */
-    uint16_t offset;
-    uint16_t record_len;
-    uint8_t *buffer;
+    ParserBuffer buffer;
+
+    RSDNSState *rs_state;
 } DNSState;
 
 #define DNS_CONFIG_DEFAULT_REQUEST_FLOOD 500
@@ -278,24 +221,27 @@ void DNSStateFree(void *s);
 AppLayerDecoderEvents *DNSGetEvents(void *state, uint64_t id);
 int DNSHasEvents(void *state);
 
-int DNSValidateRequestHeader(DNSState *, const DNSHeader *dns_header);
-int DNSValidateResponseHeader(DNSState *, const DNSHeader *dns_header);
-
-void DNSStoreQueryInState(DNSState *dns_state, const uint8_t *fqdn, const uint16_t fqdn_len,
-        const uint16_t type, const uint16_t class, const uint16_t tx_id);
-
-void DNSStoreAnswerInState(DNSState *dns_state, const int rtype, const uint8_t *fqdn,
-        const uint16_t fqdn_len, const uint16_t type, const uint16_t class, const uint16_t ttl,
-        const uint8_t *data, const uint16_t data_len, const uint16_t tx_id);
-
-const uint8_t *DNSReponseParse(DNSState *dns_state, const DNSHeader * const dns_header,
-        const uint16_t num, const DnsListEnum list, const uint8_t * const input,
-        const uint32_t input_len, const uint8_t *data);
-
-uint16_t DNSUdpResponseGetNameByOffset(const uint8_t * const input, const uint32_t input_len,
-        const uint16_t offset, uint8_t *fqdn, const size_t fqdn_size);
-
 void DNSCreateTypeString(uint16_t type, char *str, size_t str_size);
 void DNSCreateRcodeString(uint8_t rcode, char *str, size_t str_size);
+
+DNSTransaction *DNSTransactionAlloc(DNSState *state, const uint16_t tx_id);
+
+/*
+ * Rust implementation.
+ */
+
+extern RSDNSState *rs_dns_state_new(void);
+extern void rs_dns_state_free(RSDNSState *);
+extern uint64_t rs_dns_state_parse_request(RSDNSState *, const uint8_t *,
+    uint32_t);
+extern uint64_t rs_dns_state_parse_response(RSDNSState *, const uint8_t *,
+    uint32_t);
+extern void rs_dns_state_tx_free(RSDNSState *, uint64_t);
+extern RSDNSTransaction *rs_dns_state_tx_get(RSDNSState *, uint64_t);
+extern uint32_t rs_dns_state_get_next_event(RSDNSState *);
+extern uint64_t rs_dns_state_get_tx_count(RSDNSState *);
+extern int8_t rs_dns_tx_get_alstate_progress(RSDNSTransaction *, uint8_t);
+extern uint8_t rs_dns_probe(const uint8_t *, uint32_t);
+extern uint16_t rs_dns_request_get_id(RSDNSRequest *);
 
 #endif /* __APP_LAYER_DNS_COMMON_H__ */

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -117,18 +117,6 @@ static int DNSRequestParseData(Flow *f, DNSState *dns_state,
 {
     uint64_t tx_id = rs_dns_state_parse_request(dns_state->rs_state, input,
         input_len);
-
-    if (tx_id > 0) {
-        DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
-        BUG_ON(tx == NULL);
-        dns_state->transaction_max = tx_id;
-        dns_state->curr = tx;
-        tx->tx_num = tx_id;
-        tx->rs_tx = rs_dns_state_tx_get(dns_state->rs_state, tx_id - 1);
-        BUG_ON(tx->rs_tx == NULL);
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-    }
-
     SCReturnInt((tx_id > 0 ? 1 : -1));
 }
 
@@ -217,19 +205,6 @@ static int DNSResponseParseData(Flow *f, DNSState *dns_state,
 {
     uint64_t tx_id = rs_dns_state_parse_response(dns_state->rs_state, input,
         input_len);
-    BUG_ON(tx_id == 0);
-
-    if (tx_id > dns_state->transaction_max) {
-        DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
-        BUG_ON(tx == NULL);
-        dns_state->transaction_max = tx_id;
-        dns_state->curr = tx;
-        tx->tx_num = tx_id;
-        tx->rs_tx = rs_dns_state_tx_get(dns_state->rs_state, tx_id - 1);
-        BUG_ON(tx->rs_tx == NULL);
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-    }
-
     SCReturnInt((tx_id > 0 ? 1 : -1));
 }
 
@@ -402,7 +377,7 @@ void RegisterDNSTCPParsers(void)
                   "still on.", proto_name);
     }
 
-#ifdef UNITTESTS
+#ifdef __UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_DNS,
         DNSTCPParserRegisterTests);
 #endif
@@ -411,7 +386,7 @@ void RegisterDNSTCPParsers(void)
 }
 
 /* UNITTESTS */
-#ifdef UNITTESTS
+#ifdef __UNITTESTS
 
 #include "util-unittest-helper.h"
 

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -118,16 +118,6 @@ static int DNSRequestParseData(Flow *f, DNSState *dns_state,
     uint64_t tx_id = rs_dns_state_parse_request(dns_state->rs_state, input,
         input_len);
 
-    /* Drain events. */
-    for (;;) {
-        uint32_t ev = rs_dns_state_get_next_event(dns_state->rs_state);
-        if (ev == 0) {
-            break;
-        } else {
-            DNSSetEvent(dns_state, ev);
-        }
-    }
-
     if (tx_id > 0) {
         DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
         BUG_ON(tx == NULL);
@@ -228,16 +218,6 @@ static int DNSResponseParseData(Flow *f, DNSState *dns_state,
     uint64_t tx_id = rs_dns_state_parse_response(dns_state->rs_state, input,
         input_len);
     BUG_ON(tx_id == 0);
-
-    /* Pull out any events. */
-    for (;;) {
-        uint32_t ev = rs_dns_state_get_next_event(dns_state->rs_state);
-        if (ev == 0) {
-            break;
-        } else {
-            DNSSetEvent(dns_state, ev);
-        }
-    }
 
     if (tx_id > dns_state->transaction_max) {
         DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -30,10 +30,6 @@
 
 #include "threads.h"
 
-#include "util-print.h"
-#include "util-pool.h"
-#include "util-debug.h"
-
 #include "stream-tcp-private.h"
 #include "stream-tcp-reassemble.h"
 #include "stream-tcp.h"
@@ -42,7 +38,6 @@
 #include "app-layer-protos.h"
 #include "app-layer-parser.h"
 
-#include "util-spm.h"
 #include "util-unittest.h"
 
 #include "app-layer-dns-tcp.h"
@@ -377,7 +372,7 @@ void RegisterDNSTCPParsers(void)
                   "still on.", proto_name);
     }
 
-#ifdef __UNITTESTS
+#ifdef UNITTESTS
     AppLayerParserRegisterProtocolUnittests(IPPROTO_TCP, ALPROTO_DNS,
         DNSTCPParserRegisterTests);
 #endif
@@ -386,7 +381,7 @@ void RegisterDNSTCPParsers(void)
 }
 
 /* UNITTESTS */
-#ifdef __UNITTESTS
+#ifdef UNITTESTS
 
 #include "util-unittest-helper.h"
 
@@ -493,9 +488,10 @@ static int DNSTCPParserTestMultiRecord(void)
     f->alstate = state;
 
     FAIL_IF_NOT(DNSTCPRequestParse(f, f->alstate, NULL, req, reqlen, NULL));
-    FAIL_IF(state->transaction_max != 20);
+    FAIL_IF(rs_dns_state_get_tx_count(state->rs_state) != 20);
 
     UTHFreeFlow(f);
+
     PASS;
 }
 
@@ -607,9 +603,9 @@ static int DNSTCPParserTestMultiRecordPartials(void)
             DNSTCPRequestParse(f, f->alstate, NULL, req + i, 1, NULL));
     }
 
-    FAIL_IF(state->transaction_max != 20);
-
+    FAIL_IF(rs_dns_state_get_tx_count(state->rs_state) != 20);
     UTHFreeFlow(f);
+
     PASS;
 }
 

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -73,17 +73,6 @@ static int DNSUDPRequestParse(Flow *f, void *dstate,
 
     tx_id = rs_dns_state_parse_request(dns_state->rs_state, input, input_len);
 
-    if (tx_id > 0) {
-        DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
-        BUG_ON(tx == NULL);
-        dns_state->transaction_max = tx_id;
-        dns_state->curr = tx;
-        tx->tx_num = tx_id;
-        tx->rs_tx = rs_dns_state_tx_get(dns_state->rs_state, tx_id - 1);
-        BUG_ON(tx->rs_tx == NULL);
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-    }
-
     SCReturnInt((tx_id > 0 ? 1 : -1));
 }
 
@@ -112,17 +101,6 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
         SCReturnInt(-1);
 
     tx_id = rs_dns_state_parse_response(dns_state->rs_state, input, input_len);
-
-    if (tx_id > dns_state->transaction_max) {
-        DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
-        BUG_ON(tx == NULL);
-        dns_state->transaction_max = tx_id;
-        dns_state->curr = tx;
-        tx->tx_num = tx_id;
-        tx->rs_tx = rs_dns_state_tx_get(dns_state->rs_state, tx_id - 1);
-        BUG_ON(tx->rs_tx == NULL);
-        TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
-    }
 
     SCReturnInt((tx_id > 0 ? 1 : -1));
 }
@@ -256,7 +234,7 @@ void RegisterDNSUDPParsers(void)
 }
 
 /* UNITTESTS */
-#ifdef UNITTESTS
+#ifdef __UNITTESTS
 #include "util-unittest-helper.h"
 
 static int DNSUDPParserTest01 (void)

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -157,9 +157,21 @@ static void DNSUDPConfigure(void)
     DNSConfigSetGlobalMemcap(global_memcap);
 }
 
+static struct DNSContext {
+    void (*AppLayerDecoderEventsSetEventRaw)(AppLayerDecoderEvents **, uint8_t);
+    void (*AppLayerDecoderEventsFreeEvents)(AppLayerDecoderEvents **);
+    void (*DetectEngineStateFree)(DetectEngineState *);
+} DNSContext = {
+    .AppLayerDecoderEventsSetEventRaw = AppLayerDecoderEventsSetEventRaw,
+    .AppLayerDecoderEventsFreeEvents = AppLayerDecoderEventsFreeEvents,
+    .DetectEngineStateFree = DetectEngineStateFree,
+};
+
 void RegisterDNSUDPParsers(void)
 {
     char *proto_name = "dns";
+
+    rs_dns_set_context(&DNSContext);
 
     /** DNS */
     if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -73,16 +73,6 @@ static int DNSUDPRequestParse(Flow *f, void *dstate,
 
     tx_id = rs_dns_state_parse_request(dns_state->rs_state, input, input_len);
 
-    /* Drain events. */
-    for (;;) {
-        uint32_t ev = rs_dns_state_get_next_event(dns_state->rs_state);
-        if (ev == 0) {
-            break;
-        } else {
-            DNSSetEvent(dns_state, ev);
-        }
-    }
-
     if (tx_id > 0) {
         DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);
         BUG_ON(tx == NULL);
@@ -122,16 +112,6 @@ static int DNSUDPResponseParse(Flow *f, void *dstate,
         SCReturnInt(-1);
 
     tx_id = rs_dns_state_parse_response(dns_state->rs_state, input, input_len);
-
-    /* Pull out any events. */
-    for (;;) {
-        uint32_t ev = rs_dns_state_get_next_event(dns_state->rs_state);
-        if (ev == 0) {
-            break;
-        } else {
-            DNSSetEvent(dns_state, ev);
-        }
-    }
 
     if (tx_id > dns_state->transaction_max) {
         DNSTransaction *tx = DNSTransactionAlloc(dns_state, 0);

--- a/src/app-layer.c
+++ b/src/app-layer.c
@@ -809,9 +809,11 @@ void AppLayerProfilingStoreInternal(AppLayerThreadCtx *app_tctx, Packet *p)
  */
 void AppLayerRegisterGlobalCounters(void)
 {
-    StatsRegisterGlobalCounter("dns.memuse", DNSMemcapGetMemuseCounter);
-    StatsRegisterGlobalCounter("dns.memcap_state", DNSMemcapGetMemcapStateCounter);
-    StatsRegisterGlobalCounter("dns.memcap_global", DNSMemcapGetMemcapGlobalCounter);
+    StatsRegisterGlobalCounter("dns.memuse", rs_dns_get_memuse);
+    StatsRegisterGlobalCounter("dns.memcap_state",
+        rs_dns_get_memcap_state_hit_counter);
+    StatsRegisterGlobalCounter("dns.memcap_global",
+        rs_dns_get_memcap_global_hit_counter);
     StatsRegisterGlobalCounter("http.memuse", HTPMemuseGlobalCounter);
     StatsRegisterGlobalCounter("http.memcap", HTPMemcapGlobalCounter);
 }

--- a/src/detect-engine-dns.c
+++ b/src/detect-engine-dns.c
@@ -71,7 +71,6 @@ int DetectEngineInspectDnsQueryName(ThreadVars *tv,
                                   Signature *s, Flow *f, uint8_t flags,
                                   void *alstate, void *txv, uint64_t tx_id)
 {
-    DNSTransaction *tx = (DNSTransaction *)txv;
     uint8_t *buffer;
     uint32_t buffer_len;
     int r = 0;
@@ -83,7 +82,7 @@ int DetectEngineInspectDnsQueryName(ThreadVars *tv,
         det_ctx->buffer_offset = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        if (rs_dns_tx_get_query_buffer(tx->rs_tx, i, &buffer, &buffer_len)) {
+        if (rs_dns_tx_get_query_buffer(txv, i, &buffer, &buffer_len)) {
             r = DetectEngineContentInspection(de_ctx, det_ctx,
                 s, s->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH],
                 f, buffer, buffer_len, 0,
@@ -112,12 +111,11 @@ static void PrefilterTxDnsQuery(DetectEngineThreadCtx *det_ctx,
 {
     SCEnter();
     const MpmCtx *mpm_ctx = (MpmCtx *)pectx;
-    DNSTransaction *tx = (DNSTransaction *)txv;
     uint8_t *buffer;
     uint32_t buffer_len;
 
     for (uint16_t i = 0;; i++) {
-        if (rs_dns_tx_get_query_buffer(tx->rs_tx, i, &buffer, &buffer_len)) {
+        if (rs_dns_tx_get_query_buffer(txv, i, &buffer, &buffer_len)) {
             if (buffer_len >= mpm_ctx->minlen) {
                 (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
                     &det_ctx->mtcu, &det_ctx->pmq,

--- a/src/detect-engine-dns.c
+++ b/src/detect-engine-dns.c
@@ -47,11 +47,6 @@
 #include "util-unittest-helper.h"
 #include "util-validate.h"
 
-extern uint32_t rs_dns_tx_inspect_query_name(RSDNSTransaction *,
-    void *, void *, void *, void *, void *, uint8_t, uint8_t, void *);
-extern uint8_t rs_dns_tx_get_query_buffer(RSDNSTransaction *, uint16_t,
-    uint8_t **, uint32_t *);
-
 /** \brief Do the content inspection & validation for a signature
  *
  *  \param de_ctx Detection engine context
@@ -82,7 +77,7 @@ int DetectEngineInspectDnsQueryName(ThreadVars *tv,
         det_ctx->buffer_offset = 0;
         det_ctx->inspection_recursion_counter = 0;
 
-        if (rs_dns_tx_get_query_buffer(txv, i, &buffer, &buffer_len)) {
+        if (rs_dns_tx_get_query_name(txv, i, &buffer, &buffer_len)) {
             r = DetectEngineContentInspection(de_ctx, det_ctx,
                 s, s->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH],
                 f, buffer, buffer_len, 0,
@@ -115,7 +110,7 @@ static void PrefilterTxDnsQuery(DetectEngineThreadCtx *det_ctx,
     uint32_t buffer_len;
 
     for (uint16_t i = 0;; i++) {
-        if (rs_dns_tx_get_query_buffer(txv, i, &buffer, &buffer_len)) {
+        if (rs_dns_tx_get_query_name(txv, i, &buffer, &buffer_len)) {
             if (buffer_len >= mpm_ctx->minlen) {
                 (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
                     &det_ctx->mtcu, &det_ctx->pmq,

--- a/src/detect-engine-dns.c
+++ b/src/detect-engine-dns.c
@@ -47,6 +47,11 @@
 #include "util-unittest-helper.h"
 #include "util-validate.h"
 
+extern uint32_t rs_dns_tx_inspect_query_name(RSDNSTransaction *,
+    void *, void *, void *, void *, void *, uint8_t, uint8_t, void *);
+extern uint8_t rs_dns_tx_get_query_buffer(RSDNSTransaction *, uint16_t,
+    uint8_t **, uint32_t *);
+
 /** \brief Do the content inspection & validation for a signature
  *
  *  \param de_ctx Detection engine context
@@ -67,32 +72,10 @@ int DetectEngineInspectDnsQueryName(ThreadVars *tv,
                                   void *alstate, void *txv, uint64_t tx_id)
 {
     DNSTransaction *tx = (DNSTransaction *)txv;
-    DNSQueryEntry *query = NULL;
-    uint8_t *buffer;
-    uint16_t buffer_len;
-    int r = 0;
-
-    SCLogDebug("start");
-
-    TAILQ_FOREACH(query, &tx->query_list, next) {
-        SCLogDebug("tx %p query %p", tx, query);
-        det_ctx->discontinue_matching = 0;
-        det_ctx->buffer_offset = 0;
-        det_ctx->inspection_recursion_counter = 0;
-
-        buffer = (uint8_t *)((uint8_t *)query + sizeof(DNSQueryEntry));
-        buffer_len = query->len;
-
-        //PrintRawDataFp(stdout, buffer, buffer_len);
-
-        r = DetectEngineContentInspection(de_ctx, det_ctx,
-                s, s->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH],
-                f, buffer, buffer_len, 0,
-                DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE, NULL);
-        if (r == 1)
-            break;
-    }
-    return r;
+ 
+    return rs_dns_tx_inspect_query_name(tx->rs_tx, de_ctx, det_ctx, s,
+        s->sm_lists[DETECT_SM_LIST_DNSQUERYNAME_MATCH],
+        f, 0, DETECT_ENGINE_CONTENT_INSPECTION_MODE_STATE, NULL);
 }
 
 /** \brief DNS Query Mpm prefilter callback
@@ -112,19 +95,19 @@ static void PrefilterTxDnsQuery(DetectEngineThreadCtx *det_ctx,
 
     const MpmCtx *mpm_ctx = (MpmCtx *)pectx;
     DNSTransaction *tx = (DNSTransaction *)txv;
-    DNSQueryEntry *query = NULL;
 
-    TAILQ_FOREACH(query, &tx->query_list, next) {
-        SCLogDebug("tx %p query %p", tx, query);
+    for (uint16_t i = 0; i < 0xffff; i++) {
+        uint8_t *buffer;
+        uint32_t buffer_len;
 
-        const uint8_t *buffer =
-            (const uint8_t *)((uint8_t *)query + sizeof(DNSQueryEntry));
-        const uint32_t buffer_len = query->len;
-
-        if (buffer_len >= mpm_ctx->minlen) {
-            (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
+        if (rs_dns_tx_get_query_buffer(tx->rs_tx, i, &buffer, &buffer_len)) {
+            if (buffer_len >= mpm_ctx->minlen) {
+                (void)mpm_table[mpm_ctx->mpm_type].Search(mpm_ctx,
                     &det_ctx->mtcu, &det_ctx->pmq,
                     buffer, buffer_len);
+            }
+        } else {
+            break;
         }
     }
 }

--- a/src/detect-engine-dns.c
+++ b/src/detect-engine-dns.c
@@ -85,6 +85,8 @@ int DetectEngineInspectDnsQueryName(ThreadVars *tv,
             if (r == 1) {
                 break;
             }
+        } else {
+            break;
         }
     }
 

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -132,7 +132,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
 
     if (direction == STREAM_TOSERVER) {
         
-        for (uint16_t i = 0; i < 0xffff; i++) {
+        for (uint16_t i = 0;; i++) {
             buf = rs_dns_log_txt_query(dns_tx->rs_tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
@@ -143,8 +143,11 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
                 hlog->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
                     MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
                 SCMutexUnlock(&hlog->file_ctx->fp_mutex);
+                SCFree(buf);
+            } else {
+                SCFree(buf);
+                break;
             }
-            SCFree(buf);
         }
         
     } else if (direction == STREAM_TOCLIENT) {
@@ -176,7 +179,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
         SCFree(buf);
         
         /* Answers. */
-        for (uint16_t i = 0; i < 0xffff; i++) {
+        for (uint16_t i = 0;; i++) {
             buf = rs_dns_log_txt_response_answer(dns_tx->rs_tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
@@ -188,14 +191,14 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
                     MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
                 SCMutexUnlock(&hlog->file_ctx->fp_mutex);
                 SCFree(buf);
-                continue;
+            } else {
+                SCFree(buf);
+                break;
             }
-            SCFree(buf);
-            break;
         }
         
         /* Authorities. */
-        for (uint16_t i = 0; i < 0xffff; i++) {
+        for (uint16_t i = 0;; i++) {
             buf = rs_dns_log_txt_response_authority(dns_tx->rs_tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
@@ -207,10 +210,10 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
                     MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
                 SCMutexUnlock(&hlog->file_ctx->fp_mutex);
                 SCFree(buf);
-                continue;
+            } else {
+                SCFree(buf);
+                break;
             }
-            SCFree(buf);
-            break;
         }
     }
 

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -82,7 +82,6 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
     Flow *f, void *state, void *tx, uint64_t tx_id, uint8_t direction)
 {
     LogDnsLogThread *aft = (LogDnsLogThread *)data;
-    DNSTransaction *dns_tx = (DNSTransaction *)tx;
     SCLogDebug("pcap_cnt %"PRIu64, p->pcap_cnt);
     char timebuf[64];
     CreateTimeString(&p->ts, timebuf, sizeof(timebuf));
@@ -133,7 +132,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
     if (direction == STREAM_TOSERVER) {
         
         for (uint16_t i = 0;; i++) {
-            buf = rs_dns_log_txt_query(dns_tx->rs_tx, i);
+            buf = rs_dns_log_txt_query(tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
                 MemBufferWriteString(aft->buffer,
@@ -152,7 +151,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
         
     } else if (direction == STREAM_TOCLIENT) {
         
-        buf = rs_dns_log_txt_response_rcode(dns_tx->rs_tx);
+        buf = rs_dns_log_txt_response_rcode(tx);
         if (strlen(buf) > 0) {
             MemBufferReset(aft->buffer);
             MemBufferWriteString(aft->buffer,
@@ -165,7 +164,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
         }
         SCFree(buf);
         
-        buf = rs_dns_log_txt_response_recursion(dns_tx->rs_tx);
+        buf = rs_dns_log_txt_response_recursion(tx);
         if (strlen(buf) > 0) {
             MemBufferReset(aft->buffer);
             MemBufferWriteString(aft->buffer,
@@ -180,7 +179,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
         
         /* Answers. */
         for (uint16_t i = 0;; i++) {
-            buf = rs_dns_log_txt_response_answer(dns_tx->rs_tx, i);
+            buf = rs_dns_log_txt_response_answer(tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
                 MemBufferWriteString(aft->buffer,
@@ -199,7 +198,7 @@ static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,
         
         /* Authorities. */
         for (uint16_t i = 0;; i++) {
-            buf = rs_dns_log_txt_response_authority(dns_tx->rs_tx, i);
+            buf = rs_dns_log_txt_response_authority(tx, i);
             if (strlen(buf) > 0) {
                 MemBufferReset(aft->buffer);
                 MemBufferWriteString(aft->buffer,

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -400,7 +400,6 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
 
     LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
     LogDnsFileCtx *dnslog_ctx = td->dnslog_ctx;
-    DNSTransaction *tx = txptr;
     json_t *js;
 
     if (likely(dnslog_ctx->flags & LOG_QUERIES) == 0) {
@@ -410,7 +409,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     js = CreateJSONHeader((Packet *)p, 1, "dns");
     
     for (uint16_t i = 0; i < 0xffff; i++) {
-        json_t *dnsjs = rs_dns_log_query(tx->rs_tx, i);
+        json_t *dnsjs = rs_dns_log_query(txptr, i);
         if (dnsjs == NULL) {
             break;
         }
@@ -433,7 +432,6 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
 
     LogDnsLogThread *td = (LogDnsLogThread *)thread_data;
     LogDnsFileCtx *dnslog_ctx = td->dnslog_ctx;
-    DNSTransaction *tx = txptr;
     json_t *js;
 
     if (unlikely(dnslog_ctx->flags & LOG_ANSWERS) == 0) {
@@ -443,7 +441,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     js = CreateJSONHeader((Packet *)p, 0, "dns");
     
     for (uint16_t i = 0; i < 0xffff; i++) {
-        json_t *answer = rs_dns_log_answers(tx->rs_tx, i);
+        json_t *answer = rs_dns_log_answers(txptr, i);
         if (answer == NULL) {
             break;
         }
@@ -454,7 +452,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     }
     
     for (uint16_t i = 0; i < 0xffff; i++) {
-        json_t *answer = rs_dns_log_authorities(tx->rs_tx, i);
+        json_t *answer = rs_dns_log_authorities(txptr, i);
         if (answer == NULL) {
             break;
         }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -41,6 +41,7 @@
 #include "app-layer-parser.h"
 #include "output.h"
 #include "app-layer-dns-udp.h"
+#include "app-layer-dns-common.h"
 #include "app-layer.h"
 #include "util-privs.h"
 #include "util-buffer.h"
@@ -258,6 +259,11 @@ typedef struct LogDnsLogThread_ {
     MemBuffer *buffer;
 } LogDnsLogThread;
 
+extern json_t *rs_dns_log_query(RSDNSTransaction *, uint16_t);
+extern json_t *rs_dns_log_answers(RSDNSTransaction *, uint16_t);
+extern json_t *rs_dns_log_authorities(RSDNSTransaction *, uint16_t);
+
+#if 0
 static int DNSRRTypeEnabled(uint16_t type, uint64_t flags)
 {
     if (likely(flags == ~0UL)) {
@@ -385,235 +391,7 @@ static int DNSRRTypeEnabled(uint16_t type, uint64_t flags)
             return 0;
     }
 }
-
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry) __attribute__((nonnull));
-
-static void LogQuery(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx,
-        uint64_t tx_id, DNSQueryEntry *entry)
-{
-    SCLogDebug("got a DNS request and now logging !!");
-
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
-
-    json_t *djs = json_object();
-    if (djs == NULL) {
-        return;
-    }
-
-    /* reset */
-    MemBufferReset(aft->buffer);
-
-    /* type */
-    json_object_set_new(djs, "type", json_string("query"));
-
-    /* id */
-    json_object_set_new(djs, "id", json_integer(tx->tx_id));
-
-    /* query */
-    char *c;
-    c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSQueryEntry)), entry->len);
-    if (c != NULL) {
-        json_object_set_new(djs, "rrname", json_string(c));
-        SCFree(c);
-    }
-
-    /* name */
-    char record[16] = "";
-    DNSCreateTypeString(entry->type, record, sizeof(record));
-    json_object_set_new(djs, "rrtype", json_string(record));
-
-    /* tx id (tx counter) */
-    json_object_set_new(djs, "tx_id", json_integer(tx_id));
-
-    /* dns */
-    json_object_set_new(js, "dns", djs);
-    OutputJSONBuffer(js, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(js, "dns");
-}
-
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry) __attribute__((nonnull));
-
-static void OutputAnswer(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSAnswerEntry *entry)
-{
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
-
-    json_t *js = json_object();
-    if (js == NULL)
-        return;
-
-    /* type */
-    json_object_set_new(js, "type", json_string("answer"));
-
-    /* id */
-    json_object_set_new(js, "id", json_integer(tx->tx_id));
-
-    /* rcode */
-    char rcode[16] = "";
-    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
-    json_object_set_new(js, "rcode", json_string(rcode));
-
-    /* query */
-    if (entry->fqdn_len > 0) {
-        char *c;
-        c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSAnswerEntry)),
-                entry->fqdn_len);
-        if (c != NULL) {
-            json_object_set_new(js, "rrname", json_string(c));
-            SCFree(c);
-        }
-    }
-
-    /* name */
-    char record[16] = "";
-    DNSCreateTypeString(entry->type, record, sizeof(record));
-    json_object_set_new(js, "rrtype", json_string(record));
-
-    /* ttl */
-    json_object_set_new(js, "ttl", json_integer(entry->ttl));
-
-    uint8_t *ptr = (uint8_t *)((uint8_t *)entry + sizeof(DNSAnswerEntry)+ entry->fqdn_len);
-    if (entry->type == DNS_RECORD_TYPE_A) {
-        char a[16] = "";
-        PrintInet(AF_INET, (const void *)ptr, a, sizeof(a));
-        json_object_set_new(js, "rdata", json_string(a));
-    } else if (entry->type == DNS_RECORD_TYPE_AAAA) {
-        char a[46] = "";
-        PrintInet(AF_INET6, (const void *)ptr, a, sizeof(a));
-        json_object_set_new(js, "rdata", json_string(a));
-    } else if (entry->data_len == 0) {
-        json_object_set_new(js, "rdata", json_string(""));
-    } else if (entry->type == DNS_RECORD_TYPE_TXT || entry->type == DNS_RECORD_TYPE_CNAME ||
-            entry->type == DNS_RECORD_TYPE_MX || entry->type == DNS_RECORD_TYPE_PTR ||
-            entry->type == DNS_RECORD_TYPE_NS) {
-        if (entry->data_len != 0) {
-            char buffer[256] = "";
-            uint16_t copy_len = entry->data_len < (sizeof(buffer) - 1) ?
-                entry->data_len : sizeof(buffer) - 1;
-            memcpy(buffer, ptr, copy_len);
-            buffer[copy_len] = '\0';
-            json_object_set_new(js, "rdata", json_string(buffer));
-        } else {
-            json_object_set_new(js, "rdata", json_string(""));
-        }
-    } else if (entry->type == DNS_RECORD_TYPE_SSHFP) {
-        if (entry->data_len > 2) {
-            /* get algo and type */
-            uint8_t algo = *ptr;
-            uint8_t fptype = *(ptr+1);
-
-            /* turn fp raw buffer into a nice :-separate hex string */
-            uint16_t fp_len = (entry->data_len - 2);
-            uint8_t *dptr = ptr+2;
-
-            /* c-string for ':' separated hex and trailing \0. */
-            uint32_t output_len = fp_len * 3 + 1;
-            char hexstring[output_len];
-            memset(hexstring, 0x00, output_len);
-
-            uint16_t x;
-            for (x = 0; x < fp_len; x++) {
-                char one[4];
-                snprintf(one, sizeof(one), x == fp_len - 1 ? "%02x" : "%02x:", dptr[x]);
-                strlcat(hexstring, one, output_len);
-            }
-
-            /* wrap the whole thing in it's own structure */
-            json_t *hjs = json_object();
-            if (hjs != NULL) {
-                json_object_set_new(hjs, "fingerprint", json_string(hexstring));
-                json_object_set_new(hjs, "algo", json_integer(algo));
-                json_object_set_new(hjs, "type", json_integer(fptype));
-
-                json_object_set_new(js, "sshfp", hjs);
-            }
-        }
-    }
-
-    /* reset */
-    MemBufferReset(aft->buffer);
-    json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(djs, "dns");
-
-    return;
-}
-
-static void OutputFailure(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSQueryEntry *entry) __attribute__((nonnull));
-
-static void OutputFailure(LogDnsLogThread *aft, json_t *djs,
-        DNSTransaction *tx, DNSQueryEntry *entry)
-{
-    if (!DNSRRTypeEnabled(entry->type, aft->dnslog_ctx->flags)) {
-        return;
-    }
-
-    json_t *js = json_object();
-    if (js == NULL)
-        return;
-
-    /* type */
-    json_object_set_new(js, "type", json_string("answer"));
-
-    /* id */
-    json_object_set_new(js, "id", json_integer(tx->tx_id));
-
-    /* rcode */
-    char rcode[16] = "";
-    DNSCreateRcodeString(tx->rcode, rcode, sizeof(rcode));
-    json_object_set_new(js, "rcode", json_string(rcode));
-
-    /* no answer RRs, use query for rname */
-    char *c;
-    c = BytesToString((uint8_t *)((uint8_t *)entry + sizeof(DNSQueryEntry)), entry->len);
-    if (c != NULL) {
-        json_object_set_new(js, "rrname", json_string(c));
-        SCFree(c);
-    }
-
-    /* reset */
-    MemBufferReset(aft->buffer);
-    json_object_set_new(djs, "dns", js);
-    OutputJSONBuffer(djs, aft->dnslog_ctx->file_ctx, &aft->buffer);
-    json_object_del(djs, "dns");
-
-    return;
-}
-
-static void LogAnswers(LogDnsLogThread *aft, json_t *js, DNSTransaction *tx, uint64_t tx_id)
-{
-
-    SCLogDebug("got a DNS response and now logging !!");
-
-    /* rcode != noerror */
-    if (tx->rcode) {
-        /* Most DNS servers do not support multiple queries because
-         * the rcode in response is not per-query.  Multiple queries
-         * are likely to lead to FORMERR, so log this. */
-        DNSQueryEntry *query = NULL;
-        TAILQ_FOREACH(query, &tx->query_list, next) {
-            OutputFailure(aft, js, tx, query);
-        }
-    }
-
-    DNSAnswerEntry *entry = NULL;
-    TAILQ_FOREACH(entry, &tx->answer_list, next) {
-        OutputAnswer(aft, js, tx, entry);
-    }
-
-    entry = NULL;
-    TAILQ_FOREACH(entry, &tx->authority_list, next) {
-        OutputAnswer(aft, js, tx, entry);
-    }
-
-}
+#endif
 
 static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *alstate, void *txptr, uint64_t tx_id)
@@ -625,20 +403,27 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     DNSTransaction *tx = txptr;
     json_t *js;
 
-    if (likely(dnslog_ctx->flags & LOG_QUERIES) != 0) {
-        DNSQueryEntry *query = NULL;
-        TAILQ_FOREACH(query, &tx->query_list, next) {
-            js = CreateJSONHeader((Packet *)p, 1, "dns");
-            if (unlikely(js == NULL))
-                return TM_ECODE_OK;
-
-            LogQuery(td, js, tx, tx_id, query);
-
-            json_decref(js);
-        }
+    if (likely(dnslog_ctx->flags & LOG_QUERIES) == 0) {
+        return TM_ECODE_OK;
     }
 
-    SCReturnInt(TM_ECODE_OK);
+    js = CreateJSONHeader((Packet *)p, 1, "dns");
+    
+    for (uint16_t i = 0; i < 0xffff; i++) {
+        json_t *dnsjs = rs_dns_log_query(tx->rs_tx, i);
+        if (dnsjs == NULL) {
+            break;
+        }
+        
+        json_object_set_new(js, "dns", dnsjs);
+        MemBufferReset(td->buffer);
+        OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
+        json_object_del(js, "dns");
+    }
+    
+    json_decref(js);
+    
+    return TM_ECODE_OK;
 }
 
 static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
@@ -651,16 +436,36 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     DNSTransaction *tx = txptr;
     json_t *js;
 
-    if (likely(dnslog_ctx->flags & LOG_ANSWERS) != 0) {
-        js = CreateJSONHeader((Packet *)p, 0, "dns");
-        if (unlikely(js == NULL))
-            return TM_ECODE_OK;
-
-        LogAnswers(td, js, tx, tx_id);
-
-        json_decref(js);
+    if (unlikely(dnslog_ctx->flags & LOG_ANSWERS) == 0) {
+        SCReturnInt(TM_ECODE_OK);
     }
 
+    js = CreateJSONHeader((Packet *)p, 0, "dns");
+    
+    for (uint16_t i = 0; i < 0xffff; i++) {
+        json_t *answer = rs_dns_log_answers(tx->rs_tx, i);
+        if (answer == NULL) {
+            break;
+        }
+        json_object_set_new(js, "dns", answer);
+        MemBufferReset(td->buffer);
+        OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
+        json_object_del(js, "dns");
+    }
+    
+    for (uint16_t i = 0; i < 0xffff; i++) {
+        json_t *answer = rs_dns_log_authorities(tx->rs_tx, i);
+        if (answer == NULL) {
+            break;
+        }
+        json_object_set_new(js, "dns", answer);
+        MemBufferReset(td->buffer);
+        OutputJSONBuffer(js, td->dnslog_ctx->file_ctx, &td->buffer);
+        json_object_del(js, "dns");
+    }
+
+    json_decref(js);
+    
     SCReturnInt(TM_ECODE_OK);
 }
 


### PR DESCRIPTION
Previous PR: #2526 

Major changes since last PR:
- The C transaction has been removed making the C app-layer much more minimal.
- Lua should now work.
- Memcap handling.

Notes:
- All C functions called by Rust are registered as function pointers so "cargo test" can continue to work (https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Rust_Notes#Allow-cargo-test-To-Work)
- I rewrote the buffering loop for TCP to make it a little more straight forward - this could probably move to Rust.
- According to internal profiling and wall time, Rust is still slower:
```
dns                     IPv4       6            63              726           9831          2085        131.4k  0.00  
dns                     IPv4      17       1436213              753         444141          3786          5.4b  100.00
real	0m8.446s
user	0m17.377s
sys	0m0.970s
```
- Git master:
```
dns                     IPv4       6            63              717           7275          1678        105.7k  0.00  
dns                     IPv4      17       1436220              441         157356          1842          2.6b  99.99 
real	0m6.355s
user	0m13.200s
sys	0m0.170s
```
- Attempts to optimize the hot spots have not proved useful, including more C like "unsafe" code. This may just be the cost of Rust for this use case.
- The Rust code, particularly dns.rs is a bit scattered. Some organizing and grouping of functions is needed.
- Will fail to build if jansson is not available at this time, otherwise Travis tests are passing: https://travis-ci.org/jasonish/suricata/builds/198110887


