### PR TITLE
template script: typo in app-layer setup script

### DIFF
--- a/scripts/setup-app-layer.sh
+++ b/scripts/setup-app-layer.sh
@@ -6,7 +6,7 @@ set -e
 #set -x
 
 # Fail if "ed" is not available.
-if ! which edx > /dev/null 2>&1; then
+if ! which ed > /dev/null 2>&1; then
     echo "error: the program \"ed\" is required for this script"
     exit 1
 fi


### PR DESCRIPTION
Check for ed was failing, as it was actually looking for edx.

No prscript as its failing with a 502 Bad Gateway, but I think its clear that prscript wouldn't test this one.
