### PR TITLE
Fixes/32x/misc/v5

### DIFF
--- a/src/app-layer-modbus.c
+++ b/src/app-layer-modbus.c
@@ -1222,15 +1222,30 @@ static int ModbusParseHeader(ModbusState   *modbus,
     SCEnter();
     uint16_t offset = 0;
 
+    int r = 0;
+
+    /* can't pass the header fields directly due to alignment (Bug 2088) */
+    uint16_t transaction_id = 0;
+    uint16_t protocol_id = 0;
+    uint16_t length = 0;
+    uint8_t unit_id = 0;
+
     /* Transaction Identifier (2 bytes) */
-    if (ModbusExtractUint16(modbus, &(header->transactionId), input, input_len, &offset)    ||
+    r = ModbusExtractUint16(modbus, &transaction_id, input, input_len, &offset);
     /* Protocol Identifier (2 bytes) */
-        ModbusExtractUint16(modbus, &(header->protocolId), input, input_len, &offset)       ||
+    r |= ModbusExtractUint16(modbus, &protocol_id, input, input_len, &offset);
     /* Length (2 bytes) */
-        ModbusExtractUint16(modbus, &(header->length), input, input_len, &offset)           ||
+    r |= ModbusExtractUint16(modbus, &length, input, input_len, &offset);
     /* Unit Identifier (1 byte) */
-        ModbusExtractUint8(modbus, &(header->unitId), input, input_len, &offset))
+    r |= ModbusExtractUint8(modbus, &unit_id, input, input_len, &offset);
+
+    if (r != 0) {
         SCReturnInt(-1);
+    }
+    header->transactionId = transaction_id;
+    header->protocolId = protocol_id;
+    header->length = length;
+    header->unitId = unit_id;
 
     SCReturnInt(0);
 }

--- a/src/output-json-dns.c
+++ b/src/output-json-dns.c
@@ -178,7 +178,8 @@ typedef enum {
     DNS_RRTYPE_TSIG,
     DNS_RRTYPE_MAILA,
     DNS_RRTYPE_ANY,
-    DNS_RRTYPE_URI
+    DNS_RRTYPE_URI,
+    DNS_RRTYPE_MAX,
 } DnsRRTypes;
 
 static struct {
@@ -753,7 +754,7 @@ static void JsonDnsLogInitFilters(LogDnsFileCtx *dnslog_ctx, ConfNode *conf)
                 if (field != NULL)
                 {
                     DnsRRTypes f;
-                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_TXT; f++)
+                    for (f = DNS_RRTYPE_A; f < DNS_RRTYPE_MAX; f++)
                     {
                         if (strcasecmp(dns_rrtype_fields[f].config_rrtype,
                                        field->val) == 0)

--- a/src/runmode-unix-socket.c
+++ b/src/runmode-unix-socket.c
@@ -66,6 +66,7 @@ const char *RunModeUnixSocketGetDefaultMode(void)
 
 #ifdef BUILD_UNIX_SOCKET
 
+static int RunModeUnixSocketSingle(void);
 static int unix_manager_file_task_running = 0;
 static int unix_manager_file_task_failed = 0;
 
@@ -753,14 +754,16 @@ TmEcode UnixSocketUnregisterTenant(json_t *cmd, json_t* answer, void *data)
 }
 #endif /* BUILD_UNIX_SOCKET */
 
+#ifdef BUILD_UNIX_SOCKET
 /**
  * \brief Single thread version of the Pcap file processing.
  */
-int RunModeUnixSocketSingle(void)
+static int RunModeUnixSocketSingle(void)
 {
-#ifdef BUILD_UNIX_SOCKET
-    PcapCommand *pcapcmd = SCMalloc(sizeof(PcapCommand));
+    if (UnixManagerInit() != 0)
+        return 1;
 
+    PcapCommand *pcapcmd = SCMalloc(sizeof(PcapCommand));
     if (unlikely(pcapcmd == NULL)) {
         SCLogError(SC_ERR_MEM_ALLOC, "Can not allocate pcap command");
         return 1;
@@ -769,20 +772,19 @@ int RunModeUnixSocketSingle(void)
     pcapcmd->running = 0;
     pcapcmd->currentfile = NULL;
 
-    UnixManagerThreadSpawn(1);
-
-    unix_socket_mode_is_running = 1;
-
     UnixManagerRegisterCommand("pcap-file", UnixSocketAddPcapFile, pcapcmd, UNIX_CMD_TAKE_ARGS);
     UnixManagerRegisterCommand("pcap-file-number", UnixSocketPcapFilesNumber, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-file-list", UnixSocketPcapFilesList, pcapcmd, 0);
     UnixManagerRegisterCommand("pcap-current", UnixSocketPcapCurrent, pcapcmd, 0);
 
     UnixManagerRegisterBackgroundTask(UnixSocketPcapFilesCheck, pcapcmd);
-#endif
+
+    UnixManagerThreadSpawn(1);
+    unix_socket_mode_is_running = 1;
 
     return 0;
 }
+#endif
 
 int RunModeUnixSocketIsActive(void)
 {

--- a/src/runmode-unix-socket.h
+++ b/src/runmode-unix-socket.h
@@ -23,7 +23,6 @@
 #ifndef __RUNMODE_UNIX_SOCKET_H__
 #define __RUNMODE_UNIX_SOCKET_H__
 
-int RunModeUnixSocketSingle(void);
 void RunModeUnixSocketRegister(void);
 const char *RunModeUnixSocketGetDefaultMode(void);
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2576,6 +2576,10 @@ static int PostConfLoadedSetup(SCInstance *suri)
             break;
     }
 
+    if (suri->runmode_custom_mode) {
+        ConfSet("runmode", suri->runmode_custom_mode);
+    }
+
     AppLayerSetup();
 
     /* Check for the existance of the default logging directory which we pick

--- a/src/unix-manager.h
+++ b/src/unix-manager.h
@@ -33,6 +33,7 @@
 SCCtrlCondT unix_manager_ctrl_cond;
 SCCtrlMutex unix_manager_ctrl_mutex;
 
+int UnixManagerInit(void);
 void UnixManagerThreadSpawn(int mode);
 void UnixSocketKillSocketThread(void);
 

--- a/src/util-pool.c
+++ b/src/util-pool.c
@@ -239,7 +239,7 @@ void PoolFree(Pool *p)
                 SCFree(pb->data);
         }
         pb->data = NULL;
-        if (! pb->flags & POOL_BUCKET_PREALLOCATED) {
+        if (!(pb->flags & POOL_BUCKET_PREALLOCATED)) {
             SCFree(pb);
         }
     }
@@ -258,7 +258,7 @@ void PoolFree(Pool *p)
             }
             pb->data = NULL;
         }
-        if (! pb->flags & POOL_BUCKET_PREALLOCATED) {
+        if (!(pb->flags & POOL_BUCKET_PREALLOCATED)) {
             SCFree(pb);
         }
     }


### PR DESCRIPTION
As #2719, but cleaning up the unix socket runmode spagetti:

Starting with explicit autofp:
<pre>
./src/suricata -c suricata.yaml --unix-socket=/tmp/suricata.socket -v -S /dev/null --runmode=autofp
Error opening file /var/log/suricata/suricata.log
[124325] 24/5/2017 -- 21:39:40 - (suricata.c:1099) <Notice> (SCPrintVersion) -- This is Suricata version 3.2dev
[124325] 24/5/2017 -- 21:39:40 - (util-cpu.c:170) <Info> (UtilCpuPrintSummary) -- CPUs/cores online: 12
[124325] 24/5/2017 -- 21:39:40 - (util-coredump-config.c:139) <Info> (CoredumpLoadConfig) -- Could not set core dump size to unlimited; it's set to the hard limit.
[124325] 24/5/2017 -- 21:39:40 - (util-conf.c:109) <Info> (ConfUnixSocketIsEnable) -- Running in live mode, activating unix socket
[124325] 24/5/2017 -- 21:39:40 - (util-classification-config.c:370) <Info> (SCClassConfParseFile) -- Added "35" classification types from the classification file
[124325] 24/5/2017 -- 21:39:40 - (util-reference-config.c:352) <Info> (SCRConfParseFile) -- Added "20" reference types from the reference.config file
[124325] 24/5/2017 -- 21:39:40 - (detect.c:502) <Info> (SigLoadSignatures) -- No signatures supplied.
[124325] 24/5/2017 -- 21:39:40 - (util-threshold-config.c:1188) <Info> (SCThresholdConfParseFile) -- Threshold config parsed: 0 rule(s) found
[124325] 24/5/2017 -- 21:39:40 - (unix-manager.c:124) <Info> (UnixNew) -- Using unix socket file '/tmp/suricata.socket'
[124325] 24/5/2017 -- 21:39:40 - (tm-threads.c:2163) <Notice> (TmThreadWaitOnThreadInit) -- all 0 packet processing threads, 0 management threads initialized, engine started.
</pre>

Pass pcap
<pre>
PYTHONPATH=scripts/suricatasc/src python scripts/suricatasc/suricatasc -v /tmp/suricata.socket -c "pcap-file /home/victor/sync/pcap/sandnet.pcap /tmp/test"
SND: {"version": "0.1"}
RCV: {"return": "OK"}
SND: {"command": "command-list"}
RCV: {"message": {"count": 19, "commands": ["shutdown", "command-list", "help", "version", "uptime", "running-mode", "capture-mode", "conf-get", "dump-counters", "reload-rules", "register-tenant-handler", "unregister-tenant-handler", "register-tenant", "reload-tenant", "unregister-tenant", "pcap-file", "pcap-file-number", "pcap-file-list", "pcap-current"]}, "return": "OK"}
SND: {"command": "pcap-file", "arguments": {"output-dir": "/tmp/test", "filename": "/home/victor/sync/pcap/sandnet.pcap"}}
RCV: {"message": "Successfully added file to list", "return": "OK"}
{"message": "Successfully added file to list", "return": "OK"}
</pre>

Now see that it uses many threads:
<pre>
[124326] 24/5/2017 -- 21:40:33 - (runmode-unix-socket.c:266) <Info> (UnixSocketAddPcapFile) -- Added file '/home/victor/sync/pcap/sandnet.pcap' to list
[124326] 24/5/2017 -- 21:40:33 - (runmode-unix-socket.c:312) <Info> (UnixSocketPcapFilesCheck) -- Starting run for '/home/victor/sync/pcap/sandnet.pcap'
[124326] 24/5/2017 -- 21:40:33 - (runmode-unix-socket.c:339) <Info> (UnixSocketPcapFilesCheck) -- pcap-file.tenant-id not set
[124326] 24/5/2017 -- 21:40:34 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- fast output device (regular) initialized: fast.log
[124326] 24/5/2017 -- 21:40:34 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- eve-log output device (regular) initialized: eve.json
[124326] 24/5/2017 -- 21:40:34 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- stats output device (regular) initialized: stats.log
[124609] 24/5/2017 -- 21:40:34 - (source-pcap-file.c:267) <Info> (ReceivePcapFileThreadInit) -- reading pcap file /home/victor/sync/pcap/sandnet.pcap
[124326] 24/5/2017 -- 21:40:34 - (tm-threads.c:2163) <Notice> (TmThreadWaitOnThreadInit) -- all 13 packet processing threads, 4 management threads initialized, engine started.
[124609] 24/5/2017 -- 21:40:34 - (util-checksum.c:86) <Info> (ChecksumAutoModeCheck) -- No packets with invalid checksum, assuming checksum offloading is NOT used
[124609] 24/5/2017 -- 21:40:40 - (source-pcap-file.c:228) <Info> (ReceivePcapFileLoop) -- pcap file end of file reached (pcap err code 0)
[124609] 24/5/2017 -- 21:40:41 - (source-pcap-file.c:388) <Notice> (ReceivePcapFileThreadExitStats) -- Pcap-file module read 1354508 packets, 413760573 bytes
</pre>

Same for single:
<pre>
./src/suricata -c suricata.yaml --unix-socket=/tmp/suricata.socket -v -S /dev/null --runmode=single
Error opening file /var/log/suricata/suricata.log
[125093] 24/5/2017 -- 21:42:05 - (suricata.c:1099) <Notice> (SCPrintVersion) -- This is Suricata version 3.2dev
[125093] 24/5/2017 -- 21:42:05 - (util-cpu.c:170) <Info> (UtilCpuPrintSummary) -- CPUs/cores online: 12
[125093] 24/5/2017 -- 21:42:05 - (util-coredump-config.c:139) <Info> (CoredumpLoadConfig) -- Could not set core dump size to unlimited; it's set to the hard limit.
[125093] 24/5/2017 -- 21:42:05 - (util-conf.c:109) <Info> (ConfUnixSocketIsEnable) -- Running in live mode, activating unix socket
[125093] 24/5/2017 -- 21:42:05 - (util-classification-config.c:370) <Info> (SCClassConfParseFile) -- Added "35" classification types from the classification file
[125093] 24/5/2017 -- 21:42:05 - (util-reference-config.c:352) <Info> (SCRConfParseFile) -- Added "20" reference types from the reference.config file
[125093] 24/5/2017 -- 21:42:05 - (detect.c:502) <Info> (SigLoadSignatures) -- No signatures supplied.
[125093] 24/5/2017 -- 21:42:05 - (util-threshold-config.c:1188) <Info> (SCThresholdConfParseFile) -- Threshold config parsed: 0 rule(s) found
[125093] 24/5/2017 -- 21:42:05 - (unix-manager.c:124) <Info> (UnixNew) -- Using unix socket file '/tmp/suricata.socket'
[125093] 24/5/2017 -- 21:42:05 - (tm-threads.c:2163) <Notice> (TmThreadWaitOnThreadInit) -- all 0 packet processing threads, 0 management threads initialized, engine started.
[125104] 24/5/2017 -- 21:42:08 - (runmode-unix-socket.c:266) <Info> (UnixSocketAddPcapFile) -- Added file '/home/victor/sync/pcap/sandnet.pcap' to list
[125104] 24/5/2017 -- 21:42:08 - (runmode-unix-socket.c:312) <Info> (UnixSocketPcapFilesCheck) -- Starting run for '/home/victor/sync/pcap/sandnet.pcap'
[125104] 24/5/2017 -- 21:42:08 - (runmode-unix-socket.c:339) <Info> (UnixSocketPcapFilesCheck) -- pcap-file.tenant-id not set
[125104] 24/5/2017 -- 21:42:08 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- fast output device (regular) initialized: fast.log
[125104] 24/5/2017 -- 21:42:08 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- eve-log output device (regular) initialized: eve.json
[125104] 24/5/2017 -- 21:42:08 - (util-logopenfile.c:307) <Info> (SCConfLogOpenGeneric) -- stats output device (regular) initialized: stats.log
[125121] 24/5/2017 -- 21:42:08 - (source-pcap-file.c:267) <Info> (ReceivePcapFileThreadInit) -- reading pcap file /home/victor/sync/pcap/sandnet.pcap
[125104] 24/5/2017 -- 21:42:08 - (tm-threads.c:2163) <Notice> (TmThreadWaitOnThreadInit) -- all 1 packet processing threads, 4 management threads initialized, engine started.
[125121] 24/5/2017 -- 21:42:08 - (util-checksum.c:86) <Info> (ChecksumAutoModeCheck) -- No packets with invalid checksum, assuming checksum offloading is NOT used
[125121] 24/5/2017 -- 21:42:26 - (source-pcap-file.c:228) <Info> (ReceivePcapFileLoop) -- pcap file end of file reached (pcap err code 0)
[125121] 24/5/2017 -- 21:42:27 - (source-pcap-file.c:388) <Notice> (ReceivePcapFileThreadExitStats) -- Pcap-file module read 1354508 packets, 413760573 bytes
</pre>

https://redmine.openinfosecfoundation.org/issues/1675