### PR TITLE
unix-socket: return failure on failure - v1

### DIFF
--- a/src/unix-manager.c
+++ b/src/unix-manager.c
@@ -914,7 +914,7 @@ static TmEcode UnixManagerThreadInit(ThreadVars *t, void *initdata, void **data)
         } else {
             SCLogWarning(SC_ERR_INITIALIZATION,
                     "Unable to create unix command socket");
-            return TM_ECODE_OK;
+            return TM_ECODE_FAILED;
         }
     }
 


### PR DESCRIPTION
UnixManagerThreadInit needs to return a failure code if the socket
fails to initialize to avoid entering the UnixManager loop which
will continuously fail on the call to bind, as no listening
socket was setup.

This can occur when the socket fails to initialize due to a
permissions error and fatal init errors is not on.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/117
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/469
