### PR TITLE
dnp3: in template, include files own headers

### DIFF
--- a/scripts/dnp3-gen/dnp3-gen.py
+++ b/scripts/dnp3-gen/dnp3-gen.py
@@ -68,6 +68,7 @@ util_lua_dnp3_objects_c_template = """/* Copyright (C) 2015 Open Information Sec
 #include <lauxlib.h>
 
 #include "util-lua.h"
+#include "util-lua-dnp3-objects.h"
 
 /**
  * \\brief Push an object point item onto the stack.
@@ -155,6 +156,7 @@ output_json_dnp3_objects_template = """/* Copyright (C) 2015 Open Information Se
 
 #include "app-layer-dnp3.h"
 #include "app-layer-dnp3-objects.h"
+#include "output-json-dnp3-objects.h"
 
 #ifdef HAVE_LIBJANSSON
 


### PR DESCRIPTION
To deal with -Wmissing-prototypes as added in
ab1200fbd7fd4d3e0fe097fab3b3bcfefaba7e2e

Note: Change was already applied to source files, this just
updates the generation.

As noted here:
https://github.com/inliniac/suricata/pull/2684

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/142
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/494
