### PR TITLE
app-layer gap handling - v6.1

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -232,6 +232,7 @@ typedef struct DNSState_ {
     uint16_t offset;
     uint16_t record_len;
     uint8_t *buffer;
+    uint8_t gap;               /**< Flag set when a gap has occurred. */
 } DNSState;
 
 #define DNS_CONFIG_DEFAULT_REQUEST_FLOOD 500

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -127,6 +127,9 @@ typedef struct AppLayerParserProtoCtx_
      * STREAM_TOSERVER, STREAM_TOCLIENT */
     uint8_t first_data_dir;
 
+    /* Option flags such as supporting gaps or not. */
+    uint64_t flags;
+
 #ifdef UNITTESTS
     void (*RegisterUnittests)(void);
 #endif
@@ -360,6 +363,16 @@ void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto, AppPro
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].first_data_dir |=
         (direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+
+    SCReturn;
+}
+
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint64_t flags)
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].flags |= flags;
 
     SCReturn;
 }
@@ -980,14 +993,15 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     if (p->StateAlloc == NULL)
         goto end;
 
-    /* Do this check before calling AppLayerParse */
     if (flags & STREAM_GAP) {
-        SCLogDebug("stream gap detected (missing packets), "
-                   "this is not yet supported.");
-
-        if (f->alstate != NULL)
-            AppLayerParserStreamTruncated(f->proto, alproto, f->alstate, flags);
-        goto error;
+        if (!(p->flags & APP_LAYER_PARSER_OPT_ACCEPT_GAPS)) {
+            SCLogDebug("app-layer parser does not accept gaps");
+            if (f->alstate != NULL) {
+                AppLayerParserStreamTruncated(f->proto, alproto, f->alstate,
+                        flags);
+            }
+            goto error;
+        }
     }
 
     /* Get the parser state (if any) */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -30,10 +30,14 @@
 #include "util-file.h"
 #include "stream-tcp-private.h"
 
+/* Flags for AppLayerParserState. */
 #define APP_LAYER_PARSER_EOF                    0x01
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
 #define APP_LAYER_PARSER_NO_REASSEMBLY          0x04
 #define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD  0x08
+
+/* Flags for AppLayerParserProtoCtx. */
+#define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U64(0)
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
@@ -115,6 +119,8 @@ int AppLayerParserRegisterParser(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto,
                                               AppProto alproto,
                                               uint8_t direction);
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint64_t flags);
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
                            void *(*StateAlloc)(void),
                            void (*StateFree)(void *));


### PR DESCRIPTION
Previous PR: #2660 

For parsers configured to handle gaps, pass stream gaps onto them by sending NULL data with a positive input length where the length if the number of bytes lost in the gap.

Add gap handling to DNS for an example. In the DNS case a flag is set on the state that a gap occurred. On the next input data the data is re-probed to see if it can continue.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/146
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/498
