### PR TITLE
dev - application layer gap handling - v8

### DIFF
--- a/src/app-layer-dns-common.h
+++ b/src/app-layer-dns-common.h
@@ -232,6 +232,8 @@ typedef struct DNSState_ {
     uint16_t offset;
     uint16_t record_len;
     uint8_t *buffer;
+    uint8_t gap_ts;               /**< Flag set when a gap has occurred. */
+    uint8_t gap_tc;               /**< Flag set when a gap has occurred. */
 } DNSState;
 
 #define DNS_CONFIG_DEFAULT_REQUEST_FLOOD 500

--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -58,6 +58,9 @@ struct DNSTcpHeader_ {
 } __attribute__((__packed__));
 typedef struct DNSTcpHeader_ DNSTcpHeader;
 
+static uint16_t DNSTcpProbingParser(uint8_t *input, uint32_t ilen,
+        uint32_t *offset);
+
 /** \internal
  *  \param input_len at least enough for the DNSTcpHeader
  */
@@ -288,6 +291,13 @@ static int DNSTCPRequestParse(Flow *f, void *dstate,
     DNSState *dns_state = (DNSState *)dstate;
     SCLogDebug("starting %u", input_len);
 
+    if (input == NULL && input_len > 0) {
+        SCLogDebug("Input is NULL, but len is %"PRIu32": must be a gap.",
+                input_len);
+        dns_state->gap_ts = 1;
+        SCReturnInt(1);
+    }
+
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
         SCReturnInt(1);
     }
@@ -299,6 +309,18 @@ static int DNSTCPRequestParse(Flow *f, void *dstate,
     /* probably a rst/fin sending an eof */
     if (input == NULL || input_len == 0) {
         goto insufficient_data;
+    }
+
+    /* Clear gap state. */
+    if (dns_state->gap_ts) {
+        if (DNSTcpProbingParser(input, input_len, NULL) == ALPROTO_DNS) {
+            SCLogDebug("New data probed as DNS, clearing gap state.");
+            BufferReset(dns_state);
+            dns_state->gap_ts = 0;
+        } else {
+            SCLogDebug("Unable to sync DNS parser, leaving gap state.");
+            SCReturnInt(1);
+        }
     }
 
 next_record:
@@ -508,6 +530,13 @@ static int DNSTCPResponseParse(Flow *f, void *dstate,
 {
     DNSState *dns_state = (DNSState *)dstate;
 
+    if (input == NULL && input_len > 0) {
+        SCLogDebug("Input is NULL, but len is %"PRIu32": must be a gap.",
+                input_len);
+        dns_state->gap_tc = 1;
+        SCReturnInt(1);
+    }
+
     if (input == NULL && AppLayerParserStateIssetFlag(pstate, APP_LAYER_PARSER_EOF)) {
         SCReturnInt(1);
     }
@@ -519,6 +548,18 @@ static int DNSTCPResponseParse(Flow *f, void *dstate,
     /* probably a rst/fin sending an eof */
     if (input == NULL || input_len == 0) {
         goto insufficient_data;
+    }
+
+    /* Clear gap state. */
+    if (dns_state->gap_tc) {
+        if (DNSTcpProbingParser(input, input_len, NULL) == ALPROTO_DNS) {
+            SCLogDebug("New data probed as DNS, clearing gap state.");
+            BufferReset(dns_state);
+            dns_state->gap_tc = 0;
+        } else {
+            SCLogDebug("Unable to sync DNS parser, leaving gap state.");
+            SCReturnInt(1);
+        }
     }
 
 next_record:
@@ -712,6 +753,11 @@ void RegisterDNSTCPParsers(void)
         AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_DNS,
                                                                DNSGetAlstateProgressCompletionStatus);
         DNSAppLayerRegisterGetEventInfo(IPPROTO_TCP, ALPROTO_DNS);
+
+        /* This parser accepts gaps. */
+        AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_DNS,
+                APP_LAYER_PARSER_OPT_ACCEPT_GAPS);
+
     } else {
         SCLogInfo("Parsed disabled for %s protocol. Protocol detection"
                   "still on.", proto_name);

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -127,6 +127,9 @@ typedef struct AppLayerParserProtoCtx_
      * STREAM_TOSERVER, STREAM_TOCLIENT */
     uint8_t first_data_dir;
 
+    /* Option flags such as supporting gaps or not. */
+    uint64_t flags;
+
 #ifdef UNITTESTS
     void (*RegisterUnittests)(void);
 #endif
@@ -360,6 +363,16 @@ void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto, AppPro
 
     alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].first_data_dir |=
         (direction & (STREAM_TOSERVER | STREAM_TOCLIENT));
+
+    SCReturn;
+}
+
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint64_t flags)
+{
+    SCEnter();
+
+    alp_ctx.ctxs[FlowGetProtoMapping(ipproto)][alproto].flags |= flags;
 
     SCReturn;
 }
@@ -980,14 +993,15 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
     if (p->StateAlloc == NULL)
         goto end;
 
-    /* Do this check before calling AppLayerParse */
     if (flags & STREAM_GAP) {
-        SCLogDebug("stream gap detected (missing packets), "
-                   "this is not yet supported.");
-
-        if (f->alstate != NULL)
-            AppLayerParserStreamTruncated(f->proto, alproto, f->alstate, flags);
-        goto error;
+        if (!(p->flags & APP_LAYER_PARSER_OPT_ACCEPT_GAPS)) {
+            SCLogDebug("app-layer parser does not accept gaps");
+            if (f->alstate != NULL) {
+                AppLayerParserStreamTruncated(f->proto, alproto, f->alstate,
+                        flags);
+            }
+            goto error;
+        }
     }
 
     /* Get the parser state (if any) */

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -30,10 +30,14 @@
 #include "util-file.h"
 #include "stream-tcp-private.h"
 
+/* Flags for AppLayerParserState. */
 #define APP_LAYER_PARSER_EOF                    0x01
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
 #define APP_LAYER_PARSER_NO_REASSEMBLY          0x04
 #define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD  0x08
+
+/* Flags for AppLayerParserProtoCtx. */
+#define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U64(0)
 
 int AppLayerParserProtoIsRegistered(uint8_t ipproto, AppProto alproto);
 
@@ -115,6 +119,8 @@ int AppLayerParserRegisterParser(uint8_t ipproto, AppProto alproto,
 void AppLayerParserRegisterParserAcceptableDataDirection(uint8_t ipproto,
                                               AppProto alproto,
                                               uint8_t direction);
+void AppLayerParserRegisterOptionFlags(uint8_t ipproto, AppProto alproto,
+        uint64_t flags);
 void AppLayerParserRegisterStateFuncs(uint8_t ipproto, AppProto alproto,
                            void *(*StateAlloc)(void),
                            void (*StateFree)(void *));


### PR DESCRIPTION
Previous PR: #2704 

Changes from last PR:
- GetAppBuffer can calculate the size of the gap, that is the amount of missing data before actual data. Use this for gap notification.
- This means that the gap is sent to the app-layer immediately upon the ack, instead it won't be notified until there is data after the gap. I'm am not yet sure if this matters though, but it makes for a simpler implementation.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/156
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/508
