### PR TITLE
Os/windows mingw/v4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,7 @@
         #endif
     ]])
 
-    AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h w32api/wtypes.h], [], [],
+    AC_CHECK_HEADERS([windows.h winsock2.h ws2tcpip.h w32api/wtypes.h wincrypt.h], [], [],
                     [[
                         #ifndef _X86_
                         #define _X86_
@@ -170,7 +170,7 @@
     # Checks for library functions.
     AC_FUNC_MALLOC
     AC_FUNC_REALLOC
-    AC_CHECK_FUNCS([gettimeofday memset strcasecmp strchr strdup strerror strncasecmp strtol strtoul memchr memrchr])
+    AC_CHECK_FUNCS([gettimeofday memset strcasecmp strchr strdup strerror strncasecmp strtol strtoul memchr memrchr clock_gettime])
 
     OCFLAGS=$CFLAGS
     CFLAGS=""

--- a/qa/coccinelle/banned-functions.cocci
+++ b/qa/coccinelle/banned-functions.cocci
@@ -3,7 +3,7 @@ identifier i;
 position p1;
 @@
 
-\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strndup@i\|strchrnul@i\)(...)@p1
+\(strtok@i\|sprintf@i\|strcat@i\|strcpy@i\|strncpy@i\|strncat@i\|strndup@i\|strchrnul@i\|rand@i\|rand_r@i\)(...)@p1
 
 @script:python@
 p1 << banned.p1;

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2149,11 +2149,12 @@ static void HTPConfigSetDefaultsPhase1(HTPCfgRec *cfg_prec)
     cfg_prec->request.inspect_window = HTP_CONFIG_DEFAULT_REQUEST_INSPECT_WINDOW;
     cfg_prec->response.inspect_min_size = HTP_CONFIG_DEFAULT_RESPONSE_INSPECT_MIN_SIZE;
     cfg_prec->response.inspect_window = HTP_CONFIG_DEFAULT_RESPONSE_INSPECT_WINDOW;
-#ifndef AFLFUZZ_NO_RANDOM
-    cfg_prec->randomize = HTP_CONFIG_DEFAULT_RANDOMIZE;
-#else
-    cfg_prec->randomize = 0;
-#endif
+
+    if (!g_disable_randomness) {
+        cfg_prec->randomize = HTP_CONFIG_DEFAULT_RANDOMIZE;
+    } else {
+        cfg_prec->randomize = 0;
+    }
     cfg_prec->randomize_range = HTP_CONFIG_DEFAULT_RANDOMIZE_RANGE;
 
     htp_config_register_request_header_data(cfg_prec->cfg, HTPCallbackRequestHeaderData);
@@ -2471,9 +2472,9 @@ static void HTPConfigParseParameters(HTPCfgRec *cfg_prec, ConfNode *s,
                     (size_t)HTP_CONFIG_DEFAULT_FIELD_LIMIT_SOFT,
                     (size_t)limit);
         } else if (strcasecmp("randomize-inspection-sizes", p->name) == 0) {
-#ifndef AFLFUZZ_NO_RANDOM
-            cfg_prec->randomize = ConfValIsTrue(p->val);
-#endif
+            if (!g_disable_randomness) {
+                cfg_prec->randomize = ConfValIsTrue(p->val);
+            }
         } else if (strcasecmp("randomize-inspection-range", p->name) == 0) {
             uint32_t range = atoi(p->val);
             if (range > 100) {

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -2720,9 +2720,9 @@ static int HTPRegisterPatternsForProtocolDetection(void)
     char *spacings[] = { "|20|", "|09|", NULL };
     char *versions[] = { "HTTP/0.9", "HTTP/1.0", "HTTP/1.1", NULL };
 
-    uint methods_pos;
-    uint spacings_pos;
-    uint versions_pos;
+    int methods_pos;
+    int spacings_pos;
+    int versions_pos;
     int register_result;
     char method_buffer[32] = "";
 
@@ -2754,7 +2754,7 @@ static int HTPRegisterPatternsForProtocolDetection(void)
             return -1;
         }
     }
-    
+
     return 0;
 }
 

--- a/src/app-layer-htp.c
+++ b/src/app-layer-htp.c
@@ -77,6 +77,7 @@
 #include "decode-events.h"
 
 #include "util-memcmp.h"
+#include "util-random.h"
 
 //#define PRINT
 
@@ -2199,12 +2200,15 @@ static void HTPConfigSetDefaultsPhase2(char *name, HTPCfgRec *cfg_prec)
     if (cfg_prec->randomize) {
         int rdrange = cfg_prec->randomize_range;
 
+        long int r = RandomGet();
         cfg_prec->request.inspect_min_size +=
             (int) (cfg_prec->request.inspect_min_size *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+
+        r = RandomGet();
         cfg_prec->request.inspect_window +=
             (int) (cfg_prec->request.inspect_window *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
         SCLogConfig("'%s' server has 'request-body-minimal-inspect-size' set to"
                   " %d and 'request-body-inspect-window' set to %d after"
                   " randomization.",
@@ -2213,12 +2217,15 @@ static void HTPConfigSetDefaultsPhase2(char *name, HTPCfgRec *cfg_prec)
                   cfg_prec->request.inspect_window);
 
 
+        r = RandomGet();
         cfg_prec->response.inspect_min_size +=
             (int) (cfg_prec->response.inspect_min_size *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+
+        r = RandomGet();
         cfg_prec->response.inspect_window +=
             (int) (cfg_prec->response.inspect_window *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
 
         SCLogConfig("'%s' server has 'response-body-minimal-inspect-size' set to"
                   " %d and 'response-body-inspect-window' set to %d after"

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -134,9 +134,8 @@ void DefragInitConfig(char quiet)
     DefragTrackerQueueInit(&defragtracker_spare_q);
 
 #ifndef AFLFUZZ_NO_RANDOM
-    unsigned int seed = RandomTimePreseed();
     /* set defaults */
-    defrag_config.hash_rand   = (int)(DEFRAG_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
+    defrag_config.hash_rand   = (uint32_t)RandomGet();
 #endif
     defrag_config.hash_size   = DEFRAG_DEFAULT_HASHSIZE;
     defrag_config.memcap      = DEFRAG_DEFAULT_MEMCAP;

--- a/src/defrag-hash.c
+++ b/src/defrag-hash.c
@@ -133,10 +133,8 @@ void DefragInitConfig(char quiet)
     SC_ATOMIC_INIT(defragtracker_prune_idx);
     DefragTrackerQueueInit(&defragtracker_spare_q);
 
-#ifndef AFLFUZZ_NO_RANDOM
     /* set defaults */
     defrag_config.hash_rand   = (uint32_t)RandomGet();
-#endif
     defrag_config.hash_size   = DEFRAG_DEFAULT_HASHSIZE;
     defrag_config.memcap      = DEFRAG_DEFAULT_MEMCAP;
     defrag_config.prealloc    = DEFRAG_DEFAULT_PREALLOC;

--- a/src/flow.c
+++ b/src/flow.c
@@ -349,10 +349,8 @@ void FlowInitConfig(char quiet)
     FlowQueueInit(&flow_spare_q);
     FlowQueueInit(&flow_recycle_q);
 
-#ifndef AFLFUZZ_NO_RANDOM
     /* set defaults */
     flow_config.hash_rand   = (uint32_t)RandomGet();
-#endif
     flow_config.hash_size   = FLOW_DEFAULT_HASHSIZE;
     flow_config.memcap      = FLOW_DEFAULT_MEMCAP;
     flow_config.prealloc    = FLOW_DEFAULT_PREALLOC;

--- a/src/flow.c
+++ b/src/flow.c
@@ -350,9 +350,8 @@ void FlowInitConfig(char quiet)
     FlowQueueInit(&flow_recycle_q);
 
 #ifndef AFLFUZZ_NO_RANDOM
-    unsigned int seed = RandomTimePreseed();
     /* set defaults */
-    flow_config.hash_rand   = (int)( FLOW_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
+    flow_config.hash_rand   = (uint32_t)RandomGet();
 #endif
     flow_config.hash_size   = FLOW_DEFAULT_HASHSIZE;
     flow_config.memcap      = FLOW_DEFAULT_MEMCAP;

--- a/src/host.c
+++ b/src/host.c
@@ -141,10 +141,8 @@ void HostInitConfig(char quiet)
     SC_ATOMIC_INIT(host_prune_idx);
     HostQueueInit(&host_spare_q);
 
-#ifndef AFLFUZZ_NO_RANDOM
     /* set defaults */
     host_config.hash_rand   = (uint32_t)RandomGet();
-#endif
     host_config.hash_size   = HOST_DEFAULT_HASHSIZE;
     host_config.memcap      = HOST_DEFAULT_MEMCAP;
     host_config.prealloc    = HOST_DEFAULT_PREALLOC;

--- a/src/host.c
+++ b/src/host.c
@@ -142,9 +142,8 @@ void HostInitConfig(char quiet)
     HostQueueInit(&host_spare_q);
 
 #ifndef AFLFUZZ_NO_RANDOM
-    unsigned int seed = RandomTimePreseed();
     /* set defaults */
-    host_config.hash_rand   = (int)( HOST_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
+    host_config.hash_rand   = (uint32_t)RandomGet();
 #endif
     host_config.hash_size   = HOST_DEFAULT_HASHSIZE;
     host_config.memcap      = HOST_DEFAULT_MEMCAP;

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -137,10 +137,8 @@ void IPPairInitConfig(char quiet)
     SC_ATOMIC_INIT(ippair_prune_idx);
     IPPairQueueInit(&ippair_spare_q);
 
-#ifndef AFLFUZZ_NO_RANDOM
     /* set defaults */
     ippair_config.hash_rand   = (uint32_t)RandomGet();
-#endif
     ippair_config.hash_size   = IPPAIR_DEFAULT_HASHSIZE;
     ippair_config.memcap      = IPPAIR_DEFAULT_MEMCAP;
     ippair_config.prealloc    = IPPAIR_DEFAULT_PREALLOC;

--- a/src/ippair.c
+++ b/src/ippair.c
@@ -138,9 +138,8 @@ void IPPairInitConfig(char quiet)
     IPPairQueueInit(&ippair_spare_q);
 
 #ifndef AFLFUZZ_NO_RANDOM
-    unsigned int seed = RandomTimePreseed();
     /* set defaults */
-    ippair_config.hash_rand   = (int)( IPPAIR_DEFAULT_HASHSIZE * (rand_r(&seed) / RAND_MAX + 1.0));
+    ippair_config.hash_rand   = (uint32_t)RandomGet();
 #endif
     ippair_config.hash_size   = IPPAIR_DEFAULT_HASHSIZE;
     ippair_config.memcap      = IPPAIR_DEFAULT_MEMCAP;

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -73,6 +73,7 @@
 #include "util-misc.h"
 #include "util-validate.h"
 #include "util-runmodes.h"
+#include "util-random.h"
 
 #include "source-pcap-file.h"
 
@@ -505,8 +506,6 @@ void StreamTcpInitConfig(char quiet)
                 exit(EXIT_FAILURE);
             }
         }
-        /* set a "random" seed */
-        srandom(time(0));
     }
 
     char *temp_stream_reassembly_toserver_chunk_size_str;
@@ -526,9 +525,10 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (randomize) {
+        long int r = RandomGet();
         stream_config.reassembly_toserver_chunk_size +=
             (int) (stream_config.reassembly_toserver_chunk_size *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
     }
     StreamMsgQueueSetMinChunkLen(FLOW_PKT_TOSERVER,
             stream_config.reassembly_toserver_chunk_size);
@@ -550,9 +550,10 @@ void StreamTcpInitConfig(char quiet)
     }
 
     if (randomize) {
+        long int r = RandomGet();
         stream_config.reassembly_toclient_chunk_size +=
             (int) (stream_config.reassembly_toclient_chunk_size *
-                   (random() * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
+                   (r * 1.0 / RAND_MAX - 0.5) * rdrange / 100);
     }
 
     StreamMsgQueueSetMinChunkLen(FLOW_PKT_TOCLIENT,

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -220,6 +220,13 @@ int sc_set_caps = FALSE;
 /** highest mtu of the interfaces we monitor */
 int g_default_mtu = 0;
 
+/** disable randomness to get reproducible results accross runs */
+#ifndef AFLFUZZ_NO_RANDOM
+int g_disable_randomness = 0;
+#else
+int g_disable_randomness = 1;
+#endif
+
 int EngineModeIsIPS(void)
 {
     return (g_engine_mode == ENGINE_MODE_IPS);
@@ -1461,6 +1468,7 @@ static TmEcode ParseCommandLine(int argc, char** argv, SCInstance *suri)
         {"netmap", optional_argument, 0, 0},
         {"pcap", optional_argument, 0, 0},
         {"simulate-ips", 0, 0 , 0},
+        {"no-random", 0, &g_disable_randomness, 1},
 
         /* AFL app-layer options. */
         {"afl-http-request", required_argument, 0 , 0},

--- a/src/suricata.h
+++ b/src/suricata.h
@@ -172,6 +172,7 @@ typedef struct SCInstance_ {
 void GlobalsInitPreConfig();
 
 extern volatile uint8_t suricata_ctl_flags;
+extern int g_disable_randomness;
 
 /* uppercase to lowercase conversion lookup table */
 uint8_t g_u8_lowercasetable[256];

--- a/src/util-device.c
+++ b/src/util-device.c
@@ -179,7 +179,7 @@ static int LiveSafeDeviceName(const char *devname, char *newdevname, size_t dest
         snprintf(newdevname, half+1, "%s", devname);
 
         /* Add the amount of spaces wanted */
-        for (uint i = half; i < half+spaces; i++) {
+        for (size_t i = half; i < half+spaces; i++) {
             length = strlcat(newdevname, ".", destlen);
         }
 

--- a/src/util-random.c
+++ b/src/util-random.c
@@ -31,6 +31,9 @@
 
 long int RandomGet(void)
 {
+    if (g_disable_randomness)
+        return 0;
+
     HCRYPTPROV p;
     if (!(CryptAcquireContext(&p, NULL, NULL,
                 PROV_RSA_FULL, 0))) {
@@ -50,6 +53,9 @@ long int RandomGet(void)
 #elif defined(HAVE_CLOCK_GETTIME)
 long int RandomGet(void)
 {
+    if (g_disable_randomness)
+        return 0;
+
     struct timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
 
@@ -60,6 +66,9 @@ long int RandomGet(void)
 #else
 long int RandomGet(void)
 {
+    if (g_disable_randomness)
+        return 0;
+
     struct timeval tv;
     memset(&tv, 0, sizeof(tv));
     gettimeofday(&tv, NULL);

--- a/src/util-random.h
+++ b/src/util-random.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2017 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -18,13 +18,13 @@
 /**
  * \file
  *
- * \author Pablo Rincon <pablo.rincon.crespo@gmail.com>
+ * \author Victor Julien <victor@inliniac.net>
  */
 
 #ifndef __UTIL_RANDOM_H__
 #define __UTIL_RANDOM_H__
 
-unsigned int RandomTimePreseed(void);
+long int RandomGet(void);
 
 #endif /* __UTIL_RANDOM_H__ */
 


### PR DESCRIPTION
Add support for Windows random API. Create a single call to replace all rand, rand_r calls. Black list rand, rand_r.

Add --no-random commandline to disable randomness from hashes, body sizes. This to create more reproducible results.


PRscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/91
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/599

@jasonish even though we don't use random for crypto, it might still be good to have a look :)