### PR TITLE
Http body logging v1

### DIFF
--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -54,6 +54,7 @@
 #include "output.h"
 #include "output-json.h"
 #include "output-json-dnp3.h"
+#include "output-json-alert.h"
 #include "output-json-http.h"
 #include "output-json-tls.h"
 #include "output-json-ssh.h"
@@ -78,6 +79,7 @@ typedef struct AlertJsonOutputCtx_ {
     LogFileCtx* file_ctx;
     uint16_t flags;
     uint32_t payload_buffer_size;
+    uint32_t http_body_buffer_size;
     HttpXFFCfg *xff_cfg;
 } AlertJsonOutputCtx;
 
@@ -86,6 +88,7 @@ typedef struct JsonAlertLogThread_ {
     LogFileCtx* file_ctx;
     MemBuffer *json_buffer;
     MemBuffer *payload_buffer;
+    MemBuffer *http_body_buffer;
     AlertJsonOutputCtx* json_output_ctx;
 } JsonAlertLogThread;
 
@@ -250,6 +253,7 @@ static void AlertJsonPacket(const Packet *p, json_t *js)
 static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 {
     MemBuffer *payload = aft->payload_buffer;
+    MemBuffer *http_buffer = aft->http_body_buffer;
     AlertJsonOutputCtx *json_output_ctx = aft->json_output_ctx;
     json_t *hjs = NULL;
 
@@ -283,9 +287,10 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
 
                 /* http alert */
                 if (proto == ALPROTO_HTTP) {
-                    hjs = JsonHttpAddMetadata(p->flow, pa->tx_id);
-                    if (hjs)
+                    hjs = JsonHttpAddMetadata(p->flow, pa->tx_id, json_output_ctx->flags, http_buffer);
+                    if (hjs) {
                         json_object_set_new(js, "http", hjs);
+                    }
                 }
             }
         }
@@ -577,10 +582,19 @@ static TmEcode JsonAlertLogThreadInit(ThreadVars *t, void *initdata, void **data
 
     aft->payload_buffer = MemBufferCreateNew(json_output_ctx->payload_buffer_size);
     if (aft->payload_buffer == NULL) {
+        MemBufferFree(aft->json_buffer);
         SCFree(aft);
         return TM_ECODE_FAILED;
     }
-    
+
+    aft->http_body_buffer = MemBufferCreateNew(json_output_ctx->http_body_buffer_size);
+    if (aft->http_body_buffer == NULL) {
+        MemBufferFree(aft->json_buffer);
+        MemBufferFree(aft->payload_buffer);
+        SCFree(aft);
+        return TM_ECODE_FAILED;
+    }
+
     *data = (void *)aft;
     return TM_ECODE_OK;
 }
@@ -594,6 +608,7 @@ static TmEcode JsonAlertLogThreadDeinit(ThreadVars *t, void *data)
 
     MemBufferFree(aft->json_buffer);
     MemBufferFree(aft->payload_buffer);
+    MemBufferFree(aft->http_body_buffer);
 
     /* clear memory */
     memset(aft, 0, sizeof(JsonAlertLogThread));
@@ -648,6 +663,7 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
     json_output_ctx->xff_cfg = xff_cfg;
 
     uint32_t payload_buffer_size = JSON_STREAM_BUFFER_SIZE;
+    uint32_t http_body_buffer_size = JSON_STREAM_BUFFER_SIZE;
 
     if (conf != NULL) {
         const char *payload = ConfNodeLookupChildValue(conf, "payload");
@@ -655,6 +671,9 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         const char *packet  = ConfNodeLookupChildValue(conf, "packet");
         const char *payload_printable = ConfNodeLookupChildValue(conf, "payload-printable");
         const char *http = ConfNodeLookupChildValue(conf, "http");
+        const char *http_body = ConfNodeLookupChildValue(conf, "http-body");
+        const char *http_body_printable = ConfNodeLookupChildValue(conf, "http-body-printable");
+        const char *http_body_buffer_value = ConfNodeLookupChildValue(conf, "http-body-buffer-size");
         const char *tls = ConfNodeLookupChildValue(conf, "tls");
         const char *ssh = ConfNodeLookupChildValue(conf, "ssh");
         const char *smtp = ConfNodeLookupChildValue(conf, "smtp");
@@ -680,6 +699,16 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         if (http != NULL) {
             if (ConfValIsTrue(http)) {
                 json_output_ctx->flags |= LOG_JSON_HTTP;
+            }
+        }
+        if (http_body != NULL) {
+            if (ConfValIsTrue(http_body)) {
+                json_output_ctx->flags |= LOG_JSON_HTTP_BODY_BASE64;
+            }
+        }
+        if (http_body_printable != NULL) {
+            if (ConfValIsTrue(http_body_printable)) {
+                json_output_ctx->flags |= LOG_JSON_HTTP_BODY;
             }
         }
         if (smtp != NULL) {
@@ -708,6 +737,17 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
                 payload_buffer_size = value;
             }
         }
+        if (http_body_buffer_value != NULL) {
+            uint32_t value;
+            if (ParseSizeStringU32(http_body_buffer_value, &value) < 0) {
+                SCLogError(SC_ERR_ALERT_PAYLOAD_BUFFER, "Error parsing "
+                           "libhtp.response-body-inspect-window - %s. "
+                           "Killing engine", http_body_buffer_value);
+                exit(EXIT_FAILURE);
+            } else {
+                http_body_buffer_size = value;
+            }
+        }
         if (packet != NULL) {
             if (ConfValIsTrue(packet)) {
                 json_output_ctx->flags |= LOG_JSON_PACKET;
@@ -724,7 +764,8 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
             }
         }
 
-	json_output_ctx->payload_buffer_size = payload_buffer_size;
+        json_output_ctx->payload_buffer_size = payload_buffer_size;
+        json_output_ctx->http_body_buffer_size = http_body_buffer_size;
         HttpXFFGetCfg(conf, xff_cfg);
     }
 }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -72,17 +72,6 @@
 
 #ifdef HAVE_LIBJANSSON
 
-#define LOG_JSON_PAYLOAD        0x001
-#define LOG_JSON_PACKET         0x002
-#define LOG_JSON_PAYLOAD_BASE64 0x004
-#define LOG_JSON_HTTP           0x008
-#define LOG_JSON_TLS            0x010
-#define LOG_JSON_SSH            0x020
-#define LOG_JSON_SMTP           0x040
-#define LOG_JSON_TAGGED_PACKETS 0x080
-#define LOG_JSON_DNP3           0x100
-#define LOG_JSON_VARS           0x200
-
 #define JSON_STREAM_BUFFER_SIZE 4096
 
 typedef struct AlertJsonOutputCtx_ {

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -29,6 +29,19 @@
 
 void JsonAlertLogRegister(void);
 #ifdef HAVE_LIBJANSSON
+#define LOG_JSON_PAYLOAD            BIT_U32(1)
+#define LOG_JSON_PACKET             BIT_U32(2)
+#define LOG_JSON_PAYLOAD_BASE64     BIT_U32(3)
+#define LOG_JSON_HTTP               BIT_U32(4)
+#define LOG_JSON_TLS                BIT_U32(5)
+#define LOG_JSON_SSH                BIT_U32(6)
+#define LOG_JSON_SMTP               BIT_U32(7)
+#define LOG_JSON_TAGGED_PACKETS     BIT_U32(8)
+#define LOG_JSON_HTTP_BODY          BIT_U32(9)
+#define LOG_JSON_HTTP_BODY_BASE64   BIT_U32(10)
+#define LOG_JSON_DNP3               BIT_U32(11)
+#define LOG_JSON_VARS               BIT_U32(12)
+
 void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js);
 #endif /* HAVE_LIBJANSSON */
 

--- a/src/output-json-alert.h
+++ b/src/output-json-alert.h
@@ -41,6 +41,7 @@ void JsonAlertLogRegister(void);
 #define LOG_JSON_HTTP_BODY_BASE64   BIT_U32(10)
 #define LOG_JSON_DNP3               BIT_U32(11)
 #define LOG_JSON_VARS               BIT_U32(12)
+#define LOG_JSON_FILE               BIT_U32(13)
 
 void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js);
 #endif /* HAVE_LIBJANSSON */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -92,7 +92,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
 
     switch (p->flow->alproto) {
         case ALPROTO_HTTP:
-            hjs = JsonHttpAddMetadata(p->flow, ff->txid);
+            hjs = JsonHttpAddMetadata(p->flow, ff->txid, 0, NULL);
             if (hjs)
                 json_object_set_new(js, "http", hjs);
             break;

--- a/src/output-json-file.h
+++ b/src/output-json-file.h
@@ -26,4 +26,8 @@
 
 void JsonFileLogRegister(void);
 
+#ifdef HAVE_LIBJANSSON
+json_t *JsonFileAddMetadata(const Packet *p, uint64_t tx_id);
+#endif /* HAVE_LIBJANSSON */
+
 #endif /* __OUTPUT_JSON_FILE_H__ */

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -351,7 +351,7 @@ void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx)
     json_object_set_new(js, "length", json_integer(tx->response_message_len));
 }
 
-static void HttpBodyToPrintable(HtpBody *body, MemBuffer *buffer)
+static void HttpBodyToBuffer(HtpBody *body, MemBuffer *buffer)
 {
     HtpBodyChunk *cur = body->first;
     for ( ; cur != NULL; cur = cur->next) {
@@ -372,7 +372,7 @@ static void JsonHttpLogJSONBodyPrintable(json_t *js, htp_tx_t *tx, void *data)
             uint64_t buf_len = body->content_len_so_far + 1;
             uint8_t printable_buf[buf_len];
             uint32_t offset = 0;
-            HttpBodyToPrintable(body, buffer);
+            HttpBodyToBuffer(body, buffer);
             PrintStringsToBuffer(printable_buf, &offset,
                                  sizeof(printable_buf),
                                  buffer->buffer, buffer->offset);
@@ -391,7 +391,7 @@ static void JsonHttpLogJSONBodyBase64(json_t *js, htp_tx_t *tx, void *data)
     if (htud != NULL) {
         HtpBody *body = &htud->response_body;
         if (body != NULL) {
-            HttpBodyToPrintable(body, data);
+            HttpBodyToBuffer(body, data);
             unsigned long len = buffer->offset * 2 + 1;
             uint8_t encoded[len];
             Base64Encode(buffer->buffer, buffer->offset, encoded, &len);

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -47,7 +47,9 @@
 #include "util-proto-name.h"
 #include "util-logopenfile.h"
 #include "util-time.h"
+#include "util-crypt.h"
 #include "output-json.h"
+#include "output-json-alert.h"
 
 #ifdef HAVE_LIBJANSSON
 
@@ -349,6 +351,55 @@ void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx)
     json_object_set_new(js, "length", json_integer(tx->response_message_len));
 }
 
+static void HttpBodyToPrintable(HtpBody *body, MemBuffer *buffer)
+{
+    HtpBodyChunk *cur = body->first;
+    for ( ; cur != NULL; cur = cur->next) {
+        uint8_t *data = NULL;
+        uint32_t data_len = 0;
+        StreamingBufferSegmentGetData(body->sb, &cur->sbseg, (const uint8_t **)&data, &data_len);
+        MemBufferWriteRaw(buffer, data, data_len);
+    }
+}
+
+static void JsonHttpLogJSONBodyPrintable(json_t *js, htp_tx_t *tx, void *data)
+{
+    MemBuffer *buffer = (MemBuffer *)data;
+    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
+    if (htud != NULL) {
+        HtpBody *body = &htud->response_body;
+        if (body != NULL) {
+            uint64_t buf_len = body->content_len_so_far + 1;
+            uint8_t printable_buf[buf_len];
+            uint32_t offset = 0;
+            HttpBodyToPrintable(body, buffer);
+            PrintStringsToBuffer(printable_buf, &offset,
+                                 sizeof(printable_buf),
+                                 buffer->buffer, buffer->offset);
+            /* avoid to add an empty object */
+            if (offset > 0) {
+                json_object_set_new(js, "http_body", json_string((char *)printable_buf));
+            }
+        }
+    }
+}
+
+static void JsonHttpLogJSONBodyBase64(json_t *js, htp_tx_t *tx, void *data)
+{
+    MemBuffer *buffer = (MemBuffer *)data;
+    HtpTxUserData *htud = (HtpTxUserData *)htp_tx_get_user_data(tx);
+    if (htud != NULL) {
+        HtpBody *body = &htud->response_body;
+        if (body != NULL) {
+            HttpBodyToPrintable(body, data);
+            unsigned long len = buffer->offset * 2 + 1;
+            uint8_t encoded[len];
+            Base64Encode(buffer->buffer, buffer->offset, encoded, &len);
+            json_object_set_new(js, "http_body_base64", json_string((char *)encoded));
+        }
+    }
+}
+
 /* JSON format logging */
 static void JsonHttpLogJSON(JsonHttpLogThread *aft, json_t *js, htp_tx_t *tx, uint64_t tx_id)
 {
@@ -395,7 +446,7 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     SCReturnInt(TM_ECODE_OK);
 }
 
-json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id)
+json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id, uint16_t flags, void *data)
 {
     HtpState *htp_state = (HtpState *)FlowGetAppState(f);
     if (htp_state) {
@@ -408,7 +459,12 @@ json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id)
 
             JsonHttpLogJSONBasic(hjs, tx);
             JsonHttpLogJSONExtended(hjs, tx);
-
+            if (flags & LOG_JSON_HTTP_BODY) {
+                JsonHttpLogJSONBodyPrintable(hjs, tx, data);
+            }
+            if (flags & LOG_JSON_HTTP_BODY_BASE64) {
+                JsonHttpLogJSONBodyBase64(hjs, tx, data);
+            }
             return hjs;
         }
     }

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -460,9 +460,11 @@ json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id, uint16_t flags, void 
             JsonHttpLogJSONBasic(hjs, tx);
             JsonHttpLogJSONExtended(hjs, tx);
             if (flags & LOG_JSON_HTTP_BODY) {
+                MemBufferReset((MemBuffer *)data);
                 JsonHttpLogJSONBodyPrintable(hjs, tx, data);
             }
             if (flags & LOG_JSON_HTTP_BODY_BASE64) {
+                MemBufferReset((MemBuffer *)data);
                 JsonHttpLogJSONBodyBase64(hjs, tx, data);
             }
             return hjs;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -378,7 +378,7 @@ static void JsonHttpLogJSONBodyPrintable(json_t *js, htp_tx_t *tx, void *data)
                                  buffer->buffer, buffer->offset);
             /* avoid to add an empty object */
             if (offset > 0) {
-                json_object_set_new(js, "http_body", json_string((char *)printable_buf));
+                json_object_set_new(js, "http_body_printable", json_string((char *)printable_buf));
             }
         }
     }
@@ -395,7 +395,7 @@ static void JsonHttpLogJSONBodyBase64(json_t *js, htp_tx_t *tx, void *data)
             unsigned long len = buffer->offset * 2 + 1;
             uint8_t encoded[len];
             Base64Encode(buffer->buffer, buffer->offset, encoded, &len);
-            json_object_set_new(js, "http_body_base64", json_string((char *)encoded));
+            json_object_set_new(js, "http_body", json_string((char *)encoded));
         }
     }
 }

--- a/src/output-json-http.h
+++ b/src/output-json-http.h
@@ -29,7 +29,7 @@ void JsonHttpLogRegister(void);
 #ifdef HAVE_LIBJANSSON
 void JsonHttpLogJSONBasic(json_t *js, htp_tx_t *tx);
 void JsonHttpLogJSONExtended(json_t *js, htp_tx_t *tx);
-json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id);
+json_t *JsonHttpAddMetadata(const Flow *f, uint64_t tx_id, uint16_t flags, void *data);
 #endif /* HAVE_LIBJANSSON */
 
 #endif /* __OUTPUT_JSON_HTTP_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -172,6 +172,7 @@ outputs:
             smtp: yes                # enable dumping of smtp fields
             dnp3: yes                # enable dumping of DNP3 fields
             vars: yes                # enable dumping of flowbits and other vars
+            filename: yes            # enable dumping of files
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,6 +164,9 @@ outputs:
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
             http: yes                # enable dumping of http fields
+            # http-body: yes           # enable dumping of http body in Base64
+            # http-body-printable: yes # enable dumping of http body in printable format
+            # http-body-buffer-size: 4kb # max size of HTTP body buffer to output in eve-log
             tls: yes                 # enable dumping of tls fields
             ssh: yes                 # enable dumping of ssh fields
             smtp: yes                # enable dumping of smtp fields


### PR DESCRIPTION
This patchset adds the http body in the alert event in base64 or printable format.

Ticket: https://redmine.openinfosecfoundation.org/issues/2095

Prscript:
- PR glongo: https://buildbot.openinfosecfoundation.org/builders/glongo/builds/137
- PR glongo-pcap: https://buildbot.openinfosecfoundation.org/builders/glongo-pcap/builds/1