### PR TITLE
Call LiveGetShortName on correct variable

### DIFF
--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -170,7 +170,7 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
 
         for (lthread = 0; lthread < nlive; lthread++) {
             const char *dev = LiveGetDeviceName(lthread);
-            const char *visual_devname = LiveGetShortName(live_dev);
+            const char *visual_devname = LiveGetShortName(dev);
             void *aconf;
             int threads_count;
 


### PR DESCRIPTION
https://github.com/inliniac/suricata/commit/bb2d8a713382984b90b20d425230f32ce4106b3e introduced
the `dev` variable and replaced referenced to `live_dev` with `dev`, except in one place.
As a result, suricata can now log '[ERRCODE: SC_ERR_INVALID_VALUE(130)] - Name of device should not be null'
on start-up with pfring.

https://redmine.openinfosecfoundation.org/issues/2097