### PR TITLE
af_packet fanout support ('cluster_qm' mode) was not properly detected.

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -1888,8 +1888,7 @@ int AFPIsFanoutSupported(void)
     int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
     if (fd != -1) {
         uint16_t mode = PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG;
-        uint16_t id = 1;
-        uint32_t option = (mode << 16) | (id & 0xffff);
+        uint32_t option = mode << 16;
         int r = setsockopt(fd, SOL_PACKET, PACKET_FANOUT,(void *)&option, sizeof(option));
         close(fd);
 


### PR DESCRIPTION
setsockopt() was called with wrong params and returned EINVAL despite
fanout was actually supported.