### PR TITLE
lua: add function to get flow timestamps as epoch

### DIFF
--- a/doc/userguide/output/lua-output.rst
+++ b/doc/userguide/output/lua-output.rst
@@ -147,6 +147,17 @@ flow
       return needs
   end
 
+SCFlowTimestamps
+~~~~~~~~~~~~~~~~
+
+Get timestamps (seconds and microseconds) of the first and the last packet from
+the flow.
+
+::
+
+  startts, lastts = SCFlowTimestamps()
+  startts_s, lastts_s, startts_us, lastts_us = SCFlowTimestamps()
+
 SCFlowTimeString
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add function `SCFlowTimestamps()` to get startts (both seconds and microseconds) and lastts from flow.

Examples:
```lua
startts, lastts = SCFlowTimestamps()
startts_s, lastts_s, startts_us, lastts_us = SCFlowTimestamps()
```

https://redmine.openinfosecfoundation.org/issues/2061

Prscript:
- PR thus-pcap: https://buildbot.openinfosecfoundation.org/builders/thus-pcap/builds/121
- PR thus: https://buildbot.openinfosecfoundation.org/builders/thus/builds/121