### PR TITLE
dns: fix flood handling to avoid evasions - v1

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -226,13 +226,24 @@ typedef struct DNSState_ {
                                    * number of subsequent requests
                                    * without a response. */
     uint16_t events;
-    uint16_t givenup;
+    uint16_t flooded;             /**< Set after a flooded event has
+                                   * been raised then cleared when the
+                                   * number of unreplied requests
+                                   * reaches 0. */
 
     /* used by TCP only */
     uint16_t offset;
     uint16_t record_len;
     uint8_t *buffer;
 } DNSState;
+
+typedef struct DNSConfig_ {
+    uint32_t request_flood;
+    uint32_t state_memcap;  /**< memcap in bytes per state */
+    uint64_t global_memcap; /**< memcap in bytes globally for parser */
+} DNSConfig;
+
+extern DNSConfig dns_config;
 
 #define DNS_CONFIG_DEFAULT_REQUEST_FLOOD 500
 #define DNS_CONFIG_DEFAULT_STATE_MEMCAP 512*1024
@@ -266,7 +277,7 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction);
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 
 void DNSStateTransactionFree(void *state, uint64_t tx_id);
-DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id);
+DNSTransaction *DNSTransactionFindByTxId(DNSState *dns_state, const uint16_t tx_id);
 
 int DNSStateHasTxDetectState(void *alstate);
 DetectEngineState *DNSGetTxDetectState(void *vtx);

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -198,7 +198,8 @@ static int DNSRequestParseData(Flow *f, DNSState *dns_state, const uint8_t *inpu
 
     if (dns_state != NULL) {
         if (timercmp(&dns_state->last_req, &dns_state->last_resp, >=)) {
-            if (dns_state->window <= dns_state->unreplied_cnt) {
+            if ((dns_state->window < dns_config.request_flood) &&
+                (dns_state->window <= dns_state->unreplied_cnt)) {
                 dns_state->window++;
             }
         }


### PR DESCRIPTION
If a flow hit a DNS flood state with valid requests, new requests
that would match a block rule would be passed, or if not in IPS
mode, not logged/alerted.

To handle this the flood logic will not give up parsing anymore,
but instead the window is used to control how many outstanding
requests can be in memory, with a flood alert raised when number
of outstanding requests hits the limit, and the alert state cleared
when all DNS requests have been marked as replied (or reply lost).

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/85
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/437
