### PR TITLE
dns flood handling  - v2

### DIFF
--- a/src/app-layer-dns-common.c
+++ b/src/app-layer-dns-common.c
@@ -197,7 +197,8 @@ void *DNSGetTx(void *alstate, uint64_t tx_id)
 
     /* no luck with the fast tracks, do the full list walk */
     TAILQ_FOREACH(tx, &dns_state->tx_list, next) {
-        SCLogDebug("tx->tx_num %u, tx_id %"PRIu64, tx->tx_num, (tx_id+1));
+        SCLogDebug("tx->tx_num %"PRIu64", tx_id %"PRIu64, tx->tx_num,
+            (tx_id+1));
         if ((tx_id+1) != tx->tx_num)
             continue;
 
@@ -345,7 +346,8 @@ void DNSStateTransactionFree(void *state, uint64_t tx_id)
     SCLogDebug("state %p, id %"PRIu64, dns_state, tx_id);
 
     TAILQ_FOREACH(tx, &dns_state->tx_list, next) {
-        SCLogDebug("tx %p tx->tx_num %u, tx_id %"PRIu64, tx, tx->tx_num, (tx_id+1));
+        SCLogDebug("tx %p tx->tx_num %"PRIu64", tx_id %"PRIu64, tx, tx->tx_num,
+            (tx_id+1));
         if ((tx_id+1) < tx->tx_num)
             break;
         else if ((tx_id+1) > tx->tx_num)
@@ -565,7 +567,7 @@ void DNSStoreQueryInState(DNSState *dns_state, const uint8_t *fqdn, const uint16
         TAILQ_INSERT_TAIL(&dns_state->tx_list, tx, next);
         dns_state->curr = tx;
         tx->tx_num = dns_state->transaction_max;
-        SCLogDebug("new tx %u with internal id %u", tx->tx_id, tx->tx_num);
+        SCLogDebug("new tx %u with internal id %"PRIu64, tx->tx_id, tx->tx_num);
         dns_state->unreplied_cnt++;
     }
 

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -226,13 +226,24 @@ typedef struct DNSState_ {
                                    * number of subsequent requests
                                    * without a response. */
     uint16_t events;
-    uint16_t givenup;
+    uint16_t flooded;             /**< Set after a flooded event has
+                                   * been raised then cleared when the
+                                   * number of unreplied requests
+                                   * reaches 0. */
 
     /* used by TCP only */
     uint16_t offset;
     uint16_t record_len;
     uint8_t *buffer;
 } DNSState;
+
+typedef struct DNSConfig_ {
+    uint32_t request_flood;
+    uint32_t state_memcap;  /**< memcap in bytes per state */
+    uint64_t global_memcap; /**< memcap in bytes globally for parser */
+} DNSConfig;
+
+extern DNSConfig dns_config;
 
 #define DNS_CONFIG_DEFAULT_REQUEST_FLOOD 500
 #define DNS_CONFIG_DEFAULT_STATE_MEMCAP 512*1024
@@ -266,7 +277,7 @@ int DNSGetAlstateProgress(void *tx, uint8_t direction);
 int DNSGetAlstateProgressCompletionStatus(uint8_t direction);
 
 void DNSStateTransactionFree(void *state, uint64_t tx_id);
-DNSTransaction *DNSTransactionFindByTxId(const DNSState *dns_state, const uint16_t tx_id);
+DNSTransaction *DNSTransactionFindByTxId(DNSState *dns_state, const uint16_t tx_id);
 
 int DNSStateHasTxDetectState(void *alstate);
 DetectEngineState *DNSGetTxDetectState(void *vtx);

--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -188,8 +188,8 @@ typedef struct DNSAnswerEntry_ {
 
 /** \brief DNS Transaction, request/reply with same TX id. */
 typedef struct DNSTransaction_ {
-    uint16_t tx_num;                                /**< internal: id */
-    uint16_t tx_id;                                 /**< transaction id */
+    uint64_t tx_num;                                /**< internal: id */
+    uint16_t tx_id;                                 /**< DNS transaction id */
     uint32_t logged;                                /**< flags for loggers done logging */
     uint8_t replied;                                /**< bool indicating request is
                                                          replied to. */

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -198,7 +198,8 @@ static int DNSRequestParseData(Flow *f, DNSState *dns_state, const uint8_t *inpu
 
     if (dns_state != NULL) {
         if (timercmp(&dns_state->last_req, &dns_state->last_resp, >=)) {
-            if (dns_state->window <= dns_state->unreplied_cnt) {
+            if ((dns_state->window < dns_config.request_flood) &&
+                (dns_state->window <= dns_state->unreplied_cnt)) {
                 dns_state->window++;
             }
         }

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -83,7 +83,8 @@ static int DNSUDPRequestParse(Flow *f, void *dstate,
 
     if (dns_state != NULL) {
         if (timercmp(&dns_state->last_req, &dns_state->last_resp, >=)) {
-            if (dns_state->window <= dns_state->unreplied_cnt) {
+            if ((dns_state->window < dns_config.request_flood) &&
+                (dns_state->window <= dns_state->unreplied_cnt)) {
                 dns_state->window++;
             }
         }
@@ -699,7 +700,7 @@ static int DNSUDPParserTestDelayedResponse(void)
 }
 
 /**
- * \test Test entering the flood/givenup state.
+ * \test Test entering the flood/flooded state.
  */
 static int DNSUDPParserTestFlood(void)
 {
@@ -715,6 +716,14 @@ static int DNSUDPParserTestFlood(void)
     };
     size_t reqlen = sizeof(req);
 
+    uint8_t res[] = {
+        0x00, 0x01, 0x81, 0x00, 0x00, 0x01, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x03, 0x77, 0x77, 0x77,
+        0x06, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x03,
+        0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, 0x01,
+    };
+    size_t reslen = sizeof(res);
+
     DNSState *state = DNSStateAlloc();
     FAIL_IF_NULL(state);
     Flow *f = UTHBuildFlow(AF_INET, "1.1.1.1", "2.2.2.2", 1024, 53);
@@ -724,11 +733,11 @@ static int DNSUDPParserTestFlood(void)
     f->alstate = state;
 
     uint16_t txid;
-    for (txid = 1; txid <= DNS_CONFIG_DEFAULT_REQUEST_FLOOD + 1; txid++) {
+    for (txid = 1; txid < DNS_CONFIG_DEFAULT_REQUEST_FLOOD; txid++) {
         req[0] = (txid >> 8) & 0xff;
         req[1] = txid & 0xff;
         FAIL_IF_NOT(DNSUDPRequestParse(f, f->alstate, NULL, req, reqlen, NULL));
-        FAIL_IF(state->givenup);
+        FAIL_IF(state->flooded);
     }
 
     /* With one more request we should enter a flooded state. */
@@ -736,7 +745,20 @@ static int DNSUDPParserTestFlood(void)
     req[0] = (txid >> 8) & 0xff;
     req[1] = txid & 0xff;
     FAIL_IF_NOT(DNSUDPRequestParse(f, f->alstate, NULL, req, reqlen, NULL));
-    FAIL_IF(!state->givenup);
+    FAIL_IF(!state->flooded);
+
+    /* Now test that we come out of the flooded state as replies get
+     * answered. */
+    for (uint16_t i = 0; i < DNS_CONFIG_DEFAULT_REQUEST_FLOOD + 2; i++) {
+        txid++;
+        req[0] = (txid >> 8) & 0xff;
+        req[1] = txid & 0xff;
+        FAIL_IF_NOT(DNSUDPRequestParse(f, f->alstate, NULL, req, reqlen, NULL));
+        FAIL_IF_NOT(DNSUDPResponseParse(f, f->alstate, NULL, res, reslen,
+                NULL));
+    }
+    FAIL_IF(state->flooded);
+    FAIL_IF(state->unreplied_cnt != 0);
 
     /* Also free's state. */
     UTHFreeFlow(f);
@@ -832,7 +854,7 @@ static int DNSUDPParserTestLostResponse(void)
     /* Response to the third request. */
     res[1] = 0x03;
     FAIL_IF_NOT(DNSUDPResponseParse(f, f->alstate, NULL, res, reslen, NULL));
-    FAIL_IF_NOT(state->unreplied_cnt == 2);
+    FAIL_IF_NOT(state->unreplied_cnt == 1);
     FAIL_IF_NOT(state->window == 3);
     tx = TAILQ_FIRST(&state->tx_list);
     FAIL_IF_NULL(tx);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -745,10 +745,16 @@ uint64_t AppLayerTransactionGetActiveLogOnly(Flow *f, uint8_t flags)
     void *tx;
     int state_progress;
 
+    int found = 0;
     for (; idx < total_txs; idx++) {
         tx = AppLayerParserGetTx(f->proto, f->alproto, f->alstate, idx);
-        if (tx == NULL)
+        if (tx == NULL) {
+            if (!found) {
+                f->alparser->inspect_id[flags & STREAM_TOSERVER ? 0 : 1] = idx;
+            }
             continue;
+        }
+        found = 1;
         state_progress = AppLayerParserGetStateProgress(f->proto, f->alproto, tx, flags);
         if (state_progress >= state_done_progress)
             continue;


### PR DESCRIPTION
The most recent commit is the under review it. It opportunistically increments the inspect_id as it comes across NULL transactions that will never be non-null. This is not specific to DNS, but helps DNS when logging is enabled. See note below for when logging is not enabled.

Note: There is an issue where detection is enabled (rules or no rules) but there are no loggers where DNSGetAlstateProgress never gets called in the TOCLIENT direction, this leads to a build of transactions as they are never free'd by the app-layer, even though they are marked lost to make them "complete". This is probably because there is no traffic in the TOCLIENT direction.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/87
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/439
