### PR TITLE
http: fix body tracking corner case

### DIFF
--- a/src/app-layer-htp-body.c
+++ b/src/app-layer-htp-body.c
@@ -93,37 +93,25 @@ int HtpBodyAppendChunk(const HTPCfgDir *hcfg, HtpBody *body,
             SCReturnInt(-1);
     }
 
+    /* New chunk */
+    bd = (HtpBodyChunk *)HTPCalloc(1, sizeof(HtpBodyChunk));
+    if (bd == NULL) {
+        SCReturnInt(-1);
+    }
+
+    if (StreamingBufferAppend(body->sb, &bd->sbseg, data, len) != 0) {
+        HTPFree(bd, sizeof(HtpBodyChunk));
+        SCReturnInt(-1);
+    }
+
     if (body->first == NULL) {
-        /* New chunk */
-        bd = (HtpBodyChunk *)HTPCalloc(1, sizeof(HtpBodyChunk));
-        if (bd == NULL) {
-            SCReturnInt(-1);
-        }
-
-        if (StreamingBufferAppend(body->sb, &bd->sbseg, data, len) != 0) {
-            HTPFree(bd, sizeof(HtpBodyChunk));
-            SCReturnInt(-1);
-        }
-
         body->first = body->last = bd;
-
-        body->content_len_so_far = len;
     } else {
-        bd = (HtpBodyChunk *)HTPCalloc(1, sizeof(HtpBodyChunk));
-        if (bd == NULL) {
-            SCReturnInt(-1);
-        }
-
-        if (StreamingBufferAppend(body->sb, &bd->sbseg, data, len) != 0) {
-            HTPFree(bd, sizeof(HtpBodyChunk));
-            SCReturnInt(-1);
-        }
-
         body->last->next = bd;
         body->last = bd;
-
-        body->content_len_so_far += len;
     }
+    body->content_len_so_far += len;
+
     SCLogDebug("body %p", body);
 
     SCReturnInt(0);


### PR DESCRIPTION
In some cases, observed with inspect limits 0, the body tracking could
get confused. When all chunks were already freed, a new chunk would
be considered to be the start of the body. This would overwrite the
bodies 'content_len_so_far' tracker, instead of adding to it. This in
turn could lead to a assertion abort in the inspection code.

This patch redoes the append code to always add the current lenght. It
cleans up the code to remove redundant logic.

Issue: https://redmine.openinfosecfoundation.org/issues/2078
Reported-By: Jørgen Bøhnsdalen

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/77
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/585
