### PR TITLE
alert: silence compiler type warning

### DIFF
--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -512,10 +512,10 @@ static int PacketToData(const Packet *p, const PacketAlert *pa, idmef_alert_t *a
             AddIntData(alert, "tcp_win", TCP_GET_WINDOW(p));
             AddIntData(alert, "tcp_sum", TCP_GET_SUM(p));
             AddIntData(alert, "tcp_urp", TCP_GET_URG_POINTER(p));
-            if (p->tcpvars.ts_val != NULL) {
+            if (p->tcpvars.ts_val != 0) {
                 AddIntData(alert, "tcp_tsval", TCP_GET_TSVAL(p));
             }
-            if (p->tcpvars.ts_ecr != NULL) {
+            if (p->tcpvars.ts_ecr != 0) {
                 AddIntData(alert, "tcp_tsecr", TCP_GET_TSECR(p));
             }
             if (p->tcph != NULL) {
@@ -961,4 +961,3 @@ void AlertPreludeRegister (void)
         AlertPreludeThreadInit, AlertPreludeThreadDeinit, NULL);
 }
 #endif /* PRELUDE */
-


### PR DESCRIPTION
The `ts_ecr` and `ts_val` struct fields are integer types (being timestamps), not pointers. This leads GCC 6.3.0 to complain about comparisons to `NULL`:

```
alert-prelude.c: In function ‘PacketToData’:
alert-prelude.c:515:35: warning: comparison between pointer and integer
             if (p->tcpvars.ts_val != NULL) {
                                   ^~
alert-prelude.c:518:35: warning: comparison between pointer and integer
             if (p->tcpvars.ts_ecr != NULL) {
                                   ^~
```
This PR adresses this by comparing these values to 0.

I ran the Dockerized prscript, builds completed successfully:
- https://steinbiss.name/suri/silence-type-warning-v1/features.html
