### PR TITLE
Ethernet header v4

### DIFF
--- a/src/detect-engine-profile.c
+++ b/src/detect-engine-profile.c
@@ -58,7 +58,7 @@ static void DumpFp(const SigMatch *sm, char *pat_orig, uint32_t pat_orig_sz, cha
 SCMutex g_rule_dump_write_m = SCMUTEX_INITIALIZER;
 void RulesDumpMatchArray(const DetectEngineThreadCtx *det_ctx, const Packet *p)
 {
-    json_t *js = CreateJSONHeader(p, 0, "inspectedrules");
+    json_t *js = CreateJSONHeader(p, 0, "inspectedrules", 0);
     if (js == NULL)
         return;
     json_t *ir = json_object();

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -269,7 +269,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if (p->alerts.cnt == 0 && !(p->flags & PKT_HAS_TAG))
         return TM_ECODE_OK;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "alert");
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "alert",
+                                  json_output_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 
@@ -458,7 +459,8 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
     if ((p->flags & PKT_HAS_TAG) && (json_output_ctx->flags &
             LOG_JSON_TAGGED_PACKETS)) {
         MemBufferReset(aft->json_buffer);
-        json_t *packetjs = CreateJSONHeader((Packet *)p, 0, "packet");
+        json_t *packetjs = CreateJSONHeader((Packet *)p, 0, "packet",
+                                            json_output_ctx->file_ctx->options_flags);
         if (unlikely(packetjs != NULL)) {
             AlertJsonPacket(p, packetjs);
             OutputJSONBuffer(packetjs, aft->file_ctx, &aft->json_buffer);

--- a/src/output-json-dnp3.c
+++ b/src/output-json-dnp3.c
@@ -311,7 +311,8 @@ static int JsonDNP3LoggerToServer(ThreadVars *tv, void *thread_data,
 
     MemBufferReset(buffer);
     if (tx->has_request && tx->request_done) {
-        json_t *js = CreateJSONHeader((Packet *)p, 1, "dnp3");
+        json_t *js = CreateJSONHeader((Packet *)p, 1, "dnp3",
+                                      thread->dnp3log_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }
@@ -337,7 +338,8 @@ static int JsonDNP3LoggerToClient(ThreadVars *tv, void *thread_data,
 
     MemBufferReset(buffer);
     if (tx->has_response && tx->response_done) {
-        json_t *js = CreateJSONHeader((Packet *)p, 1, "dnp3");
+        json_t *js = CreateJSONHeader((Packet *)p, 1, "dnp3",
+                                      thread->dnp3log_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL)) {
             return TM_ECODE_OK;
         }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -628,7 +628,7 @@ static int JsonDnsLoggerToServer(ThreadVars *tv, void *thread_data,
     if (likely(dnslog_ctx->flags & LOG_QUERIES) != 0) {
         DNSQueryEntry *query = NULL;
         TAILQ_FOREACH(query, &tx->query_list, next) {
-            js = CreateJSONHeader((Packet *)p, 1, "dns");
+            js = CreateJSONHeader((Packet *)p, 1, "dns", dnslog_ctx->file_ctx->options_flags);
             if (unlikely(js == NULL))
                 return TM_ECODE_OK;
 
@@ -652,7 +652,7 @@ static int JsonDnsLoggerToClient(ThreadVars *tv, void *thread_data,
     json_t *js;
 
     if (likely(dnslog_ctx->flags & LOG_ANSWERS) != 0) {
-        js = CreateJSONHeader((Packet *)p, 0, "dns");
+        js = CreateJSONHeader((Packet *)p, 0, "dns", dnslog_ctx->file_ctx->options_flags);
         if (unlikely(js == NULL))
             return TM_ECODE_OK;
 

--- a/src/output-json-drop.c
+++ b/src/output-json-drop.c
@@ -86,7 +86,8 @@ static int g_droplog_flows_start = 1;
 static int DropLogJSON (JsonDropLogThread *aft, const Packet *p)
 {
     uint16_t proto = 0;
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "drop");//TODO const
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "drop",
+                                  aft->drop_ctx->file_ctx->options_flags);//TODO const
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -82,7 +82,8 @@ typedef struct JsonFileLogThread_ {
  */
 static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const File *ff)
 {
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "fileinfo"); //TODO const
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "fileinfo",
+                                  aft->filelog_ctx->file_ctx->options_flags); //TODO const
     json_t *hjs = NULL;
     if (unlikely(js == NULL))
         return;

--- a/src/output-json-http.c
+++ b/src/output-json-http.c
@@ -375,7 +375,9 @@ static int JsonHttpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     htp_tx_t *tx = txptr;
     JsonHttpLogThread *jhl = (JsonHttpLogThread *)thread_data;
 
-    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "http", tx_id); //TODO const
+    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "http",
+                                          jhl->httplog_ctx->file_ctx->options_flags,
+                                          tx_id); //TODO const
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-smtp.c
+++ b/src/output-json-smtp.c
@@ -88,7 +88,9 @@ static int JsonSmtpLogger(ThreadVars *tv, void *thread_data, const Packet *p, Fl
     JsonEmailLogThread *jhl = (JsonEmailLogThread *)thread_data;
 
     json_t *sjs;
-    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "smtp", tx_id);
+    json_t *js = CreateJSONHeaderWithTxId((Packet *)p, 1, "smtp",
+                                          jhl->emaillog_ctx->file_ctx->options_flags,
+                                          tx_id);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json-ssh.c
+++ b/src/output-json-ssh.c
@@ -104,7 +104,8 @@ static int JsonSshLogger(ThreadVars *tv, void *thread_data, const Packet *p,
             ssh_state->srv_hdr.software_version == NULL)
         return 0;
 
-    json_t *js = CreateJSONHeader((Packet *)p, 1, "ssh");//TODO
+    json_t *js = CreateJSONHeader((Packet *)p, 1, "ssh",
+                                  ssh_ctx->file_ctx->options_flags);//TODO
     if (unlikely(js == NULL))
         return 0;
 

--- a/src/output-json-template.c
+++ b/src/output-json-template.c
@@ -74,7 +74,8 @@ static int JsonTemplateLogger(ThreadVars *tv, void *thread_data,
 
     SCLogNotice("Logging template transaction %"PRIu64".", templatetx->tx_id);
     
-    js = CreateJSONHeader((Packet *)p, 0, "template");
+    js = CreateJSONHeader((Packet *)p, 0, "template",
+                          thread->templatelog_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return TM_ECODE_FAILED;
     }

--- a/src/output-json-tls.c
+++ b/src/output-json-tls.c
@@ -355,7 +355,8 @@ static int JsonTlsLogger(ThreadVars *tv, void *thread_data, const Packet *p,
         return 0;
     }
 
-    json_t *js = CreateJSONHeader((Packet *)p, 1, "tls");
+    json_t *js = CreateJSONHeader((Packet *)p, 1, "tls",
+                                  tls_ctx->file_ctx->options_flags);
     if (unlikely(js == NULL)) {
         return 0;
     }

--- a/src/output-json-vars.c
+++ b/src/output-json-vars.c
@@ -81,7 +81,7 @@ typedef struct JsonVarsLogThread_ {
 
 static int VarsJson(ThreadVars *tv, JsonVarsLogThread *aft, const Packet *p)
 {
-    json_t *js = CreateJSONHeader((Packet *)p, 0, "vars");
+    json_t *js = CreateJSONHeader((Packet *)p, 0, "vars", 0);
     if (unlikely(js == NULL))
         return TM_ECODE_OK;
 

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -388,7 +388,7 @@ void CreateJSONFlowId(json_t *js, const Flow *f)
 }
 
 json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
-                         const char *event_type)
+                         const char *event_type, uint8_t options_flags)
 {
     char timebuf[64];
 
@@ -468,7 +468,7 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
             break;
     }
 
-    if (p->ethh) {
+    if (options_flags & LOGFILE_LOG_ETHERNET && p->ethh) {
         json_t *ejs = json_object();
         if (ejs != NULL) {
             char eth_addr[19];
@@ -507,9 +507,10 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
 }
 
 json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive,
-                                 const char *event_type, uint64_t tx_id)
+                                 const char *event_type, uint8_t options_flags,
+                                 uint64_t tx_id)
 {
-    json_t *js = CreateJSONHeader(p, direction_sensitive, event_type);
+    json_t *js = CreateJSONHeader(p, direction_sensitive, event_type, options_flags);
     if (unlikely(js == NULL))
         return NULL;
 
@@ -744,6 +745,11 @@ OutputCtx *OutputJsonInitCtx(ConfNode *conf)
                            "invalid sensor-is: %s", sensor_id_s);
                 exit(EXIT_FAILURE);
             }
+        }
+
+        const char *v = ConfNodeLookupChildValue(conf, "log-ethernet");
+        if (v != NULL && ConfValIsTrue(v)) {
+            json_ctx->file_ctx->options_flags |= LOGFILE_LOG_ETHERNET;
         }
 
         json_ctx->file_ctx->type = json_ctx->json_out;

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -468,6 +468,41 @@ json_t *CreateJSONHeader(const Packet *p, int direction_sensitive,
             break;
     }
 
+    if (p->ethh) {
+        json_t *ejs = json_object();
+        if (ejs != NULL) {
+            char eth_addr[19];
+            uint8_t *src, *dst;
+
+            if ((PKT_IS_TOSERVER(p))) {
+                src = p->ethh->eth_dst;
+                dst = p->ethh->eth_src;
+            } else {
+                src = p->ethh->eth_src;
+                dst = p->ethh->eth_dst;
+            }
+
+            json_object_set_new(ejs, "type", json_integer(ntohs(p->ethh->eth_type)));
+            snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+                    src[0],
+                    src[1],
+                    src[2],
+                    src[3],
+                    src[4],
+                    src[5]);
+            json_object_set_new(ejs, "src", json_string(eth_addr));
+            snprintf(eth_addr, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+                    dst[0],
+                    dst[1],
+                    dst[2],
+                    dst[3],
+                    dst[4],
+                    dst[5]);
+            json_object_set_new(ejs, "dst", json_string(eth_addr));
+            json_object_set_new(js, "ether", ejs);
+        }
+    }
+
     return js;
 }
 

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -43,8 +43,8 @@ void JsonAddVars(const Packet *p, const Flow *f, json_t *js);
 void CreateJSONFlowId(json_t *js, const Flow *f);
 void JsonTcpFlags(uint8_t flags, json_t *js);
 void JsonFiveTuple(const Packet *, int, json_t *);
-json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type);
-json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint64_t tx_id);
+json_t *CreateJSONHeader(const Packet *p, int direction_sensative, const char *event_type, uint8_t options_flags);
+json_t *CreateJSONHeaderWithTxId(const Packet *p, int direction_sensitive, const char *event_type, uint8_t options_flags, uint64_t tx_id);
 int OutputJSONBuffer(json_t *js, LogFileCtx *file_ctx, MemBuffer **buffer);
 OutputCtx *OutputJsonInitCtx(ConfNode *);
 

--- a/src/util-logopenfile.h
+++ b/src/util-logopenfile.h
@@ -112,6 +112,9 @@ typedef struct LogFileCtx_ {
     /* flags to set when sending over a socket */
     uint8_t send_flags;
 
+    /* flag to store the options */
+    uint8_t options_flags;
+
     /* Flag if file is a regular file or not.  Only regular files
      * allow for rotataion. */
     uint8_t is_regular;
@@ -137,6 +140,8 @@ typedef struct LogFileCtx_ {
 #define LOGFILE_HEADER_WRITTEN  0x01
 #define LOGFILE_ALERTS_PRINTED  0x02
 #define LOGFILE_ROTATE_INTERVAL 0x04
+
+#define LOGFILE_LOG_ETHERNET   0x01
 
 LogFileCtx *LogFileNewCtx(void);
 int LogFileFreeCtx(LogFileCtx *);

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -158,6 +158,7 @@ outputs:
       #  pipelining:
       #    enabled: yes ## set enable to yes to enable query pipelining
       #    batch-size: 10 ## number of entry to keep in buffer
+      #log-ethernet: yes
       types:
         - alert:
             # payload: yes             # enable dumping payload in Base64


### PR DESCRIPTION
Rebase of https://github.com/inliniac/suricata/pull/2415

The flag containing the option about addition of ethernet header is kept in the filectx (as it is done for json_flags). It could be used for other output than JSON and could contains other information.