### PR TITLE
logging - non-blocking writes to socket - v2

### DIFF
--- a/src/output-json.c
+++ b/src/output-json.c
@@ -720,6 +720,11 @@ static void OutputJsonDeInitCtx(OutputCtx *output_ctx)
 {
     OutputJsonCtx *json_ctx = (OutputJsonCtx *)output_ctx->data;
     LogFileCtx *logfile_ctx = json_ctx->file_ctx;
+    if (logfile_ctx->dropped) {
+        SCLogWarning(SC_WARN_EVENT_DROPPED,
+                "%"PRIu64" events were dropped due to slow or "
+                "disconnected socket", logfile_ctx->dropped);
+    }
     LogFileFreeCtx(logfile_ctx);
     SCFree(json_ctx);
     SCFree(output_ctx);

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -338,6 +338,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_ERR_REDIS);
         CASE_CODE (SC_ERR_VAR_LIMIT);
         CASE_CODE (SC_WARN_CHMOD);
+        CASE_CODE (SC_WARN_EVENT_DROPPED);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -328,6 +328,7 @@ typedef enum {
     SC_ERR_VAR_LIMIT,
     SC_WARN_DUPLICATE_OUTPUT,
     SC_WARN_CHMOD,
+    SC_WARN_EVENT_DROPPED,
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -121,6 +121,57 @@ static int SCLogUnixSocketReconnect(LogFileCtx *log_ctx)
     return log_ctx->fp ? 1 : 0;
 }
 
+static int SCLogFileWriteSocket(const char *buffer, int buffer_len,
+        LogFileCtx *ctx)
+{
+    int tries = 0;
+    int ret = 0;
+    bool reopen = false;
+
+    if (ctx->fp == NULL && ctx->is_sock) {
+        SCLogUnixSocketReconnect(ctx);
+    }
+
+tryagain:
+    ret = -1;
+    reopen = 0;
+    errno = 0;
+    if (ctx->fp != NULL) {
+        int fd = fileno(ctx->fp);
+        ssize_t size = send(fd, buffer, buffer_len, MSG_DONTWAIT);
+        if (size > -1) {
+            ret = 0;
+        } else {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                SCLogDebug("Socket would block, dropping event.");
+            } else if (errno == EINTR) {
+                if (tries++ == 0) {
+                    SCLogDebug("Interrupted system call, trying again.");
+                    goto tryagain;
+                }
+                SCLogDebug("Too many interrupted system calls, "
+                        "dropping event.");
+            } else {
+                /* Some other error. Assume badness and reopen. */
+                SCLogDebug("Send failed: %s", strerror(errno));
+                reopen = true;
+            }
+        }
+    }
+
+    if (reopen && tries++ == 0) {
+        if (SCLogUnixSocketReconnect(ctx)) {
+            goto tryagain;
+        }
+    }
+
+    if (ret == -1) {
+        ctx->dropped++;
+    }
+
+    return ret;
+}
+
 /**
  * \brief Write buffer to log file.
  * \retval 0 on failure; otherwise, the return value of fwrite (number of
@@ -130,28 +181,22 @@ static int SCLogFileWrite(const char *buffer, int buffer_len, LogFileCtx *log_ct
 {
     SCMutexLock(&log_ctx->fp_mutex);
 
-    /* Check for rotation. */
-    if (log_ctx->rotation_flag) {
-        log_ctx->rotation_flag = 0;
-        SCConfLogReopen(log_ctx);
-    }
-
     int ret = 0;
 
-    if (log_ctx->fp == NULL && log_ctx->is_sock)
-        SCLogUnixSocketReconnect(log_ctx);
+    if (log_ctx->is_sock) {
+        ret = SCLogFileWriteSocket(buffer, buffer_len, log_ctx);
+    } else {
 
-    if (log_ctx->fp) {
-        clearerr(log_ctx->fp);
-        ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
-        fflush(log_ctx->fp);
+        /* Check for rotation. */
+        if (log_ctx->rotation_flag) {
+            log_ctx->rotation_flag = 0;
+            SCConfLogReopen(log_ctx);
+        }
 
-        if (ferror(log_ctx->fp) && log_ctx->is_sock) {
-            /* Error on Unix socket, maybe needs reconnect */
-            if (SCLogUnixSocketReconnect(log_ctx)) {
-                ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
-                fflush(log_ctx->fp);
-            }
+        if (log_ctx->fp) {
+            clearerr(log_ctx->fp);
+            ret = fwrite(buffer, buffer_len, 1, log_ctx->fp);
+            fflush(log_ctx->fp);
         }
     }
 

--- a/src/util-logopenfile.c
+++ b/src/util-logopenfile.c
@@ -127,9 +127,15 @@ static int SCLogFileWriteSocket(const char *buffer, int buffer_len,
     int tries = 0;
     int ret = 0;
     bool reopen = false;
+    int flags = 0;
 
     if (ctx->fp == NULL && ctx->is_sock) {
         SCLogUnixSocketReconnect(ctx);
+    }
+
+    /* Set flags for a non-blocking write if live. */
+    if (TimeModeIsLive()) {
+        flags |= MSG_DONTWAIT;
     }
 
 tryagain:
@@ -138,7 +144,7 @@ tryagain:
     errno = 0;
     if (ctx->fp != NULL) {
         int fd = fileno(ctx->fp);
-        ssize_t size = send(fd, buffer, buffer_len, MSG_DONTWAIT);
+        ssize_t size = send(fd, buffer, buffer_len, flags);
         if (size > -1) {
             ret = 0;
         } else {

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -127,6 +127,10 @@ typedef struct LogFileCtx_ {
 
     /* Set to true if the filename should not be timestamped. */
     bool nostamp;
+
+    /* Socket types may need to drop events to keep from blocking
+     * Suricata. */
+    uint64_t dropped;
 } LogFileCtx;
 
 /* Min time (msecs) before trying to reconnect a Unix domain socket */


### PR DESCRIPTION
Previous PR: #2603 

Related issue:
https://redmine.openinfosecfoundation.org/issues/2039

One way to address sockets that are blocking on write, (which also blocks Suricata in general) is to drop the event if the write to the socket will block.

This isn't as feature-full as for an internal message queue could be which could buffer the packets until the socket no longer blocks, but in many cases buffering just delays having to drop events, especially if the other end of the socket continually can't keep up.

Here we do socket writes with a non-blocking send and up a counter if it failed to send. The second commit is an example of a logger logging the drop count. But we probably want a real stat for this that is in the event log.

Changes from last PR:
- Log drops for eve in one location on exit (only if there are drops)
- Retry loop cleanup.
- If not running live, don't do a non-blocking write.

I looked at a stats counter, but it was non-trivial to one via the stats API to do the various entry points into the logger (ie: flow). Will revisit though.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/120
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/472
