### PR TITLE
Metadata and source/target identification

### DIFF
--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -173,9 +173,10 @@ format of priority is:
 Metadata
 --------
 
-Suricata ignores the words behind meta data.  Suricata supports this
-keyword because it is part of the signature language.  The format is:
+Suricata partially ignores the words behind meta data. Suricata only looks for
+the target keyword that is used to determine which side of the IP connection is
+the target of the attack.  The format is:
 
 ::
 
-  metadata:......;
+  metadata:...., target [client|server], ....;

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2017 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -253,7 +253,8 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
  *
  * \return 0 if ok
  */
-static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
+static int EventToSourceTarget(const PacketAlert *pa, const Packet *p,
+                               idmef_alert_t *alert)
 {
     int ret;
     idmef_node_t *node;
@@ -265,6 +266,8 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     static char saddr[128], daddr[128];
     uint8_t ip_vers;
     uint8_t ip_proto;
+    uint16_t sp, dp;
+    uint8_t invert = 0;
 
     SCEnter();
 
@@ -274,16 +277,77 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     if ( ! IPH_IS_VALID(p) )
         SCReturnInt(0);
 
+
+    if (pa->flags & PACKET_ALERT_HAS_METADATA) {
+        if (pa->flags & PACKET_ALERT_SRC_IS_TARGET) {
+            invert = 1;
+        } else {
+            invert = 0;
+        }
+    } else {
+        invert = 0;
+    }
+
     if (PKT_IS_IPV4(p)) {
         ip_vers = 4;
         ip_proto = IPV4_GET_RAW_IPPROTO(p->ip4h);
-        PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), saddr, sizeof(saddr));
-        PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), daddr, sizeof(daddr));
+        if (p->flow) {
+            Flow *f = p->flow;
+            if (invert) {
+                PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), saddr, sizeof(saddr));
+                PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), daddr, sizeof(daddr));
+                sp = f->dp;
+                dp = f->sp;
+            } else {
+                PrintInet(AF_INET, (const void *)&(f->src.addr_data32[0]), saddr, sizeof(saddr));
+                PrintInet(AF_INET, (const void *)&(f->dst.addr_data32[0]), daddr, sizeof(daddr));
+                sp = f->sp;
+                dp = f->dp;
+            }
+        } else  {
+            if (invert) {
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), saddr, sizeof(saddr));
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), daddr, sizeof(daddr));
+                sp = p->dp;
+                dp = p->sp;
+            } else {
+                PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), saddr, sizeof(saddr));
+                PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), daddr, sizeof(daddr));
+                sp = p->sp;
+                dp = p->dp;
+
+            }
+        }
     } else if (PKT_IS_IPV6(p)) {
         ip_vers = 6;
         ip_proto = IPV6_GET_L4PROTO(p);
-        PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), saddr, sizeof(saddr));
-        PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), daddr, sizeof(daddr));
+        if (p->flow) {
+            Flow *f = p->flow;
+            if (invert) {
+                PrintInet(AF_INET6, (const void *)&(f->src.address), saddr, sizeof(saddr));
+                PrintInet(AF_INET6, (const void *)&(f->dst.address), daddr, sizeof(daddr));
+                sp = f->sp;
+                dp = f->dp;
+            } else {
+                PrintInet(AF_INET6, (const void *)&(f->dst.address), saddr, sizeof(saddr));
+                PrintInet(AF_INET6, (const void *)&(f->src.address), daddr, sizeof(daddr));
+                sp = f->dp;
+                dp = f->sp;
+
+            }
+        } else {
+            if (invert) {
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), saddr, sizeof(saddr));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), daddr, sizeof(daddr));
+                sp = p->dp;
+                dp = p->sp;
+            } else {
+                PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), saddr, sizeof(saddr));
+                PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), daddr, sizeof(daddr));
+                sp = p->sp;
+                dp = p->dp;
+            }
+        }
     } else
         SCReturnInt(0);
 
@@ -296,7 +360,7 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
-        idmef_service_set_port(service, p->sp);
+        idmef_service_set_port(service, sp);
 
     idmef_service_set_ip_version(service, ip_vers);
     idmef_service_set_iana_protocol_number(service, ip_proto);
@@ -324,7 +388,7 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
-        idmef_service_set_port(service, p->dp);
+        idmef_service_set_port(service, dp);
 
     idmef_service_set_ip_version(service, ip_vers);
     idmef_service_set_iana_protocol_number(service, ip_proto);
@@ -908,7 +972,7 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
     if (unlikely(ret < 0))
         goto err;
 
-    ret = EventToSourceTarget(p, alert);
+    ret = EventToSourceTarget(pa, p, alert);
     if (unlikely(ret < 0))
         goto err;
 

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -643,7 +643,7 @@ static int EventToReference(const PacketAlert *pa, const Packet *p, idmef_classi
     SCReturnInt(0);
 }
 
-static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, uint8_t *buf, uint32_t buflen)
+static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
 {
     int ret;
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -267,15 +267,21 @@ typedef struct PacketAlert_ {
 /** After processing an alert by the thresholding module, if at
  *  last it gets triggered, we might want to stick the drop action to
  *  the flow on IPS mode */
-#define PACKET_ALERT_FLAG_DROP_FLOW     0x01
+#define PACKET_ALERT_FLAG_DROP_FLOW    BIT_U8(0)
 /** alert was generated based on state */
-#define PACKET_ALERT_FLAG_STATE_MATCH   0x02
+#define PACKET_ALERT_FLAG_STATE_MATCH   BIT_U8(1)
 /** alert was generated based on stream */
-#define PACKET_ALERT_FLAG_STREAM_MATCH  0x04
+#define PACKET_ALERT_FLAG_STREAM_MATCH  BIT_U8(1)
 /** alert is in a tx, tx_id set */
-#define PACKET_ALERT_FLAG_TX            0x08
+#define PACKET_ALERT_FLAG_TX            BIT_U8(3)
 /** action was changed by rate_filter */
-#define PACKET_ALERT_RATE_FILTER_MODIFIED   0x10
+#define PACKET_ALERT_RATE_FILTER_MODIFIED   BIT_U8(4)
+/** alert has source which is target of attack */
+#define PACKET_ALERT_SRC_IS_TARGET   BIT_U8(5)
+/** alert has destination which is target of attack */
+#define PACKET_ALERT_DEST_IS_TARGET   BIT_U8(6)
+
+#define PACKET_ALERT_HAS_METADATA   (PACKET_ALERT_DEST_IS_TARGET|PACKET_ALERT_SRC_IS_TARGET)
 
 #define PACKET_ALERT_MAX 15
 

--- a/src/detect-engine-alert.c
+++ b/src/detect-engine-alert.c
@@ -195,6 +195,7 @@ int PacketAlertAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
         return 0;
 
     SCLogDebug("sid %"PRIu32"", s->id);
+    SCLogDebug("alert flags: %d", det_ctx->alert_flags);
 
     /* It should be usually the last, so check it before iterating */
     if (p->alerts.cnt == 0 || (p->alerts.cnt > 0 &&
@@ -202,7 +203,7 @@ int PacketAlertAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
         /* We just add it */
         p->alerts.alerts[p->alerts.cnt].num = s->num;
         p->alerts.alerts[p->alerts.cnt].action = s->action;
-        p->alerts.alerts[p->alerts.cnt].flags = flags;
+        p->alerts.alerts[p->alerts.cnt].flags = det_ctx->alert_flags | flags;
         p->alerts.alerts[p->alerts.cnt].s = s;
         p->alerts.alerts[p->alerts.cnt].tx_id = tx_id;
     } else {
@@ -216,7 +217,7 @@ int PacketAlertAppend(DetectEngineThreadCtx *det_ctx, const Signature *s,
 
         p->alerts.alerts[i].num = s->num;
         p->alerts.alerts[i].action = s->action;
-        p->alerts.alerts[i].flags = flags;
+        p->alerts.alerts[i].flags = det_ctx->alert_flags | flags;
         p->alerts.alerts[i].s = s;
         p->alerts.alerts[i].tx_id = tx_id;
     }

--- a/src/detect-metadata.c
+++ b/src/detect-metadata.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2010 Open Information Security Foundation
+/* Copyright (C) 2007-2017 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -28,22 +28,133 @@
 
 #include "suricata-common.h"
 #include "detect.h"
+#include "detect-parse.h"
+#include "detect-metadata.h"
+
+#define PARSE_REGEX "^\\s*([^\\s]+)\\s+([^\\s]+)(?:,\\s*([^\\s]+)\\s+([^\\s]+))*$"
+#define PARSE_TAG_REGEX "\\s*([^\\s]+)\\s+([^,]+)\\s*"
+
+static pcre *parse_regex;
+static pcre_extra *parse_regex_study;
+static pcre *parse_tag_regex;
+static pcre_extra *parse_tag_regex_study;
 
 static int DetectMetadataSetup (DetectEngineCtx *, Signature *, char *);
+static int DetectMetadataMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
+                          Packet *p, const Signature *s, const SigMatchCtx *ctx);
 
 void DetectMetadataRegister (void)
 {
     sigmatch_table[DETECT_METADATA].name = "metadata";
-    sigmatch_table[DETECT_METADATA].desc = "ignored by suricata";
+    sigmatch_table[DETECT_METADATA].desc = "partially used by suricata";
     sigmatch_table[DETECT_METADATA].url = DOC_URL DOC_VERSION "/rules/meta.html#metadata";
-    sigmatch_table[DETECT_METADATA].Match = NULL;
+    sigmatch_table[DETECT_METADATA].Match = DetectMetadataMatch;
     sigmatch_table[DETECT_METADATA].Setup = DetectMetadataSetup;
     sigmatch_table[DETECT_METADATA].Free  = NULL;
     sigmatch_table[DETECT_METADATA].RegisterTests = NULL;
+
+    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
+    DetectSetupParseRegexes(PARSE_TAG_REGEX, &parse_tag_regex, &parse_tag_regex_study);
 }
 
-static int DetectMetadataSetup (DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
+
+static int DetectMetadataMatch(ThreadVars *t, DetectEngineThreadCtx *det_ctx,
+                          Packet *p, const Signature *s, const SigMatchCtx *ctx)
 {
+    const DetectMetadataData *ddata = (DetectMetadataData *)ctx;
+
+    det_ctx->alert_flags |= ddata->flags;
+
+    return 1;
+}
+
+static void* DetectMetadataParse(char *rawstr)
+{
+    DetectMetadataData *de = NULL;
+#define MAX_SUBSTRINGS 30
+    int ret = 0, res = 0;
+    int ov[MAX_SUBSTRINGS];
+
+    ret = pcre_exec(parse_regex, parse_regex_study, rawstr, strlen(rawstr), 0, 0, ov, MAX_SUBSTRINGS);
+    if (ret < 2) {
+        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32
+                ", string %s", ret, rawstr);
+        goto error;
+    }
+
+    char *saveptr = NULL;
+    char * kv = strtok_r(rawstr, ",", &saveptr);
+
+    /* now check key value */
+    do {
+        const char *key;
+        const char *value;
+
+        ret = pcre_exec(parse_tag_regex, parse_tag_regex_study, kv, strlen(kv), 0, 0, ov, MAX_SUBSTRINGS);
+        if (ret < 2) {
+            SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32
+                    ", string %s", ret, rawstr);
+            goto error;
+        }
+
+        res =  pcre_get_substring(kv, ov, MAX_SUBSTRINGS, 1, &key);
+        if (res < 0) {
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            goto error;
+        }
+
+        res =  pcre_get_substring(kv, ov, MAX_SUBSTRINGS, 2, &value);
+        if (res < 0) {
+            SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+            goto error;
+        }
+
+        SCLogDebug("key: %s, value: %s", key, value);
+        if (!strncmp(key, "target", 7)) {
+            if (!strncmp(value, "client", 7)) {
+                de = SCMalloc(sizeof(DetectMetadataData));
+                if (unlikely(de == NULL))
+                    goto error;
+                de->flags = PACKET_ALERT_SRC_IS_TARGET;
+                break;
+            } else if (!strncmp(value, "server", 7)) {
+                de = SCMalloc(sizeof(DetectMetadataData));
+                if (unlikely(de == NULL))
+                    goto error;
+                de->flags = PACKET_ALERT_DEST_IS_TARGET;
+                break;
+            } else {
+                SCLogError(SC_ERR_INVALID_VALUE, "only src and dest are support for target metadata");
+                goto error;
+            }
+        }
+        kv = strtok_r(NULL, ",", &saveptr);
+    } while (kv);
+
+    return de;
+
+error:
+    return NULL;
+}
+
+static int DetectMetadataSetup(DetectEngineCtx *de_ctx, Signature *s, char *rawstr)
+{
+    SigMatch *sm = NULL;
+
+    /* parse the option, if NULL we are not doing anything */
+    DetectMetadataData *ddata = DetectMetadataParse(rawstr);
+    if (ddata == NULL)
+        return 0;
+
+    /* if we have something to do with the metadata then create the sm */
+    sm = SigMatchAlloc();
+    if (sm == NULL)
+        return -1;
+
+    sm->type = DETECT_METADATA;
+    sm->ctx = (SigMatchCtx *) ddata;
+
+    SigMatchAppendSMToList(s, sm, DETECT_SM_LIST_POSTMATCH);
     return 0;
 }
 

--- a/src/detect-metadata.h
+++ b/src/detect-metadata.h
@@ -28,8 +28,22 @@ typedef struct DetectMetadataData_ {
     uint8_t flags;
 } DetectMetadataData;
 
+/**
+ * \brief Signature metadata list.
+ */
+typedef struct DetectMetadata_ {
+    /* pointer to key */
+    char *key;
+    /* value data */
+    char *value;
+    /* next reference in the signature */
+    struct DetectMetadata_ *next;
+} DetectMetadata;
+
 /* prototypes */
 void DetectMetadataRegister (void);
+
+void DetectMetadataFree(DetectMetadata *mdata);
 
 #endif /* __DETECT_METADATA_H__ */
 

--- a/src/detect-metadata.h
+++ b/src/detect-metadata.h
@@ -24,6 +24,10 @@
 #ifndef __DETECT_METADATA_H__
 #define __DETECT_METADATA_H__
 
+typedef struct DetectMetadataData_ {
+    uint8_t flags;
+} DetectMetadataData;
+
 /* prototypes */
 void DetectMetadataRegister (void);
 

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1079,6 +1079,36 @@ Signature *SigAlloc (void)
 
 /**
  * \internal
+ * \brief Free Medadata list
+ *
+ * \param s Pointer to the signature
+ */
+static void SigMetadataFree(Signature *s)
+{
+    SCEnter();
+
+    DetectMetadata *mdata = NULL;
+    DetectMetadata *next_mdata = NULL;
+
+    if (s == NULL) {
+        SCReturn;
+    }
+
+    SCLogDebug("s %p, s->metadata %p", s, s->metadata);
+
+    for (mdata = s->metadata; mdata != NULL;)   {
+        next_mdata = mdata->next;
+        DetectMetadataFree(mdata);
+        mdata = next_mdata;
+    }
+
+    s->metadata = NULL;
+
+    SCReturn;
+}
+
+/**
+ * \internal
  * \brief Free Reference list
  *
  * \param s Pointer to the signature
@@ -1187,6 +1217,7 @@ void SigFree(Signature *s)
     }
 
     SigRefFree(s);
+    SigMetadataFree(s);
 
     DetectEngineAppInspectionEngineSignatureFree(s);
 

--- a/src/detect.h
+++ b/src/detect.h
@@ -901,6 +901,8 @@ typedef struct DetectEngineThreadCtx_ {
     int base64_decoded_len;
     int base64_decoded_len_max;
 
+    uint8_t alert_flags;
+
 #ifdef PROFILING
     struct SCProfileData_ *rule_perf_data;
     int rule_perf_data_size;

--- a/src/detect.h
+++ b/src/detect.h
@@ -30,6 +30,7 @@
 
 #include "detect-engine-proto.h"
 #include "detect-reference.h"
+#include "detect-metadata.h"
 #include "packet-queue.h"
 
 #include "util-prefilter.h"
@@ -453,6 +454,8 @@ typedef struct Signature_ {
     char *class_msg;
     /** Reference */
     DetectReference *references;
+    /** Metadata */
+    DetectMetadata *metadata;
 
     /* Be careful, this pointer is only valid while parsing the sig,
      * to warn the user about any possible problem */

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -43,6 +43,7 @@
 #include "detect-engine.h"
 #include "detect-engine-mpm.h"
 #include "detect-reference.h"
+#include "detect-metadata.h"
 #include "app-layer-parser.h"
 #include "app-layer-dnp3.h"
 #include "app-layer-htp.h"
@@ -82,6 +83,7 @@
 #define LOG_JSON_TAGGED_PACKETS 0x080
 #define LOG_JSON_DNP3           0x100
 #define LOG_JSON_VARS           0x200
+#define LOG_JSON_METADATA       0x400
 
 #define JSON_STREAM_BUFFER_SIZE 4096
 
@@ -173,7 +175,8 @@ static void AlertJsonDnp3(const Flow *f, json_t *js)
     return;
 }
 
-void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
+void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js,
+                     AlertJsonOutputCtx *json_output_ctx)
 {
     char *action = "allowed";
     /* use packet action if rate_filter modified the action */
@@ -285,6 +288,18 @@ void AlertJsonHeader(const Packet *p, const PacketAlert *pa, json_t *js)
         json_object_set_new(ajs, "target", tjs);
     }
 
+    if (json_output_ctx->flags & LOG_JSON_METADATA) {
+        if (pa->s->metadata) {
+            DetectMetadata* kv = pa->s->metadata;
+            json_t *mjs = json_object();
+            while (kv) {
+                json_object_set_new(mjs, kv->key, json_string(kv->value));
+                kv = kv->next;
+            }
+            json_object_set_new(ajs, "metadata", mjs);
+        }
+    }
+
     /* alert */
     json_object_set_new(js, "alert", ajs);
 }
@@ -353,7 +368,7 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
         MemBufferReset(aft->json_buffer);
 
         /* alert */
-        AlertJsonHeader(p, pa, js);
+        AlertJsonHeader(p, pa, js, json_output_ctx);
 
         if (IS_TUNNEL_PKT(p)) {
             AlertJsonTunnel(p, js);
@@ -743,7 +758,13 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         const char *tagged_packets = ConfNodeLookupChildValue(conf, "tagged-packets");
         const char *dnp3 = ConfNodeLookupChildValue(conf, "dnp3");
         const char *vars = ConfNodeLookupChildValue(conf, "vars");
+        const char *metadata = ConfNodeLookupChildValue(conf, "metadata");
 
+        if (metadata != NULL) {
+            if (ConfValIsTrue(metadata)) {
+                json_output_ctx->flags |= LOG_JSON_METADATA;
+            }
+        }
         if (vars != NULL) {
             if (ConfValIsTrue(vars)) {
                 json_output_ctx->flags |= LOG_JSON_VARS;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -170,6 +170,7 @@ outputs:
             smtp: yes                # enable dumping of smtp fields
             dnp3: yes                # enable dumping of DNP3 fields
             vars: yes                # enable dumping of flowbits and other vars
+            #metadata: yes            # enable dumping of key/value pairs defined by metadata keyword of signature
 
             # Enable the logging of tagged packets for rules using the
             # "tag" keyword.


### PR DESCRIPTION
Source and destination IP are choozen from the flow and this is not corresponding to the nature of the attack. There is in fact no way to know in an alert which from source and destination is the target of the attack. This patchset is adressing this by updating the way metadata are used. The special keyword `target`is introduced and it is used to indicate which side of the flow (`client`or `server`) is the target of the attack.

IDMEF has a definition of Source and Target which is the one defined here. So the Prelude code has been updated to invert src and dest IP if necessary (as Source was src and Target dest by default).
 
On EVE side, if the target metdata is defined, the output is now the following:
```
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 1,
    "rev": 1,
    "signature": "connection to home",
    "severity": 3,
    "source": {
      "ip": "2001:31d0:000a:f68a:0000:0000:0000:0001",
      "port": 80
    },
    "target": {
      "ip": "2a01:0e34:ee97:b130:c685:08ff:dab3:c9c8",
      "port": 48390
    }
```
As a work on metadata was done, this patchset also adds an option to log metadata key -> value in the alert event. With this information a user will be able to better categorize the events. This is even more true if we consider the enhanced version of Emerging threats ruleset where a lot of metadata have been added.
For instance we have, rules in this ruleset looking like that
```
alert http $EXTERNAL_NET $HTTP_PORTS -> $HOME_NET any (msg:"ET WEB_CLIENT Obfuscated Javascript // ptth"; flow:from_server,established; content:"200"; http_stat_code; file_data; content:"//|3a|ptth"; classtype:bad-unknown; sid:2012325; rev:4; metadata:affected_product Web_Browsers, affected_product Web_Browser_Plugins, attack_target Client_Endpoint, deployment Perimeter, tag Web_Client_Attacks, target client, signature_severity Major, created_at 2011_02_21, updated_at 2016_07_01;)
```
Here `target client` has been added. With that metadata, we have the following alert:
```
  "alert": {
    "action": "allowed",
    "gid": 1,
    "signature_id": 2012325,
    "rev": 4,
    "signature": "ET WEB_CLIENT Obfuscated Javascript // ptth",
    "category": "Potentially Bad Traffic",
    "severity": 2,
    "source": {
      "ip": "64.27.26.79",
      "port": 80
    },
    "target": {
      "ip": "192.168.2.5",
      "port": 1148
    },
    "metadata": {
      "target": "client",
      "tag": "Web_Client_Attacks",
      "deployment": "Perimeter",
      "attack_target": "Client_Endpoint",
      "affected_product": "Web_Browsers"
    }
  },
```

As Prelude build was not issuing a warning, this patchset is also fixing this.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/253
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/35