### PR TITLE
Clarify how iprep works in the documentation

### DIFF
--- a/doc/userguide/reputation/ipreputation/ip-reputation-format.rst
+++ b/doc/userguide/reputation/ipreputation/ip-reputation-format.rst
@@ -6,12 +6,12 @@ Description of IP Reputation file formats. For the configuration see :doc:`ip-re
 Categories file
 ~~~~~~~~~~~~~~~
 
-The categories file provides a mapping between a category number, short name and long description. It's a simple CSV file:
+The categories file provides a mapping between a category number, short name, and long description. It's a simple CSV file:
 
 ::
 
 
-  <id>,<short name>,<discription>
+  <id>,<short name>,<description>
 
 Example:
 
@@ -27,9 +27,13 @@ Reputation file
 ~~~~~~~~~~~~~~~
 
 The reputation file lists a reputation score for hosts in the categories. It's a simple CSV file:
-> <ip>,<cat>,<score>
 
-The IP is an IPv4 address in the quad-dotted notation. The category is the number as defined in the categories file and the value is a number between 1 and 127. 0 means no data.
+::
+
+
+  <ip>,<category>,<reputation score>
+
+The IP is an IPv4 address in the quad-dotted notation. The category is the number as defined in the categories file. The reputation score is the confidence that this IP is in the specified category, represented by a number between 1 and 127 (0 means no data).
 
 Example:
 

--- a/doc/userguide/reputation/ipreputation/ip-reputation-rules.rst
+++ b/doc/userguide/reputation/ipreputation/ip-reputation-rules.rst
@@ -10,16 +10,16 @@ The iprep directive matches on the IP reputation information for a host.
 
 ::
 
-  iprep:<side to check>,<cat>,<operator>,<value>
+  iprep:<side to check>,<category>,<operator>,<reputation score>
 
 
 side to check: <any|src|dst|both>
 
-cat: the category short name
+category: the category short name
 
 operator: <, >, =
 
-value: 1-127
+reputation score: 1-127
 
 Example:
 
@@ -27,6 +27,8 @@ Example:
 
 
   alert ip $HOME_NET any -> any any (msg:"IPREP internal host talking to CnC server"; flow:to_server; iprep:dst,CnC,>,30; sid:1; rev:1;)
+
+This rule will alert when a system in $HOME_NET performs a client request while communicating with any IP in the CnC category that has a reputation score set to greater than 30.
 
 IP-only
 ~~~~~~~

--- a/doc/userguide/reputation/ipreputation/ip-reputation-rules.rst
+++ b/doc/userguide/reputation/ipreputation/ip-reputation-rules.rst
@@ -28,7 +28,7 @@ Example:
 
   alert ip $HOME_NET any -> any any (msg:"IPREP internal host talking to CnC server"; flow:to_server; iprep:dst,CnC,>,30; sid:1; rev:1;)
 
-This rule will alert when a system in $HOME_NET performs a client request while communicating with any IP in the CnC category that has a reputation score set to greater than 30.
+This rule will alert when a system in $HOME_NET acts as a client while communicating with any IP in the CnC category that has a reputation score set to greater than 30.
 
 IP-only
 ~~~~~~~


### PR DESCRIPTION
Fixed a typo and improved formatting for the iprep documentation.  Also added consistency to terms used in the documentation in hopes of explaining the feature more clearly.