### PR TITLE
detect-parse: improve common parser

### DIFF
--- a/src/detect-content.h
+++ b/src/detect-content.h
@@ -106,11 +106,11 @@ typedef struct DetectContentData_ {
 void DetectContentRegister (void);
 uint32_t DetectContentMaxId(DetectEngineCtx *);
 DetectContentData *DetectContentParse(SpmGlobalThreadCtx *spm_global_thread_ctx,
-                                      char *contentstr);
+                                      const char *contentstr);
 int DetectContentDataParse(const char *keyword, const char *contentstr,
-    uint8_t **pstr, uint16_t *plen, uint32_t *flags);
+    uint8_t **pstr, uint16_t *plen);
 DetectContentData *DetectContentParseEncloseQuotes(SpmGlobalThreadCtx *spm_global_thread_ctx,
-                                      char *contentstr);
+        const char *contentstr);
 
 int DetectContentSetup(DetectEngineCtx *de_ctx, Signature *s, char *contentstr);
 void DetectContentPrint(DetectContentData *);

--- a/src/detect-flowvar.c
+++ b/src/detect-flowvar.c
@@ -125,7 +125,7 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, char *raws
     const char *str_ptr;
     uint8_t *content = NULL;
     uint16_t contentlen = 0;
-    uint32_t contentflags = 0;
+    uint32_t contentflags = s->init_data->negated ? DETECT_CONTENT_NEGATED : 0;
 
     ret = pcre_exec(parse_regex, parse_regex_study, rawstr, strlen(rawstr), 0, 0, ov, MAX_SUBSTRINGS);
     if (ret != 3) {
@@ -147,7 +147,15 @@ static int DetectFlowvarSetup (DetectEngineCtx *de_ctx, Signature *s, char *raws
     }
     varcontent = (char *)str_ptr;
 
-    res = DetectContentDataParse("flowvar", varcontent, &content, &contentlen, &contentflags);
+    if (strlen(varcontent) >= 2) {
+        if (varcontent[0] == '"')
+            varcontent++;
+        if (varcontent[strlen(varcontent)-1] == '"')
+            varcontent[strlen(varcontent)-1] = '\0';
+    }
+    SCLogDebug("varcontent %s", varcontent);
+
+    res = DetectContentDataParse("flowvar", varcontent, &content, &contentlen);
     if (res == -1)
         goto error;
 

--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -45,40 +45,18 @@ void DetectMsgRegister (void)
     sigmatch_table[DETECT_MSG].Setup = DetectMsgSetup;
     sigmatch_table[DETECT_MSG].Free = NULL;
     sigmatch_table[DETECT_MSG].RegisterTests = DetectMsgRegisterTests;
+    sigmatch_table[DETECT_MSG].flags = SIGMATCH_QUOTES_MANDATORY;
 }
 
 static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, char *msgstr)
 {
-    char *str = NULL;
-    uint16_t len;
-    uint16_t pos = 0;
-    uint16_t slen = 0;
-
-    slen = strlen(msgstr);
+    size_t slen = strlen(msgstr);
     if (slen == 0)
-        goto error;
+        return -1;
 
-    /* skip the first spaces */
-    while (pos < slen && isspace((unsigned char)msgstr[pos]))
-        pos++;
-
-    /* Strip leading and trailing "s. */
-    if (msgstr[pos] == '\"') {
-        str = SCStrdup(msgstr + pos + 1);
-        if (unlikely(str == NULL))
-            goto error;
-        if (strlen(str) && str[strlen(str) - 1] == '\"') {
-            str[strlen(str)-1] = '\0';
-        }
-    } else {
-        SCLogError(SC_ERR_INVALID_VALUE, "format error \'%s\'", msgstr);
-        goto error;
-    }
-
-    len = strlen(str);
-    if (len == 0)
-        goto error;
-
+    char input[slen + 1];
+    strlcpy(input, msgstr, slen + 1);
+    char *str = input;
     char converted = 0;
 
     {
@@ -86,7 +64,7 @@ static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, char *msgstr)
         uint8_t escape = 0;
 
         /* it doesn't matter if we need to escape or not we remove the extra "\" to mimic snort */
-        for (i = 0, x = 0; i < len; i++) {
+        for (i = 0, x = 0; i < slen; i++) {
             //printf("str[%02u]: %c\n", i, str[i]);
             if(!escape && str[i] == '\\') {
                 escape = 1;
@@ -119,22 +97,17 @@ static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, char *msgstr)
 #endif
 
         if (converted) {
-            len = x;
-            str[len] = '\0';
+            slen = x;
+            str[slen] = '\0';
         }
     }
 
-    s->msg = SCMalloc(len + 1);
+    s->msg = SCStrdup(str);
     if (s->msg == NULL)
         goto error;
-
-    strlcpy(s->msg, str, len + 1);
-
-    SCFree(str);
     return 0;
 
 error:
-    SCFree(str);
     return -1;
 }
 

--- a/src/detect-replace.c
+++ b/src/detect-replace.c
@@ -69,25 +69,25 @@ void DetectReplaceRegister (void)
     sigmatch_table[DETECT_REPLACE].Setup = DetectReplaceSetup;
     sigmatch_table[DETECT_REPLACE].Free  = NULL;
     sigmatch_table[DETECT_REPLACE].RegisterTests = DetectReplaceRegisterTests;
+    sigmatch_table[DETECT_REPLACE].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
 }
 
 int DetectReplaceSetup(DetectEngineCtx *de_ctx, Signature *s, char *replacestr)
 {
     uint8_t *content = NULL;
     uint16_t len = 0;
-    uint32_t flags = 0;
     SigMatch *pm = NULL;
     DetectContentData *ud = NULL;
 
-    int ret = DetectContentDataParse("replace", replacestr, &content, &len, &flags);
-    if (ret == -1)
-        goto error;
-
-    if (flags & DETECT_CONTENT_NEGATED) {
+    if (s->init_data->negated) {
         SCLogError(SC_ERR_INVALID_VALUE, "Can't negate replacement string: %s",
                    replacestr);
         goto error;
     }
+
+    int ret = DetectContentDataParse("replace", replacestr, &content, &len);
+    if (ret == -1)
+        goto error;
 
     switch (run_mode) {
         case RUNMODE_NFQ:

--- a/src/detect-ssh-proto-version.c
+++ b/src/detect-ssh-proto-version.c
@@ -80,6 +80,7 @@ void DetectSshVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Setup = DetectSshVersionSetup;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].Free  = DetectSshVersionFree;
     sigmatch_table[DETECT_AL_SSH_PROTOVERSION].RegisterTests = DetectSshVersionRegisterTests;
+    sigmatch_table[DETECT_AL_SSH_PROTOVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect-ssh-software-version.c
+++ b/src/detect-ssh-software-version.c
@@ -94,6 +94,7 @@ void DetectSshSoftwareVersionRegister(void)
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Setup = DetectSshSoftwareVersionSetup;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].Free  = DetectSshSoftwareVersionFree;
     sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].RegisterTests = DetectSshSoftwareVersionRegisterTests;
+    sigmatch_table[DETECT_AL_SSH_SOFTWAREVERSION].flags = SIGMATCH_QUOTES_OPTIONAL;
 
     DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
 

--- a/src/detect-uricontent.c
+++ b/src/detect-uricontent.c
@@ -73,6 +73,7 @@ void DetectUricontentRegister (void)
     sigmatch_table[DETECT_URICONTENT].Setup = DetectUricontentSetup;
     sigmatch_table[DETECT_URICONTENT].Free  = DetectUricontentFree;
     sigmatch_table[DETECT_URICONTENT].RegisterTests = DetectUricontentRegisterTests;
+    sigmatch_table[DETECT_URICONTENT].flags = (SIGMATCH_QUOTES_MANDATORY|SIGMATCH_HANDLE_NEGATION);
 
     g_http_uri_buffer_id = DetectBufferTypeRegister("http_uri");
 }

--- a/src/detect.h
+++ b/src/detect.h
@@ -360,6 +360,10 @@ typedef struct SignatureInitData_ {
     /** Number of sigmatches. Used for assigning SigMatch::idx */
     uint16_t sm_cnt;
 
+    /** option was prefixed with '!'. Only set for sigmatches that
+     *  have the SIGMATCH_HANDLE_NEGATION flag set. */
+    bool negated;
+
     /* used to hold flags that are used during init */
     uint32_t init_flags;
     /* coccinelle: SignatureInitData:init_flags:SIG_FLAG_INIT_ */
@@ -1108,7 +1112,18 @@ typedef struct SigGroupHead_ {
 #define SIGMATCH_NOT_BUILT      (1 << 3)
 /** sigmatch may have options, so the parser should be ready to
  *  deal with both cases */
-#define SIGMATCH_OPTIONAL_OPT   (1 << 4)
+#define SIGMATCH_OPTIONAL_OPT       (1 << 4)
+/** input may be wrapped in double quotes. They will be stripped before
+ *  input data is passed to keyword parser */
+#define SIGMATCH_QUOTES_OPTIONAL    (1 << 5)
+/** input MUST be wrapped in double quotes. They will be stripped before
+ *  input data is passed to keyword parser. Missing double quotes lead to
+ *  error and signature invalidation. */
+#define SIGMATCH_QUOTES_MANDATORY   (1 << 6)
+/** negation parsing is handled by the rule parser. Signature::init_data::negated
+ *  will be set to true or false prior to calling the keyword parser. Exclamation
+ *  mark is stripped from the input to the keyword parser. */
+#define SIGMATCH_HANDLE_NEGATION    (1 << 7)
 
 enum DetectEngineTenantSelectors
 {


### PR DESCRIPTION
In preparation of turning input to keyword parsers to const add
options to the common rule parser to enforce and strip double
quotes and parse negation support.

At registration, the keyword can register 3 extra flags:

    SIGMATCH_QUOTES_MANDATORY: value to keyword must be quoted

    SIGMATCH_QUOTES_OPTIONAL: value to keyword may be quoted

    SIGMATCH_HANDLE_NEGATION: leading ! is parsed

In all cases leading spaces are removed. If the 'quote' flags are
set, the quotes are removed from the input as well.

Prscript:
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/98
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/606
