### PR TITLE
(rfc) logging - non-blocking writes to socket - v1

### DIFF
--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -709,6 +709,12 @@ static void LogHttpLogDeInitCtx(OutputCtx *output_ctx)
 {
     LogHttpFileCtx *httplog_ctx = (LogHttpFileCtx *)output_ctx->data;
     uint32_t i;
+
+    if (httplog_ctx->file_ctx->dropped) {
+        SCLogNotice("%s: %"PRIu64" events dropped instead of logged.",
+                MODULE_NAME, httplog_ctx->file_ctx->dropped);
+    }
+
     for (i = 0; i < httplog_ctx->cf_n; i++) {
         SCFree(httplog_ctx->cf_nodes[i]);
     }

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -120,6 +120,47 @@ static int SCLogUnixSocketReconnect(LogFileCtx *log_ctx)
     return log_ctx->fp ? 1 : 0;
 }
 
+static int SCLogFileWriteSocket(const char *buffer, int buffer_len,
+        LogFileCtx *ctx)
+{
+    int tries = 0;
+    int ret = 0;
+    int reopen = false;
+
+    if (ctx->fp == NULL && ctx->is_sock) {
+        SCLogUnixSocketReconnect(ctx);
+    }
+
+tryagain:
+    ret = 0;
+    reopen = 0;
+    if (ctx->fp != NULL && tries++ < 2) {
+        int fd = fileno(ctx->fp);
+        ssize_t size = send(fd, buffer, buffer_len, MSG_DONTWAIT);
+        if (size < 1) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                ctx->dropped++;
+            } else if (tries == 0 && errno == EINTR) {
+                goto tryagain;
+            } else {
+                /* Some other error. Assume badness and reopen. */
+                reopen = true;
+            }
+            ret = -1;
+        }
+    } else {
+        ctx->dropped++;
+    }
+
+    if (reopen) {
+        if (SCLogUnixSocketReconnect(ctx)) {
+            goto tryagain;
+        }
+    }
+
+    return ret;
+}
+
 /**
  * \brief Write buffer to log file.
  * \retval 0 on failure; otherwise, the return value of fwrite (number of
@@ -127,30 +168,24 @@ static int SCLogUnixSocketReconnect(LogFileCtx *log_ctx)
  */
 static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ctx)
 {
-    SCMutexLock(&log_ctx->fp_mutex);
-
-    /* Check for rotation. */
-    if (log_ctx->rotation_flag) {
-        log_ctx->rotation_flag = 0;
-        SCConfLogReopen(log_ctx);
-    }
-
     int ret = 0;
 
-    if (log_ctx->fp == NULL && log_ctx->is_sock)
-        SCLogUnixSocketReconnect(log_ctx);
+    SCMutexLock(&log_ctx->fp_mutex);
 
-    if (log_ctx->fp) {
-        clearerr(log_ctx->fp);
-        ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
-        fflush(log_ctx->fp);
+    if (log_ctx->is_sock) {
+        ret = SCLogFileWriteSocket(buffer, buffer_len, log_ctx);
+    } else {
 
-        if (ferror(log_ctx->fp) && log_ctx->is_sock) {
-            /* Error on Unix socket, maybe needs reconnect */
-            if (SCLogUnixSocketReconnect(log_ctx)) {
-                ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
-                fflush(log_ctx->fp);
-            }
+        /* Check for rotation. */
+        if (log_ctx->rotation_flag) {
+            log_ctx->rotation_flag = 0;
+            SCConfLogReopen(log_ctx);
+        }
+
+        if (log_ctx->fp) {
+            clearerr(log_ctx->fp);
+            ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
+            fflush(log_ctx->fp);
         }
     }
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -124,6 +124,10 @@ typedef struct LogFileCtx_ {
 
     /* Set to true if the filename should not be timestamped. */
     bool nostamp;
+
+    /* Socket types may need to drop events to keep from blocking
+     * Suricata. */
+    uint64_t dropped;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
One way to address sockets that are blocking on write, (which also blocks Suricata in general) is to drop the event if the write to the socket will block.

This isn't as feature-full as for an internal message queue could be which could buffer the packets until the socket no longer blocks, but in many cases buffering just delays having to drop events, especially if the other end of the socket continually can't keep up.

Here we do socket writes with a non-blocking send and up a counter if it failed to send. The second commit is an example of a logger logging the drop count. But we probably want a real stat for this that is in the event log.

Related issue:
https://redmine.openinfosecfoundation.org/issues/2039

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/102
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/454
