### PR TITLE
logging - address coverity issues - v4

### DIFF
--- a/src/alert-debuglog.c
+++ b/src/alert-debuglog.c
@@ -304,11 +304,8 @@ static TmEcode AlertDebugLogger(ThreadVars *tv, const Packet *p, void *thread_da
         }
     }
 
-    SCMutexLock(&aft->file_ctx->fp_mutex);
     aft->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx);
-    aft->file_ctx->alerts += p->alerts.cnt;
-    SCMutexUnlock(&aft->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx, p->alerts.cnt);
 
     return TM_ECODE_OK;
 }
@@ -367,11 +364,8 @@ static TmEcode AlertDebugLogDecoderEvent(ThreadVars *tv, const Packet *p, void *
     PrintRawDataToBuffer(aft->buffer->buffer, &aft->buffer->offset, aft->buffer->size,
                          GET_PKT_DATA(p), GET_PKT_LEN(p));
 
-    SCMutexLock(&aft->file_ctx->fp_mutex);
     aft->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx);
-    aft->file_ctx->alerts += p->alerts.cnt;
-    SCMutexUnlock(&aft->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), aft->file_ctx, p->alerts.cnt);
 
     return TM_ECODE_OK;
 }

--- a/src/alert-fastlog.c
+++ b/src/alert-fastlog.c
@@ -98,12 +98,8 @@ int AlertFastLogCondition(ThreadVars *tv, const Packet *p)
 static inline void AlertFastLogOutputAlert(AlertFastLogThread *aft, char *buffer,
                                            int alert_size)
 {
-    SCMutex *file_lock = &aft->file_ctx->fp_mutex;
     /* Output the alert string and count alerts. Only need to lock here. */
-    SCMutexLock(file_lock);
-    aft->file_ctx->alerts++;
-    aft->file_ctx->Write(buffer, alert_size, aft->file_ctx);
-    SCMutexUnlock(file_lock);
+    aft->file_ctx->Write(buffer, alert_size, aft->file_ctx, 1);
 }
 
 int AlertFastLogger(ThreadVars *tv, void *data, const Packet *p)

--- a/src/alert-unified2-alert.c
+++ b/src/alert-unified2-alert.c
@@ -952,12 +952,12 @@ static int Unified2IPv6TypeAlert(ThreadVars *t, const Packet *p, void *data)
         if (ret != 1) {
             SCLogError(SC_ERR_FWRITE, "Error: fwrite failed: %s", strerror(errno));
             aun->unified2alert_ctx->file_ctx->alerts += i;
-            SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+            SCMutexUnlock(&file_ctx->fp_mutex);
             return -1;
         }
         fflush(aun->unified2alert_ctx->file_ctx->fp);
         aun->unified2alert_ctx->file_ctx->alerts++;
-        SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+        SCMutexUnlock(&file_ctx->fp_mutex);
     }
 
     return 0;
@@ -1133,13 +1133,13 @@ static int Unified2IPv4TypeAlert (ThreadVars *tv, const Packet *p, void *data)
         ret = Unified2PacketTypeAlert(aun, p, event_id, stream);
         if (ret != 1) {
             aun->unified2alert_ctx->file_ctx->alerts += i;
-            SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+            SCMutexUnlock(&file_ctx->fp_mutex);
             return -1;
         }
 
         fflush(aun->unified2alert_ctx->file_ctx->fp);
         aun->unified2alert_ctx->file_ctx->alerts++;
-        SCMutexUnlock(&aun->unified2alert_ctx->file_ctx->fp_mutex);
+        SCMutexUnlock(&file_ctx->fp_mutex);
     }
 
     return 0;

--- a/src/log-dnslog.c
+++ b/src/log-dnslog.c
@@ -96,10 +96,8 @@ static void LogQuery(LogDnsLogThread *aft, char *timebuf, char *srcip, char *dst
             " [**] %s [**] %s:%" PRIu16 " -> %s:%" PRIu16 "\n",
             record, srcip, sp, dstip, dp);
 
-    SCMutexLock(&hlog->file_ctx->fp_mutex);
     hlog->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
-    SCMutexUnlock(&hlog->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx, 0);
 }
 
 static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *dstip, Port sp, Port dp, DNSTransaction *tx, DNSAnswerEntry *entry)
@@ -159,10 +157,8 @@ static void LogAnswer(LogDnsLogThread *aft, char *timebuf, char *srcip, char *ds
             " [**] %s:%" PRIu16 " -> %s:%" PRIu16 "\n",
             srcip, sp, dstip, dp);
 
-    SCMutexLock(&hlog->file_ctx->fp_mutex);
     hlog->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
-    SCMutexUnlock(&hlog->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx, 0);
 }
 
 static int LogDnsLogger(ThreadVars *tv, void *data, const Packet *p,

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -498,10 +498,8 @@ static TmEcode LogHttpLogIPWrapper(ThreadVars *tv, void *data, const Packet *p, 
 
     aft->uri_cnt ++;
 
-    SCMutexLock(&hlog->file_ctx->fp_mutex);
     hlog->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
-    SCMutexUnlock(&hlog->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx, 0);
 
 end:
     SCReturnInt(0);

--- a/src/log-stats.c
+++ b/src/log-stats.c
@@ -156,10 +156,8 @@ int LogStatsLogger(ThreadVars *tv, void *thread_data, const StatsTable *st)
         }
     }
 
-    SCMutexLock(&aft->statslog_ctx->file_ctx->fp_mutex);
     aft->statslog_ctx->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), aft->statslog_ctx->file_ctx);
-    SCMutexUnlock(&aft->statslog_ctx->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), aft->statslog_ctx->file_ctx, 0);
 
     MemBufferReset(aft->buffer);
 

--- a/src/log-tcp-data.c
+++ b/src/log-tcp-data.c
@@ -161,10 +161,8 @@ static int LogTcpDataLoggerFile(ThreadVars *tv, void *thread_data, const Flow *f
         PrintRawDataToBuffer(aft->buffer->buffer, &aft->buffer->offset,
                 aft->buffer->size, (uint8_t *)data,data_len);
 
-        SCMutexLock(&td->file_ctx->fp_mutex);
         td->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-                MEMBUFFER_OFFSET(aft->buffer), td->file_ctx);
-        SCMutexUnlock(&td->file_ctx->fp_mutex);
+                MEMBUFFER_OFFSET(aft->buffer), td->file_ctx, 0);
     }
     SCReturnInt(TM_ECODE_OK);
 }

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -320,10 +320,8 @@ static int LogTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
 
     aft->tls_cnt++;
 
-    SCMutexLock(&hlog->file_ctx->fp_mutex);
     hlog->file_ctx->Write((const char *)MEMBUFFER_BUFFER(aft->buffer),
-        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx);
-    SCMutexUnlock(&hlog->file_ctx->fp_mutex);
+        MEMBUFFER_OFFSET(aft->buffer), hlog->file_ctx, 0);
 
     return 0;
 }

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -78,7 +78,8 @@ typedef struct LogFileCtx_ {
 #endif
     };
 
-    int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp);
+    int (*Write)(const char *buffer, int buffer_len, struct LogFileCtx_ *fp,
+            uint64_t count);
     void (*Close)(struct LogFileCtx_ *fp);
 
     /** It will be locked if the log/alert


### PR DESCRIPTION
The first commit fixes a false positive, but still confusing code where the mutex was unlocked via a different name than the lock.

The second commit is to address another false positive where Coverity could not reason that the Write function was always called under lock. This is an attempt to make it more explicit, but required some refactoring.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/95
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/447
