### PR TITLE
Next/20170208/v5

### DIFF
--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -1624,6 +1624,9 @@ int AppLayerProtoDetectConfProtoDetectionEnabled(const char *ipproto,
     ConfNode *node;
     int r;
 
+#ifdef AFLFUZZ_APPLAYER
+    goto enabled;
+#endif
     if (RunmodeIsUnittests())
         goto enabled;
 

--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -1598,7 +1598,9 @@ void RegisterDNP3Parsers(void)
             if (!AppLayerProtoDetectPPParseConfPorts("tcp", IPPROTO_TCP,
                     proto_name, ALPROTO_DNP3, 0, sizeof(DNP3LinkHeader),
                     DNP3ProbingParser, NULL)) {
+#ifndef AFLFUZZ_APPLAYER
                 return;
+#endif
             }
         }
 

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -404,9 +404,11 @@ void RegisterDNSUDPParsers(void)
                                                 DNSUdpProbingParser, NULL);
             /* if we have no config, we enable the default port 53 */
             if (!have_cfg) {
+#ifndef AFLFUZZ_APPLAYER
                 SCLogWarning(SC_ERR_DNS_CONFIG, "no DNS UDP config found, "
                                                 "enabling DNS detection on "
                                                 "port 53.");
+#endif
                 AppLayerProtoDetectPPRegister(IPPROTO_UDP, "53",
                                    ALPROTO_DNS, 0, sizeof(DNSHeader),
                                    STREAM_TOSERVER, DNSUdpProbingParser, NULL);

--- a/src/app-layer-enip.c
+++ b/src/app-layer-enip.c
@@ -482,7 +482,9 @@ void RegisterENIPTCPParsers(void)
                     proto_name, ALPROTO_ENIP, 0, sizeof(ENIPEncapHdr),
                     ENIPProbingParser, ENIPProbingParser))
             {
+#ifndef AFLFUZZ_APPLAYER
                 return;
+#endif
             }
         }
 

--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1497,11 +1497,7 @@ void RegisterModbusParsers(void)
         return;
 #endif
     }
-#ifndef AFLFUZZ_APPLAYER
     if (AppLayerParserConfParserEnabled("tcp", proto_name)) {
-#else
-    if (1) {
-#endif
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOSERVER, ModbusParseRequest);
         AppLayerParserRegisterParser(IPPROTO_TCP, ALPROTO_MODBUS, STREAM_TOCLIENT, ModbusParseResponse);
         AppLayerParserRegisterStateFuncs(IPPROTO_TCP, ALPROTO_MODBUS, ModbusStateAlloc, ModbusStateFree);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -1344,8 +1344,8 @@ int AppLayerParserRequestFromFile(AppProto alproto, char *filename)
         int start = 1;
         while (1) {
             int done = 0;
-            size_t result = fread(&buffer, 1, sizeof(buffer), fp);
-            if (result < sizeof(buffer))
+            size_t size = fread(&buffer, 1, sizeof(buffer), fp);
+            if (size < sizeof(buffer))
                 done = 1;
 
             //SCLogInfo("result %u done %d start %d", (uint)result, done, start);
@@ -1361,7 +1361,7 @@ int AppLayerParserRequestFromFile(AppProto alproto, char *filename)
             //PrintRawDataFp(stdout, buffer, result);
 
             (void)AppLayerParserParse(NULL, alp_tctx, f, alproto, flags,
-                                      buffer, result);
+                                      buffer, size);
             if (done)
                 break;
         }
@@ -1421,8 +1421,8 @@ int AppLayerParserFromFile(AppProto alproto, char *filename)
         int flip = 0;
         while (1) {
             int done = 0;
-            size_t result = fread(&buffer, 1, sizeof(buffer), fp);
-            if (result < sizeof(buffer))
+            size_t size = fread(&buffer, 1, sizeof(buffer), fp);
+            if (size < sizeof(buffer))
                 done = 1;
 
             //SCLogInfo("result %u done %d start %d", (uint)result, done, start);
@@ -1445,7 +1445,7 @@ int AppLayerParserFromFile(AppProto alproto, char *filename)
             //PrintRawDataFp(stdout, buffer, result);
 
             (void)AppLayerParserParse(NULL, alp_tctx, f, alproto, flags,
-                                      buffer, result);
+                                      buffer, size);
             if (done)
                 break;
         }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -237,8 +237,8 @@ void AppLayerParserStatePrintDetails(AppLayerParserState *pstate);
 #endif
 
 #ifdef AFLFUZZ_APPLAYER
-int AppLayerParserRequestFromFile(AppProto alproto, char *filename);
-int AppLayerParserFromFile(AppProto alproto, char *filename);
+int AppLayerParserRequestFromFile(uint8_t ipproto, AppProto alproto, char *filename);
+int AppLayerParserFromFile(uint8_t ipproto, AppProto alproto, char *filename);
 #endif
 
 /***** Unittests *****/

--- a/src/decode.c
+++ b/src/decode.c
@@ -622,13 +622,13 @@ int DecoderParseDataFromFile(char *filename, DecoderFunc Decoder) {
 
         while (1) {
             int done = 0;
-            size_t result = fread(&buffer, 1, sizeof(buffer), fp);
-            if (result < sizeof(buffer))
+            size_t size = fread(&buffer, 1, sizeof(buffer), fp);
+            if (size < sizeof(buffer))
                  done = 1;
 
             Packet *p = PacketGetFromAlloc();
             if (p != NULL) {
-                (void) Decoder (&tv, dtv, p, buffer, result, NULL);
+                (void) Decoder (&tv, dtv, p, buffer, size, NULL);
                 PacketFree(p);
             }
 

--- a/src/detect.c
+++ b/src/detect.c
@@ -588,6 +588,11 @@ SigGroupHead *SigMatchSignaturesGetSgh(DetectEngineCtx *de_ctx, DetectEngineThre
      * the decoder events sgh we have. */
     if (p->proto == 0 && p->events.cnt > 0) {
         SCReturnPtr(de_ctx->decoder_event_sgh, "SigGroupHead");
+    } else if (p->proto == 0) {
+        if (!(PKT_IS_IPV4(p) || PKT_IS_IPV6(p))) {
+            /* not IP, so nothing to do */
+            SCReturnPtr(NULL, "SigGroupHead");
+        }
     }
 
     /* select the flow_gh */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -116,6 +116,7 @@
 #include "app-layer-htp.h"
 #include "app-layer-ssl.h"
 #include "app-layer-dns-tcp.h"
+#include "app-layer-dns-udp.h"
 #include "app-layer-ssh.h"
 #include "app-layer-ftp.h"
 #include "app-layer-smtp.h"
@@ -1415,7 +1416,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterHTPParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_HTTP, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_HTTP, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-http") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1423,7 +1424,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterHTPParsers();
-                exit(AppLayerParserFromFile(ALPROTO_HTTP, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_HTTP, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-tls-request") == 0) {
                 //printf("arg: //%s\n", optarg);
@@ -1432,7 +1433,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSSLParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_TLS, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_TLS, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-tls") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1440,17 +1441,27 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSSLParsers();
-                exit(AppLayerParserFromFile(ALPROTO_TLS, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_TLS, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-dns-request") == 0) {
                 //printf("arg: //%s\n", optarg);
-                RegisterDNSTCPParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_DNS, optarg));
+                RegisterDNSUDPParsers();
+                exit(AppLayerParserRequestFromFile(IPPROTO_UDP, ALPROTO_DNS, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-dns") == 0) {
                 //printf("arg: //%s\n", optarg);
                 AppLayerParserSetup();
+                RegisterDNSUDPParsers();
+                exit(AppLayerParserFromFile(IPPROTO_UDP, ALPROTO_DNS, optarg));
+
+            } else if(strcmp((long_opts[option_index]).name, "afl-dnstcp-request") == 0) {
+                //printf("arg: //%s\n", optarg);
                 RegisterDNSTCPParsers();
-                exit(AppLayerParserFromFile(ALPROTO_DNS, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_DNS, optarg));
+            } else if(strcmp((long_opts[option_index]).name, "afl-dnstcp") == 0) {
+                //printf("arg: //%s\n", optarg);
+                AppLayerParserSetup();
+                RegisterDNSTCPParsers();
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_DNS, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-ssh-request") == 0) {
                 //printf("arg: //%s\n", optarg);
@@ -1458,7 +1469,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 SpmTableSetup();
                 AppLayerProtoDetectSetup();
                 RegisterSSHParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_SSH, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_SSH, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-ssh") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1466,7 +1477,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSSHParsers();
-                exit(AppLayerParserFromFile(ALPROTO_SSH, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_SSH, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-ftp-request") == 0) {
                 //printf("arg: //%s\n", optarg);
@@ -1475,7 +1486,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterFTPParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_FTP, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_FTP, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-ftp") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1483,7 +1494,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterFTPParsers();
-                exit(AppLayerParserFromFile(ALPROTO_FTP, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_FTP, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-smtp-request") == 0) {
                 //printf("arg: //%s\n", optarg);
@@ -1492,7 +1503,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSMTPParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_SMTP, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_SMTP, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-smtp") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1500,7 +1511,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSMTPParsers();
-                exit(AppLayerParserFromFile(ALPROTO_SMTP, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_SMTP, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-smb-request") == 0) {
                 //printf("arg: //%s\n", optarg);
@@ -1508,7 +1519,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 SpmTableSetup();
                 AppLayerProtoDetectSetup();
                 RegisterSMBParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_SMB, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_SMB, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-smb") == 0) {
                 //printf("arg: //%s\n", optarg);
                 MpmTableSetup();
@@ -1516,36 +1527,36 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
                 AppLayerProtoDetectSetup();
                 AppLayerParserSetup();
                 RegisterSMBParsers();
-                exit(AppLayerParserFromFile(ALPROTO_SMB, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_SMB, optarg));
 
             } else if(strcmp((long_opts[option_index]).name, "afl-modbus-request") == 0) {
                 //printf("arg: //%s\n", optarg);
                 AppLayerParserSetup();
                 RegisterModbusParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_MODBUS, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_MODBUS, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-modbus") == 0) {
                 //printf("arg: //%s\n", optarg);
                 AppLayerParserSetup();
                 RegisterModbusParsers();
-                exit(AppLayerParserFromFile(ALPROTO_MODBUS, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_MODBUS, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-enip-request") == 0) {
                 //printf("arg: //%s\n", optarg);
                 AppLayerParserSetup();
                 RegisterENIPTCPParsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_ENIP, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_ENIP, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-enip") == 0) {
                 //printf("arg: //%s\n", optarg);
                 AppLayerParserSetup();
                 RegisterENIPTCPParsers();
-                exit(AppLayerParserFromFile(ALPROTO_ENIP, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_ENIP, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-dnp3-request") == 0) {
                 AppLayerParserSetup();
                 RegisterDNP3Parsers();
-                exit(AppLayerParserRequestFromFile(ALPROTO_DNP3, optarg));
+                exit(AppLayerParserRequestFromFile(IPPROTO_TCP, ALPROTO_DNP3, optarg));
             } else if(strcmp((long_opts[option_index]).name, "afl-dnp3") == 0) {
                 AppLayerParserSetup();
                 RegisterDNP3Parsers();
-                exit(AppLayerParserFromFile(ALPROTO_DNP3, optarg));
+                exit(AppLayerParserFromFile(IPPROTO_TCP, ALPROTO_DNP3, optarg));
 #endif
 #ifdef AFLFUZZ_MIME
             } else if(strcmp((long_opts[option_index]).name, "afl-mime") == 0) {

--- a/src/util-decode-mime.c
+++ b/src/util-decode-mime.c
@@ -2645,11 +2645,11 @@ int MimeParserDataFromFile(char *filename)
 
         while (1) {
             int done = 0;
-            size_t result = fread(&buffer, 1, sizeof(buffer), fp);
-            if (result < sizeof(buffer))
+            size_t size = fread(&buffer, 1, sizeof(buffer), fp);
+            if (size < sizeof(buffer))
                 done = 1;
 
-            (void) MimeDecParseLine(buffer, result, 1, state);
+            (void) MimeDecParseLine(buffer, size, 1, state);
 
             if (done)
                 break;


### PR DESCRIPTION
Merge #2544 plus:
- fix AFL mode for ENIP
- add --afl-dnstcp and --afl-dnstcp-request, the existing dns options now apply to UDP
- address https://redmine.openinfosecfoundation.org/issues/2017

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/65
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/573