### PR TITLE
issue 2049 - detect: don't consider an empty rule file an error - v2

### DIFF
--- a/src/detect.c
+++ b/src/detect.c
@@ -475,10 +475,14 @@ int SigLoadSignatures(DetectEngineCtx *de_ctx, char *sig_file, int sig_file_excl
                     ret = ProcessSigFiles(de_ctx, sfile, &sig_stat, &good_sigs, &bad_sigs);
                     SCFree(sfile);
 
-                    if (ret != 0 || good_sigs == 0) {
-                        if (de_ctx->failure_fatal == 1) {
-                            exit(EXIT_FAILURE);
-                        }
+                    if (de_ctx->failure_fatal && ret != 0) {
+                        /* Some rules failed to load, just exit as
+                         * errors would have already been logged. */
+                        exit(EXIT_FAILURE);
+                    }
+
+                    if (good_sigs == 0) {
+                        SCLogConfig("No rules loaded from %s.", file->val);
                     }
                 }
             }


### PR DESCRIPTION
Previous PR: #2613 

A much simpler approach, don't consider a rule file with 0 rules loaded an error, if there were no rule loading errors.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/122
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/474
