### PR TITLE
output-json-alert: log 'tunnel' JSON object when alerting on traffic in tunnel

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -278,7 +278,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* tls alert */
                 if (proto == ALPROTO_TLS)
                     AlertJsonTls(p->flow, js);
             }
@@ -288,7 +288,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* ssh alert */
                 if (proto == ALPROTO_SSH)
                     AlertJsonSsh(p->flow, js);
             }
@@ -298,7 +298,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
 
-                /* http alert */
+                /* smtp alert */
                 if (proto == ALPROTO_SMTP) {
                     hjs = JsonSMTPAddMetadata(p->flow, pa->tx_id);
                     if (hjs)
@@ -314,6 +314,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         if (json_output_ctx->flags & LOG_JSON_DNP3) {
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
+
+                /* dnp3 alert */
                 if (proto == ALPROTO_DNP3) {
                     AlertJsonDnp3(p->flow, js);
                 }

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -280,6 +280,101 @@ void JsonTcpFlags(uint8_t flags, json_t *js)
         json_object_set_new(js, "cwr", json_true());
 }
 
+/**
+ * \brief Add five tuple from packet to JSON object
+ *
+ * \param p Packet
+ * \param direction_sensitive Indicate direction sensitivity
+ * \param js JSON object
+ */
+void JsonFiveTuple(const Packet *p, int direction_sensitive, json_t *js)
+{
+    char srcip[46], dstip[46];
+    Port sp, dp;
+    char proto[16];
+
+    srcip[0] = '\0';
+    dstip[0] = '\0';
+
+    if (direction_sensitive) {
+        if ((PKT_IS_TOSERVER(p))) {
+            if (PKT_IS_IPV4(p)) {
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                          srcip, sizeof(srcip));
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                          dstip, sizeof(dstip));
+            } else if (PKT_IS_IPV6(p)) {
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                          srcip, sizeof(srcip));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                          dstip, sizeof(dstip));
+            }
+            sp = p->sp;
+            dp = p->dp;
+        } else {
+            if (PKT_IS_IPV4(p)) {
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                          srcip, sizeof(srcip));
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                          dstip, sizeof(dstip));
+            } else if (PKT_IS_IPV6(p)) {
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                          srcip, sizeof(srcip));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                          dstip, sizeof(dstip));
+            }
+            sp = p->dp;
+            dp = p->sp;
+        }
+    } else {
+        if (PKT_IS_IPV4(p)) {
+            PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                      srcip, sizeof(srcip));
+            PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                      dstip, sizeof(dstip));
+        } else if (PKT_IS_IPV6(p)) {
+            PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                      srcip, sizeof(srcip));
+            PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                      dstip, sizeof(dstip));
+        }
+        sp = p->sp;
+        dp = p->dp;
+    }
+
+    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
+        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
+    } else {
+        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
+    }
+
+    json_object_set_new(js, "src_ip", json_string(srcip));
+
+    switch(p->proto) {
+        case IPPROTO_ICMP:
+            break;
+        case IPPROTO_UDP:
+        case IPPROTO_TCP:
+        case IPPROTO_SCTP:
+            json_object_set_new(js, "src_port", json_integer(sp));
+            break;
+    }
+
+    json_object_set_new(js, "dest_ip", json_string(dstip));
+
+    switch(p->proto) {
+        case IPPROTO_ICMP:
+            break;
+        case IPPROTO_UDP:
+        case IPPROTO_TCP:
+        case IPPROTO_SCTP:
+            json_object_set_new(js, "dest_port", json_integer(dp));
+            break;
+    }
+
+    json_object_set_new(js, "proto", json_string(proto));
+}
+
 void CreateJSONFlowId(json_t *js, const Flow *f)
 {
     if (f == NULL)
@@ -295,57 +390,12 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
                          const char *event_type)
 {
     char timebuf[64];
-    char srcip[46], dstip[46];
-    Port sp, dp;
 
     json_t *js = json_object();
     if (unlikely(js == NULL))
         return NULL;
 
     CreateIsoTimeString(&p->ts, timebuf, sizeof(timebuf));
-
-    srcip[0] = '\0';
-    dstip[0] = '\0';
-    if (direction_sensitive) {
-        if ((PKT_IS_TOSERVER(p))) {
-            if (PKT_IS_IPV4(p)) {
-                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
-                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
-            } else if (PKT_IS_IPV6(p)) {
-                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
-                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
-            }
-            sp = p->sp;
-            dp = p->dp;
-        } else {
-            if (PKT_IS_IPV4(p)) {
-                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), srcip, sizeof(srcip));
-                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), dstip, sizeof(dstip));
-            } else if (PKT_IS_IPV6(p)) {
-                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), srcip, sizeof(srcip));
-                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), dstip, sizeof(dstip));
-            }
-            sp = p->dp;
-            dp = p->sp;
-        }
-    } else {
-        if (PKT_IS_IPV4(p)) {
-            PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), srcip, sizeof(srcip));
-            PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), dstip, sizeof(dstip));
-        } else if (PKT_IS_IPV6(p)) {
-            PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), srcip, sizeof(srcip));
-            PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), dstip, sizeof(dstip));
-        }
-        sp = p->sp;
-        dp = p->dp;
-    }
-
-    char proto[16];
-    if (SCProtoNameValid(IP_GET_IPPROTO(p)) == TRUE) {
-        strlcpy(proto, known_proto[IP_GET_IPPROTO(p)], sizeof(proto));
-    } else {
-        snprintf(proto, sizeof(proto), "%03" PRIu32, IP_GET_IPPROTO(p));
-    }
 
     /* time & tx */
     json_object_set_new(js, "timestamp", json_string(timebuf));
@@ -394,28 +444,10 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
         }
     }
 
-    /* tuple */
-    json_object_set_new(js, "src_ip", json_string(srcip));
-    switch(p->proto) {
-        case IPPROTO_ICMP:
-            break;
-        case IPPROTO_UDP:
-        case IPPROTO_TCP:
-        case IPPROTO_SCTP:
-            json_object_set_new(js, "src_port", json_integer(sp));
-            break;
-    }
-    json_object_set_new(js, "dest_ip", json_string(dstip));
-    switch(p->proto) {
-        case IPPROTO_ICMP:
-            break;
-        case IPPROTO_UDP:
-        case IPPROTO_TCP:
-        case IPPROTO_SCTP:
-            json_object_set_new(js, "dest_port", json_integer(dp));
-            break;
-    }
-    json_object_set_new(js, "proto", json_string(proto));
+    /* 5-tuple */
+    JsonFiveTuple(p, direction_sensitive, js);
+
+    /* icmp */
     switch (p->proto) {
         case IPPROTO_ICMP:
             if (p->icmpv4h) {

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -42,6 +42,7 @@ int OutputJSONMemBufferCallback(const char *str, size_t size, void *data);
 void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
+void JsonFiveTuple(const Packet *, int, json_t *);
 json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type);
 json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);


### PR DESCRIPTION
Log "src_ip", "dst_ip" and "proto" for root packet (p->root) as JSON object 'tunnel' when alerting on traffic inside a tunnel. Also log recursion level to indicate tunnel depth.

Without this, it is difficult to find the traffic that triggered if the match was done inside a tunnel (e.g. GRE tunnel), since far from all network solutions decode tunnels.

Example alert with 'tunnel' object:
```json
{
  "timestamp": "2008-06-21T14:06:06.578905+0200",
  "event_type": "alert",
  "src_ip": "1.1.1.1",
  "dest_ip": "2.2.2.2",
  "proto": "ICMP",
  "icmp_type": 8,
  "icmp_code": 0,
  "alert": {
    "severity": 3,
    "category": "",
    "signature": "ICMP something something",
    "rev": 0,
    "signature_id": 1230910,
    "gid": 1,
    "action": "allowed"
  },
  "tunnel": {
    "proto": "GRE",
    "dest_ip": "10.0.0.2",
    "src_ip": "10.0.0.1",
    "depth": 1
  }
}

```

https://redmine.openinfosecfoundation.org/issues/2011

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/100
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/100