### PR TITLE
app-layer-tls: check if validity dates are already set (3.2.x)

### DIFF
--- a/src/app-layer-tls-handshake.c
+++ b/src/app-layer-tls-handshake.c
@@ -182,8 +182,10 @@ int DecodeTLSHandshakeServerCertificate(SSLState *ssl_state, uint8_t *input,
                 TLSCertificateErrCodeToWarning(ssl_state, errcode);
             } else {
                 if (i == 0) {
-                    ssl_state->server_connp.cert0_not_before = not_before;
-                    ssl_state->server_connp.cert0_not_after = not_after;
+                    if (ssl_state->server_connp.cert0_not_before == 0)
+                        ssl_state->server_connp.cert0_not_before = not_before;
+                    if (ssl_state->server_connp.cert0_not_after == 0)
+                        ssl_state->server_connp.cert0_not_after = not_after;
                 }
             }
 


### PR DESCRIPTION
Fix bug where a client certificate (if present), would overwrite the validity dates of the server certificate.

https://redmine.openinfosecfoundation.org/issues/2050

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/117
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/117