### PR TITLE
mpm-ac: fix integer overflow on allocation

### DIFF
--- a/src/util-mpm-ac.c
+++ b/src/util-mpm-ac.c
@@ -122,6 +122,28 @@ static void SCACGetConfig()
 
 /**
  * \internal
+ * \brief Check if size_t multiplication would overflow and perform operation
+ *        if safe. In case of an overflow we exit().
+ *
+ * \param a First size_t value to multiplicate.
+ * \param b Second size_t value to multiplicate.
+ *
+ * \retval The product of a and b, guaranteed to not overflow.
+ */
+static inline size_t SCACCheckSafeSizetMult(size_t a, size_t b)
+{
+    /* check for safety of multiplication operation */
+    if (b > 0 && a > SIZE_MAX / b) {
+        SCLogError(SC_ERR_MEM_ALLOC, "%"PRIuMAX" * %"PRIuMAX" > %"
+                   PRIuMAX" would overflow size_t calculating buffer size",
+                   (uintmax_t) a, (uintmax_t) b, (uintmax_t) SIZE_MAX);
+        exit(EXIT_FAILURE);
+    }
+    return a * b;
+}
+
+/**
+ * \internal
  * \brief Initialize a new state in the goto and output tables.
  *
  * \param mpm_ctx Pointer to the mpm context.
@@ -131,10 +153,10 @@ static void SCACGetConfig()
 static inline int SCACReallocState(SCACCtx *ctx, uint32_t cnt)
 {
     void *ptmp;
-    int size = 0;
+    size_t size = 0;
 
     /* reallocate space in the goto table to include a new state */
-    size = cnt * ctx->single_state_size;
+    size = SCACCheckSafeSizetMult((size_t) cnt, (size_t) ctx->single_state_size);
     ptmp = SCRealloc(ctx->goto_table, size);
     if (ptmp == NULL) {
         SCFree(ctx->goto_table);
@@ -145,10 +167,11 @@ static inline int SCACReallocState(SCACCtx *ctx, uint32_t cnt)
     ctx->goto_table = ptmp;
 
     /* reallocate space in the output table for the new state */
-    int oldsize = ctx->state_count * sizeof(SCACOutputTable);
-    size = cnt * sizeof(SCACOutputTable);
-    SCLogDebug("oldsize %d size %d cnt %u ctx->state_count %u",
-            oldsize, size, cnt, ctx->state_count);
+    size_t oldsize = SCACCheckSafeSizetMult((size_t) ctx->state_count,
+        sizeof(SCACOutputTable));
+    size = SCACCheckSafeSizetMult((size_t) cnt, sizeof(SCACOutputTable));
+    SCLogDebug("oldsize %"PRIuMAX" size  %"PRIuMAX" cnt %d ctx->state_count %u",
+            (uintmax_t) oldsize, (uintmax_t) size, cnt, ctx->state_count);
 
     ptmp = SCRealloc(ctx->output_table, size);
     if (ptmp == NULL) {


### PR DESCRIPTION
The size of a memory buffer to be reallocated during state creation in the Aho-Corasick implementation was kept in a signed `int` instead of a `size_t`, leading to an overflow when large lists of long and diverse patterns cause the amount of AC states to blow up (>2GB). This case can be triggered for reproduction using a script like https://gist.github.com/satta/e47f7a6f0e44c9898804121e4d8c5f2e.

Addresses Redmine issues #1827 (https://redmine.openinfosecfoundation.org/issues/1827) and #1843 (https://redmine.openinfosecfoundation.org/issues/1843).

This PR adds the following functionality:

- A new inline function `SCACCheckSafeSizetMult()` to check whether a `size_t` multiplication overflows, `exit()` ing in this case.
- Type change of the `size` variable in `SCACReallocState()` to `size_t`.

I ran the Dockerized prscript, builds completed successfully:

- https://steinbiss.name/suri/fix-integer-overflow-1827-1843-v1/features.html