### PR TITLE
Misc 20170510 v2

### DIFF
--- a/qa/coccinelle/struct-flags.cocci
+++ b/qa/coccinelle/struct-flags.cocci
@@ -1,29 +1,29 @@
 @flags@
-SignatureHeader *struct0;
-identifier struct_flags0 =~ "^(?!SIG_FLAG).+";
+SignatureInitData *struct0;
+identifier struct_flags0 =~ "^(?!SIG_FLAG_INIT_).+";
 Signature *struct1;
 identifier struct_flags1 =~ "^(?!SIG_FLAG).+";
-Signature *struct2;
-identifier struct_flags2 =~ "^(?!SIG_FLAG_INIT_).+";
+Flow *struct2;
+identifier struct_flags2 =~ "^(?!FLOWFILE_).+";
 Flow *struct3;
-identifier struct_flags3 =~ "^(?!FLOW_).+";
-TcpSegment *struct4;
-identifier struct_flags4 =~ "^(?!SEGMENTTCP_FLAG).+";
-TcpStream *struct5;
-identifier struct_flags5 =~ "^(?!STREAMTCP_STREAM_FLAG_).+";
-TcpSession *struct6;
-identifier struct_flags6 =~ "^(?!STREAMTCP_FLAG).+";
+identifier struct_flags3 =~ "^(?!FLOW_END_FLAG_).+";
+TcpStream *struct4;
+identifier struct_flags4 =~ "^(?!STREAMTCP_STREAM_FLAG_).+";
+TcpSession *struct5;
+identifier struct_flags5 =~ "^(?!STREAMTCP_FLAG).+";
+TcpStreamCnf *struct6;
+identifier struct_flags6 =~ "^(?!STREAMTCP_INIT_).+";
 Packet *struct7;
 identifier struct_flags7 =~ "^(?!FLOW_PKT_).+";
 position p1;
 @@
 
 (
-struct0->flags@p1 |= struct_flags0
+struct0->init_flags@p1 |= struct_flags0
 |
-struct0->flags@p1 & struct_flags0
+struct0->init_flags@p1 & struct_flags0
 |
-struct0->flags@p1 &= ~struct_flags0
+struct0->init_flags@p1 &= ~struct_flags0
 |
 struct1->flags@p1 |= struct_flags1
 |
@@ -31,17 +31,17 @@ struct1->flags@p1 & struct_flags1
 |
 struct1->flags@p1 &= ~struct_flags1
 |
-struct2->init_flags@p1 |= struct_flags2
+struct2->file_flags@p1 |= struct_flags2
 |
-struct2->init_flags@p1 & struct_flags2
+struct2->file_flags@p1 & struct_flags2
 |
-struct2->init_flags@p1 &= ~struct_flags2
+struct2->file_flags@p1 &= ~struct_flags2
 |
-struct3->flags@p1 |= struct_flags3
+struct3->flow_end_flags@p1 |= struct_flags3
 |
-struct3->flags@p1 & struct_flags3
+struct3->flow_end_flags@p1 & struct_flags3
 |
-struct3->flags@p1 &= ~struct_flags3
+struct3->flow_end_flags@p1 &= ~struct_flags3
 |
 struct4->flags@p1 |= struct_flags4
 |

--- a/src/runmode-af-packet.c
+++ b/src/runmode-af-packet.c
@@ -264,11 +264,17 @@ static void *ParseAFPConfig(const char *iface)
                     iface,
                     aconf->out_iface);
             aconf->copy_mode = AFP_COPY_MODE_IPS;
+            if (aconf->flags & AFP_TPACKET_V3) {
+                SCLogWarning(SC_ERR_RUNMODE, "Using tpacket_v3 in IPS mode will result in high latency");
+            }
         } else if (strcmp(copymodestr, "tap") == 0) {
             SCLogInfo("AF_PACKET TAP mode activated %s->%s",
                     iface,
                     aconf->out_iface);
             aconf->copy_mode = AFP_COPY_MODE_TAP;
+            if (aconf->flags & AFP_TPACKET_V3) {
+                SCLogWarning(SC_ERR_RUNMODE, "Using tpacket_v3 in TAP mode will result in high latency");
+            }
         } else {
             SCLogInfo("Invalid mode (not in tap, ips)");
         }

--- a/src/stream-tcp-inline.c
+++ b/src/stream-tcp-inline.c
@@ -33,20 +33,6 @@
 #include "util-unittest.h"
 #include "util-unittest-helper.h"
 
-/** defined in stream-tcp-reassemble.c */
-extern int stream_inline;
-
-/**
- *  \brief See if stream engine is operating in inline mode
- *
- *  \retval 0 no
- *  \retval 1 yes
- */
-int StreamTcpInlineMode(void)
-{
-    return stream_inline;
-}
-
 /**
  *  \brief Compare the shared data portion of two segments
  *

--- a/src/stream-tcp-inline.h
+++ b/src/stream-tcp-inline.h
@@ -26,7 +26,6 @@
 
 #include "stream-tcp-private.h"
 
-int StreamTcpInlineMode(void);
 int StreamTcpInlineSegmentCompare(TcpStream *, Packet *, TcpSegment *);
 void StreamTcpInlineSegmentReplacePacket(TcpStream *, Packet *, TcpSegment *);
 

--- a/src/stream-tcp-util.c
+++ b/src/stream-tcp-util.c
@@ -40,8 +40,6 @@
 
 /* unittest helper functions */
 
-extern int stream_inline;
-
 void StreamTcpUTInit(TcpReassemblyThreadCtx **ra_ctx)
 {
     StreamTcpInitConfig(TRUE);
@@ -52,11 +50,11 @@ void StreamTcpUTDeinit(TcpReassemblyThreadCtx *ra_ctx)
 {
     StreamTcpReassembleFreeThreadCtx(ra_ctx);
     StreamTcpFreeConfig(TRUE);
-    stream_inline = 0;
+    stream_config.flags &= ~STREAMTCP_INIT_FLAG_INLINE;
 }
 
 void StreamTcpUTInitInline(void) {
-    stream_inline = 1;
+    stream_config.flags |= STREAMTCP_INIT_FLAG_INLINE;
 }
 
 void StreamTcpUTSetupSession(TcpSession *ssn)

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -428,12 +428,14 @@ void StreamTcpInitConfig(char quiet)
     int bypass = 0;
     if ((ConfGetBool("stream.bypass", &bypass)) == 1) {
         if (bypass == 1) {
-            stream_config.bypass = 1;
-        } else {
-            stream_config.bypass = 0;
+            stream_config.flags |= STREAMTCP_INIT_FLAG_BYPASS;
         }
-    } else {
-        stream_config.bypass = 0;
+    }
+
+    if (!quiet) {
+        SCLogConfig("stream \"bypass\": %s",
+                    (stream_config.flags & STREAMTCP_INIT_FLAG_BYPASS)
+                    ? "enabled" : "disabled");
     }
 
     int drop_invalid = 0;
@@ -443,10 +445,6 @@ void StreamTcpInitConfig(char quiet)
         }
     } else {
         stream_config.flags |= STREAMTCP_INIT_FLAG_DROP_INVALID;
-    }
-
-    if (!quiet) {
-        SCLogConfig("stream \"bypass\": %s", bypass ? "enabled" : "disabled");
     }
 
     if ((ConfGetInt("stream.max-synack-queued", &value)) == 1) {
@@ -5919,7 +5917,7 @@ int StreamTcpSegmentForEach(const Packet *p, uint8_t flag, StreamSegmentCallback
 
 int StreamTcpBypassEnabled(void)
 {
-    return stream_config.bypass;
+    return (stream_config.flags & STREAMTCP_INIT_FLAG_BYPASS);
 }
 
 void TcpSessionSetReassemblyDepth(TcpSession *ssn, uint32_t size)

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -36,6 +36,7 @@
 #define STREAMTCP_INIT_FLAG_CHECKSUM_VALIDATION    BIT_U8(0)
 #define STREAMTCP_INIT_FLAG_DROP_INVALID           BIT_U8(1)
 #define STREAMTCP_INIT_FLAG_BYPASS                 BIT_U8(2)
+#define STREAMTCP_INIT_FLAG_INLINE                 BIT_U8(3)
 
 /*global flow data*/
 typedef struct TcpStreamCnf_ {
@@ -213,6 +214,7 @@ void StreamTcpStreamCleanup(TcpStream *stream);
 /* check if bypass is enabled */
 int StreamTcpBypassEnabled(void);
 int StreamTcpInlineDropInvalid(void);
+int StreamTcpInlineMode(void);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -33,7 +33,8 @@
 #define STREAM_VERBOSE    FALSE
 /* Flag to indicate that the checksum validation for the stream engine
    has been enabled */
-#define STREAMTCP_INIT_FLAG_CHECKSUM_VALIDATION    0x01
+#define STREAMTCP_INIT_FLAG_CHECKSUM_VALIDATION    BIT_U8(0)
+#define STREAMTCP_INIT_FLAG_DROP_INVALID           BIT_U8(1)
 
 /*global flow data*/
 typedef struct TcpStreamCnf_ {
@@ -210,6 +211,7 @@ void StreamTcpSessionCleanup(TcpSession *ssn);
 void StreamTcpStreamCleanup(TcpStream *stream);
 /* check if bypass is enabled */
 int StreamTcpBypassEnabled(void);
+int StreamTcpInlineDropInvalid(void);
 
 int TcpSessionPacketSsnReuse(const Packet *p, const Flow *f, const void *tcp_ssn);
 

--- a/src/stream-tcp.h
+++ b/src/stream-tcp.h
@@ -35,6 +35,7 @@
    has been enabled */
 #define STREAMTCP_INIT_FLAG_CHECKSUM_VALIDATION    BIT_U8(0)
 #define STREAMTCP_INIT_FLAG_DROP_INVALID           BIT_U8(1)
+#define STREAMTCP_INIT_FLAG_BYPASS                 BIT_U8(2)
 
 /*global flow data*/
 typedef struct TcpStreamCnf_ {
@@ -47,6 +48,7 @@ typedef struct TcpStreamCnf_ {
 
     uint16_t stream_init_flags; /**< new stream flags will be initialized to this */
 
+    /* coccinelle: TcpStreamCnf:flags:STREAMTCP_INIT_ */ 
     uint8_t flags;
     uint8_t max_synack_queued;
 
@@ -59,7 +61,6 @@ typedef struct TcpStreamCnf_ {
     uint16_t reassembly_toserver_chunk_size;
     uint16_t reassembly_toclient_chunk_size;
 
-    int bypass;
     bool streaming_log_api;
 
     StreamingBufferConfig sbcnf;

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -1173,6 +1173,7 @@ flow-timeouts:
 #   midstream: false            # don't allow midstream session pickups
 #   async-oneside: false        # don't enable async stream handling
 #   inline: no                  # stream inline mode
+#   drop-invalid: yes           # in inline mode, drop packets that are invalid with regards to streaming engine
 #   max-synack-queued: 5        # Max different SYN/ACKs to queue
 #   bypass: no                  # Bypass packets when stream.depth is reached
 #

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -566,7 +566,8 @@ af-packet:
     # Lock memory map to avoid it goes to swap. Be careful that over suscribing could lock
     # your system
     #mmap-locked: yes
-    # Use experimental tpacket_v3 capture mode, only active if use-mmap is true
+    # Use tpacket_v3 capture mode, only active if use-mmap is true
+    # Don't use it in IPS or TAP mode as it causes severe latency
     #tpacket-v3: yes
     # Ring size will be computed with respect to max_pending_packets and number
     # of threads. You can set manually the ring size in number of packets by setting


### PR DESCRIPTION
Update of #2699. It adds a few patches making use of flags on top of previous fixed commits.

The IPS no drop invalid is disabled by default and it is meant to be used as last hope when an IPS setup is dropping packets. 

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/280
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/64
