### PR TITLE
TEST flow: track longest packet 'pause' / 'gap'

### DIFF
--- a/src/flow-util.h
+++ b/src/flow-util.h
@@ -57,6 +57,7 @@
         (f)->alproto_tc = 0; \
         (f)->de_ctx_version = 0; \
         (f)->thread_id = 0; \
+        (f)->lastts_gap = 0; \
         (f)->alparser = NULL; \
         (f)->alstate = NULL; \
         (f)->sgh_toserver = NULL; \
@@ -97,6 +98,7 @@
         (f)->alproto_tc = 0; \
         (f)->de_ctx_version = 0; \
         (f)->thread_id = 0; \
+        (f)->lastts_gap = 0; \
         (f)->sgh_toserver = NULL; \
         (f)->sgh_toclient = NULL; \
         GenericVarFree((f)->flowvar); \

--- a/src/flow.c
+++ b/src/flow.c
@@ -249,6 +249,9 @@ void FlowHandlePacketUpdate(Flow *f, Packet *p)
 
     int state = SC_ATOMIC_GET(f->flow_state);
 
+    if (f->lastts.tv_sec > 0) {
+        f->lastts_gap = MAX((p->ts.tv_sec - f->lastts.tv_sec), f->lastts_gap);
+    }
     if (state != FLOW_STATE_CAPTURE_BYPASSED) {
         /* update the last seen timestamp of this flow */
         COPY_TIMESTAMP(&p->ts, &f->lastts);

--- a/src/flow.h
+++ b/src/flow.h
@@ -392,6 +392,9 @@ typedef struct Flow_
     /** Thread ID for the stream/detect portion of this flow */
     FlowThreadId thread_id;
 
+    /** Max time in seconds between 2 flow updates */
+    uint32_t lastts_gap;
+
     /** application level storage ptrs.
      *
      */

--- a/src/output-json-flow.c
+++ b/src/output-json-flow.c
@@ -214,6 +214,8 @@ static void JsonFlowLogJSON(JsonFlowLogThread *aft, json_t *js, Flow *f)
 
     json_object_set_new(hjs, "start", json_string(timebuf1));
     json_object_set_new(hjs, "end", json_string(timebuf2));
+    if (f->lastts_gap > 0)
+        json_object_set_new(hjs, "max_pause", json_integer(f->lastts_gap));
 
     int32_t age = f->lastts.tv_sec - f->startts.tv_sec;
     json_object_set_new(hjs, "age",


### PR DESCRIPTION
Track the max difference between packet updates in a flow. Print
the max value as 'max_pause' in the flow record. Useful for
determining what a reasonable timeout value could be for flows.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/79
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/587