### PR TITLE
rfc: json builder as an alternative to jansson - v5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -695,68 +695,68 @@
         exit 1
     fi
 
-  # libjansson
-    enable_jansson="no"
-    AC_ARG_WITH(libjansson_includes,
-            [  --with-libjansson-includes=DIR  libjansson include directory],
-            [with_libjansson_includes="$withval"],[with_libjansson_includes=no])
-    AC_ARG_WITH(libjansson_libraries,
-            [  --with-libjansson-libraries=DIR    libjansson library directory],
-            [with_libjansson_libraries="$withval"],[with_libjansson_libraries="no"])
+  dnl # libjansson
+  dnl   enable_jansson="no"
+  dnl   AC_ARG_WITH(libjansson_includes,
+  dnl           [  --with-libjansson-includes=DIR  libjansson include directory],
+  dnl           [with_libjansson_includes="$withval"],[with_libjansson_includes=no])
+  dnl   AC_ARG_WITH(libjansson_libraries,
+  dnl           [  --with-libjansson-libraries=DIR    libjansson library directory],
+  dnl           [with_libjansson_libraries="$withval"],[with_libjansson_libraries="no"])
 
-    if test "$with_libjansson_includes" != "no"; then
-        CPPFLAGS="${CPPFLAGS} -I${with_libjansson_includes}"
-    fi
+  dnl   if test "$with_libjansson_includes" != "no"; then
+  dnl       CPPFLAGS="${CPPFLAGS} -I${with_libjansson_includes}"
+  dnl   fi
 
-    enable_jansson="no"
-    enable_unixsocket="no"
+  dnl   enable_jansson="no"
+  dnl   enable_unixsocket="no"
 
-    AC_ARG_ENABLE(unix-socket,
-           AS_HELP_STRING([--enable-unix-socket], [Enable unix socket [default=test]]),[enable_unixsocket="$enableval"],[enable_unixsocket=test])
+  dnl   AC_ARG_ENABLE(unix-socket,
+  dnl          AS_HELP_STRING([--enable-unix-socket], [Enable unix socket [default=test]]),[enable_unixsocket="$enableval"],[enable_unixsocket=test])
 
-    AC_CHECK_HEADER(jansson.h,JANSSON="yes",JANSSON="no")
-    if test "$JANSSON" = "yes"; then
-        if test "$with_libjansson_libraries" != "no"; then
-            LDFLAGS="${LDFLAGS}  -L${with_libjansson_libraries}"
-        fi
+  dnl   AC_CHECK_HEADER(jansson.h,JANSSON="yes",JANSSON="no")
+  dnl   if test "$JANSSON" = "yes"; then
+  dnl       if test "$with_libjansson_libraries" != "no"; then
+  dnl           LDFLAGS="${LDFLAGS}  -L${with_libjansson_libraries}"
+  dnl       fi
 
-	    AC_CHECK_LIB(jansson, json_dump_callback,, JANSSON="no")
-        enable_jansson="yes"
-        if test "$JANSSON" = "no"; then
-            echo
-            echo "   Jansson >= 2.2 is required for features like unix socket"
-            echo "   Go get it from your distribution or from:"
-            echo "     http://www.digip.org/jansson/"
-            echo
-            if test "x$enable_unixsocket" = "xyes"; then
-                exit 1
-            fi
-            enable_unixsocket="no"
-            enable_jansson="no"
-        else
-            case $host in
-                *-*-mingw32*)
-                    ;;
-                *-*-cygwin)
-                    ;;
-                *)
-                    if test "x$enable_unixsocket" = "xtest"; then
-                        enable_unixsocket="yes"
-                    fi
-                    ;;
-            esac
-        fi
-    else
-        if test "x$enable_unixsocket" = "xyes"; then
-            echo
-            echo "   Jansson >= 2.2 is required for features like unix socket"
-            echo "   Go get it from your distribution or from:"
-            echo "     http://www.digip.org/jansson/"
-            echo
-            exit 1
-        fi
-        enable_unixsocket="no"
-    fi
+  dnl 	    AC_CHECK_LIB(jansson, json_dump_callback,, JANSSON="no")
+  dnl       enable_jansson="yes"
+  dnl       if test "$JANSSON" = "no"; then
+  dnl           echo
+  dnl           echo "   Jansson >= 2.2 is required for features like unix socket"
+  dnl           echo "   Go get it from your distribution or from:"
+  dnl           echo "     http://www.digip.org/jansson/"
+  dnl           echo
+  dnl           if test "x$enable_unixsocket" = "xyes"; then
+  dnl               exit 1
+  dnl           fi
+  dnl           enable_unixsocket="no"
+  dnl           enable_jansson="no"
+  dnl       else
+  dnl           case $host in
+  dnl               *-*-mingw32*)
+  dnl                   ;;
+  dnl               *-*-cygwin)
+  dnl                   ;;
+  dnl               *)
+  dnl                   if test "x$enable_unixsocket" = "xtest"; then
+  dnl                       enable_unixsocket="yes"
+  dnl                   fi
+  dnl                   ;;
+  dnl           esac
+  dnl       fi
+  dnl   else
+  dnl       if test "x$enable_unixsocket" = "xyes"; then
+  dnl           echo
+  dnl           echo "   Jansson >= 2.2 is required for features like unix socket"
+  dnl           echo "   Go get it from your distribution or from:"
+  dnl           echo "     http://www.digip.org/jansson/"
+  dnl           echo
+  dnl           exit 1
+  dnl       fi
+  dnl       enable_unixsocket="no"
+  dnl   fi
 
     AS_IF([test "x$enable_unixsocket" = "xyes"], [AC_DEFINE([BUILD_UNIX_SOCKET], [1], [Unix socket support enabled])])
     e_enable_evelog=$enable_jansson

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -378,6 +378,7 @@ util-ioctl.h util-ioctl.c \
 util-ip.h util-ip.c \
 util-logopenfile.h util-logopenfile.c \
 util-logopenfile-tile.h util-logopenfile-tile.c \
+util-json.h util-json.c \
 util-lua.c util-lua.h \
 util-luajit.c util-luajit.h \
 util-lua-common.c util-lua-common.h \

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -24,13 +24,13 @@
 #ifndef __OUTPUT_JSON_HTTP_H__
 #define __OUTPUT_JSON_HTTP_H__
 
+#include "util-json.h"
+
 void JsonHttpLogRegister(void);
 
-#ifdef HAVE_LIBJANSSON
-void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx);
-void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx);
-json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id);
-#endif /* HAVE_LIBJANSSON */
+void JsonHttpLogJSONBasic(SCJson *js, htp_tx_t *tx);
+void JsonHttpLogJSONExtended(SCJson *js, htp_tx_t *tx);
+bool JsonHttpAddMetadata(SCJson *js, const Flow *f, uint64_t tx_id);
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -27,10 +27,10 @@
 #include "suricata-common.h"
 #include "util-buffer.h"
 #include "util-logopenfile.h"
+#include "util-json.h"
 
 void OutputJsonRegister(void);
 
-#ifdef HAVE_LIBJANSSON
 /* helper struct for OutputJSONMemBufferCallback */
 typedef struct OutputJSONMemBufferWrapper_ {
     MemBuffer **buffer; /**< buffer to use & expand as needed */
@@ -39,11 +39,11 @@ typedef struct OutputJSONMemBufferWrapper_ {
 
 int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 
-void CreateJSONFlowId(json_t *js, const Flow *f);
-void JsonTcpFlags(uint8_t flags, json_t *js);
-json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type);
-json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
-int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
+void CreateJSONFlowId(SCJson *js, const Flow *f);
+void JsonTcpFlags(uint8_t flags, SCJson *js);
+SCJson *CreateJSONHeader(SCJson *js, const Packet *p, int direction_sensative, const char *event_type);
+SCJson *CreateJSONHeaderWithTxId(SCJson *js, const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
+int OutputJSONBuffer(SCJson *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 OutputCtx *OutputJsonInitCtx(ConfNode *);
 
 enum JsonFormat { COMPACT, INDENT };
@@ -61,7 +61,5 @@ typedef struct AlertJsonThread_ {
     /** LogFileCtx has the pointer to the file and a mutex to allow multithreading */
     LogFileCtx *file_ctx;
 } AlertJsonThread;
-
-#endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_H__ */

--- a/src/runmode-unittests.c
+++ b/src/runmode-unittests.c
@@ -96,6 +96,7 @@
 #include "util-misc.h"
 #include "util-ringbuffer.h"
 #include "util-signal.h"
+#include "util-json.h"
 
 #include "reputation.h"
 #include "util-atomic.h"
@@ -222,6 +223,7 @@ static void RegisterUnittests(void)
     AppLayerUnittestsRegister();
     MimeDecRegisterTests();
     StreamingBufferRegisterTests();
+    UtilJsonRegisterTests();
 }
 #endif
 

--- a/src/runmodes.c
+++ b/src/runmodes.c
@@ -719,12 +719,14 @@ void RunModeInitializeOutputs(void)
             continue;
 #endif
         } else if (strcmp(output->val, "eve-log") == 0) {
+#if 0
 #ifndef HAVE_LIBJANSSON
             SCLogWarning(SC_ERR_NOT_SUPPORTED,
                     "Eve-log support not compiled in. Reconfigure/"
                     "recompile with libjansson and its development "
                     "files installed to add eve-log support.");
             continue;
+#endif
 #endif
         } else if (strcmp(output->val, "lua") == 0) {
 #ifndef HAVE_LUA

--- a/src/util-json.c
+++ b/src/util-json.c
@@ -1,0 +1,718 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <stdbool.h>
+
+#include "suricata-common.h"
+#include "util-json.h"
+#include "util-unittest.h"
+
+#define INITIAL_SIZE 12000
+
+#define STATES 256
+
+enum SCJsonState {
+    NEW = 0,
+    OBJECT_FIRST,
+    OBJECT_NTH,
+    LIST_FIRST,
+    LIST_NTH,
+    CLOSED,
+};
+
+struct Mark {
+    size_t offset;
+    int    state[STATES];
+    int    state_id;
+};
+
+typedef struct SCJson_ {
+    char        *buf;
+    size_t       size;
+    int          state[STATES];
+    int          state_id;
+    bool         growable;
+    struct Mark  mark;
+} SCJson;
+
+static uint8_t state(SCJson *js)
+{
+    return js->state[js->state_id];
+}
+
+static void state_set(SCJson *js, int state)
+{
+    js->state[js->state_id] = state;
+}
+
+static bool state_push(SCJson *js, int state)
+{
+    BUG_ON(js->state_id + 1 == STATES);
+    if (js->state_id + 1 == STATES) {
+        return false;
+    }
+    js->state[++js->state_id] = state;
+    return true;
+}
+
+static void state_pop(SCJson *js)
+{
+    BUG_ON(js->state_id - 1 < 0);
+    js->state_id--;
+}
+
+/**
+ * \brief Encode a string into the JSON buffer. An assumption is made
+ * that the buffer has already been checked to make sure the encoded
+ * string fits.
+ */
+static size_t encode_string(SCJson *js, size_t offset, const char *val)
+{
+    size_t ioffset = offset;
+    BUG_ON(js->size - offset < (strlen(val) * 2));
+    js->buf[offset++] = '"';
+    bool done = false;
+    for (size_t i = 0; !done; i++) {
+        switch (val[i]) {
+            case '"': /* Double quote. */
+            case '\\': /* Backslash. */
+            case '/': /* Slash. */
+                js->buf[offset++] = '\\';
+                break;
+            case '\n': /* New line. */
+                js->buf[offset++] = '\\';
+                js->buf[offset++] = 'n';
+                continue;
+            case '\r': /* Carriage return. */
+                js->buf[offset++] = '\\';
+                js->buf[offset++] = 'r';
+                continue;
+            case '\t': /* Tab. */
+                js->buf[offset++] = '\\';
+                js->buf[offset++] = 't';
+                continue;
+            case 0x0c: /* Form feed. */
+                js->buf[offset++] = '\\';
+                js->buf[offset++] = 'f';
+                continue;
+            case 0x08: /* Back space. */
+                js->buf[offset++] = '\\';
+                js->buf[offset++] = 'b';
+                continue;
+            case '\0':
+                js->buf[offset++] = '"';
+                done = true;
+                break;
+            default:
+                break;
+        }
+        js->buf[offset++] = val[i];
+    }
+    return offset - ioffset;
+}
+
+/**
+ * \brief Check the size of the buffer and grow as needed.
+ *
+ * \param js point to the json object
+ * \param n number of remaining bytes in buffer required
+ */
+static bool SCJsonCheckSize(SCJson *js, size_t n)
+{
+    size_t required = strlen(js->buf) + n + 1;
+
+    if (required > js->size) {
+        if (!js->growable) {
+            return false;
+        }
+        size_t len = required * 2;
+        char *buf = SCRealloc(js->buf, len);
+        if (buf != NULL) {
+            js->buf = buf;
+            js->size = len;
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * \brief Create a new JSON builder.
+ */
+SCJson *SCJsonNew(void)
+{
+    SCJson *js = SCCalloc(1, sizeof(*js));
+    if (js != NULL) {
+        js->buf = SCCalloc(1, INITIAL_SIZE);
+        if (js->buf == NULL) {
+            SCFree(js);
+            return NULL;
+        }
+        js->size = INITIAL_SIZE;
+        js->growable = true;
+    }
+
+    return js;
+}
+
+/**
+ * \brief Create a new JSON builder using an existing buffer.
+ *
+ * The buffer will not be grown as needed so it should be of
+ * sufficient size, and the return value of all operations should be
+ * checked as they will return false if the buffer isn't large enough
+ * to build the JSON.
+ */
+SCJson *SCJsonWrap(char *buf, size_t size)
+{
+    SCJson *js = SCCalloc(1, sizeof(*js));
+    if (js != NULL) {
+        js->buf = buf;
+        js->size = size;
+        js->growable = false;
+    }
+
+    return js;
+}
+
+/**
+ * \brief Free the JSON builder.
+ */
+void SCJsonFree(SCJson *js)
+{
+    if (js != NULL) {
+        if (js->growable) {
+            SCFree(js->buf);
+        }
+        SCFree(js);
+    }
+}
+
+/**
+ * \brief Reset a JSON builder for re-use.
+ */
+void SCJsonReset(SCJson *js)
+{
+    js->state_id = 0;
+    js->state[0] = NEW;
+    js->buf[0] = '\0';
+}
+
+
+/**
+ * \brief Get the pointer to the JSON buffer.
+ */
+const char *SCJsonGetBuf(SCJson *js)
+{ 
+    return js->buf;
+}
+
+/**
+ * \brief Opens a JSON object, or more simply write a "{" to the
+ *     buffer.
+ */
+bool SCJsonOpenObject(SCJson *js)
+{
+    if (!SCJsonCheckSize(js, 1)) {
+        return false;
+    }
+    strncat(js->buf, "{", 1);
+    state_set(js, CLOSED);
+    state_push(js, OBJECT_FIRST);
+    return true;
+}
+
+/**
+ * \brief Close a JSON object, or more simply write a "}" to the
+ *     buffer.
+ */
+bool SCJsonCloseObject(SCJson *js)
+{
+    if (!SCJsonCheckSize(js, 1)) {
+        return false;
+    }
+    switch (state(js)) {
+        case OBJECT_FIRST:
+        case OBJECT_NTH:
+            break;
+        default:
+            return false;
+    }
+    strncat(js->buf, "}", 1);
+    state_pop(js);
+    return true;
+}
+
+/**
+ * \brief Start a new object with the given key.
+ */
+bool SCJsonStartObject(SCJson *js, const char *key)
+{
+    size_t len = strlen(key) + 5;
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len)) {
+        return false;
+    }
+
+    if (js->state[js->state_id] == OBJECT_NTH) {
+        strncat(js->buf, ",", 1);
+    } else if (js->state[js->state_id] != OBJECT_FIRST) {
+        return false;
+    }
+
+    snprintf(scratch, len, "\"%s\":{", key);
+    strncat(js->buf, scratch, len);
+    state_set(js, OBJECT_NTH);
+    state_push(js, OBJECT_FIRST);
+
+    return true;
+}
+
+/**
+ * \brief Start a list with the given key.
+ */
+bool SCJsonStartList(SCJson *js, const char *key)
+{
+    size_t len = strlen(key) + 5;
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len)) {
+        return false;
+    }
+
+    if (state(js) == OBJECT_NTH) {
+        strncat(js->buf, ",", 1);
+    } else if (state(js) != OBJECT_FIRST) {
+        return false;
+    }
+
+    snprintf(scratch, len, "\"%s\":[", key);
+    strncat(js->buf, scratch, len);
+    state_push(js, LIST_FIRST);
+
+    return true;
+}
+
+/**
+ * \brief Close out a list by printing a "]".
+ */
+bool SCJsonCloseList(SCJson *js)
+{
+    if (!SCJsonCheckSize(js, 1)) {
+        return false;
+    }
+
+    switch (state(js)) {
+        case LIST_FIRST:
+        case LIST_NTH:
+            break;
+        default:
+            return false;
+    }
+    strncat(js->buf, "]", 1);
+    state_pop(js);
+    return true;
+}
+
+/**
+ * \brief Set a key/value pair with a string value.
+ */
+bool SCJsonSetString(SCJson *js, const char *key, const char *val)
+{
+    if (val == NULL) {
+        val = "";
+    }
+
+    /* The size is:
+     * - quote
+     * - strlen(key)
+     * - quote
+     * - colon
+     * - quote
+     * - strlen(val) * 2
+     * - quote
+     */
+    size_t len = 5 + strlen(key);
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len + (strlen(val) * 2))) {
+        return false;
+    }
+
+    if (state(js) == OBJECT_NTH) {
+        strncat(js->buf, ",", 1);
+    }
+
+    snprintf(scratch, len, "\"%s\":", key);
+    strncat(js->buf, scratch, len);
+    encode_string(js, strlen(js->buf), val);
+
+    state_set(js, OBJECT_NTH);
+
+    return true;
+}
+
+/**
+ * \brief Set a key/value pair with an integer value.
+ */
+bool SCJsonSetInt(SCJson *js, const char *key, const intmax_t val)
+{
+    size_t len = strlen(key) + 32 + 4;
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len)) {
+        return false;
+    }
+
+    if (state(js) == OBJECT_NTH) {
+        strncat(js->buf, ",", 1);
+    }
+
+    snprintf(scratch, len, "\"%s\":%"PRIiMAX, key, val);
+    strncat(js->buf, scratch, len);
+
+    state_set(js, OBJECT_NTH);
+
+    return true;
+}
+
+/**
+ * \brief Set a key/value pair with a boolean value.
+ */
+bool SCJsonSetBool(SCJson *js, const char *key, const bool val)
+{
+    /* 2->", 1->:, 1->false, 1->\0 = 9 */
+    size_t len = strlen(key) + 9;
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len)) {
+        return false;
+    }
+
+    if (state(js) == OBJECT_NTH) {
+        strncat(js->buf, ",", 1);
+    }
+
+    if (val) {
+        snprintf(scratch, len, "\"%s\":true", key);
+    } else {
+        snprintf(scratch, len, "\"%s\":false", key);
+    }
+
+    strncat(js->buf, scratch, len);
+
+    state_set(js, OBJECT_NTH);
+
+    return true;
+}
+
+/**
+ * \brief Append a string value to a list.
+ */
+bool SCJsonAppendString(SCJson *js, const char *val)
+{
+    if (!SCJsonCheckSize(js, strlen(val) * 2)) {
+        return false;
+    }
+
+    switch (state(js)) {
+        case LIST_NTH:
+            strncat(js->buf, ",", 1);
+        case LIST_FIRST:
+            break;
+        default:
+            return false;
+    }
+
+    encode_string(js, strlen(js->buf), val);
+    state_set(js, LIST_NTH);
+
+    return true;
+}
+
+/**
+ * \brief Append an integer value to a list.
+ */
+bool SCJsonAppendInt(SCJson *js, const intmax_t val)
+{
+    int len = 32 + 4;
+    char scratch[len];
+
+    if (!SCJsonCheckSize(js, len)) {
+        return false;
+    }
+
+    switch (state(js)) {
+        case LIST_NTH:
+            strncat(js->buf, ",", 1);
+        case LIST_FIRST:
+            break;
+        default:
+            return false;
+    }
+
+    snprintf(scratch, len, "%"PRIiMAX, val);
+    strncat(js->buf, scratch, len);
+
+    state_set(js, LIST_NTH);
+
+    return true;
+}
+
+/**
+ * \brief Mark the current state of the SCJson object so it can be
+ *     rewound to this state after some writes.
+ *
+ * Only one mark is allowed, meaning the buffer to can only be rewound
+ * to the last call to SCJsonMark.
+ *
+ * Useful when sequential lines of JSON start with the same header,
+ * the object can be marked and the end of the common data, written
+ * to, then rewound for the next line.
+ */
+void SCJsonMark(SCJson *js)
+{
+    memcpy(&js->mark.state, &js->state, sizeof(js->state));
+    js->mark.state_id = js->state_id;
+    js->mark.offset = strlen(js->buf);
+}
+
+/**
+ * \brief Rewind to the state of the last call to SCJsonMark.
+ */
+void SCJsonRewind(SCJson *js)
+{
+    memcpy(&js->state, &js->mark.state, sizeof(js->state));
+    js->state_id = js->mark.state_id;
+    js->buf[js->mark.offset] = '\0';
+}
+
+#ifdef UNITTESTS
+
+static int UtilJsonTest01(void)
+{
+    SCJson *js = SCJsonNew();
+    FAIL_IF_NULL(js);
+
+    SCJsonOpenObject(js);
+    FAIL_IF(strcmp(js->buf, "{"));
+
+    SCJsonSetString(js, "one", "one");
+    FAIL_IF(strcmp(js->buf, "{\"one\":\"one\""));
+
+    SCJsonSetString(js, "two", "val with \"quote\"");
+    char *expected = "{\"one\":\"one\","
+        "\"two\":\"val with \\\"quote\\\"\"";
+    FAIL_IF(strcmp(js->buf, expected));
+
+    /* Add a list. */
+    SCJsonStartList(js, "a-list");
+    FAIL_IF(state(js) != LIST_FIRST);
+    SCJsonAppendString(js, "with \"a\" quote");
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\"";
+    FAIL_IF(strcmp(js->buf, expected));
+    FAIL_IF(state(js) != LIST_NTH);
+
+    SCJsonAppendInt(js, 2);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2";
+    FAIL_IF(state(js) != LIST_NTH);
+    FAIL_IF(strcmp(js->buf, expected));
+
+    SCJsonCloseList(js);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2]";
+    FAIL_IF(state(js) != OBJECT_NTH);
+    FAIL_IF(strcmp(js->buf, expected));
+
+    SCJsonStartObject(js, "nested");
+    FAIL_IF(state(js) != OBJECT_FIRST);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2"
+        "]"
+        ",\"nested\":{";
+    FAIL_IF(strcmp(js->buf, expected));
+
+    SCJsonSetInt(js, "three", 3);
+    FAIL_IF(state(js) != OBJECT_NTH);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2"
+        "]"
+        ",\"nested\":{"
+        "\"three\":3";
+    FAIL_IF(strcmp(js->buf, expected));
+
+    SCJsonCloseObject(js);
+    FAIL_IF(state(js) != OBJECT_NTH);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2"
+        "]"
+        ",\"nested\":{"
+        "\"three\":3"
+        "}";
+    FAIL_IF(strcmp(js->buf, expected));
+
+    FAIL_IF_NOT(SCJsonCloseObject(js));
+    FAIL_IF(state(js) != CLOSED);
+    expected = "{"
+        "\"one\":\"one\""
+        ",\"two\":\"val with \\\"quote\\\"\""
+        ",\"a-list\":[\"with \\\"a\\\" quote\""
+        ",2"
+        "]"
+        ",\"nested\":{"
+        "\"three\":3"
+        "}"
+        "}";
+    FAIL_IF(strcmp(js->buf, expected));
+
+    /* Close on a fully closed object, should fail. */
+    FAIL_IF(SCJsonCloseObject(js));
+
+    SCJsonFree(js);
+    PASS;
+}
+
+static int UtilJsonTestGrow(void)
+{
+    SCJson *js = SCJsonNew();
+    FAIL_IF_NULL(js);
+
+    char buf[(INITIAL_SIZE * 2) + 1];
+    for (uint i = 0; i < INITIAL_SIZE * 2; i++) {
+        strlcat(buf, "A", sizeof(buf));
+    }
+    FAIL_IF(strlen(buf) != INITIAL_SIZE * 2);
+
+    SCJsonOpenObject(js);
+    FAIL_IF_NOT(SCJsonSetString(js, "key", buf));
+    SCJsonCloseObject(js);
+
+    SCJsonFree(js);
+
+    PASS;
+}
+
+static int UtilJsonTestWrapped(void)
+{
+    /* Create a buffer big enough for {"a":"aa"
+     *
+     * As this is 9 chars we need 10 for the NULL byte. But we also
+     * require enough space fo the val to double size for escaping
+     * reasons. So we actually need 12. */
+    size_t size = 12;
+    char wrapped[size];
+    wrapped[0] = '\0';
+
+    SCJson *js = SCJsonWrap(wrapped, size);
+    FAIL_IF_NULL(js);
+
+    FAIL_IF_NOT(SCJsonOpenObject(js));
+    FAIL_IF(strlen(js->buf) != 1);
+
+    /* This will add: "a":"aaa" (9 chars).  With a size of 12, and one
+     * char already written we only have room for 8 chars to keep the
+     * NUL byte.
+     *
+     * If this was allowed we'd overwrite the NUL byte.
+     */
+    FAIL_IF(SCJsonSetString(js, "a", "aaa"));
+
+    /* But adding only 7 chars should work. */
+    FAIL_IF_NOT(SCJsonSetString(js, "a", "aa"));
+    FAIL_IF(strlen(js->buf) != 9);
+    FAIL_IF(strcmp(js->buf, "{\"a\":\"aa\""));
+
+    SCJsonFree(js);
+
+    PASS;
+}
+
+static int UtilJsonTestMark(void)
+{
+    SCJson *js = SCJsonNew();
+
+    SCJsonOpenObject(js);
+    SCJsonSetString(js, "one", "one");
+    SCJsonMark(js);
+    SCJsonStartList(js, "list");
+    SCJsonAppendInt(js, 1);
+    char *expected = "{\"one\":\"one\",\"list\":[1";
+    FAIL_IF(strcmp(js->buf, expected) != 0);
+
+    SCJsonRewind(js);
+    expected = "{\"one\":\"one\"";
+    FAIL_IF(strlen(expected) != strlen(js->buf) ||
+        strcmp(js->buf, expected) != 0);
+
+    SCJsonSetString(js, "two", "two");
+    expected = "{\"one\":\"one\",\"two\":\"two\"";
+    FAIL_IF(strlen(expected) != strlen(js->buf) ||
+        strcmp(js->buf, expected) != 0);
+
+    SCJsonFree(js);
+    PASS;
+}
+
+static int UtilJsonTestReset(void)
+{
+    SCJson *js = SCJsonNew();
+    FAIL_IF_NULL(js);
+
+    SCJsonOpenObject(js);
+    SCJsonSetString(js, "key", "val");
+    FAIL_IF(strcmp(js->buf, "{\"key\":\"val\"") != 0);
+
+    SCJsonReset(js);
+    FAIL_IF(strlen(js->buf) != 0);
+
+    SCJsonFree(js);
+    PASS;
+}
+
+#endif /* UNITTESTS */
+
+void UtilJsonRegisterTests(void)
+{
+#ifdef UNITTESTS
+    UtRegisterTest("UtilJsonTest01", UtilJsonTest01);
+    UtRegisterTest("UtilJsonTestGrow", UtilJsonTestGrow);
+    UtRegisterTest("UtilJsonTestWrapped", UtilJsonTestWrapped);
+    UtRegisterTest("UtilJsonTestMark", UtilJsonTestMark);
+    UtRegisterTest("UtilJsonTestReset", UtilJsonTestReset);
+#endif
+}

--- a/src/util-json.h
+++ b/src/util-json.h
@@ -1,0 +1,43 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include <stdbool.h>
+
+#pragma once
+
+typedef struct SCJson_ SCJson;
+
+SCJson *SCJsonNew(void);
+SCJson *SCJsonWrap(char *buf, size_t size);
+void SCJsonReset(SCJson *js);
+void SCJsonFree(SCJson *js);
+const char *SCJsonGetBuf(SCJson *js);
+bool SCJsonOpenObject(SCJson *js);
+bool SCJsonCloseObject(SCJson *js);
+bool SCJsonSetString(SCJson *js, const char *key, const char *val);
+bool SCJsonSetInt(SCJson *js, const char *key, const intmax_t val);
+bool SCJsonSetBool(SCJson *js, const char *key, const bool val);
+bool SCJsonStartObject(SCJson *js, const char *key);
+bool SCJsonStartList(SCJson *js, const char *key);
+bool SCJsonAppendString(SCJson *js, const char *val);
+bool SCJsonAppendInt(SCJson *js, const intmax_t val);
+bool SCJsonCloseList(SCJson *js);
+
+void SCJsonMark(SCJson *js);
+void SCJsonRewind(SCJson *js);
+
+void UtilJsonRegisterTests(void);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -136,7 +136,7 @@ outputs:
 
   # Extensible Event Format (nicknamed EVE) event log in JSON format
   - eve-log:
-      enabled: @e_enable_evelog@
+      enabled: yes
       filetype: regular #regular|syslog|unix_dgram|unix_stream|redis
       filename: eve.json
       #prefix: "@cee: " # prefix to prepend to each log entry


### PR DESCRIPTION
This is an implementation of a JSON string builder to build JSON strings with the idea of being more efficient than Jansson as our requirements are not too complex.

For a given pcap, with catch-all rules and logging payload, printable payload and packet, the run time is typically 1.5x faster with this than using libjansson.

Only alert, dns, http and netflow have been been migrated. Jansson has been completely disabled for the purpose of development to make sure not existing dependency has crept in, which is also the reason for some #if 0's still lingering.

Prscript:
Build successful for jasonish-pcap
Build failure for jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/440

Note: Prscript fails due to use of strncat.  I used strncat as it performed measurably better than strlcat, but I'll revisit that.