### PR TITLE
Target keyword v2

### DIFF
--- a/doc/userguide/output/eve/eve-json-format.rst
+++ b/doc/userguide/output/eve/eve-json-format.rst
@@ -64,6 +64,27 @@ Example:
 
 Action is set to "allowed" unless a rule used the "drop" action and Suricata is in IPS mode, or when the rule used the "reject" action.
 
+It can also contain information about Source and Target of the attack in the alert.source and alert.target field it target keyword is used in
+the signature.
+
+::
+
+   "alert": {
+     "action": "allowed",
+     "gid": 1,
+     "signature_id": 1,
+     "rev": 1,
+     "signature": "HTTP body talking about corruption",
+     "severity": 3,
+     "source": {
+       "ip": "192.168.43.32",
+       "port": 36292
+     },
+     "target": {
+       "ip": "179.60.192.3",
+       "port": 80
+     },
+
 Event type: HTTP
 ----------------
 

--- a/doc/userguide/rules/meta.rst
+++ b/doc/userguide/rules/meta.rst
@@ -179,3 +179,20 @@ keyword because it is part of the signature language.  The format is:
 ::
 
   metadata:......;
+
+Target
+------
+
+The target keyword allows the rules writer to specify which side of the
+alert is the target of the attack. If specified, the alert event is enhanced
+to contain information about source and target.
+
+The format is:
+
+::
+
+ target: [src_ip|dest_ip]
+
+If the value is src_ip then the source IP in the generated event (src_ip
+field in JSON) is the target of the attack. If target is set to dest_ip
+then the target is the destination IP in the generated event.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -234,6 +234,7 @@ detect-ssl-state.c detect-ssl-state.h \
 detect-ssl-version.c detect-ssl-version.h \
 detect-stream_size.c detect-stream_size.h \
 detect-tag.c detect-tag.h \
+detect-target.c detect-target.h \
 detect-template.c detect-template.h \
 detect-template-buffer.c detect-template-buffer.h \
 detect-threshold.c detect-threshold.h \

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2007-2014 Open Information Security Foundation
+/* Copyright (C) 2007-2017 Open Information Security Foundation
  *
  * You can copy, redistribute or modify this Program under the terms of
  * the GNU General Public License version 2 as published by the Free
@@ -255,7 +255,8 @@ static int EventToImpact(const PacketAlert *pa, const Packet *p, idmef_alert_t *
  *
  * \return 0 if ok
  */
-static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
+static int EventToSourceTarget(const PacketAlert *pa, const Packet *p,
+                               idmef_alert_t *alert)
 {
     int ret;
     idmef_node_t *node;
@@ -267,6 +268,8 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     static char saddr[128], daddr[128];
     uint8_t ip_vers;
     uint8_t ip_proto;
+    uint16_t sp, dp;
+    uint8_t invert = 0;
 
     SCEnter();
 
@@ -276,16 +279,45 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
     if ( ! IPH_IS_VALID(p) )
         SCReturnInt(0);
 
+    if (pa->s->flags & SIG_FLAG_HAS_TARGET) {
+        if (pa->s->flags & SIG_FLAG_SRC_IS_TARGET) {
+            invert = 1;
+        } else {
+            invert = 0;
+        }
+    } else {
+        invert = 0;
+    }
+
     if (PKT_IS_IPV4(p)) {
         ip_vers = 4;
         ip_proto = IPV4_GET_RAW_IPPROTO(p->ip4h);
-        PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), saddr, sizeof(saddr));
-        PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), daddr, sizeof(daddr));
+        if (invert) {
+            PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), saddr, sizeof(saddr));
+            PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), daddr, sizeof(daddr));
+            sp = p->dp;
+            dp = p->sp;
+        } else {
+            PrintInet(AF_INET, (const void *)GET_IPV4_SRC_ADDR_PTR(p), saddr, sizeof(saddr));
+            PrintInet(AF_INET, (const void *)GET_IPV4_DST_ADDR_PTR(p), daddr, sizeof(daddr));
+            sp = p->sp;
+            dp = p->dp;
+
+        }
     } else if (PKT_IS_IPV6(p)) {
         ip_vers = 6;
         ip_proto = IPV6_GET_L4PROTO(p);
-        PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), saddr, sizeof(saddr));
-        PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), daddr, sizeof(daddr));
+        if (invert) {
+            PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), saddr, sizeof(saddr));
+            PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), daddr, sizeof(daddr));
+            sp = p->dp;
+            dp = p->sp;
+        } else {
+            PrintInet(AF_INET6, (const void *)GET_IPV6_SRC_ADDR(p), saddr, sizeof(saddr));
+            PrintInet(AF_INET6, (const void *)GET_IPV6_DST_ADDR(p), daddr, sizeof(daddr));
+            sp = p->sp;
+            dp = p->dp;
+        }
     } else
         SCReturnInt(0);
 
@@ -298,7 +330,7 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
-        idmef_service_set_port(service, p->sp);
+        idmef_service_set_port(service, sp);
 
     idmef_service_set_ip_version(service, ip_vers);
     idmef_service_set_iana_protocol_number(service, ip_proto);
@@ -326,7 +358,7 @@ static int EventToSourceTarget(const Packet *p, idmef_alert_t *alert)
         SCReturnInt(ret);
 
     if ( p->tcph || p->udph )
-        idmef_service_set_port(service, p->dp);
+        idmef_service_set_port(service, dp);
 
     idmef_service_set_ip_version(service, ip_vers);
     idmef_service_set_iana_protocol_number(service, ip_proto);
@@ -910,7 +942,7 @@ static int AlertPreludeLogger(ThreadVars *tv, void *thread_data, const Packet *p
     if (unlikely(ret < 0))
         goto err;
 
-    ret = EventToSourceTarget(p, alert);
+    ret = EventToSourceTarget(pa, p, alert);
     if (unlikely(ret < 0))
         goto err;
 

--- a/src/alert-prelude.c
+++ b/src/alert-prelude.c
@@ -645,7 +645,7 @@ static int EventToReference(const PacketAlert *pa, const Packet *p, idmef_classi
     SCReturnInt(0);
 }
 
-static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, uint8_t *buf, uint32_t buflen)
+static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, const uint8_t *buf, uint32_t buflen)
 {
     int ret;
 
@@ -662,7 +662,7 @@ static int PreludePrintStreamSegmentCallback(const Packet *p, void *data, uint8_
  *
  * \return TM_ECODE_OK if ok, else TM_ECODE_FAILED
  */
-static TmEcode AlertPreludeThreadInit(ThreadVars *t, void *initdata, void **data)
+static TmEcode AlertPreludeThreadInit(ThreadVars *t, const void *initdata, void **data)
 {
     AlertPreludeThread *aun;
 

--- a/src/detect-target.c
+++ b/src/detect-target.c
@@ -102,14 +102,14 @@ static int DetectTargetParse(Signature *s, const char *targetstr)
     if (!strcmp(value, "src_ip")) {
         if (s->flags & SIG_FLAG_DEST_IS_TARGET) {
             SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
-                       "Multiple conflicting value of target keyword");
+                       "Conflicting values of target keyword");
             goto error;
         }
         s->flags |= SIG_FLAG_SRC_IS_TARGET;
     } else if (!strcmp(value, "dest_ip")) {
         if (s->flags & SIG_FLAG_SRC_IS_TARGET) {
             SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
-                       "Multiple conflicting value of target keyword");
+                       "Conflicting values of target keyword");
             goto error;
         }
         s->flags |= SIG_FLAG_DEST_IS_TARGET;

--- a/src/detect-target.c
+++ b/src/detect-target.c
@@ -1,0 +1,170 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ *
+ * target keyword allow rules writer to specify information about target of the attack
+ */
+
+#include "suricata-common.h"
+#include "util-unittest.h"
+
+#include "detect-parse.h"
+#include "detect-engine.h"
+
+#include "detect-target.h"
+
+/**
+ * \brief Regex for parsing our keyword options
+ */
+#define PARSE_REGEX  "^\\s*(src_ip|dest_ip)\\s*$"
+
+static pcre *parse_regex;
+static pcre_extra *parse_regex_study;
+
+/* Prototypes of functions registered in DetectTargetRegister below */
+static int DetectTargetSetup (DetectEngineCtx *, Signature *, const char *);
+static void DetectTargetRegisterTests (void);
+
+/**
+ * \brief Registration function for target keyword
+ *
+ */
+void DetectTargetRegister(void) {
+    /* keyword name: this is how the keyword is used in a rule */
+    sigmatch_table[DETECT_TARGET].name = "target";
+    /* description: listed in "suricata --list-keywords=all" */
+    sigmatch_table[DETECT_TARGET].desc = "indicate to output module which side is the target of the attack";
+    /* link to further documentation of the keyword. Normally on the Suricata redmine/wiki */
+    sigmatch_table[DETECT_TARGET].url =  DOC_URL DOC_VERSION "/rules/meta.html#target";
+    /* match function is called when the signature is inspected on a packet */
+    sigmatch_table[DETECT_TARGET].Match = NULL;
+    /* setup function is called during signature parsing, when the target
+     * keyword is encountered in the rule */
+    sigmatch_table[DETECT_TARGET].Setup = DetectTargetSetup;
+    /* free function is called when the detect engine is freed. Normally at
+     * shutdown, but also during rule reloads. */
+    sigmatch_table[DETECT_TARGET].Free = NULL;
+    /* registers unittests into the system */
+    sigmatch_table[DETECT_TARGET].RegisterTests = DetectTargetRegisterTests;
+
+    /* set up the PCRE for keyword parsing */
+    DetectSetupParseRegexes(PARSE_REGEX, &parse_regex, &parse_regex_study);
+}
+
+/**
+ * \brief This function is used to parse target options passed via target: keyword
+ *
+ * \param targetstr Pointer to the user provided target options
+ *
+ * \retval targetd pointer to DetectTargetData on success
+ * \retval NULL on failure
+ */
+static int DetectTargetParse(Signature *s, const char *targetstr)
+{
+#define MAX_SUBSTRINGS 30
+    int ret = 0, res = 0;
+    int ov[MAX_SUBSTRINGS];
+    char value[10];
+
+    ret = pcre_exec(parse_regex, parse_regex_study,
+                    targetstr, strlen(targetstr), 0, 0, ov, MAX_SUBSTRINGS);
+    if (ret < 1) {
+        SCLogError(SC_ERR_PCRE_MATCH, "pcre_exec parse error, ret %" PRId32 ", string %s", ret, targetstr);
+        return 0;
+    }
+
+    res = pcre_copy_substring(targetstr, ov, MAX_SUBSTRINGS, 1,
+                              value, sizeof(value));
+    if (res < 0) {
+        SCLogError(SC_ERR_PCRE_GET_SUBSTRING, "pcre_get_substring failed");
+        return 0;
+    }
+
+    /* now check key value */
+    if (!strcmp(value, "src_ip")) {
+        if (s->flags & SIG_FLAG_DEST_IS_TARGET) {
+            SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
+                       "Multiple conflicting value of target keyword");
+            goto error;
+        }
+        s->flags |= SIG_FLAG_SRC_IS_TARGET;
+    } else if (!strcmp(value, "dest_ip")) {
+        if (s->flags & SIG_FLAG_SRC_IS_TARGET) {
+            SCLogError(SC_ERR_CONFLICTING_RULE_KEYWORDS,
+                       "Multiple conflicting value of target keyword");
+            goto error;
+        }
+        s->flags |= SIG_FLAG_DEST_IS_TARGET;
+    } else {
+        SCLogError(SC_ERR_INVALID_VALUE, "only 'src_ip' and 'dest_ip' are supported for target target option");
+        goto error;
+    }
+    return 0;
+
+error:
+    return -1;
+}
+
+/**
+ * \brief parse the options from the 'target' keyword in the rule into
+ *        the Signature data structure.
+ *
+ * \param de_ctx pointer to the Detection Engine Context
+ * \param s pointer to the Current Signature
+ * \param targetstr pointer to the user provided target options
+ *
+ * \retval 0 on Success
+ * \retval -1 on Failure
+ */
+static int DetectTargetSetup(DetectEngineCtx *de_ctx, Signature *s, const char *targetstr)
+{
+    int ret = DetectTargetParse(s, targetstr);
+    if (ret < 0)
+        return -1;
+
+    return 0;
+}
+
+#ifdef UNITTESTS
+
+static int DetectTargetSignatureTest01(void)
+{
+    DetectEngineCtx *de_ctx = DetectEngineCtxInit();
+    FAIL_IF_NULL(de_ctx);
+
+    Signature *sig = DetectEngineAppendSig(de_ctx, "alert ip any any -> any any (target: dest_ip; sid:1; rev:1;)");
+    FAIL_IF_NULL(sig);
+
+    DetectEngineCtxFree(de_ctx);
+    PASS;
+}
+
+#endif /* UNITTESTS */
+
+/**
+ * \brief this function registers unit tests for DetectTarget
+ */
+void DetectTargetRegisterTests(void) {
+#ifdef UNITTESTS
+    UtRegisterTest("DetectTargetSignatureTest01",
+                   DetectTargetSignatureTest01);
+#endif /* UNITTESTS */
+}

--- a/src/detect-target.h
+++ b/src/detect-target.h
@@ -1,0 +1,29 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Eric Leblond <eric@regit.org>
+ */
+
+#ifndef __DETECT_TARGET_H__
+#define __DETECT_TARGET_H__
+
+void DetectTargetRegister(void);
+
+#endif /* __DETECT_TARGET_H__ */

--- a/src/detect.c
+++ b/src/detect.c
@@ -173,6 +173,7 @@
 #include "detect-geoip.h"
 #include "detect-app-layer-protocol.h"
 #include "detect-template.h"
+#include "detect-target.h"
 #include "detect-template-buffer.h"
 #include "detect-bypass.h"
 #include "detect-engine-content-inspection.h"
@@ -3930,6 +3931,7 @@ void SigTableSetup(void)
     DetectBase64DecodeRegister();
     DetectBase64DataRegister();
     DetectTemplateRegister();
+    DetectTargetRegister();
     DetectTemplateBufferRegister();
     DetectBypassRegister();
     DetectHttpRequestLineRegister();

--- a/src/detect.h
+++ b/src/detect.h
@@ -240,6 +240,12 @@ typedef struct DetectPort_ {
 /** Proto detect only signature.
  *  Inspected once per direction when protocol detection is done. */
 #define SIG_FLAG_PDONLY                 (1<<24)
+/** Info for Source and Target identification */
+#define SIG_FLAG_SRC_IS_TARGET          (1<<25)
+/** Info for Source and Target identification */
+#define SIG_FLAG_DEST_IS_TARGET         (1<<26)
+
+#define SIG_FLAG_HAS_TARGET     (SIG_FLAG_DEST_IS_TARGET|SIG_FLAG_SRC_IS_TARGET)
 
 /* signature init flags */
 #define SIG_FLAG_INIT_DEONLY         1  /**< decode event only signature */
@@ -909,6 +915,7 @@ typedef struct DetectEngineThreadCtx_ {
     uint8_t *base64_decoded;
     int base64_decoded_len;
     int base64_decoded_len_max;
+
 #ifdef DEBUG
     uint64_t pkt_stream_add_cnt;
     uint64_t payload_mpm_cnt;
@@ -1342,6 +1349,7 @@ enum {
     DETECT_BASE64_DATA,
 
     DETECT_TEMPLATE,
+    DETECT_TARGET,
     DETECT_AL_TEMPLATE_BUFFER,
 
     DETECT_BYPASS,


### PR DESCRIPTION
Update of #2761.

This addresses the comments and simplify the code. It now directly link source and target to the src_ip and dest_ip of the alert as specified in the written doc (no more using the flow). For Prelude, it removes the flow part and use packet instead. In the case of EVE it does copy the already computed fields to limit the computation.

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/290
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/74
