### PR TITLE
defrag: fix argument used in macro to match signature - v1

### DIFF
--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -407,7 +407,7 @@ static inline uint32_t DefragHashGetKey(Packet *p)
        CMP_ADDR(&(d1)->dst_addr, &(d2)->dst)) || \
       (CMP_ADDR(&(d1)->src_addr, &(d2)->dst) && \
        CMP_ADDR(&(d1)->dst_addr, &(d2)->src))) && \
-     (d1)->proto == IP_GET_IPPROTO(p) &&        \
+     (d1)->proto == IP_GET_IPPROTO(d2) &&   \
      (d1)->id == (id) && \
      (d1)->vlan_id[0] == (d2)->vlan_id[0] && \
      (d1)->vlan_id[1] == (d2)->vlan_id[1])


### PR DESCRIPTION
"p" was being used in the macro but was not an argument to
the macro, but it worked due to the context of the macro.

Use the actual macro argument, d2, instead of p.

Results in no change to generated code.

Comment resulting in PR:
https://github.com/inliniac/suricata/commit/4a04f814b15762eb446a5ead4d69d021512df6f8#commitcomment-21401303

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/106
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/458
