### PR TITLE
travis: fix mac builds (unlink pcre before installing) - v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,10 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update
+
+        # Unlink pcre in case its already installed.
+        brew unlink pcre || true
+
         brew install pkg-config libmagic libyaml nss nspr jansson libnet lua \
             pcre hiredis
     fi


### PR DESCRIPTION
It looks like Travis changed their Mac image and pcre is now
installed by default. In case it gets removed again, just unlink
it before re-installing so it doesn't fail on install.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/105
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/457