### PR TITLE
rfc - rust integration - v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,9 @@ matrix:
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,cocci"
+        - NAME="linux,gcc,cocci,rust"
         - *default-cflags
+        - ENABLE_RUST="yes"
       addons:
         apt:
           sources:
@@ -135,6 +136,11 @@ script:
     fi
 
 before_install:
+  - |
+    if [[ "$ENABLE_RUST" == "yes" ]]; then
+        curl https://sh.rustup.rs -sSf | sh -s -- -y
+    fi
+  - export PATH=$HOME/.cargo/bin:$PATH
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         brew update

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = ChangeLog COPYING LICENSE suricata.yaml.in \
              classification.config threshold.config \
              reference.config
-SUBDIRS = $(HTP_DIR) src qa rules doc contrib scripts
+SUBDIRS = $(HTP_DIR) rust src qa rules doc contrib scripts
 
 CLEANFILES = stamp-h[0-9]*
 

--- a/configure.ac
+++ b/configure.ac
@@ -1929,6 +1929,24 @@
     fi
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
+# Cargo/Rust.
+  AC_PATH_PROG(HAVE_CARGO, cargo, "no")
+  AC_PATH_PROG(HAVE_RUSTC, rustc, "no")
+  if test "x$HAVE_CARGO" != "xno"; then
+     if test "x$HAVE_RUSTC" != "xno"; then
+        enable_rust=yes
+        AC_DEFINE([HAVE_RUST],[1],[Enable Rust language])
+	if test "x$enable_debug" = "xyes"; then
+	   RUST_LDADD="../rust/target/debug/libsuricata.a -lrt -ldl"
+	else
+	   RUST_LDADD="../rust/target/release/libsuricata.a -lrt -ldl"
+	fi
+	AC_SUBST(RUST_LDADD)
+     fi
+  fi
+  AM_CONDITIONAL([HAVE_RUST], [test "x$enable_rust" = "xyes"])
+  AC_CONFIG_LINKS([rust/Cargo.toml:rust/Cargo.toml])
+
 # get revision
     if test -f ./revision; then
         REVISION=`cat ./revision`
@@ -2007,7 +2025,7 @@ AC_SUBST(CONFIGURE_PREFIX)
 AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 
-AC_OUTPUT(Makefile src/Makefile qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/configure.ac
+++ b/configure.ac
@@ -1930,6 +1930,7 @@
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
 # Cargo/Rust.
+  rust_vendor_comment="# "
   AC_PATH_PROG(HAVE_CARGO, cargo, "no")
   AC_PATH_PROG(HAVE_RUSTC, rustc, "no")
   if test "x$HAVE_CARGO" != "xno"; then
@@ -1942,10 +1943,15 @@
 	   RUST_LDADD="../rust/target/release/libsuricata.a -lrt -ldl"
 	fi
 	AC_SUBST(RUST_LDADD)
+	AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
+	if test "x$have_rust_vendor" = "xyes"; then
+	   rust_vendor_comment=""
+	fi
      fi
   fi
   AM_CONDITIONAL([HAVE_RUST], [test "x$enable_rust" = "xyes"])
-  AC_CONFIG_LINKS([rust/Cargo.toml:rust/Cargo.toml])
+  AC_SUBST(rust_vendor_comment)
+  AM_CONDITIONAL([HAVE_RUST_VENDOR], [test "x$have_rust_vendor" = "xyes"])
 
 # get revision
     if test -f ./revision; then
@@ -2025,7 +2031,7 @@ AC_SUBST(CONFIGURE_PREFIX)
 AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/rust/.cargo/config.in
+++ b/rust/.cargo/config.in
@@ -1,0 +1,8 @@
+@rust_vendor_comment@[source]
+@rust_vendor_comment@
+@rust_vendor_comment@[source.crates-io]
+@rust_vendor_comment@registry = 'https://github.com/rust-lang/crates.io-index'
+@rust_vendor_comment@replace-with = 'vendored-sources'
+@rust_vendor_comment@
+@rust_vendor_comment@[source.vendored-sources]
+@rust_vendor_comment@directory = './vendor'

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,2 +1,2 @@
 target
-Cargo.lock
+vendor

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,0 +1,21 @@
+[root]
+name = "suricata"
+version = "4.0.0-dev"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum nom 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d4598834859fedb9a0a69d5b862a970e77982a92f544d547257a4d49469067"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,5 +6,5 @@ version = "4.0.0-dev"
 crate-type = ["staticlib"]
 
 [dependencies]
-nom = "^2.1.0"
+nom = "2.1.0"
 libc = "0.2.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "suricata"
+version = "4.0.0-dev"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+nom = "^2.1.0"
+libc = "0.2.0"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,0 +1,28 @@
+EXTRA_DIST = 	Cargo.toml \
+		src/lib.rs
+
+if HAVE_RUST
+all-local:
+# If building in an alternate directory, Cargo.toml gets linked in by
+# AC_CONFIG_LINKS, but that doesn't support directories. So instead of
+# linking everything file under src, just link in the src directory
+# here.
+	if ! test -e src; then \
+		ln -s $(top_srcdir)/rust/src .; \
+	fi
+if DEBUG
+	cargo build
+else
+	cargo build --release
+endif
+
+clean-local:
+	cargo clean
+	rm -f Cargo.lock
+
+check:
+	cargo test
+else
+all-local clean-local check:
+endif
+

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -1,28 +1,35 @@
 EXTRA_DIST = 	Cargo.toml \
-		src/lib.rs
+		Cargo.lock \
+		src/lib.rs \
+		.cargo/config.in \
+		vendor
+
+if HAVE_RUST_VENDOR
+FROZEN = --frozen
+endif
+
+if !DEBUG
+RELEASE = --release
+endif
 
 if HAVE_RUST
 all-local:
-# If building in an alternate directory, Cargo.toml gets linked in by
-# AC_CONFIG_LINKS, but that doesn't support directories. So instead of
-# linking everything file under src, just link in the src directory
-# here.
-	if ! test -e src; then \
-		ln -s $(top_srcdir)/rust/src .; \
-	fi
-if DEBUG
-	cargo build
-else
-	cargo build --release
-endif
+	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
+		cargo build $(RELEASE) $(FROZEN)
 
 clean-local:
-	cargo clean
-	rm -f Cargo.lock
+	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
+		cargo clean
+
+distclean-local:
+	rm -rf vendor
 
 check:
-	cargo test
+	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
+		cargo test
 else
 all-local clean-local check:
 endif
 
+vendor:
+	cargo vendor > /dev/null

--- a/rust/src/conf.rs
+++ b/rust/src/conf.rs
@@ -1,0 +1,67 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+use std::os::raw::c_char;
+use std::ffi::{CString, CStr};
+use std::ptr;
+use std::str;
+
+use log::*;
+
+extern {
+    fn ConfGet(key: *const c_char, res: *mut *const c_char) -> i8;
+}
+
+// Return the string value of a configuration value.
+pub fn conf_get(key: &str) -> Option<&str> {
+    let mut vptr: *const c_char = ptr::null_mut();
+    
+    unsafe {
+        if ConfGet(CString::new(key).unwrap().as_ptr(), &mut vptr) != 1 {
+            SCLogInfo!("Failed to find value for key {}", key);
+            return None;
+        }
+    }
+
+    if vptr == ptr::null() {
+        return None;
+    }
+
+    let value = str::from_utf8(unsafe{
+        CStr::from_ptr(vptr).to_bytes()
+    }).unwrap();
+
+    return Some(value);
+}
+
+// Return the value of key as a boolean. A value that is not set is
+// the same as having it set to false.
+pub fn conf_get_bool(key: &str) -> bool {
+    match conf_get(key) {
+        Some(val) => {
+            match val {
+                "1" | "yes" | "true" | "on" => {
+                    return true;
+                },
+                _ => {},
+            }
+        },
+        None => {},
+    }
+
+    return false;
+}

--- a/rust/src/dns/mod.rs
+++ b/rust/src/dns/mod.rs
@@ -15,6 +15,22 @@
  * 02110-1301, USA.
  */
 
-void rs_log_init(int32_t level);
+use log::*;
+use conf;
 
-void rs_dns_init(void);
+#[no_mangle]
+pub extern "C" fn rs_dns_init() {
+    SCLogNotice!("Initializing DNS analyzer");
+    
+    match conf::conf_get("app-layer.protocols.dns.tcp.enabled") {
+        Some(val) => SCLogNotice!("- TCP is enabled: {}", val),
+        None => SCLogNotice!("- TCP is not enabled."),
+    }
+
+    match conf::conf_get("app-layer.protocols.dns.udp.enabled") {
+        Some(val) => SCLogNotice!("- UDP is enabled: {}", val),
+        None => SCLogNotice!("- UDP is not enabled."),
+    }
+}
+
+

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,3 @@
+#[test]
+fn it_works() {
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,2 @@
-#[test]
-fn it_works() {
-}
+#[macro_use]
+pub mod log;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,2 +1,5 @@
 #[macro_use]
 pub mod log;
+
+pub mod conf;
+

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,4 +2,4 @@
 pub mod log;
 
 pub mod conf;
-
+pub mod dns;

--- a/rust/src/log.rs
+++ b/rust/src/log.rs
@@ -1,0 +1,156 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#![cfg_attr(feature = "type_name", feature(core_intrinsics))]
+
+extern crate libc;
+
+use std::os::raw::c_char;
+use std::ffi::{CString};
+use std::path::Path;
+
+pub enum Level {
+    NotSet = -1,
+    None = 0,
+    Emergency,
+    Alert,
+    Critical,
+    Error,
+    Warning,
+    Notice,
+    Info,
+    Perf,
+    Config,
+    Debug,
+}
+
+pub static mut LEVEL: i32 = Level::NotSet as i32;
+
+extern {
+    fn SCLogMessage(level: libc::c_int,
+                    filename: *const c_char,
+                    line: libc::c_uint,
+                    function: *const c_char,
+                    code: libc::c_int,
+                    message: *const c_char) -> libc::c_int;
+}
+
+pub fn get_log_level() -> i32 {
+    unsafe {
+        LEVEL
+    }
+}
+
+fn basename(filename: &str) -> &str {
+    let path = Path::new(filename);
+    for os_str in path.file_name() {
+        for basename in os_str.to_str() {
+            return basename;
+        }
+    }
+    return filename;
+}
+
+pub fn sclog(level: Level, file: &str, line: u32, function: &str,
+         code: i32, message: &str)
+{
+    let filename = basename(file);
+
+    unsafe {
+        SCLogMessage(level as i32,
+                     CString::new(filename).unwrap().as_ptr(),
+                     line,
+                     CString::new(function).unwrap().as_ptr(),
+                     code,
+                     CString::new(message).unwrap().as_ptr());
+    }
+}
+
+// A macro which expends to the function name from which it was
+// invoked.
+#[cfg(feature = "type_name")]
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            extern crate core;
+            unsafe { core::intrinsics::type_name::<T>() }
+        }
+        let name = type_name_of(f);
+        &name[6..name.len() - 4]
+    }}
+}
+
+// A macro that expends to some static text when the underlying
+// feature to get at the function name is not available.
+#[cfg(not(feature = "type_name"))]
+macro_rules! function {
+    () => {{ "<rust>" }}
+}
+
+#[macro_export]
+macro_rules!do_log {
+    ($level:expr, $file:expr, $line:expr, $function:expr, $code:expr,
+     $($arg:tt)*) => {
+        if get_log_level() >= $level as i32 {
+            sclog($level, $file, $line, $function, $code,
+                  &(format!($($arg)*)));
+        }
+    }
+}
+
+#[macro_export]
+macro_rules!SCLogNotice {
+    ($($arg:tt)*) => {
+        do_log!(Level::Notice, file!(), line!(), function!(), 0, $($arg)*);
+    }
+}
+
+#[macro_export]
+macro_rules!SCLogInfo {
+    ($($arg:tt)*) => {
+        do_log!(Level::Info, file!(), line!(), function!(), 0, $($arg)*);
+    }
+}
+
+#[macro_export]
+macro_rules!SCLogPerf {
+    ($($arg:tt)*) => {
+        do_log!(Level::Perf, file!(), line!(), function!(), 0, $($arg)*);
+    }
+}
+
+#[macro_export]
+macro_rules!SCLogConfig {
+    ($($arg:tt)*) => {
+        do_log!(Level::Config, file!(), line!(), function!(), 0, $($arg)*);
+    }
+}
+
+#[macro_export]
+macro_rules!SCLogDebug {
+    ($($arg:tt)*) => {
+        do_log!(Level::Debug, file!(), line!(), function!(), 0, $($arg)*);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rs_log_init(level: i32) {
+    unsafe {
+        LEVEL = level;
+    }
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -461,7 +461,7 @@ AM_CPPFLAGS = $(all_includes)
 
 # the library search path.
 suricata_LDFLAGS = $(all_libraries) ${SECLDFLAGS}
-suricata_LDADD = $(HTP_LDADD)
+suricata_LDADD = $(HTP_LDADD) $(RUST_LDADD)
 
 # Rules to build CUDA ptx modules
 if BUILD_CUDA

--- a/src/app-layer-dns-udp.c
+++ b/src/app-layer-dns-udp.c
@@ -50,6 +50,8 @@
 
 #include "app-layer-dns-udp.h"
 
+#include "rust.h"
+
 /** \internal
  *  \brief Parse DNS request packet
  */
@@ -383,6 +385,12 @@ static void DNSUDPConfigure(void)
 
 void RegisterDNSUDPParsers(void)
 {
+#ifdef HAVE_RUST
+    /* If DNS was implemented in Rust, we could call into the rust
+     * init function here. */
+    rs_dns_init();
+#endif
+
     char *proto_name = "dns";
 
     /** DNS */

--- a/src/rust.h
+++ b/src/rust.h
@@ -1,0 +1,18 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+void rs_log_init(int32_t level);

--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -43,6 +43,10 @@
 #include "util-unittest.h"
 #include "util-syslog.h"
 
+#ifdef HAVE_RUST
+#include "rust.h"
+#endif
+
 #include "conf.h"
 
 /* holds the string-enum mapping for the enums held in the table SCLogLevel */
@@ -1253,6 +1257,10 @@ void SCLogInitLogModule(SCLogInitData *sc_lid)
     sc_log_module_cleaned = 0;
 
     //SCOutputPrint(sc_did->startup_message);
+
+#ifdef HAVE_RUST
+    rs_log_init(sc_log_global_log_level);
+#endif
 
     return;
 }


### PR DESCRIPTION
RFC for incorporating Rust into the build.

Unlike other approaches, uses a single crate and a single static library.

On dist, the Rust dependencies are vendored (copied) and provided in the resulting tarball allowing the build to be done offline (cargo won't go out to the network to get deps).

Prscript failed due to a bad path in make distcheck, will be fixing up.

Prscript:
- You can watch build progress at https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/477
- You can watch build progress at https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/125
- Waiting for build completion
- Build successful for jasonish-pcap
- Build failure for jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/477
