### PR TITLE
tcp: fix checksum validation when 0xffff - v1

### DIFF
--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -639,7 +639,7 @@ static int Unified2PrintStreamSegmentCallback(const Packet *p, void *data, uint8
         FakeIPv4Hdr *fakehdr = (FakeIPv4Hdr *)aun->iphdr;
 
         fakehdr->tcph.th_sum = TCPCalculateChecksum(fakehdr->ip4h.s_ip_addrs,
-                (uint16_t *)&fakehdr->tcph, buflen + sizeof(TCPHdr));
+                (uint16_t *)&fakehdr->tcph, buflen + sizeof(TCPHdr), 0);
         fakehdr->ip4h.ip_csum = IPV4CalculateChecksum((uint16_t *)&fakehdr->ip4h,
                 IPV4_GET_RAW_HLEN(&fakehdr->ip4h));
     }

--- a/src/decode-tcp.c
+++ b/src/decode-tcp.c
@@ -236,8 +236,9 @@ static int TCPCalculateValidChecksumtest01(void)
 
     csum = *( ((uint16_t *)raw_tcp) + 8);
 
-    return (csum == TCPCalculateChecksum((uint16_t *) raw_ipshdr,
-                                         (uint16_t *)raw_tcp, sizeof(raw_tcp)));
+    FAIL_IF(TCPCalculateChecksum((uint16_t *)raw_ipshdr,
+            (uint16_t *)raw_tcp, sizeof(raw_tcp), csum) != 0);
+    PASS;
 }
 
 static int TCPCalculateInvalidChecksumtest02(void)
@@ -256,8 +257,9 @@ static int TCPCalculateInvalidChecksumtest02(void)
 
     csum = *( ((uint16_t *)raw_tcp) + 8);
 
-    return (csum != TCPCalculateChecksum((uint16_t *) raw_ipshdr,
-                                         (uint16_t *)raw_tcp, sizeof(raw_tcp)));
+    FAIL_IF(TCPCalculateChecksum((uint16_t *) raw_ipshdr,
+            (uint16_t *)raw_tcp, sizeof(raw_tcp), csum) == 0);
+    PASS;
 }
 
 static int TCPV6CalculateValidChecksumtest03(void)

--- a/src/decode-tcp.h
+++ b/src/decode-tcp.h
@@ -164,7 +164,8 @@ typedef struct TCPVars_
 void DecodeTCPRegisterTests(void);
 
 /** -------- Inline functions ------- */
-static inline uint16_t TCPCalculateChecksum(uint16_t *, uint16_t *, uint16_t);
+static inline uint16_t TCPCalculateChecksum(uint16_t *, uint16_t *, uint16_t,
+    uint16_t);
 static inline uint16_t TCPV6CalculateChecksum(uint16_t *, uint16_t *, uint16_t);
 
 /**
@@ -174,16 +175,17 @@ static inline uint16_t TCPV6CalculateChecksum(uint16_t *, uint16_t *, uint16_t);
  *             part of the pseudoheader for computing the checksum
  * \param pkt  Pointer to the start of the TCP packet
  * \param tlen Total length of the TCP packet(header + payload)
+ * \param init The current checksum if validating, 0 if generating.
  *
  * \retval csum Checksum for the TCP packet
  */
 static inline uint16_t TCPCalculateChecksum(uint16_t *shdr, uint16_t *pkt,
-                                            uint16_t tlen)
+                                            uint16_t tlen, uint16_t init)
 {
     uint16_t pad = 0;
-    uint32_t csum = shdr[0];
+    uint32_t csum = init;
 
-    csum += shdr[1] + shdr[2] + shdr[3] + htons(6) + htons(tlen);
+    csum += shdr[0] + shdr[1] + shdr[2] + shdr[3] + htons(6) + htons(tlen);
 
     csum += pkt[0] + pkt[1] + pkt[2] + pkt[3] + pkt[4] + pkt[5] + pkt[6] +
         pkt[7] + pkt[9];
@@ -193,7 +195,9 @@ static inline uint16_t TCPCalculateChecksum(uint16_t *shdr, uint16_t *pkt,
 
     while (tlen >= 32) {
         csum += pkt[0] + pkt[1] + pkt[2] + pkt[3] + pkt[4] + pkt[5] + pkt[6] +
-            pkt[7] + pkt[8] + pkt[9] + pkt[10] + pkt[11] + pkt[12] + pkt[13] +
+            pkt[7] +
+            pkt[8] +
+            pkt[9] + pkt[10] + pkt[11] + pkt[12] + pkt[13] +
             pkt[14] + pkt[15];
         tlen -= 32;
         pkt += 16;

--- a/src/detect-csum.c
+++ b/src/detect-csum.c
@@ -338,11 +338,13 @@ static int DetectTCPV4CsumMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
     if (p->level4_comp_csum == -1)
         p->level4_comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
                                                    (uint16_t *)p->tcph,
-                                                   (p->payload_len + TCP_GET_HLEN(p)));
+                                                   (p->payload_len +
+                                                       TCP_GET_HLEN(p)),
+                                                   p->tcph->th_sum);
 
-    if (p->level4_comp_csum == p->tcph->th_sum && cd->valid == 1)
+    if (p->level4_comp_csum == 0 && cd->valid == 1)
         return 1;
-    else if (p->level4_comp_csum != p->tcph->th_sum && cd->valid == 0)
+    else if (p->level4_comp_csum != 0 && cd->valid == 0)
         return 1;
     else
         return 0;

--- a/src/detect.c
+++ b/src/detect.c
@@ -5811,7 +5811,6 @@ int SigTest26TCPV4Keyword(void)
 
     ThreadVars th_v;
     DetectEngineThreadCtx *det_ctx = NULL;
-    int result = 0;
 
     memset(&th_v, 0, sizeof(ThreadVars));
     memset(p1, 0, SIZE_OF_PACKET);
@@ -5842,9 +5841,7 @@ int SigTest26TCPV4Keyword(void)
     p2->proto = IPPROTO_TCP;
 
     DetectEngineCtx *de_ctx = DetectEngineCtxInit();
-    if (de_ctx == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx);
 
     de_ctx->flags |= DE_QUIET;
 
@@ -5852,43 +5849,31 @@ int SigTest26TCPV4Keyword(void)
                                "alert ip any any -> any any "
                                "(content:\"|DE 01 03|\"; tcpv4-csum:valid; dsize:20; "
                                "msg:\"tcpv4-csum keyword check(1)\"; sid:1;)");
-    if (de_ctx->sig_list == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx->sig_list);
 
     de_ctx->sig_list->next = SigInit(de_ctx,
                                      "alert ip any any -> any any "
                                      "(content:\"|DE 01 03|\"; tcpv4-csum:invalid; "
                                      "msg:\"tcpv4-csum keyword check(1)\"; "
                                      "sid:2;)");
-    if (de_ctx->sig_list->next == NULL) {
-        goto end;
-    }
+    FAIL_IF_NULL(de_ctx->sig_list->next);
 
     SigGroupBuild(de_ctx);
     DetectEngineThreadCtxInit(&th_v, (void *)de_ctx,(void *)&det_ctx);
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p1);
-    if (!(PacketAlertCheck(p1, 1))) {
-        printf("sig 1 didn't match: ");
-        goto end;
-    }
+    FAIL_IF(!(PacketAlertCheck(p1, 1)));
 
     SigMatchSignatures(&th_v, de_ctx, det_ctx, p2);
-    if (!(PacketAlertCheck(p2, 2))) {
-        printf("sig 2 didn't match: ");
-        goto end;
-    }
+    FAIL_IF(!(PacketAlertCheck(p2, 2)));
 
-    result = 1;
-end:
     SigGroupCleanup(de_ctx);
     SigCleanSignatures(de_ctx);
     DetectEngineThreadCtxDeinit(&th_v, (void *)det_ctx);
     DetectEngineCtxFree(de_ctx);
     SCFree(p1);
     SCFree(p2);
-    return result;
+    PASS;
 }
 
 /* Test SigTest26TCPV4Keyword but also check for invalid IPV4 checksum */

--- a/src/flow-timeout.c
+++ b/src/flow-timeout.c
@@ -240,14 +240,14 @@ static inline Packet *FlowForceReassemblyPseudoPacketSetup(Packet *p,
 
     if (FLOW_IS_IPV4(f)) {
         p->tcph->th_sum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                                               (uint16_t *)p->tcph, 20);
+                                               (uint16_t *)p->tcph, 20, 0);
         /* calc ipv4 csum as we may log it and barnyard might reject
          * a wrong checksum */
         p->ip4h->ip_csum = IPV4CalculateChecksum((uint16_t *)p->ip4h,
                 IPV4_GET_RAW_HLEN(p->ip4h));
     } else if (FLOW_IS_IPV6(f)) {
         p->tcph->th_sum = TCPCalculateChecksum(p->ip6h->s_ip6_addrs,
-                                               (uint16_t *)p->tcph, 20);
+                                              (uint16_t *)p->tcph, 20, 0);
     }
 
     memset(&p->ts, 0, sizeof(struct timeval));

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4710,7 +4710,8 @@ static inline int StreamTcpValidateChecksum(Packet *p)
             p->level4_comp_csum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
                                                        (uint16_t *)p->tcph,
                                                        (p->payload_len +
-                                                        TCP_GET_HLEN(p)));
+                                                       TCP_GET_HLEN(p)),
+                                                       p->tcph->th_sum);
         } else if (PKT_IS_IPV6(p)) {
             p->level4_comp_csum = TCPV6CalculateChecksum(p->ip6h->s_ip6_addrs,
                                                          (uint16_t *)p->tcph,
@@ -4719,9 +4720,8 @@ static inline int StreamTcpValidateChecksum(Packet *p)
         }
     }
 
-    if (p->level4_comp_csum != p->tcph->th_sum) {
+    if (p->level4_comp_csum != 0) {
         ret = 0;
-        SCLogDebug("Checksum of received packet %p is invalid",p);
         if (p->livedev) {
             (void) SC_ATOMIC_ADD(p->livedev->invalid_checksums, 1);
         } else if (p->pcap_cnt) {

--- a/src/util-checksum.c
+++ b/src/util-checksum.c
@@ -34,7 +34,7 @@ int ReCalculateChecksum(Packet *p)
             /* TCP */
             p->tcph->th_sum = 0;
             p->tcph->th_sum = TCPCalculateChecksum(p->ip4h->s_ip_addrs,
-                    (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)));
+                    (uint16_t *)p->tcph, (p->payload_len + TCP_GET_HLEN(p)), 0);
         } else if (PKT_IS_UDP(p)) {
             p->udph->uh_sum = 0;
             p->udph->uh_sum = UDPV4CalculateChecksum(p->ip4h->s_ip_addrs,


### PR DESCRIPTION
Issue:
https://redmine.openinfosecfoundation.org/issues/2041

One approach is to fixing this issue to just validate the
checksum instead of regenerating it and comparing it. This
method is used in some kernels and other network tools.

When validating, the current checksum is passed in as an
initial argument which will cause the final checksum to be 0
if OK. If generating a checksum, 0 is passed and the result
is the generated checksum.

If OK, I'll apply this same idea to the other checksum functions.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/93
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/445
