### PR TITLE
log-tlsstore: fix error handling

### DIFF
--- a/src/log-tlsstore.c
+++ b/src/log-tlsstore.c
@@ -131,6 +131,7 @@ static void LogTlsLogPem(LogTlsStoreLogThread *aft, const Packet *p, SSLState *s
             if (ptmp == NULL) {
                 SCFree(aft->enc_buf);
                 aft->enc_buf = NULL;
+                aft->enc_buf_len = 0;
                 SCLogWarning(SC_ERR_MEM_ALLOC, "Can't allocate data for base64 encoding");
                 goto end_fp;
             }


### PR DESCRIPTION
In case of realloc error, the length of the encoding buffer was not
resetted and this could result in trying to write to NULL pointer.

PR builds:
* https://buildbot.openinfosecfoundation.org/builders/regit/builds/272
* https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/55
