### PR TITLE
3.2.x: Makefile: fix race condition in make install-full

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,10 @@ CLEANFILES = stamp-h[0-9]*
 install-data-am:
 	@echo "Run 'make install-conf' if you want to install initial configuration files. Or 'make install-full' to install configuration and rules";
 
-install-full: install install-conf install-rules
+install-full:
+	$(MAKE) install
+	$(MAKE) install-conf
+	$(MAKE) install-rules
 
 install-conf:
 	install -d "$(DESTDIR)$(e_sysconfdir)"


### PR DESCRIPTION
Use recursive make for the install process so it
is executed in a predictable order.

Addresses issue:
https://redmine.openinfosecfoundation.org/issues/1470
which triggered on OSX/macOS.

Issue:
https://redmine.openinfosecfoundation.org/issues/2043

Prscript:
- https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/446
- https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/94