### PR TITLE
logging: support file rotation

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -181,6 +181,21 @@ YAML::
 To reduce verbosity the output can be filtered by supplying the record types
 to be logged under ``custom``.
 
+Date modifiers in filename
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to use date modifiers in the eve-log filename.
+
+::
+
+   outputs:
+     - eve-log:
+         filename: eve-%s.json
+
+The example above adds epoch time to the filename. All the date modifiers from the
+C library should be supported. See the man page for ``strftime`` for all supported
+modifiers.
+
 Rotate log file
 ~~~~~~~~~~~~~~~
 

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -181,6 +181,35 @@ YAML::
 To reduce verbosity the output can be filtered by supplying the record types
 to be logged under ``custom``.
 
+Rotate log file
+~~~~~~~~~~~~~~~
+
+Eve-log can be configured to rotate based on time.
+
+::
+
+  outputs:
+    - eve-log:
+        filename: eve-%Y-%m-%d-%H:%M.json
+        rotate-interval: minute
+
+The example above creates a new log file each minute, where the filename contains
+a timestamp. Other supported ``rotate-interval`` values are ``hour`` and ``day``.
+
+In addition to this, it is also possible to specify the ``rotate-interval`` as a
+relative value. One example is to rotate the log file each X seconds.
+
+::
+
+  outputs:
+    - eve-log:
+        filename: eve-%Y-%m-%d-%H:%M:%S.json
+        rotate-interval: 30s
+
+The example above rotates eve-log each 30 seconds. This could be replaced with
+``30m`` to rotate every 30 minutes, ``30h`` to rotate every 30 hours, ``30d``
+to rotate every 30 days, or ``30w`` to rotate every 30 weeks.
+
 Multiple Logger Instances
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <libgen.h>
 
 #include "suricata-common.h" /* errno.h, string.h, etc. */
 #include "tm-modules.h"      /* LogFileCtx */
@@ -183,6 +184,41 @@ static char *SCLogFilenameFromPattern(const char *pattern)
     return filename;
 }
 
+/** \brief recursively create missing log directories
+ *  \param path path to log file
+ *  \retval 0 on success
+ *  \retval -1 on error
+ */
+static int SCLogCreateDirectoryTree(const char *filepath)
+{
+    char pathbuf[PATH_MAX];
+    char *p;
+    size_t len = strlen(filepath);
+
+    if (len > PATH_MAX - 1) {
+        return -1;
+    }
+
+    strlcpy(pathbuf, filepath, len);
+
+    for (p = pathbuf + 1; *p; p++) {
+        if (*p == '/') {
+            /* Truncate, while creating directory */
+            *p = '\0';
+
+            if (mkdir(pathbuf, S_IRWXU | S_IRGRP | S_IXGRP) != 0) {
+                if (errno != EEXIST) {
+                    return -1;
+                }
+            }
+
+            *p = '/';
+        }
+    }
+
+    return 0;
+}
+
 static void SCLogFileClose(LogFileCtx *log_ctx)
 {
     if (log_ctx->fp)
@@ -202,6 +238,12 @@ SCLogOpenFileFp(const char *path, const char *append_setting)
 
     char *filename = SCLogFilenameFromPattern(path);
     if (filename == NULL) {
+        return NULL;
+    }
+
+    int rc = SCLogCreateDirectoryTree(filename);
+    if (rc < 0) {
+        SCFree(filename);
         return NULL;
     }
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -155,6 +155,26 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
     return ret;
 }
 
+/** \brief generate filename based on pattern
+ *  \param pattern pattern to use
+ *  \retval char* on success
+ *  \retval NULL on error
+ */
+static char *SCLogFilenameFromPattern(const char *pattern)
+{
+    char *filename = SCMalloc(PATH_MAX);
+    if (filename == NULL) {
+        return NULL;
+    }
+
+    int rc = SCTimeToStringPattern(time(NULL), pattern, filename, PATH_MAX);
+    if (rc != 0) {
+        return NULL;
+    }
+
+    return filename;
+}
+
 static void SCLogFileClose(LogFileCtx *log_ctx)
 {
     if (log_ctx->fp)
@@ -172,15 +192,22 @@ SCLogOpenFileFp(const char *path, const char *append_setting)
 {
     FILE *ret = NULL;
 
+    char *filename = SCLogFilenameFromPattern(path);
+    if (filename == NULL) {
+        return NULL;
+    }
+
     if (ConfValIsTrue(append_setting)) {
-        ret = fopen(path, "a");
+        ret = fopen(filename, "a");
     } else {
-        ret = fopen(path, "w");
+        ret = fopen(filename, "w");
     }
 
     if (ret == NULL)
         SCLogError(SC_ERR_FOPEN, "Error opening file: \"%s\": %s",
-                   path, strerror(errno));
+                   filename, strerror(errno));
+
+    SCFree(filename);
     return ret;
 }
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -133,6 +133,14 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
         SCConfLogReopen(log_ctx);
     }
 
+    if (log_ctx->flags & LOGFILE_ROTATE_INTERVAL) {
+        time_t now = time(NULL);
+        if (now >= log_ctx->rotate_time) {
+            SCConfLogReopen(log_ctx);
+            log_ctx->rotate_time = now + log_ctx->rotate_interval;
+        }
+    }
+
     int ret = 0;
 
     if (log_ctx->fp == NULL && log_ctx->is_sock)
@@ -273,6 +281,36 @@ SCConfLogOpenGeneric(ConfNode *conf,
         snprintf(log_path, PATH_MAX, "%s", filename);
     } else {
         snprintf(log_path, PATH_MAX, "%s/%s", log_dir, filename);
+    }
+
+    /* Rotate log file based on time */
+    const char *rotate_int = ConfNodeLookupChildValue(conf, "rotate-interval");
+    if (rotate_int != NULL) {
+        time_t now = time(NULL);
+        log_ctx->flags |= LOGFILE_ROTATE_INTERVAL;
+
+        /* Use a specific time */
+        if (strcmp(rotate_int, "minute") == 0) {
+            log_ctx->rotate_time = now + SCGetSecondsUntil(rotate_int, now);
+            log_ctx->rotate_interval = 60;
+        } else if (strcmp(rotate_int, "hour") == 0) {
+            log_ctx->rotate_time = now + SCGetSecondsUntil(rotate_int, now);
+            log_ctx->rotate_interval = 3600;
+        } else if (strcmp(rotate_int, "day") == 0) {
+            log_ctx->rotate_time = now + SCGetSecondsUntil(rotate_int, now);
+            log_ctx->rotate_interval = 86400;
+        }
+
+        /* Use a timer */
+        else {
+            log_ctx->rotate_interval = SCParseTimeSizeString(rotate_int);
+            if (log_ctx->rotate_interval == 0) {
+                SCLogError(SC_ERR_INVALID_NUMERIC_VALUE,
+                           "invalid rotate-interval value");
+                exit(EXIT_FAILURE);
+            }
+            log_ctx->rotate_time = now + log_ctx->rotate_interval;
+        }
     }
 
     filetype = ConfNodeLookupChildValue(conf, "filetype");

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -99,6 +99,13 @@ typedef struct LogFileCtx_ {
     int sock_type;
     uint64_t reconn_timer;
 
+    /** The next time to rotate log file, if rotate interval is
+        specified. */
+    time_t rotate_time;
+
+    /** The interval to rotate the log file */
+    uint64_t rotate_interval;
+
     /**< Used by some alert loggers like the unified ones that append
      * the date onto the end of files. */
     char *prefix;
@@ -126,8 +133,9 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_RECONN_MIN_TIME     500
 
 /* flags for LogFileCtx */
-#define LOGFILE_HEADER_WRITTEN 0x01
-#define LOGFILE_ALERTS_PRINTED 0x02
+#define LOGFILE_HEADER_WRITTEN  0x01
+#define LOGFILE_ALERTS_PRINTED  0x02
+#define LOGFILE_ROTATE_INTERVAL 0x04
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -503,3 +503,80 @@ int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str, size_t 
 
     return 0;
 }
+
+/**
+ * \brief Parse string containing time size (1m, 1h, etc).
+ *
+ * \param str String to parse.
+ *
+ * \retval size on success.
+ * \retval 0 on failure.
+ */
+uint64_t SCParseTimeSizeString (const char *str)
+{
+    uint64_t size = 0;
+    uint64_t modifier = 1;
+    char last = str[strlen(str)-1];
+
+    switch (last)
+    {
+        case '0' ... '9':
+            break;
+        /* seconds */
+        case 's':
+            break;
+        /* minutes */
+        case 'm':
+            modifier = 60;
+            break;
+        /* hours */
+        case 'h':
+            modifier = 60 * 60;
+            break;
+        /* days */
+        case 'd':
+            modifier = 60 * 60 * 24;
+            break;
+        /* weeks */
+        case 'w':
+            modifier = 60 * 60 * 24 * 7;
+            break;
+        /* invalid */
+        default:
+            return 0;
+    }
+
+    errno = 0;
+    size = strtoumax(str, NULL, 10);
+    if (errno) {
+        return 0;
+    }
+
+    return (size * modifier);
+}
+
+/**
+ * \brief Get seconds until a time unit changes.
+ *
+ * \param str   String containing time type (minute, hour, etc).
+ * \param epoch Epoch time.
+ *
+ * \retval seconds.
+ */
+uint64_t SCGetSecondsUntil (const char *str, time_t epoch)
+{
+    uint64_t seconds = 0;
+    struct tm tm;
+    memset(&tm, 0, sizeof(tm));
+    struct tm *tp = (struct tm *)SCLocalTime(epoch, &tm);
+
+    if (strcmp(str, "minute") == 0)
+        seconds = 60 - tp->tm_sec;
+    else if (strcmp(str, "hour") == 0)
+        seconds = (60 * (60 - tp->tm_min)) + (60 - tp->tm_sec);
+    else if (strcmp(str, "day") == 0)
+        seconds = (3600 * (24 - tp->tm_hour)) + (60 * (60 - tp->tm_min)) +
+                  (60 - tp->tm_sec);
+
+    return seconds;
+}

--- a/src/util-time.c
+++ b/src/util-time.c
@@ -469,3 +469,37 @@ int SCStringPatternToTime (char *string, char **patterns, int num_patterns,
 
     return 0;
 }
+
+/**
+ * \brief Convert epoch time to string pattern.
+ *
+ * This function converts epoch time to a string based on a pattern.
+ *
+ * \param epoch   Epoch time.
+ * \param pattern String pattern.
+ * \param str     Formated string.
+ * \param size    Size of allocated string.
+ *
+ * \retval 0 on success.
+ * \retval 1 on failure.
+ */
+int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str, size_t size)
+{
+    struct tm tm;
+    memset(&tm, 0, sizeof(tm));
+    struct tm *tp = (struct tm *)SCLocalTime(epoch, &tm);
+    char buffer[PATH_MAX] = { 0 };
+
+    if (unlikely(tp == NULL)) {
+        return 1;
+    }
+
+    int r = strftime(buffer, sizeof(buffer), pattern, tp);
+    if (r == 0) {
+        return 1;
+    }
+
+    strlcpy(str, buffer, size);
+
+    return 0;
+}

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -59,6 +59,8 @@ int SCStringPatternToTime (char *string, char **patterns,
                            int num_patterns, struct tm *time);
 int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str,
                            size_t size);
+uint64_t SCParseTimeSizeString (const char *str);
+uint64_t SCGetSecondsUntil (const char *str, time_t epoch);
 
 #endif /* __UTIL_TIME_H__ */
 

--- a/src/util-time.h
+++ b/src/util-time.h
@@ -57,6 +57,8 @@ void CreateUtcIsoTimeString (const struct timeval *ts, char *str, size_t size);
 time_t SCMkTimeUtc (struct tm *tp);
 int SCStringPatternToTime (char *string, char **patterns,
                            int num_patterns, struct tm *time);
+int SCTimeToStringPattern (time_t epoch, const char *pattern, char *str,
+                           size_t size);
 
 #endif /* __UTIL_TIME_H__ */
 


### PR DESCRIPTION
Add support for log file rotation, without the need for external tools like logrotate.

The pull request basically adds three new features for all the loggers. It allows the user to use date modifiers in the log filename in suricata.yaml, e.g.:

```yaml
outputs:
  - eve-log:
      filename: eve-%Y-%m-%d-%H:%M:%S.json
```

It also adds log file rotation based on either minute/hour/day or a relative value like X seconds/minutes/hours/days/weeks, e.g.:

```yaml
outputs:
  - eve-log:
      filename: eve-%Y-%m-%d-%H:%M:%S.json
      rotate-interval: minute
```

The example above rotates the eve-log every minute. This could be changed to 'rotate-interval: 120s' to rotate the file every 120 seconds instead.

The last feature is to create new directories when needed. This enables us to use date modifiers to create directory structures (like often done by tools like rsyslog), e.g.:

```yaml
outputs:
  - eve-log:
      filename: /var/log/suricata/%Y/%m/%d/eve-%H.json
      rotate-interval: hour
```

The example above would create a new folder per day and rotate the eve-log every hour.

https://redmine.openinfosecfoundation.org/issues/1323
(it rotates on time and not size, so I'm not sure it  entirely solves this issue)

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/95
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/95