### PR TITLE
dns: fix log filtering

### DIFF
--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -179,7 +179,8 @@ typedef enum {
     DNS_RRTYPE_TSIG,
     DNS_RRTYPE_MAILA,
     DNS_RRTYPE_ANY,
-    DNS_RRTYPE_URI
+    DNS_RRTYPE_URI,
+    DNS_RRTYPE_MAX,
 } DnsRRTypes;
 
 static struct {
@@ -754,7 +755,7 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
                 if (field != NULL)
                 {
                     DnsRRTypes f;
-                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_TXT; f++)
+                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
                     {
                         if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
                                        field->val) == 0)


### PR DESCRIPTION
Previously only a subset of the records could be selected
in custom. Now allow any to be selected.

For example, using:
```
custom: [aaaa]
````
Would not log AAAA records, but instead no DNS records would be logged.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/147
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/499
