### PR TITLE
util-daemon: user-configurable umask setting

### DIFF
--- a/src/util-daemon.c
+++ b/src/util-daemon.c
@@ -28,6 +28,7 @@
 #include "runmodes.h"
 #include "util-daemon.h"
 #include "util-debug.h"
+#include "util-byte.h"
 #include "conf.h"
 
 #ifndef OS_WIN32
@@ -121,7 +122,14 @@ void Daemonize (void)
         /* Child continues here */
         char *daemondir;
 
-        umask(027);
+        char *daemon_umask;
+        if (ConfGet("daemon-umask", &daemon_umask) == 1) {
+            uint16_t mask;
+            if (ByteExtractStringUint16(&mask, 8, strlen(daemon_umask),
+                                        daemon_umask) > 0) {
+                umask((mode_t)mask);
+            }
+        }
 
         sid = setsid();
         if (sid < 0) {

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -909,6 +909,11 @@ asn1-max-frames: 256
 # Default: "/"
 #daemon-directory: "/"
 
+# Daemon umask.
+# Suricata will use this umask if it is provided. By default it will use the
+# umask passed on by the parent process.
+#daemon-umask: 022
+
 # Suricata core dump configuration. Limits the size of the core dump file to
 # approximately max-dump. The actual core dump size will be a multiple of the
 # page size. Core dumps that would be larger than max-dump are truncated. On


### PR DESCRIPTION
Make umask user-configurable by adding 'daemon-umask' to suricata.yaml.

```yaml
# Daemon umask.
# Suricata will use this umask if it is provided. By default it will use the
# umask passed on by the parent process.
daemon-umask: 022
```

https://redmine.openinfosecfoundation.org/issues/1678

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/113
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/113
