### PR TITLE
dhcp - dhcp app-layer - v1.ish

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ app-layer.c app-layer.h \
 app-layer-dcerpc.c app-layer-dcerpc.h \
 app-layer-dcerpc-udp.c app-layer-dcerpc-udp.h \
 app-layer-detect-proto.c app-layer-detect-proto.h \
+app-layer-dhcp.c app-layer-dhcp.h \
 app-layer-dnp3.c app-layer-dnp3.h \
 app-layer-dnp3-objects.c app-layer-dnp3-objects.h \
 app-layer-dns-common.c app-layer-dns-common.h \
@@ -281,6 +282,7 @@ output-file.c output-file.h \
 output-filedata.c output-filedata.h \
 output-flow.c output-flow.h \
 output-json-alert.c output-json-alert.h \
+output-json-dhcp.c output-json-dhcp.h \
 output-json-dns.c output-json-dns.h \
 output-json-dnp3.c output-json-dnp3.h \
 output-json-dnp3-objects.c output-json-dnp3-objects.h \

--- a/src/app-layer-detect-proto.c
+++ b/src/app-layer-detect-proto.c
@@ -697,6 +697,8 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                         printf("            alproto: ALPROTO_MODBUS\n");
                     else if (pp_pe->alproto == ALPROTO_ENIP)
                         printf("            alproto: ALPROTO_ENIP\n");
+                    else if (pp_pe->alproto == ALPROTO_DHCP)
+                        printf("            alproto: ALPROTO_DHCP\n");
                     else if (pp_pe->alproto == ALPROTO_TEMPLATE)
                         printf("            alproto: ALPROTO_TEMPLATE\n");
                     else if (pp_pe->alproto == ALPROTO_DNP3)
@@ -754,6 +756,8 @@ static void AppLayerProtoDetectPrintProbingParsers(AppLayerProtoDetectProbingPar
                     printf("            alproto: ALPROTO_MODBUS\n");
                 else if (pp_pe->alproto == ALPROTO_ENIP)
                     printf("            alproto: ALPROTO_ENIP\n");
+                else if (pp_pe->alproto == ALPROTO_DHCP)
+                    printf("            alproto: ALPROTO_DHCP\n");
                 else if (pp_pe->alproto == ALPROTO_TEMPLATE)
                     printf("            alproto: ALPROTO_TEMPLATE\n");
                 else if (pp_pe->alproto == ALPROTO_DNP3)

--- a/src/app-layer-dhcp.c
+++ b/src/app-layer-dhcp.c
@@ -1,0 +1,722 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file DHCP application layer detector and parser.
+ *
+ * \author Tom DeCanio <decanio.tom@gmail.com>
+ */
+
+#include "suricata-common.h"
+#include "stream.h"
+#include "conf.h"
+
+#include "util-print.h"
+#include "util-unittest.h"
+
+#include "app-layer-detect-proto.h"
+#include "app-layer-parser.h"
+
+#include "app-layer-dhcp.h"
+
+//#define PRINT
+
+/* The default port to probe for echo traffic if not provided in the
+ * configuration file. */
+#define DHCP_DEFAULT_SERVER_PORT "67"
+#define DHCP_DEFAULT_CLIENT_PORT "68"
+
+#define DHCP_MIN_FRAME_LEN 232
+
+/* Enum of app-layer events for an echo protocol. Normally you might
+ * have events for errors in parsing data, like unexpected data being
+ * received. For echo we'll make something up, and log an app-layer
+ * level alert if an empty message is received.
+ *
+ * Example rule:
+ *
+ * alert dhcp any any -> any any (msg:"SURCATA dhcp empty message"; \
+ *    app-layer-event:dhcp.empty_message; sid:X; rev:Y;)
+ */
+enum {
+    DHCP_DECODER_EVENT_EMPTY_MESSAGE,
+};
+
+SCEnumCharMap dhcp_decoder_event_table[] = {
+    {"EMPTY_MESSAGE", DHCP_DECODER_EVENT_EMPTY_MESSAGE},
+};
+
+static uint32_t dhcp_config_max_transactions = 32;
+
+static DHCPState dhcpGlobalState;
+
+static void DHCPTxFree(DHCPState *dhcp, void *tx, uint32_t locked)
+{
+    DHCPTransaction *dhcptx = tx;
+
+    if (dhcptx->request_buffer != NULL)
+        SCFree(dhcptx->request_buffer);
+
+    if (dhcptx->response_buffer != NULL)
+        SCFree(dhcptx->response_buffer);
+
+    if (dhcptx->decoder_events != NULL)
+        AppLayerDecoderEventsFreeEvents(&dhcptx->decoder_events);
+
+    if (dhcptx->de_state != NULL)
+        DetectEngineStateFree(dhcptx->de_state);
+
+    SCFree(tx);
+
+    if (unlikely(locked == 0)) {
+        SCMutexLock(&dhcp->lock);
+    }
+    dhcp->transaction_count++;
+    if (unlikely(locked == 0)) {
+        SCMutexUnlock(&dhcp->lock);
+    }
+}
+
+static DHCPTransaction *DHCPTxAlloc(DHCPState *dhcp)
+{
+    DHCPTransaction *tx;
+
+    /* limit outstanding transactions */
+    SCMutexLock(&dhcp->lock);
+    if (unlikely(dhcp->transaction_count > dhcp_config_max_transactions)) {
+        /* toss out the oldest */
+        tx = TAILQ_FIRST(&dhcp->tx_list);
+        if (likely(tx != NULL)) {
+            TAILQ_REMOVE(&dhcp->tx_list, tx, next);
+            DHCPTxFree(dhcp, tx, 1);
+        }
+    }
+    SCMutexUnlock(&dhcp->lock);
+
+    tx = SCCalloc(1, sizeof(DHCPTransaction));
+    if (unlikely(tx == NULL)) {
+        return NULL;
+    }
+
+    SCMutexLock(&dhcp->lock);
+
+    /* Increment the transaction ID on the state each time one is
+     * allocated. */
+    tx->tx_id = dhcp->transaction_max++;
+    dhcp->transaction_count++;
+
+    TAILQ_INSERT_TAIL(&dhcp->tx_list, tx, next);
+
+    SCMutexUnlock(&dhcp->lock);
+
+    return tx;
+}
+
+static SC_ATOMIC_DECLARE(uint64_t, DHCPStateAllocCount);
+
+static void *DHCPStateAlloc(void)
+{
+    /* TBD: possibly make this per vlan */
+    DHCPState *state = &dhcpGlobalState;
+
+    if (SC_ATOMIC_CAS(&state->initialized, 0, 1) == 1) {
+        SCMutexInit(&state->lock, NULL);
+        TAILQ_INIT(&state->tx_list);
+        SC_ATOMIC_INIT(DHCPStateAllocCount);
+    }
+    SC_ATOMIC_ADD(DHCPStateAllocCount, 1);
+    return state;
+}
+
+static void DHCPStateFree(void *state)
+{
+    DHCPState *dhcp_state = state;
+    DHCPTransaction *tx;
+    uint64_t count = SC_ATOMIC_SUB(DHCPStateAllocCount, 1);
+    /* free in-flight transactions with last DHCPStateFree */
+    if (count == 0) {
+        SCMutexLock(&dhcp_state->lock);
+        while ((tx = TAILQ_FIRST(&dhcp_state->tx_list)) != NULL) {
+            TAILQ_REMOVE(&dhcp_state->tx_list, tx, next);
+            DHCPTxFree(dhcp_state, tx, 1);
+        }
+        SCMutexUnlock(&dhcp_state->lock);
+    }
+}
+
+/**
+ * \brief Callback from the application layer to have a transaction freed.
+ *
+ * \param state a void pointer to the dhcpState object.
+ * \param tx_id the transaction ID to free.
+ */
+static void DHCPStateTxFree(void *state, uint64_t tx_id)
+{
+    DHCPState *dhcp = state;
+    DHCPTransaction *tx = NULL, *ttx;
+
+    SCLogDebug("Freeing transaction %"PRIu64, tx_id);
+
+    SCMutexLock(&dhcp->lock);
+    TAILQ_FOREACH_SAFE(tx, &dhcp->tx_list, next, ttx) {
+
+        /* Continue if this is not the transaction we are looking
+         * for. */
+        if (tx->tx_id != tx_id) {
+            continue;
+        }
+
+        /* Remove and free the transaction. */
+        TAILQ_REMOVE(&dhcp->tx_list, tx, next);
+        DHCPTxFree(dhcp, tx, 1);
+
+        SCMutexUnlock(&dhcp->lock);
+        return;
+    }
+    SCMutexUnlock(&dhcp->lock);
+
+    SCLogDebug("Transaction %"PRIu64" not found.", tx_id);
+}
+
+static int DHCPStateGetEventInfo(const char *event_name, int *event_id,
+    AppLayerEventType *event_type)
+{
+    *event_id = SCMapEnumNameToValue(event_name, dhcp_decoder_event_table);
+    if (*event_id == -1) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%s\" not present in "
+                   "DHCP enum map table.",  event_name);
+        /* This should be treated as fatal. */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
+static AppLayerDecoderEvents *DHCPGetEvents(void *state, uint64_t tx_id)
+{
+    DHCPState *dhcp_state = state;
+    DHCPTransaction *tx;
+
+    SCMutexLock(&dhcp_state->lock);
+    TAILQ_FOREACH(tx, &dhcp_state->tx_list, next) {
+        if (tx->tx_id == tx_id) {
+            SCMutexUnlock(&dhcp_state->lock);
+            return tx->decoder_events;
+        }
+    }
+    SCMutexUnlock(&dhcp_state->lock);
+
+    return NULL;
+}
+
+static int DHCPHasEvents(void *state)
+{
+    DHCPState *echo = state;
+    return echo->events;
+}
+
+static DHCPTransaction *DHCPGetTxByXid(void *state, uint32_t xid)
+{
+    DHCPState *dhcp = state;
+    DHCPTransaction *tx, *ttx;
+
+    SCLogDebug("Requested tx XID %"PRIu32".", xid);
+
+    SCMutexLock(&dhcp->lock);
+    TAILQ_FOREACH_SAFE(tx, &dhcp->tx_list, next, ttx) {
+        if (tx->logged) {
+            /* Remove and free the transaction. */
+            TAILQ_REMOVE(&dhcp->tx_list, tx, next);
+            DHCPTxFree(dhcp, tx, 1);
+            continue;
+        }
+        if (tx->xid == xid) {
+            SCMutexUnlock(&dhcp->lock);
+            SCLogDebug("Transaction %"PRIu32" found, returning tx object %p.",
+                xid, tx);
+            return tx;
+        }
+    }
+    SCMutexUnlock(&dhcp->lock);
+
+    SCLogDebug("Transaction ID %"PRIu32" not found.", xid);
+
+    return NULL;
+}
+
+/**
+ * \brief Probe the input to see if it looks like echo.
+ *
+ * \retval ALPROTO_DHCP if it looks like echo, otherwise
+ *     ALPROTO_UNKNOWN.
+ */
+static AppProto DHCPToServerProbingParser(uint8_t *input, uint32_t input_len,
+    uint32_t *offset)
+{
+    /* TBD: have the infrastructure call us back with the flow struct *
+     * so that we can check that this arrived on the proper 5 tuple
+     */
+    //PrintRawDataFp(stdout, input, input_len);
+
+    if (input_len >= DHCP_MIN_FRAME_LEN) {
+        BOOTPHdr *bootp = (BOOTPHdr *)input;
+
+        if ((bootp->op == BOOTP_REQUEST) &&
+            (bootp->htype == BOOTP_ETHERNET) &&
+            (bootp->hlen == 6) &&
+            (bootp->magic == ntohl(BOOTP_DHCP_MAGIC_COOKIE))) {
+            DHCPOpt *dhcp = (DHCPOpt *)(input + sizeof(BOOTPHdr));
+
+            if ((dhcp->code == DHCP_DHCP_MSG_TYPE) &&
+                (dhcp->len == 1)) {
+
+                SCLogDebug("Detected as ALPROTO_DHCP.");
+                return ALPROTO_DHCP;
+            }
+        }
+    }
+
+    SCLogDebug("Protocol not detected as ALPROTO_DHCP.");
+    return ALPROTO_UNKNOWN;
+}
+
+/**
+ * \brief Probe the input to see if it looks like echo.
+ *
+ * \retval ALPROTO_DHCP if it looks like echo, otherwise
+ *     ALPROTO_UNKNOWN.
+ */
+static AppProto DHCPToClientProbingParser(uint8_t *input, uint32_t input_len,
+    uint32_t *offset)
+{
+    /* TBD: have the infrastructure call us back with the flow struct *
+     * so that we can check that this arrived on the proper 5 tuple
+     */
+    //PrintRawDataFp(stdout, input, input_len);
+
+    if (input_len >= DHCP_MIN_FRAME_LEN) {
+        BOOTPHdr *bootp = (BOOTPHdr *)input;
+
+        if ((bootp->op == BOOTP_REPLY) &&
+            (bootp->htype == BOOTP_ETHERNET) &&
+            (bootp->hlen == 6) &&
+            (bootp->magic == ntohl(BOOTP_DHCP_MAGIC_COOKIE))) {
+            DHCPOpt *dhcp = (DHCPOpt *)(input + sizeof(BOOTPHdr));
+
+            if ((dhcp->code == DHCP_DHCP_MSG_TYPE) &&
+                (dhcp->len == 1)) {
+
+                SCLogDebug("Detected as ALPROTO_DHCP.");
+                return ALPROTO_DHCP;
+            }
+        }
+    }
+
+    SCLogDebug("Protocol not detected as ALPROTO_DHCP.");
+    return ALPROTO_UNKNOWN;
+}
+
+static int DHCPParse(Flow *f, void *state,
+    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    void *local_data)
+{
+    DHCPState *dhcp_state = state;
+
+    /* Likely connection closed, we can just return here. */
+    if ((input == NULL || input_len == 0) &&
+        AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
+        return 0;
+    }
+
+    /* Probably don't want to create a transaction in this case
+     * either. */
+    if (input == NULL || input_len == 0) {
+        return 0;
+    }
+
+    /* Normally you would parse out data here and store it in the
+     * transaction object, but as this is echo, we'll just record the
+     * request data. */
+
+    if (input_len >= DHCP_MIN_FRAME_LEN) {
+        BOOTPHdr *bootp = (BOOTPHdr *)input;
+
+        if ((bootp->op == BOOTP_REQUEST) &&
+            (bootp->htype == BOOTP_ETHERNET) &&
+            (bootp->hlen == 6) &&
+            (bootp->magic == ntohl(BOOTP_DHCP_MAGIC_COOKIE))) {
+
+            SCLogDebug("Parsing DHCP request len=%"PRIu32"state=%p", input_len, dhcp_state);
+#ifdef PRINT
+            PrintRawDataFp(stdout, input, input_len);
+#endif
+
+            DHCPOpt *dhcp = (DHCPOpt *)(input + sizeof(BOOTPHdr));
+
+            if ((dhcp->code == DHCP_DHCP_MSG_TYPE) &&
+                (dhcp->len == 1)) {
+                DHCPTransaction *tx;
+
+                switch (dhcp->args[0]) {
+                    case DHCP_DISCOVER:
+                    case DHCP_REQUEST:
+                        tx = DHCPGetTxByXid(dhcp_state, bootp->xid);
+                        if (unlikely(tx == NULL)) {
+                            tx = DHCPTxAlloc(dhcp_state);
+                            if (unlikely(tx == NULL)) {
+                                SCLogDebug("Failed to allocate new DHCP tx.");
+                                goto end;
+                            }
+                            tx->xid = bootp->xid;
+                            SCLogDebug("Allocated DHCP tx %"PRIu64".", ntohl(tx->xid));
+                            tx->request_buffer_len = input_len - sizeof(BOOTPHdr);
+                            tx->request_buffer = SCMalloc(tx->request_buffer_len);
+                            if (unlikely(tx->request_buffer == NULL)) {
+                                /* TBD: need to remove from global tx list */
+                                DHCPTxFree(dhcp_state, tx, 0);
+                                goto end;
+                            }
+                            memcpy(tx->request_buffer, dhcp, tx->request_buffer_len);
+                        }
+                        break;
+                    case DHCP_INFORM:
+                        tx = DHCPGetTxByXid(dhcp_state, bootp->xid);
+                        if (unlikely(tx == NULL)) {
+                            tx = DHCPTxAlloc(dhcp_state);
+                            if (unlikely(tx == NULL)) {
+                                SCLogDebug("Failed to allocate new DHCP tx.");
+                                goto end;
+                            }
+                            SCLogDebug("Allocated DHCP tx %"PRIu64".", ntohl(tx->tx_id));
+                            tx->xid = bootp->xid;
+                            tx->request_client_ip = bootp->ciaddr;
+                            tx->request_buffer_len = input_len - sizeof(BOOTPHdr);
+                            tx->request_buffer = SCMalloc(tx->request_buffer_len);
+                            if (unlikely(tx->request_buffer == NULL)) {
+                                /* TBD: need to remove from global tx list */
+                                DHCPTxFree(dhcp_state, tx, 0);
+                                goto end;
+                            }
+                            memcpy(tx->request_buffer, dhcp, tx->request_buffer_len);
+                        }
+                        break;
+                    case DHCP_RELEASE:
+                    case DHCP_DECLINE:
+                        tx = DHCPGetTxByXid(dhcp_state, bootp->xid);
+                        if (unlikely(tx == NULL)) {
+                            tx = DHCPTxAlloc(dhcp_state);
+                            if (unlikely(tx == NULL)) {
+                                SCLogDebug("Failed to allocate new DHCP tx.");
+                                goto end;
+                            }
+                            tx->xid = bootp->xid;
+                            SCLogDebug("Allocated DHCP tx %"PRIu64".", ntohl(tx->xid));
+                            tx->request_buffer_len = input_len - sizeof(BOOTPHdr);
+                            tx->request_buffer = SCMalloc(tx->request_buffer_len);
+                            if (unlikely(tx->request_buffer == NULL)) {
+                                /* TBD: need to remove from global tx list */
+                                DHCPTxFree(dhcp_state, tx, 0);
+                                goto end;
+                            }
+                            memcpy(tx->request_buffer, dhcp, tx->request_buffer_len);
+                            /* response to release not required */
+                            tx->response_unneeded = 1;
+                            tx->response_done = 1;
+                        }
+                        break;
+                    default:
+                        SCLogDebug("DHCP unknown %d", dhcp->args[0]);
+                        break;
+                }
+            }
+        } else if ((bootp->op == BOOTP_REPLY) &&
+            (bootp->htype == BOOTP_ETHERNET) &&
+            (bootp->hlen == 6) &&
+            (bootp->magic == ntohl(BOOTP_DHCP_MAGIC_COOKIE))) {
+
+            SCLogDebug("Parsing DHCP reply len=%"PRIu32"state=%p", input_len, dhcp_state);
+#ifdef PRINT
+            PrintRawDataFp(stdout, input, input_len);
+#endif
+
+            BOOTPHdr *bootp = (BOOTPHdr *)input;
+            DHCPOpt *dhcp = (DHCPOpt *)(input + sizeof(BOOTPHdr));
+
+            if ((dhcp->code == DHCP_DHCP_MSG_TYPE) &&
+                (dhcp->len == 1)) {
+                DHCPTransaction *tx;
+
+                switch (dhcp->args[0]) {
+                    case DHCP_OFFER:
+                    case DHCP_ACK:
+                        tx = DHCPGetTxByXid(dhcp_state, bootp->xid);
+                        if (unlikely(tx == NULL)) {
+                            goto end;
+                        }
+                        tx->response_client_ip = bootp->yiaddr;
+                        if (tx->response_buffer == NULL) {
+                            tx->response_buffer_len = input_len - sizeof(BOOTPHdr);
+                            tx->response_buffer = SCMalloc(tx->response_buffer_len);
+                            if (unlikely(tx->response_buffer == NULL)) {
+                                /* TBD: need to remove from global tx list */
+                                DHCPTxFree(dhcp_state, tx, 0);
+                                goto end;
+                            }
+                            memcpy(tx->response_buffer, dhcp, tx->response_buffer_len);
+                            tx->response_done = 1;
+                        }
+                        break;
+                    case DHCP_NACK:
+                        tx = DHCPGetTxByXid(dhcp_state, bootp->xid);
+                        if (unlikely(tx == NULL)) {
+                            goto end;
+                        }
+                        if (tx->response_buffer == NULL) {
+                            tx->response_buffer_len = input_len - sizeof(BOOTPHdr);
+                            tx->response_buffer = SCMalloc(tx->response_buffer_len);
+                            if (unlikely(tx->response_buffer == NULL)) {
+                                /* TBD: need to remove from global tx list */
+                                DHCPTxFree(dhcp_state, tx, 0);
+                                goto end;
+                            }
+                            memcpy(tx->response_buffer, dhcp, tx->response_buffer_len);
+                            tx->response_done = 1;
+                        }
+                        break;
+                    default:
+                        SCLogDebug("DHCP unknown %d", dhcp->args[0]);
+                        break;
+                }
+            }
+        }
+
+    }
+
+end:    
+    return 0;
+}
+
+static uint64_t DHCPGetTxCnt(void *state)
+{
+    DHCPState *dhcp = state;
+    SCLogDebug("Current tx count is %"PRIu64".", dhcp->transaction_max);
+    return dhcp->transaction_max;
+}
+
+static void *DHCPGetTx(void *state, uint64_t tx_id)
+{
+    DHCPState *dhcp = state;
+    DHCPTransaction *tx;
+
+    SCLogDebug("Requested tx ID %"PRIu64".", tx_id);
+
+    SCMutexLock(&dhcp->lock);
+    TAILQ_FOREACH(tx, &dhcp->tx_list, next) {
+        if (tx->tx_id == tx_id) {
+            SCMutexUnlock(&dhcp->lock);
+            SCLogDebug("Transaction %"PRIu64" found, returning tx object %p.",
+                tx_id, tx);
+            return tx;
+        }
+    }
+    SCMutexUnlock(&dhcp->lock);
+
+    SCLogDebug("Transaction ID %"PRIu64" not found.", tx_id);
+    return NULL;
+}
+
+/**
+ * \brief Called by the application layer.
+ *
+ * In most cases 1 can be returned here.
+ */
+static int DHCPGetAlstateProgressCompletionStatus(uint8_t direction) {
+    return 1;
+}
+
+/**
+ * \brief Return the state of a transaction in a given direction.
+ *
+ * In the case of the echo protocol, the existence of a transaction
+ * means that the request is done. However, some protocols that may
+ * need multiple chunks of data to complete the request may need more
+ * than just the existence of a transaction for the request to be
+ * considered complete.
+ *
+ * For the response to be considered done, the response for a request
+ * needs to be seen.  The response_done flag is set on response for
+ * checking here.
+ */
+static int DHCPGetStateProgress(void *tx, uint8_t direction)
+{
+    DHCPTransaction *dhcptx = tx;
+
+    SCLogDebug("Transaction progress requested for tx ID %"PRIu64
+        ", direction=0x%02x", dhcptx->tx_id, direction);
+
+    if (dhcptx->response_done) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * \brief ???
+ */
+static DetectEngineState *DHCPGetTxDetectState(void *vtx)
+{
+    DHCPTransaction *tx = vtx;
+    return tx->de_state;
+}
+
+/**
+ * \brief ???
+ */
+static int DHCPSetTxDetectState(void *state, void *vtx,
+    DetectEngineState *s)
+{
+    DHCPTransaction *tx = vtx;
+    tx->de_state = s;
+    return 0;
+}
+
+void RegisterDHCPParsers(void)
+{
+    char *proto_name = "dhcp";
+
+    if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {
+
+        SCLogNotice("DHCP UDP protocol detection enabled.");
+
+        AppLayerProtoDetectRegisterProtocol(ALPROTO_DHCP, proto_name);
+
+        if (RunmodeIsUnittests()) {
+
+            SCLogNotice("Unittest mode, registeringd default configuration.");
+            AppLayerProtoDetectPPRegister(IPPROTO_TCP, DHCP_DEFAULT_SERVER_PORT,
+                ALPROTO_DHCP, 0, DHCP_MIN_FRAME_LEN, STREAM_TOSERVER,
+                DHCPToServerProbingParser, NULL);
+
+            AppLayerProtoDetectPPRegister(IPPROTO_TCP, DHCP_DEFAULT_CLIENT_PORT,
+                ALPROTO_DHCP/*_CLIENT*/, 0, DHCP_MIN_FRAME_LEN, STREAM_TOSERVER,
+                DHCPToClientProbingParser, NULL);
+
+        }
+        else {
+
+            if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
+                    proto_name, ALPROTO_DHCP, 0, DHCP_MIN_FRAME_LEN,
+                    DHCPToServerProbingParser, NULL)) {
+                SCLogNotice("No DHCP app-layer configuration, enabling DHCP"
+                    " detection UDP detection on port %s.",
+                    DHCP_DEFAULT_SERVER_PORT);
+                AppLayerProtoDetectPPRegister(IPPROTO_UDP,
+                    DHCP_DEFAULT_SERVER_PORT, ALPROTO_DHCP, 0,
+                    DHCP_MIN_FRAME_LEN, STREAM_TOSERVER,
+                    DHCPToServerProbingParser, NULL);
+            }
+
+            if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
+                    proto_name, ALPROTO_DHCP/*_CLIENT*/, 0, DHCP_MIN_FRAME_LEN,
+                    DHCPToClientProbingParser, NULL)) {
+                SCLogNotice("No DHCP app-layer configuration, enabling DHCP"
+                    " detection UDP detection on port %s.",
+                    DHCP_DEFAULT_CLIENT_PORT);
+                AppLayerProtoDetectPPRegister(IPPROTO_UDP,
+                    DHCP_DEFAULT_CLIENT_PORT, ALPROTO_DHCP/*_CLIENT*/, 0,
+                    DHCP_MIN_FRAME_LEN, STREAM_TOSERVER,
+                    DHCPToClientProbingParser, NULL);
+            }
+
+
+        }
+
+    }
+
+    else {
+        SCLogNotice("Protocol detecter and parser disabled for DHCP.");
+        return;
+    }
+
+    if (AppLayerParserConfParserEnabled("udp", proto_name)) {
+
+        SCLogNotice("Registering DHCP protocol parser.");
+
+        /* Register functions for state allocation and freeing. A
+         * state is allocated for every new DHCP flow. */
+        AppLayerParserRegisterStateFuncs(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPStateAlloc, DHCPStateFree);
+
+        /* Register request parser for parsing frame from server to client. */
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_DHCP,
+            STREAM_TOSERVER, DHCPParse);
+
+        /* Register response parser for parsing frames from server to client. */
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_DHCP,
+            STREAM_TOCLIENT, DHCPParse);
+
+        /* Register a function to be called by the application layer
+         * when a transaction is to be freed. */
+        AppLayerParserRegisterTxFreeFunc(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPStateTxFree);
+
+        /* Register a function to return the current transaction count. */
+        AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPGetTxCnt);
+
+        /* Transaction handling. */
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DHCP,
+            DHCPGetAlstateProgressCompletionStatus);
+        AppLayerParserRegisterGetStateProgressFunc(IPPROTO_UDP,
+            ALPROTO_DHCP, DHCPGetStateProgress);
+        AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPGetTx);
+
+        /* Application layer event handling. */
+        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPHasEvents);
+
+        /* What is this being registered for? */
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_DHCP,
+            NULL, DHCPGetTxDetectState, DHCPSetTxDetectState);
+
+        AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPStateGetEventInfo);
+        AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_DHCP,
+            DHCPGetEvents);
+    }
+    else {
+        SCLogNotice("DHCP protocol parsing disabled.");
+    }
+
+#ifdef UNITTESTS
+    AppLayerParserRegisterProtocolUnittests(IPPROTO_UDP, ALPROTO_DHCP,
+        DHCPParserRegisterTests);
+#endif
+}
+
+#ifdef UNITTESTS
+#endif
+
+void DHCPParserRegisterTests(void)
+{
+#ifdef UNITTESTS
+#endif
+}

--- a/src/app-layer-dhcp.c
+++ b/src/app-layer-dhcp.c
@@ -324,7 +324,7 @@ static AppProto DHCPToClientProbingParser(uint8_t *input, uint32_t input_len,
 
 static int DHCPParse(Flow *f, void *state,
     AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
-    void *local_data)
+    void *local_data, uint8_t direction)
 {
     DHCPState *dhcp_state = state;
     DHCPGlobalState *global = dhcp_state->global;
@@ -459,31 +459,13 @@ static int DHCPParse(Flow *f, void *state,
                                 goto end;
                             }
                             memcpy(tx->response_buffer, dhcp, tx->response_buffer_len);
-                            Packet *p = tx->p = &tx->response_p;
-                            p->ts = f->lastts;
-                            if (FLOW_IS_IPV4(f)) {
-                                FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->src,
-                                                              &p->src);
-                                FLOW_COPY_IPV4_ADDR_TO_PACKET(&f->dst,
-                                                              &p->dst);
-                                p->ip4h++; /* force PKT_IS_IPV4 in logger */
-                            } else if (FLOW_IS_IPV4(f)) {
-                                FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->src,
-                                                              &p->src);
-                                FLOW_COPY_IPV6_ADDR_TO_PACKET(&f->dst,
-                                                              &p->dst);
-                                p->ip6h++; /* force PKT_IS_IPV6 in logger */
-                            }
-                            p->sp = f->sp;
-                            p->dp = f->dp;
-                            p->proto = f->proto;
-                            p->recursion_level = f->recursion_level;
-                            p->vlan_id[0] = f->vlan_id[0];
-                            p->vlan_id[1] = f->vlan_id[1];
-                            p->flow = f;
-
                             tx->response_seen = 1;
                         }
+
+                        if (direction == TOSERVER) {
+                            tx->reverse_flow = 1;
+                        }
+
                         break;
                     default:
                         SCLogDebug("DHCP unknown %d", dhcp->args[0]);
@@ -495,6 +477,20 @@ static int DHCPParse(Flow *f, void *state,
 
 end:    
     return 0;
+}
+
+static int DHCPParseToServer(Flow *f, void *state,
+        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        void *local_data)
+{
+    return DHCPParse(f, state, pstate, input, input_len, local_data, TOSERVER);
+}
+
+static int DHCPParseToClient(Flow *f, void *state,
+        AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+        void *local_data)
+{
+    return DHCPParse(f, state, pstate, input, input_len, local_data, TOCLIENT);
 }
 
 static uint64_t DHCPGetTxCnt(void *state)
@@ -652,11 +648,11 @@ void RegisterDHCPParsers(void)
 
         /* Register request parser for parsing frame from server to client. */
         AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_DHCP,
-            STREAM_TOSERVER, DHCPParse);
+            STREAM_TOSERVER, DHCPParseToServer);
 
         /* Register response parser for parsing frames from server to client. */
         AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_DHCP,
-            STREAM_TOCLIENT, DHCPParse);
+            STREAM_TOCLIENT, DHCPParseToClient);
 
         /* Register a function to be called by the application layer
          * when a transaction is to be freed. */

--- a/src/app-layer-dhcp.c
+++ b/src/app-layer-dhcp.c
@@ -128,13 +128,6 @@ static void *DHCPStateAlloc(void)
 {
     /* TBD: possibly make this per vlan */
     DHCPState *state = &dhcpGlobalState;
-
-    if (SC_ATOMIC_CAS(&state->initialized, 0, 1) == 1) {
-        SCMutexInit(&state->lock, NULL);
-        TAILQ_INIT(&state->tx_list);
-        SC_ATOMIC_INIT(DHCPStateAllocCount);
-    }
-    SC_ATOMIC_ADD(DHCPStateAllocCount, 1);
     return state;
 }
 
@@ -698,6 +691,10 @@ void RegisterDHCPParsers(void)
             DHCPStateGetEventInfo);
         AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_DHCP,
             DHCPGetEvents);
+
+        /* Initialize global state. */
+        SCMutexInit(&dhcpGlobalState.lock, NULL);
+        TAILQ_INIT(&dhcpGlobalState.tx_list);
     }
     else {
         SCLogNotice("DHCP protocol parsing disabled.");

--- a/src/app-layer-dhcp.c
+++ b/src/app-layer-dhcp.c
@@ -433,7 +433,6 @@ static int DHCPParse(Flow *f, void *state,
             PrintRawDataFp(stdout, input, input_len);
 #endif
 
-            BOOTPHdr *bootp = (BOOTPHdr *)input;
             DHCPOpt *dhcp = (DHCPOpt *)(input + sizeof(BOOTPHdr));
 
             if ((dhcp->code == DHCP_DHCP_MSG_TYPE) &&
@@ -586,7 +585,7 @@ static int DHCPSetTxDetectState(void *state, void *vtx,
 
 void RegisterDHCPParsers(void)
 {
-    char *proto_name = "dhcp";
+    const char *proto_name = "dhcp";
 
     if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {
 

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -132,6 +132,10 @@ typedef struct DHCPTransaction_ {
 
     DetectEngineState *de_state;
 
+    Packet *p;
+    Packet response_p;          /* copy of response Packet when request/response
+                                 * processed out of order. */
+
     TAILQ_ENTRY(DHCPTransaction_) next;
 
 } DHCPTransaction;

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -124,8 +124,10 @@ typedef struct DHCPTransaction_ {
         uint8_t response_client_ip_bytes[sizeof(uint32_t)];
     };
 
-    uint32_t response_done : 1; /*<< Flag to be set when the response is
-                            * seen. */
+    uint32_t request_seen : 1; /*<< Flag to be set when the request is
+                                * seen. */
+    uint32_t response_seen : 1; /*<< Flag to be set when the response is
+                                * seen. */
     uint32_t response_unneeded : 1;
 
     DetectEngineState *de_state;

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -140,7 +140,7 @@ typedef struct DHCPTransaction_ {
 
 } DHCPTransaction;
 
-typedef struct DHCPState_ {
+typedef struct DHCPGlobalState_ {
 
     SCMutex lock;    /** Mutex for access to tx_list */
 
@@ -166,6 +166,6 @@ typedef struct DHCPState_ {
 
     uint16_t events; /**< Number of application layer events created
                       * for this state. */
-} DHCPState;
+} DHCPGlobalState;
 
 #endif /* __APP_LAYER_DHCP_H__ */

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -1,0 +1,165 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Tom DeCanio <decanio.tom@gmail.com>
+ */
+
+#ifndef __APP_LAYER_DHCP_H__
+#define __APP_LAYER_DHCP_H__
+
+#include "detect-engine-state.h"
+
+#include "queue.h"
+
+void RegisterDHCPParsers(void);
+void DHCPParserRegisterTests(void);
+
+#define BOOTP_REQUEST 1
+#define BOOTP_REPLY 2
+#define BOOTP_ETHERNET 1
+#define BOOTP_DHCP_MAGIC_COOKIE 0x63825363
+
+typedef struct BOOTPHdr_ {
+    uint8_t op;
+    uint8_t htype;
+    uint8_t hlen;
+    uint8_t hops;
+    uint32_t xid;
+    uint16_t secs;
+    uint16_t flags;
+    uint32_t ciaddr;
+    uint32_t yiaddr;
+    uint32_t siaddr;
+    uint32_t giaddr;
+    uint32_t chaddr[4];
+    uint8_t  zeros[192];
+    uint32_t magic;
+} BOOTPHdr;
+
+
+#define DHCP_DHCP_MSG_TYPE 53
+
+#define DHCP_DISCOVER 1
+#define DHCP_OFFER 2
+#define DHCP_REQUEST 3
+#define DHCP_DECLINE 4
+#define DHCP_ACK 5
+#define DHCP_NACK 6
+#define DHCP_RELEASE 7
+#define DHCP_INFORM 8
+
+#define DHCP_OPT_SUBNET_MASK 1
+#define DHCP_OPT_ROUTER_IP 3
+#define DHCP_OPT_DNS_IP 6
+#define DHCP_OPT_HOSTNAME 12
+#define DHCP_OPT_REQUESTED_IP 50
+#define DHCP_OPT_IP_LEASE_TIME 51
+#define DHCP_OPT_TYPE 53
+#define DHCP_OPT_SERVER_ID 54
+#define DHCP_OPT_PARAM_REQ_LIST 55
+#define DHCP_OPT_IP_RENEWAL_TIME 58
+#define DHCP_OPT_IP_REBINDING_TIME 59
+#define DHCP_OPT_VENDOR_CLASS 60
+#define DHCP_OPT_CLIENT_ID 61
+#define DHCP_OPT_TFTP_IP 66
+#define DHCP_OPT_END 255
+
+#define DHCP_PARAM_SUBNET_MASK 1
+#define DHCP_PARAM_ROUTER 3
+#define DHCP_PARAM_DNS_SERVER 6
+#define DHCP_PARAM_DOMAIN 15
+#define DHCP_PARAM_ARP_TIMEOUT 35
+#define DHCP_PARAM_NTP_SERVER 42
+#define DHCP_PARAM_TFTP_SERVER_NAME 66
+#define DHCP_PARAM_TFTP_SERVER_IP 150
+
+typedef struct DHCPOpt_ {
+    uint8_t code;
+    uint8_t len;
+    uint8_t args[];
+} DHCPOpt;
+
+typedef struct DHCPTransaction_ {
+
+    uint64_t tx_id;             /*<< Internal transaction ID. */
+
+    AppLayerDecoderEvents *decoder_events; /*<< Application layer
+                                            * events that occurred
+                                            * while parsing this
+                                            * transaction. */
+
+    uint32_t xid;
+    uint32_t logged;
+
+    uint8_t *request_buffer;
+    uint32_t request_buffer_len;
+
+    union {
+        uint32_t request_client_ip;
+        uint8_t request_client_ip_bytes[sizeof(uint32_t)];
+    };
+
+    uint8_t *response_buffer;
+    uint32_t response_buffer_len;
+
+    union {
+        uint32_t response_client_ip;
+        uint8_t response_client_ip_bytes[sizeof(uint32_t)];
+    };
+
+    uint32_t response_done : 1; /*<< Flag to be set when the response is
+                            * seen. */
+    uint32_t response_unneeded : 1;
+
+    DetectEngineState *de_state;
+
+    TAILQ_ENTRY(DHCPTransaction_) next;
+
+} DHCPTransaction;
+
+typedef struct DHCPState_ {
+
+    SCMutex lock;    /** Mutex for access to tx_list */
+
+
+    SC_ATOMIC_DECLARE(uint32_t, initialized);
+
+    TAILQ_HEAD(, DHCPTransaction_) tx_list; /**< List of DHCP transactions
+                                       * associated with this
+                                       * state. */
+
+    uint64_t transaction_max; /**< A count of the number of
+                               * transactions created.  The
+                               * transaction ID for each transaction
+                               * is allocted by incrementing this
+                               * value. */
+
+    /* Indicates the current transaction being logged. 
+     */
+    uint64_t log_id;
+
+    uint32_t transaction_count; /**< A count of the number of
+                                 * in-progress transactions. */
+
+    uint16_t events; /**< Number of application layer events created
+                      * for this state. */
+} DHCPState;
+
+#endif /* __APP_LAYER_DHCP_H__ */

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -136,9 +136,10 @@ typedef struct DHCPTransaction_ {
 
     DetectEngineState *de_state;
 
-    Packet *p;
-    Packet response_p;          /* copy of response Packet when request/response
-                                 * processed out of order. */
+    uint8_t reverse_flow; /*<< Set when the flow is the reverse of
+                           * what Suricata detected. This is because
+                           * the response can be on a new flow, which
+                           * Suricata will flag as to server. */
 
     TAILQ_ENTRY(DHCPTransaction_) next;
 

--- a/src/app-layer-dhcp.h
+++ b/src/app-layer-dhcp.h
@@ -90,6 +90,8 @@ typedef struct BOOTPHdr_ {
 #define DHCP_PARAM_TFTP_SERVER_NAME 66
 #define DHCP_PARAM_TFTP_SERVER_IP 150
 
+struct DHCPState_;
+
 typedef struct DHCPOpt_ {
     uint8_t code;
     uint8_t len;
@@ -97,6 +99,8 @@ typedef struct DHCPOpt_ {
 } DHCPOpt;
 
 typedef struct DHCPTransaction_ {
+
+    struct DHCPState_ *state;
 
     uint64_t tx_id;             /*<< Internal transaction ID. */
 
@@ -167,5 +171,9 @@ typedef struct DHCPGlobalState_ {
     uint16_t events; /**< Number of application layer events created
                       * for this state. */
 } DHCPGlobalState;
+
+typedef struct DHCPState_ {
+    DHCPGlobalState *global;
+} DHCPState;
 
 #endif /* __APP_LAYER_DHCP_H__ */

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -60,6 +60,7 @@
 #include "app-layer-modbus.h"
 #include "app-layer-enip.h"
 #include "app-layer-dnp3.h"
+#include "app-layer-dhcp.h"
 #include "app-layer-template.h"
 
 #include "conf.h"
@@ -1254,6 +1255,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterENIPUDPParsers();
     RegisterENIPTCPParsers();
     RegisterDNP3Parsers();
+    RegisterDHCPParsers();
     RegisterTemplateParsers();
 
     /** IMAP */

--- a/src/app-layer-protos.c
+++ b/src/app-layer-protos.c
@@ -81,6 +81,9 @@ const char *AppProtoToString(AppProto alproto)
         case ALPROTO_DNP3:
             proto_name = "dnp3";
             break;
+        case ALPROTO_DHCP:
+            proto_name = "dhcp";
+            break;
         case ALPROTO_TEMPLATE:
             proto_name = "template";
             break;

--- a/src/app-layer-protos.h
+++ b/src/app-layer-protos.h
@@ -44,6 +44,7 @@ enum AppProtoEnum {
     ALPROTO_MODBUS,
     ALPROTO_ENIP,
     ALPROTO_DNP3,
+    ALPROTO_DHCP,
     ALPROTO_TEMPLATE,
 
     /* used by the probing parser when alproto detection fails

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -64,12 +64,12 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
 {
     DHCPTransaction *dhcptx = tx;
     LogDHCPLogThread *thread = thread_data;
-    DHCPGlobalState *dhcpState = state;
+    DHCPGlobalState *dhcpState = ((DHCPState *)state)->global;
     MemBuffer *buffer = thread->buffer;
     json_t *js = NULL, *dhcpjs = NULL, *reqjs = NULL, *rspjs = NULL;
     uint8_t request_type = 0;
 
-    SCLogDebug("Logging DHCP transaction %"PRIu64".", dhcptx->tx_id);
+    SCLogNotice("Logging DHCP transaction %"PRIu64".", dhcptx->tx_id);
     if (dhcpState->log_id > tx_id) {
         SCLogDebug("Already logged DHCP transaction %"PRIu64".", dhcptx->tx_id);
         return TM_ECODE_OK;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -1,0 +1,580 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#include "suricata-common.h"
+#include "debug.h"
+#include "detect.h"
+#include "pkt-var.h"
+#include "conf.h"
+
+#include "threads.h"
+#include "threadvars.h"
+#include "tm-threads.h"
+
+#include "util-unittest.h"
+#include "util-buffer.h"
+#include "util-debug.h"
+#include "util-byte.h"
+
+#include "output.h"
+#include "output-json.h"
+
+#include "app-layer.h"
+#include "app-layer-parser.h"
+
+#include "app-layer-dhcp.h"
+
+//#define PRINT
+
+#ifdef HAVE_LIBJANSSON
+#include <jansson.h>
+
+typedef struct LogDHCPFileCtx_ {
+    LogFileCtx *file_ctx;
+    uint32_t    flags;
+} LogDHCPFileCtx;
+
+typedef struct LogDHCPLogThread_ {
+    LogDHCPFileCtx *dhcplog_ctx;
+    uint32_t        count;
+    MemBuffer       *buffer;
+} LogDHCPLogThread;
+
+static inline int JsonDHCPOptEnd(DHCPOpt *dhcp_opt)
+{
+    return (dhcp_opt->code == DHCP_OPT_END) ? 1 : 0;
+}
+
+static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
+    const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
+{
+    DHCPTransaction *dhcptx = tx;
+    LogDHCPLogThread *thread = thread_data;
+    DHCPState *dhcpState = state;
+    MemBuffer *buffer = thread->buffer;
+    json_t *js = NULL, *dhcpjs = NULL, *reqjs = NULL, *rspjs = NULL;
+    uint8_t request_type = 0;
+
+    SCLogDebug("Logging DHCP transaction %"PRIu64".", dhcptx->tx_id);
+    if (dhcpState->log_id > tx_id) {
+        SCLogDebug("Already logged DHCP transaction %"PRIu64".", dhcptx->tx_id);
+        return TM_ECODE_OK;
+    }
+    if (dhcptx->logged) {
+        SCLogDebug("Already logged DHCP transaction %"PRIu64".", dhcptx->tx_id);
+        return TM_ECODE_OK;
+    }
+    if (unlikely(dhcptx->request_buffer == NULL)) {
+        if (unlikely((dhcptx->response_unneeded == 0) &&
+                     (dhcptx->response_buffer == NULL))) {
+            goto error;
+        }
+    }
+    
+    js = CreateJSONHeader((Packet *)p, 0, "dhcp");
+    if (unlikely(js == NULL)) {
+        goto error;
+    }
+
+    dhcpjs = json_object();
+    if (unlikely(dhcpjs == NULL)) {
+        goto error;
+    }
+    reqjs = json_object();
+    if (unlikely(reqjs == NULL)) {
+        goto error;
+    }
+    if (dhcptx->response_unneeded == 0) {
+        rspjs = json_object();
+        if (unlikely(rspjs == NULL)) {
+            goto error;
+        }
+    }
+
+    uint32_t offset, option_size;
+    DHCPOpt *dhcp_opt = (DHCPOpt *)dhcptx->request_buffer;
+    for (offset = 0;
+         JsonDHCPOptEnd(dhcp_opt) == 0 && offset <= dhcptx->request_buffer_len;
+         offset += option_size) {
+
+        dhcp_opt = (DHCPOpt *)&dhcptx->request_buffer[offset];
+
+        if (unlikely(JsonDHCPOptEnd(dhcp_opt) == 0)) {
+            option_size = offsetof(DHCPOpt, args) + dhcp_opt->len;
+            if (offset + option_size > dhcptx->request_buffer_len) {
+                goto error;
+            }
+        } else {
+            option_size = offsetof(DHCPOpt, len);
+        }
+
+        switch (dhcp_opt->code) {
+            case DHCP_OPT_TYPE: {
+                char *s = "";
+                request_type = dhcp_opt->args[0];
+                switch (request_type) {
+                    case DHCP_DISCOVER:
+                        s = "discover";
+                        break;
+                    case DHCP_REQUEST:
+                        s = "request";
+                        break;
+                    case DHCP_INFORM:
+                        s = "inform";
+                        break;
+                    case DHCP_RELEASE:
+                        s = "release";
+                        break;
+                    case DHCP_DECLINE:
+                        s = "decline";
+                        break;
+                }
+                json_object_set_new(reqjs, "type", json_string(s));
+                if (request_type == DHCP_INFORM) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                                     "%d.%d.%d.%d",
+                                     dhcptx->request_client_ip_bytes[0],
+                                     dhcptx->request_client_ip_bytes[1],
+                                     dhcptx->request_client_ip_bytes[2],
+                                     dhcptx->request_client_ip_bytes[3]);
+                    json_object_set_new(reqjs, "client_ip", json_string(ipaddr));
+                }
+                }
+                break;
+            case DHCP_OPT_HOSTNAME: {
+                char *s = BytesToString(dhcp_opt->args, dhcp_opt->len);
+                json_object_set_new(reqjs, "host_name", json_string(s));
+                SCFree(s);
+                }
+                break;
+            case DHCP_OPT_VENDOR_CLASS: {
+                char *s = BytesToString(dhcp_opt->args, dhcp_opt->len);
+                json_object_set_new(reqjs, "vendor_class", json_string(s));
+                SCFree(s);
+                }
+                break;
+            case DHCP_OPT_CLIENT_ID:
+                if ((option_size - offsetof(DHCPOpt, args) > 1) &&
+                    (dhcp_opt->args[0] == BOOTP_ETHERNET)) {
+
+                     if (option_size - offsetof(DHCPOpt, args) >= 7) {
+                         char macaddr[6*3+1];
+                         snprintf(macaddr, sizeof(macaddr),
+                                  "%02x:%02x:%02x:%02x:%02x:%02x",
+                                  dhcp_opt->args[1],
+                                  dhcp_opt->args[2],
+                                  dhcp_opt->args[3],
+                                  dhcp_opt->args[4],
+                                  dhcp_opt->args[5],
+                                  dhcp_opt->args[6]);
+                         json_object_set_new(reqjs, "client_id",
+                                             json_string(macaddr));
+                    }
+                }
+                break;
+            case DHCP_OPT_REQUESTED_IP:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(reqjs, "client_ip",
+                                        json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_SERVER_ID:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(reqjs, "server_ip",
+                                        json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_PARAM_REQ_LIST: {
+                json_t *parmsjs = json_array();
+                if (likely(parmsjs != NULL)) {
+                    uint8_t i;
+                    for (i = 0; i < dhcp_opt->len; i++) {
+                        switch (dhcp_opt->args[i]) {
+                            case DHCP_PARAM_SUBNET_MASK:
+                                 json_array_append(parmsjs, json_string("subnet_mask"));
+                                 break;
+                            case DHCP_PARAM_ROUTER:
+                                 json_array_append(parmsjs, json_string("router"));
+                                 break;
+                            case DHCP_PARAM_DNS_SERVER:
+                                 json_array_append(parmsjs, json_string("dns_server"));
+                                 break;
+                            case DHCP_PARAM_DOMAIN:
+                                 json_array_append(parmsjs, json_string("domain"));
+                                 break;
+                            case DHCP_PARAM_ARP_TIMEOUT:
+                                 json_array_append(parmsjs, json_string("arp_timeout"));
+                                 break;
+                            case DHCP_PARAM_NTP_SERVER:
+                                 json_array_append(parmsjs, json_string("ntp_server"));
+                                 break;
+                            case DHCP_PARAM_TFTP_SERVER_NAME:
+                                 json_array_append(parmsjs, json_string("tftp_server_name"));
+                                 break;
+                            case DHCP_PARAM_TFTP_SERVER_IP:
+                                 json_array_append(parmsjs, json_string("tftp_server_ip"));
+                                 break;
+                        }
+                    }
+                    json_object_set_new(reqjs, "params", parmsjs);
+                }
+                }
+                break;
+            case DHCP_OPT_END:
+                break;
+        }
+    }
+
+    if (dhcptx->response_unneeded == 0) {
+    dhcp_opt = (DHCPOpt *)dhcptx->response_buffer;
+    for (offset = 0;
+         JsonDHCPOptEnd(dhcp_opt) == 0 && offset <= dhcptx->response_buffer_len;
+         offset += option_size) {
+
+        dhcp_opt = (DHCPOpt *)&dhcptx->response_buffer[offset];
+
+        if (unlikely(JsonDHCPOptEnd(dhcp_opt) == 0)) {
+            option_size = offsetof(DHCPOpt, args) + dhcp_opt->len;
+            if (offset + option_size > dhcptx->response_buffer_len) {
+                goto error;
+            }
+        } else {
+            option_size = offsetof(DHCPOpt, len);
+        }
+
+        switch (dhcp_opt->code) {
+            case DHCP_OPT_TYPE: {
+                char *s = "";
+                switch (dhcp_opt->args[0]) {
+                    case DHCP_OFFER:
+                        s = "offer";
+                        break;
+                    case DHCP_ACK:
+                        s = "ack";
+                        break;
+                    case DHCP_NACK:
+                        s = "nak";
+                        break;
+                }
+                json_object_set_new(rspjs, "type", json_string(s));
+                /* purposely placed here to place in metadata after "type" */
+                if ((request_type == DHCP_REQUEST) &&
+                    (dhcp_opt->args[0] == DHCP_ACK)) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                                     "%d.%d.%d.%d",
+                                     dhcptx->response_client_ip_bytes[0],
+                                     dhcptx->response_client_ip_bytes[1],
+                                     dhcptx->response_client_ip_bytes[2],
+                                     dhcptx->response_client_ip_bytes[3]);
+                    json_object_set_new(rspjs, "client_ip", json_string(ipaddr));
+                }
+                }
+                break;
+            case DHCP_OPT_ROUTER_IP:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(rspjs, "router_ip",
+                                        json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_DNS_IP:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(rspjs, "dns_ip", json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_TFTP_IP:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(rspjs, "tftp_ip", json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_IP_RENEWAL_TIME:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    json_object_set_new(rspjs, "renewal_time",
+                                        json_integer((int)dhcp_opt->args[0]<<24|
+                                                     (int)dhcp_opt->args[1]<<16|
+                                                     (int)dhcp_opt->args[2]<<8|
+                                                     (int)dhcp_opt->args[3]));
+                }
+                break;
+            case DHCP_OPT_IP_REBINDING_TIME:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    json_object_set_new(rspjs, "rebinding_time",
+                                        json_integer((int)dhcp_opt->args[0]<<24|
+                                                     (int)dhcp_opt->args[1]<<16|
+                                                     (int)dhcp_opt->args[2]<<8|
+                                                     (int)dhcp_opt->args[3]));
+                }
+                break;
+            case DHCP_OPT_IP_LEASE_TIME:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    json_object_set_new(rspjs, "lease_time",
+                                        json_integer((int)dhcp_opt->args[0]<<24|
+                                                     (int)dhcp_opt->args[1]<<16|
+                                                     (int)dhcp_opt->args[2]<<8|
+                                                     (int)dhcp_opt->args[3]));
+                }
+                break;
+            case DHCP_OPT_SERVER_ID:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char ipaddr[4*4+1];
+                    snprintf(ipaddr, sizeof(ipaddr),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(rspjs, "server_ip", json_string(ipaddr));
+                }
+                break;
+            case DHCP_OPT_SUBNET_MASK:
+                if (option_size - offsetof(DHCPOpt, args) >= 4) {
+                    char mask[4*4+1];
+                    snprintf(mask, sizeof(mask),
+                             "%d.%d.%d.%d",
+                             dhcp_opt->args[0],
+                             dhcp_opt->args[1],
+                             dhcp_opt->args[2],
+                             dhcp_opt->args[3]);
+                    json_object_set_new(rspjs, "subnet_mask", json_string(mask));
+                }
+                break;
+            case DHCP_OPT_END:
+                break;
+        }
+    }
+    }
+
+    dhcptx->logged = 1;
+    json_object_set_new(dhcpjs, "id", json_integer(ntohl(dhcptx->xid)));
+    /* match wireshark
+    * char buf[16];
+    * sprintf(buf, "0x%x", ntohl(dhcptx->xid));
+    * json_object_set_new(dhcpjs, "xid", json_string(buf));
+    */
+    json_object_set_new(dhcpjs, "request", reqjs);
+    if (dhcptx->response_unneeded == 0) {
+        json_object_set_new(dhcpjs, "response", rspjs);
+    }
+    json_object_set_new(js, "dhcp", dhcpjs);
+
+    MemBufferReset(buffer);
+    OutputJSONBuffer(js, thread->dhcplog_ctx->file_ctx, &thread->buffer);
+
+#ifdef PRINT
+    char *js_s = json_dumps(js, JSON_PRESERVE_ORDER|JSON_COMPACT|JSON_ENSURE_ASCII|JSON_ESCAPE_SLASH);
+    printf("%s\n", js_s);
+    free(js_s);
+#endif
+
+    json_object_clear(js);
+    json_decref(js);
+
+    dhcpState->log_id++;
+
+    return TM_ECODE_OK;
+    
+error:
+    if (rspjs != NULL) {
+        json_decref(rspjs);
+    }
+    if (reqjs != NULL) {
+        json_decref(reqjs);
+    }
+    if (dhcpjs != NULL) {
+        json_decref(dhcpjs);
+    }
+    if (js != NULL) {
+        json_decref(js);
+    }
+    return TM_ECODE_FAILED;
+}
+
+static void OutputDHCPLogDeInitCtx(OutputCtx *output_ctx)
+{
+    LogDHCPFileCtx *dhcplog_ctx = (LogDHCPFileCtx *)output_ctx->data;
+    if (dhcplog_ctx != NULL) {
+        LogFileFreeCtx(dhcplog_ctx->file_ctx);
+        SCFree(dhcplog_ctx);
+    }
+    SCFree(output_ctx);
+}
+
+static void OutputDHCPLogDeInitCtxSub(OutputCtx *output_ctx)
+{
+    LogDHCPFileCtx *dhcplog_ctx = (LogDHCPFileCtx *)output_ctx->data;
+    if (dhcplog_ctx != NULL) {
+        SCFree(dhcplog_ctx);
+    }
+    SCFree(output_ctx);
+}
+
+#define DEFAULT_LOG_FILENAME "dhcp.json"
+static OutputCtx *OutputDHCPLogInit(ConfNode *conf)
+{
+    LogFileCtx *file_ctx = LogFileNewCtx();
+    if(file_ctx == NULL) {
+        SCLogError(SC_ERR_SMTP_LOG_GENERIC, "couldn't create new file_ctx");
+        return NULL;
+    }
+
+    if (SCConfLogOpenGeneric(conf, file_ctx, DEFAULT_LOG_FILENAME, 1) < 0) {
+        LogFileFreeCtx(file_ctx);
+        return NULL;
+    }
+
+    LogDHCPFileCtx *dhcp_ctx = SCCalloc(1, sizeof(*dhcp_ctx));
+    if (unlikely(dhcp_ctx == NULL)) {
+        return NULL;
+    }
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(dhcp_ctx);
+        return NULL;
+    }
+    dhcp_ctx->file_ctx = file_ctx;
+
+    output_ctx->data = dhcp_ctx;
+    output_ctx->DeInit = OutputDHCPLogDeInitCtx;
+
+    AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_DHCP);
+
+    return output_ctx;
+}
+
+static OutputCtx *OutputDHCPLogInitSub(ConfNode *conf,
+    OutputCtx *parent_ctx)
+{
+    OutputJsonCtx *ojc = parent_ctx->data;
+
+    LogDHCPFileCtx *dhcplog_ctx = SCCalloc(1, sizeof(*dhcplog_ctx));
+    if (unlikely(dhcplog_ctx == NULL)) {
+        return NULL;
+    }
+    dhcplog_ctx->file_ctx = ojc->file_ctx;
+
+    OutputCtx *output_ctx = SCCalloc(1, sizeof(*output_ctx));
+    if (unlikely(output_ctx == NULL)) {
+        SCFree(dhcplog_ctx);
+        return NULL;
+    }
+    output_ctx->data = dhcplog_ctx;
+    output_ctx->DeInit = OutputDHCPLogDeInitCtxSub;
+
+    SCLogNotice("dhcp log sub-module initialized.");
+
+    AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_DHCP);
+
+    return output_ctx;
+}
+
+#define OUTPUT_BUFFER_SIZE 65535
+
+static TmEcode JsonDHCPLogThreadInit(ThreadVars *t, void *initdata, void **data)
+{
+    LogDHCPLogThread *thread = SCCalloc(1, sizeof(*thread));
+    if (unlikely(thread == NULL)) {
+        return TM_ECODE_FAILED;
+    }
+
+    if (initdata == NULL) {
+        SCLogDebug("Error getting context for DHCP.  \"initdata\" is NULL.");
+        SCFree(thread);
+        return TM_ECODE_FAILED;
+    }
+
+    thread->buffer = MemBufferCreateNew(OUTPUT_BUFFER_SIZE);
+    if (unlikely(thread->buffer == NULL)) {
+        SCFree(thread);
+        return TM_ECODE_FAILED;
+    }
+
+    thread->dhcplog_ctx = ((OutputCtx *)initdata)->data;
+    *data = (void *)thread;
+
+    return TM_ECODE_OK;
+}
+
+static TmEcode JsonDHCPLogThreadDeinit(ThreadVars *t, void *data)
+{
+    LogDHCPLogThread *thread = (LogDHCPLogThread *)data;
+    if (thread == NULL) {
+        return TM_ECODE_OK;
+    }
+    if (thread->buffer != NULL) {
+        MemBufferFree(thread->buffer);
+    }
+    SCFree(thread);
+    return TM_ECODE_OK;
+}
+
+void JsonDHCPLogRegister(void)
+{
+    /* register as separate module */
+    OutputRegisterTxModule(LOGGER_JSON_DHCP, "JsonDHCPLog", "dhcp-json-log",
+        OutputDHCPLogInit, ALPROTO_DHCP, JsonDHCPLogger, JsonDHCPLogThreadInit,
+        JsonDHCPLogThreadDeinit, NULL);
+
+    /* Register as an eve sub-module. */
+    OutputRegisterTxSubModule(LOGGER_JSON_DHCP, "eve-log", "JsonDHCPLog",
+        "eve-log.dhcp", OutputDHCPLogInitSub, ALPROTO_DHCP, JsonDHCPLogger,
+        JsonDHCPLogThreadInit, JsonDHCPLogThreadDeinit, NULL);
+}
+
+#else /* No JSON support. */
+
+void JsonDHCPLogRegister(void)
+{
+}
+
+#endif /* HAVE_LIBJANSSON */

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -70,7 +70,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
     json_t *js = NULL, *dhcpjs = NULL, *reqjs = NULL, *rspjs = NULL;
     uint8_t request_type = 0;
 
-    SCLogNotice("Logging DHCP transaction %"PRIu64".", dhcptx->tx_id);
+    SCLogDebug("Logging DHCP transaction %"PRIu64".", dhcptx->tx_id);
     if (dhcpState->log_id > tx_id) {
         SCLogDebug("Already logged DHCP transaction %"PRIu64".", dhcptx->tx_id);
         return TM_ECODE_OK;
@@ -86,8 +86,9 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
         }
     }
     
-    dhcptx->p->pcap_cnt = p->pcap_cnt;
-    js = CreateJSONHeader(dhcptx->p, 0, "dhcp");
+    js = CreateJSONHeader(p,
+            dhcptx->reverse_flow ? DIRECTION_REVERSE : DIRECTION_PACKET,
+            "dhcp");
     if (unlikely(js == NULL)) {
         goto error;
     }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -37,6 +37,7 @@
 #include "app-layer-parser.h"
 
 #include "app-layer-dhcp.h"
+#include "output-json-dhcp.h"
 
 //#define PRINT
 
@@ -125,23 +126,23 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
 
         switch (dhcp_opt->code) {
             case DHCP_OPT_TYPE: {
-                char *s = "";
+                char *s = (char *)"";
                 request_type = dhcp_opt->args[0];
                 switch (request_type) {
                     case DHCP_DISCOVER:
-                        s = "discover";
+                        s = (char *)"discover";
                         break;
                     case DHCP_REQUEST:
-                        s = "request";
+                        s = (char *)"request";
                         break;
                     case DHCP_INFORM:
-                        s = "inform";
+                        s = (char *)"inform";
                         break;
                     case DHCP_RELEASE:
-                        s = "release";
+                        s = (char *)"release";
                         break;
                     case DHCP_DECLINE:
-                        s = "decline";
+                        s = (char *)"decline";
                         break;
                 }
                 json_object_set_new(reqjs, "type", json_string(s));
@@ -282,16 +283,16 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
 
             switch (dhcp_opt->code) {
                 case DHCP_OPT_TYPE: {
-                    char *s = "";
+                    char *s = (char *)"";
                     switch (dhcp_opt->args[0]) {
                         case DHCP_OFFER:
-                            s = "offer";
+                            s = (char *)"offer";
                             break;
                         case DHCP_ACK:
-                            s = "ack";
+                            s = (char *)"ack";
                             break;
                         case DHCP_NACK:
-                            s = "nak";
+                            s = (char *)"nak";
                             break;
                     }
                     json_object_set_new(rspjs, "type", json_string(s));
@@ -548,7 +549,7 @@ static OutputCtx *OutputDHCPLogInitSub(ConfNode *conf,
 
 #define OUTPUT_BUFFER_SIZE 65535
 
-static TmEcode JsonDHCPLogThreadInit(ThreadVars *t, void *initdata, void **data)
+static TmEcode JsonDHCPLogThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
     LogDHCPLogThread *thread = SCCalloc(1, sizeof(*thread));
     if (unlikely(thread == NULL)) {

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -158,7 +158,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
                 break;
             case DHCP_OPT_HOSTNAME: {
                 char *s = BytesToString(dhcp_opt->args, dhcp_opt->len);
-                json_object_set_new(reqjs, "host_name", json_string(s));
+                json_object_set_new(reqjs, "hostname", json_string(s));
                 SCFree(s);
                 }
                 break;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -221,28 +221,36 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
                     for (i = 0; i < dhcp_opt->len; i++) {
                         switch (dhcp_opt->args[i]) {
                             case DHCP_PARAM_SUBNET_MASK:
-                                 json_array_append(parmsjs, json_string("subnet_mask"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("subnet_mask"));
                                  break;
                             case DHCP_PARAM_ROUTER:
-                                 json_array_append(parmsjs, json_string("router"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("router"));
                                  break;
                             case DHCP_PARAM_DNS_SERVER:
-                                 json_array_append(parmsjs, json_string("dns_server"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("dns_server"));
                                  break;
                             case DHCP_PARAM_DOMAIN:
-                                 json_array_append(parmsjs, json_string("domain"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("domain"));
                                  break;
                             case DHCP_PARAM_ARP_TIMEOUT:
-                                 json_array_append(parmsjs, json_string("arp_timeout"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("arp_timeout"));
                                  break;
                             case DHCP_PARAM_NTP_SERVER:
-                                 json_array_append(parmsjs, json_string("ntp_server"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("ntp_server"));
                                  break;
                             case DHCP_PARAM_TFTP_SERVER_NAME:
-                                 json_array_append(parmsjs, json_string("tftp_server_name"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("tftp_server_name"));
                                  break;
                             case DHCP_PARAM_TFTP_SERVER_IP:
-                                 json_array_append(parmsjs, json_string("tftp_server_ip"));
+                                 json_array_append_new(parmsjs,
+                                         json_string("tftp_server_ip"));
                                  break;
                         }
                     }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -85,7 +85,8 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
         }
     }
     
-    js = CreateJSONHeader((Packet *)p, 0, "dhcp");
+    dhcptx->p->pcap_cnt = p->pcap_cnt;
+    js = CreateJSONHeader(dhcptx->p, 0, "dhcp");
     if (unlikely(js == NULL)) {
         goto error;
     }

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -64,7 +64,7 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
 {
     DHCPTransaction *dhcptx = tx;
     LogDHCPLogThread *thread = thread_data;
-    DHCPState *dhcpState = state;
+    DHCPGlobalState *dhcpState = state;
     MemBuffer *buffer = thread->buffer;
     json_t *js = NULL, *dhcpjs = NULL, *reqjs = NULL, *rspjs = NULL;
     uint8_t request_type = 0;

--- a/src/output-json-dhcp.c
+++ b/src/output-json-dhcp.c
@@ -304,28 +304,42 @@ static int JsonDHCPLogger(ThreadVars *tv, void *thread_data,
                     break;
                 case DHCP_OPT_ROUTER_IP:
                     if (option_size - offsetof(DHCPOpt, args) >= 4) {
-                        char ipaddr[4*4+1];
-                        snprintf(ipaddr, sizeof(ipaddr),
-                                 "%d.%d.%d.%d",
-                                 dhcp_opt->args[0],
-                                 dhcp_opt->args[1],
-                                 dhcp_opt->args[2],
-                                 dhcp_opt->args[3]);
-                        json_object_set_new(rspjs, "router_ip",
-                                            json_string(ipaddr));
+                        size_t off = offsetof(DHCPOpt, args);
+                        uint8_t *ptr = dhcp_opt->args;
+                        json_t *js_addrs = json_array();
+                        while (option_size - off >= 4) {
+                            char ipaddr[4*4];
+                            snprintf(ipaddr, sizeof(ipaddr),
+                                    "%d.%d.%d.%d",
+                                    ptr[0],
+                                    ptr[1],
+                                    ptr[2],
+                                    ptr[3]);
+                            json_array_append_new(js_addrs, json_string(ipaddr));
+                            off += 4;
+                            ptr += 4;
+                        }
+                        json_object_set_new(rspjs, "routers", js_addrs);
                     }
                     break;
                 case DHCP_OPT_DNS_IP:
                     if (option_size - offsetof(DHCPOpt, args) >= 4) {
-                        char ipaddr[4*4+1];
-                        snprintf(ipaddr, sizeof(ipaddr),
-                                 "%d.%d.%d.%d",
-                                 dhcp_opt->args[0],
-                                 dhcp_opt->args[1],
-                                 dhcp_opt->args[2],
-                                 dhcp_opt->args[3]);
-                        json_object_set_new(rspjs, "dns_ip",
-                                            json_string(ipaddr));
+                        size_t off = offsetof(DHCPOpt, args);
+                        uint8_t *ptr = dhcp_opt->args;
+                        json_t *js_addrs = json_array();
+                        while (option_size - off >= 4) {
+                            char ipaddr[4*4];
+                            snprintf(ipaddr, sizeof(ipaddr),
+                                    "%d.%d.%d.%d",
+                                    ptr[0],
+                                    ptr[1],
+                                    ptr[2],
+                                    ptr[3]);
+                            json_array_append_new(js_addrs, json_string(ipaddr));
+                            off += 4;
+                            ptr += 4;
+                        }
+                        json_object_set_new(rspjs, "dns", js_addrs);
                     }
                     break;
                 case DHCP_OPT_TFTP_IP:

--- a/src/output-json-dhcp.h
+++ b/src/output-json-dhcp.h
@@ -1,0 +1,23 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+#ifndef __OUTPUT_JSON_DHCP_H__
+#define __OUTPUT_JSON_DHCP_H__
+
+void JsonDHCPLogRegister(void);
+
+#endif /* __OUTPUT_JSON_DHCP_H__ */

--- a/src/output-json.c
+++ b/src/output-json.c
@@ -285,10 +285,10 @@ void JsonTcpFlags(uint8_t flags, json_t *js)
  * \brief Add five tuple from packet to JSON object
  *
  * \param p Packet
- * \param direction_sensitive Indicate direction sensitivity
+ * \param direction Direction of packet
  * \param js JSON object
  */
-void JsonFiveTuple(const Packet *p, int direction_sensitive, json_t *js)
+void JsonFiveTuple(const Packet *p, int direction, json_t *js)
 {
     char srcip[46], dstip[46];
     Port sp, dp;
@@ -297,7 +297,7 @@ void JsonFiveTuple(const Packet *p, int direction_sensitive, json_t *js)
     srcip[0] = '\0';
     dstip[0] = '\0';
 
-    if (direction_sensitive) {
+    if (direction == DIRECTION_SENSITIVE) {
         if ((PKT_IS_TOSERVER(p))) {
             if (PKT_IS_IPV4(p)) {
                 PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
@@ -327,6 +327,20 @@ void JsonFiveTuple(const Packet *p, int direction_sensitive, json_t *js)
             sp = p->dp;
             dp = p->sp;
         }
+    } else if (direction == DIRECTION_REVERSE) {
+        if (PKT_IS_IPV4(p)) {
+            PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p),
+                      srcip, sizeof(srcip));
+            PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),
+                      dstip, sizeof(dstip));
+        } else if (PKT_IS_IPV6(p)) {
+            PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p),
+                      srcip, sizeof(srcip));
+            PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p),
+                      dstip, sizeof(dstip));
+        }
+        sp = p->sp;
+        dp = p->dp;
     } else {
         if (PKT_IS_IPV4(p)) {
             PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p),

--- a/src/output-json.h
+++ b/src/output-json.h
@@ -50,6 +50,12 @@ OutputCtx *OutputJsonInitCtx(ConfNode *);
 
 enum JsonFormat { COMPACT, INDENT };
 
+enum JsonHeaderDirection {
+    DIRECTION_PACKET = 0,
+    DIRECTION_SENSITIVE,
+    DIRECTION_REVERSE,
+};
+
 /*
  * Global configuration context data
  */

--- a/src/output.c
+++ b/src/output.c
@@ -71,6 +71,7 @@
 #include "output-json-template.h"
 #include "output-lua.h"
 #include "output-json-dnp3.h"
+#include "output-json-dhcp.h"
 #include "output-json-vars.h"
 
 typedef struct RootLogger_ {
@@ -1080,6 +1081,9 @@ void OutputRegisterLoggers(void)
     /* DNP3. */
     JsonDNP3LogRegister();
     JsonVarsLogRegister();
+
+    /* DHCP */
+    JsonDHCPLogRegister();
 
     /* Template JSON logger. */
     JsonTemplateLogRegister();

--- a/src/suricata-common.h
+++ b/src/suricata-common.h
@@ -409,6 +409,7 @@ typedef enum {
     LOGGER_PRELUDE,
     LOGGER_PCAP,
     LOGGER_JSON_DNP3,
+    LOGGER_JSON_DHCP,
     LOGGER_JSON_VARS,
     LOGGER_SIZE,
 } LoggerId;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -197,6 +197,7 @@ outputs:
             # custom allows additional http fields to be included in eve-log
             # the example below adds three additional fields when uncommented
             #custom: [Accept-Encoding, Accept-Language, Authorization]
+        - dhcp
         - dns:
             # control logging of queries and answers
             # default yes, no to disable
@@ -675,6 +676,8 @@ pcap-file:
 # "detection-only" enables protocol detection only (parser disabled).
 app-layer:
   protocols:
+    dhcp:
+      enabled: yes
     tls:
       enabled: yes
       detection-ports:
@@ -1242,7 +1245,6 @@ host:
 #  hash-size: 4096
 #  prealloc: 1000
 #  memcap: 32mb
-
 
 ##
 ## Performance tuning and profiling


### PR DESCRIPTION
This PR takes Tom's latest DHCP and add some updates to it:

1. Make DNS and router IP addresses lists. Per https://www.iana.org/assignments/bootp-dhcp-parameters/bootp-dhcp-parameters.xhtml, these are referred to in the plural.  I'd like to check others.

2. I was getting duplicate log messages. This was due to the request being on the flow 0.0.0.0 -> 255.255.255.255, and the response being 10.16.1.1 -> 10.16.1.109 and the global state. From the app-layer perspective we still have 2 states, but with a single transaction owned by both states. So it ends up getting logged 2x. I think its a bit of a race condition, but for me it was almost always being logged 2x.

My fix is to actually allocate a state for each state that just wraps the global state and give each TX a pointer to this state. This allows each tx to be owned by a specific state. One thing to point out is on response we change the state that owns the TX, this is to help with the logging.

3. Rework how logging is done so we following the scheme of other request/response protocols where the source address is always the client.

Outstanding issues:

==

Given a capture like:
```
Client --> DHCP Discover
Server --> DHCP Offer
Client --> DHCP Request
Server --> DHCP ACK
```
The discover/offer and request/ack get the same transaction ID, so the request overwrites the data already recorded in the discover...  2 thoughts here. Ignore discovers for now. Its really the request/ack we are interested in. Or extend the logic handling so the request makes a new transaction, so the transaction will need a type in addition to the tx id.  For the 99% use case I don't see much value here.

==

I think I really want a "brief" logging method:

https://gist.github.com/jasonish/38ce5ec4979e83f950eea95a824aa1be

Where the current format would be the extended format.  Again, I think its about meeting 80% of the uses cases with a simpler log format.

==

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/145
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/497
