### PR TITLE
rule-parser: ignore duplicated msg keyword

### DIFF
--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -103,7 +103,12 @@ static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ms
         }
     }
 
-    s->msg = SCStrdup(str);
+    if (s->msg != NULL) {
+        SCLogWarning(SC_ERR_INVALID_RULE_ARGUMENT, "Duplicated 'msg:' keyword detected, using first one!");
+    }
+    else {
+        s->msg = SCStrdup(str);
+    }
     if (s->msg == NULL)
         goto error;
     return 0;


### PR DESCRIPTION
This fixes the leak resulted by duplicated msg keyword from https://redmine.openinfosecfoundation.org/issues/2074

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/48
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/50