### PR TITLE
Issue 2049 - Startup test inconsistencies - v1

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -475,10 +475,12 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                     ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
-                    if (ret != 0 || good_sigs == 0) {
-                        if (de_ctx->failure_fatal == 1) {
-                            exit(EXIT_FAILURE);
+                    if (de_ctx->failure_fatal && (ret != 0 || good_sigs == 0)) {
+                        if (ret == 0 && good_sigs == 0) {
+                            SCLogError(SC_ERR_NO_RULES_LOADED,
+                                    "No rules loaded from %s.", file->val);
                         }
+                        exit(EXIT_FAILURE);
                     }
                 }
             }

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -1835,10 +1835,6 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         case 'T':
             SCLogInfo("Running suricata under test mode");
             conf_test = 1;
-            if (ConfSetFinal("engine.init-failure-fatal", "1") != 1) {
-                fprintf(stderr, "ERROR: Failed to set engine init-failure-fatal.\n");
-                return TM_ECODE_FAILED;
-            }
             break;
 #ifndef OS_WIN32
         case 'D':


### PR DESCRIPTION
Related issue:
https://redmine.openinfosecfoundation.org/issues/2049

Don't implicitly turn on --init-fatal-errors when testing as it doesn't test the actual configuration the user requested. Instead it can be turned on with -T.

Also, when exiting due to a file with 0 rules loading, and --init-fatal-errors, log why its exiting instead of exiting silently - I'm not sure if 0 failure, 0 loaded rules should be a failure though.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/104
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/456
