### PR TITLE
stream gap handling - v5

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -124,6 +124,9 @@ typedef struct AppLayerParserProtoCtx_
      * STREAM_TOSERVER, STREAM_TOCLIENT */
     uint8_t first_data_dir;
 
+    /* Option flags, such as supporting gaps or not. */
+    uint8_t flags;
+
 #ifdef UNITTESTS
     void (*RegisterUnittests)(void);
 #endif
@@ -354,6 +357,16 @@ void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto, AppPro
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].first_data_dir |=
         (direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+
+    SCReturn;
+}
+
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint8_t flags)
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].flags |= flags;
 
     SCReturn;
 }
@@ -795,8 +808,13 @@ static void AppLayerParserTransactionsCleanup(Flow *f)
     }
 }
 
+#ifdef OLD_GAP
 #define IS_DISRUPTED(flags) \
     ((flags) & (STREAM_DEPTH|STREAM_GAP))
+#else
+#define IS_DISRUPTED(flags) \
+    ((flags) & (STREAM_DEPTH))
+#endif
 
 /**
  *  \brief get the progress value for a tx/protocol
@@ -944,6 +962,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     if (p->StateAlloc == NULL)
         goto end;
 
+#ifdef OLD_GAP
     /* Do this check before calling AppLayerParse */
     if (flags & STREAM_GAP) {
         SCLogDebug("stream gap detected (missing packets), "
@@ -953,6 +972,7 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
             AppLayerParserStreamTruncated(f->proto, alproto, f->alstate, flags);
         goto error;
     }
+#endif
 
     /* Get the parser state (if any) */
     pstate = f->alparser;
@@ -961,6 +981,20 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
         if (pstate == NULL)
             goto error;
     }
+
+#ifndef OLD_GAP
+    /* Do this check before calling AppLayerParse */
+    if (flags & STREAM_GAP) {
+        if (!(p->flags & APP_LAYER_PARSER_OPT_ACCEPT_GAPS)) {
+            if (f->alstate != NULL) {
+                AppLayerParserStreamTruncated(f->proto, alproto, f->alstate,
+                        flags);
+            }
+            goto error;
+        }
+        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_GAP);
+    }
+#endif
 
     if (flags & STREAM_EOF)
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_EOF);
@@ -1042,6 +1076,12 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     /* stream truncated, inform app layer */
     if (flags & STREAM_DEPTH)
         AppLayerParserStreamTruncated(f->proto, alproto, alstate, flags);
+
+    /* Clear the gap flag. Its up to the parser to regain sync if it
+     * didn't already. */
+    if (flags & STREAM_GAP) {
+        AppLayerParserStateClearFlag(pstate, APP_LAYER_PARSER_GAP);
+    }
 
  end:
     SCReturnInt(0);
@@ -1257,6 +1297,15 @@ void AppLayerParserStateSetFlag(AppLayerParserState *pstate, uint8_t flag)
     pstate->flags |= flag;
     SCReturn;
 }
+
+#ifndef OLD_GAP
+void AppLayerParserStateClearFlag(AppLayerParserState *pstate, uint8_t flag)
+{
+    SCEnter();
+    pstate->flags &= ~flag;
+    SCReturn;
+}
+#endif
 
 int AppLayerParserStateIssetFlag(AppLayerParserState *pstate, uint8_t flag)
 {

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -30,10 +30,17 @@
 #include "util-file.h"
 #include "stream-tcp-private.h"
 
+/* Flags for AppLayerParserState. */
 #define APP_LAYER_PARSER_EOF                    0x01
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
 #define APP_LAYER_PARSER_NO_REASSEMBLY          0x04
 #define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD  0x08
+#ifndef OLD_GAP
+#define APP_LAYER_PARSER_GAP                    0x10
+#endif
+
+/* Flags for AppLayerParserProtoCtx. */
+#define APP_LAYER_PARSER_OPT_ACCEPT_GAPS 0x01
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
@@ -115,6 +122,8 @@ int AppLayerParserRegisterParser(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto,
                                               AppProto alproto,
                                               uint8_t direction);
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint8_t flags);
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
                            void *(*StateAlloc)(void),
                            void (*StateFree)(void *));
@@ -219,6 +228,9 @@ void AppLayerParserRegisterProtocolParsers(void);
 
 
 void AppLayerParserStateSetFlag(AppLayerParserState *pstate, uint8_t flag);
+#ifndef OLD_GAP
+void AppLayerParserStateClearFlag(AppLayerParserState *pstate, uint8_t flag);
+#endif
 int AppLayerParserStateIssetFlag(AppLayerParserState *pstate, uint8_t flag);
 
 void AppLayerParserStreamTruncated(uint8_t ipproto, AppProto alproto, void *alstate,


### PR DESCRIPTION
Previous PR: #2619 

Changes from last PR:
- DNS TCP gap handling.

Requesting comments on this way of handling gaps in the app-layer. There are ifdef's of older code as I'm still using them for reference.. Hence this is just an RFC.

Protocols support gap handling:
- DNP3 - this is a simple record based protocol with a fixed start sequence.
- DNS (TCP) - Its very likely, though not always true that a TCP segment will be the start of a request/response. So probe it like it was new.

There is one stream test case that is broken from these changes tho.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/124
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/476
