### PR TITLE
Rust/nfs/gap/v8.6

### DIFF
--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -80,6 +80,10 @@ pub type SCFileAppendDataById = extern "C" fn (
         file_container: &FileContainer,
         track_id: u32,
         data: *const u8, data_len: u32) -> i32;
+pub type SCFileAppendGAPById = extern "C" fn (
+        file_container: &FileContainer,
+        track_id: u32,
+        data: *const u8, data_len: u32) -> i32;
 // void FilePrune(FileContainer *ffc)
 pub type SCFilePrune = extern "C" fn (
         file_container: &FileContainer);
@@ -109,6 +113,7 @@ pub struct SuricataContext {
     pub FileOpenFile: SCFileOpenFileWithId,
     pub FileCloseFile: SCFileCloseFileById,
     pub FileAppendData: SCFileAppendDataById,
+    pub FileAppendGAP: SCFileAppendGAPById,
     pub FileContainerRecycle: SCFileContainerRecycle,
     pub FilePrune: SCFilePrune,
     pub FileSetTx: SCFileSetTx,

--- a/rust/src/filetracker.rs
+++ b/rust/src/filetracker.rs
@@ -39,6 +39,7 @@ use filecontainer::*;
 pub struct FileTransferTracker {
     file_size: u64,
     tracked: u64,
+    cur_ooo: u64,   // how many bytes do we have queued from ooo chunks
     track_id: u32,
     chunk_left: u32,
 
@@ -59,6 +60,7 @@ impl FileTransferTracker {
         FileTransferTracker {
             file_size:0,
             tracked:0,
+            cur_ooo:0,
             track_id:0,
             chunk_left:0,
             tx_id:0,
@@ -92,7 +94,10 @@ impl FileTransferTracker {
         files.files_prune();
     }
 
-    fn trunc (&mut self, files: &mut FileContainer, flags: u16) {
+    pub fn trunc (&mut self, files: &mut FileContainer, flags: u16) {
+        if self.file_is_truncated {
+            return;
+        }
         let myflags = flags | 1; // TODO util-file.c::FILE_TRUNCATED
         files.file_close(&self.track_id, myflags);
         SCLogDebug!("truncated file");
@@ -116,8 +121,15 @@ impl FileTransferTracker {
 
         SCLogDebug!("NEW CHUNK: chunk_size {} fill_bytes {}", chunk_size, fill_bytes);
 
+        // for now assume that is_last means its really the last chunk
+        // so no out of order chunks coming after. This means that if
+        // the last chunk is out or order, we've missed chunks before.
         if chunk_offset != self.tracked {
             SCLogDebug!("NEW CHUNK IS OOO: expected {}, got {}", self.tracked, chunk_offset);
+            if is_last {
+                SCLogDebug!("last chunk is out of order, this means we missed data before");
+                self.trunc(files, flags);
+            }
             self.chunk_is_ooo = true;
             self.cur_ooo_chunk_offset = chunk_offset;
         }
@@ -132,19 +144,23 @@ impl FileTransferTracker {
             self.open(config, files, flags, name);
         }
 
-        let res = self.update(files, flags, data);
+        let res = self.update(files, flags, data, 0);
         SCLogDebug!("NEW CHUNK: update res {:?}", res);
         res
     }
 
+    /// update the file tracker
+    /// If gap_size > 0 'data' should not be used.
     /// return how much we consumed of data
-    pub fn update(&mut self, files: &mut FileContainer, flags: u16, data: &[u8]) -> u32 {
+    pub fn update(&mut self, files: &mut FileContainer, flags: u16, data: &[u8], gap_size: u32) -> u32 {
         let mut consumed = 0 as usize;
-        let mut is_gap = false;
+        let mut is_gap = false; //gap_size > 0;
+        let mut len = data.len() as usize;
 
-        if data.as_ptr().is_null() && data.len() > 0 {
+        if gap_size > 0 {
             self.trunc(files, flags);
             is_gap = true;
+            len = gap_size as usize;
         } else if self.file_is_truncated {
             is_gap = true;
         }
@@ -154,13 +170,13 @@ impl FileTransferTracker {
             return 0
         } else if self.chunk_left == 0 {
             SCLogDebug!("FILL BYTES {} from prev run", self.fill_bytes);
-            if data.len() >= self.fill_bytes as usize {
+            if len >= self.fill_bytes as usize {
                 consumed += self.fill_bytes as usize;
                 self.fill_bytes = 0;
                 SCLogDebug!("CHUNK(pre) fill bytes now 0");
             } else {
-                consumed += data.len();
-                self.fill_bytes -= data.len() as u8;
+                consumed += len;
+                self.fill_bytes -= len as u8;
                 SCLogDebug!("CHUNK(pre) fill bytes now still {}", self.fill_bytes);
             }
             SCLogDebug!("FILL BYTES: returning {}", consumed);
@@ -169,30 +185,36 @@ impl FileTransferTracker {
         SCLogDebug!("UPDATE: data {} chunk_left {}", data.len(), self.chunk_left);
 
         if self.chunk_left > 0 {
-            if self.chunk_left <= data.len() as u32 {
-                let d = &data[0..self.chunk_left as usize];
+            if self.chunk_left <= len as u32 {
+                if is_gap {
+                    if self.chunk_is_ooo == false {
+                        self.tracked += self.chunk_left as u64;
+                    }
+                } else { // not gap
+                    let d = &data[0..self.chunk_left as usize];
 
-                if self.chunk_is_ooo == false {
-                    if !is_gap {
+                    if self.chunk_is_ooo == false {
                         let res = files.file_append(&self.track_id, d);
                         if res != 0 { panic!("append failed"); }
-                    }
                     self.tracked += self.chunk_left as u64;
-                } else if !is_gap {
-                    SCLogDebug!("UPDATE: appending data {} to ooo chunk at offset {}/{}",
-                            d.len(), self.cur_ooo_chunk_offset, self.tracked);
-                    let c = match self.chunks.entry(self.cur_ooo_chunk_offset) {
-                        Vacant(entry) => {
-                            entry.insert(Vec::with_capacity(self.chunk_left as usize))
-                        },
-                        Occupied(entry) => entry.into_mut(),
-                    };
-                    c.extend(d);
+
+                    } else {
+                        SCLogDebug!("UPDATE: appending data {} to ooo chunk at offset {}/{}",
+                                d.len(), self.cur_ooo_chunk_offset, self.tracked);
+                        let c = match self.chunks.entry(self.cur_ooo_chunk_offset) {
+                            Vacant(entry) => {
+                                entry.insert(Vec::with_capacity(self.chunk_left as usize))
+                            },
+                                Occupied(entry) => entry.into_mut(),
+                        };
+                        c.extend(d);
+                        self.cur_ooo += d.len() as u64;
+                    }
                 }
 
                 consumed += self.chunk_left as usize;
                 if self.fill_bytes > 0 {
-                    let extra = data.len() - self.chunk_left as usize;
+                    let extra = len - self.chunk_left as usize;
                     if extra >= self.fill_bytes as usize {
                         consumed += self.fill_bytes as usize;
                         self.fill_bytes = 0;
@@ -203,7 +225,6 @@ impl FileTransferTracker {
                         SCLogDebug!("CHUNK(post) fill bytes now still {}", self.fill_bytes);
                     }
                     self.chunk_left = 0;
-                    //return consumed as u32
                 } else {
                     self.chunk_left = 0;
 
@@ -218,6 +239,7 @@ impl FileTransferTracker {
                                     }
 
                                     self.tracked += a.len() as u64;
+                                    self.cur_ooo -= a.len() as u64;
 
                                     SCLogDebug!("STORED OOO CHUNK at offset {}, tracked now {}, stored len {}", offset, self.tracked, a.len());
                                 },
@@ -255,13 +277,18 @@ impl FileTransferTracker {
                         Occupied(entry) => entry.into_mut(),
                     };
                     c.extend(data);
+                    self.cur_ooo += data.len() as u64;
                 }
 
-                self.chunk_left -= data.len() as u32;
-                consumed += data.len();
+                self.chunk_left -= len as u32;
+                consumed += len;
             }
         }
         files.files_prune();
         consumed as u32
+    }
+
+    pub fn get_queued_size(&self) -> u64 {
+        self.cur_ooo
     }
 }

--- a/rust/src/nfs/mod.rs
+++ b/rust/src/nfs/mod.rs
@@ -18,6 +18,7 @@
 pub mod types;
 #[macro_use]
 pub mod parser;
+pub mod nfs2_records;
 pub mod nfs3;
 pub mod log;
 

--- a/rust/src/nfs/nfs2_records.rs
+++ b/rust/src/nfs/nfs2_records.rs
@@ -1,0 +1,113 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+//! Nom parsers for NFSv2 records
+use nom::{be_u32, rest};
+use nfs::parser::*;
+
+#[derive(Debug,PartialEq)]
+pub struct Nfs2Handle<'a> {
+    pub value: &'a[u8],
+}
+
+named!(pub parse_nfs2_handle<Nfs2Handle>,
+    do_parse!(
+        handle: take!(32)
+        >> (
+            Nfs2Handle {
+                value:handle,
+            }
+        ))
+);
+
+#[derive(Debug,PartialEq)]
+pub struct Nfs2RequestLookup<'a> {
+    pub handle: Nfs2Handle<'a>,
+    pub name_vec: Vec<u8>,
+}
+
+named!(pub parse_nfs2_request_lookup<Nfs2RequestLookup>,
+    do_parse!(
+            handle: parse_nfs2_handle
+        >>  name_len: be_u32
+        >>  name_contents: take!(name_len)
+        >>  name_padding: rest
+        >> (
+            Nfs2RequestLookup {
+                handle:handle,
+                name_vec:name_contents.to_vec(),
+            }
+        ))
+);
+
+#[derive(Debug,PartialEq)]
+pub struct Nfs2RequestRead<'a> {
+    pub handle: Nfs2Handle<'a>,
+    pub offset: u32,
+}
+
+named!(pub parse_nfs2_request_read<Nfs2RequestRead>,
+    do_parse!(
+            handle: parse_nfs2_handle
+        >>  offset: be_u32
+        >>  count: be_u32
+        >> (
+            Nfs2RequestRead {
+                handle:handle,
+                offset:offset,
+            }
+        ))
+);
+
+named!(pub parse_nfs2_reply_read<Nfs3ReplyRead>,
+    do_parse!(
+            status: be_u32
+        >>  attr_blob: take!(68)
+        >>  data_len: be_u32
+        >>  data_contents: rest
+        >> (
+            Nfs3ReplyRead {
+                status:status,
+                attr_follows:1,
+                attr_blob:attr_blob,
+                count:data_len,
+                eof:false,
+                data_len:data_len,
+                data:data_contents,
+            }
+        ))
+);
+
+#[derive(Debug,PartialEq)]
+pub struct Nfs2Attributes<> {
+    pub atype: u32,
+    pub asize: u32,
+}
+
+named!(pub parse_nfs2_attribs<Nfs2Attributes>,
+    do_parse!(
+            atype: be_u32
+        >>  blob1: take!(16)
+        >>  asize: be_u32
+        >>  blob2: take!(44)
+        >> (
+            Nfs2Attributes {
+                atype:atype,
+                asize:asize,
+            }
+        ))
+);

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -1018,8 +1018,8 @@ impl NFS3State {
         if self.tcp_buffer_ts.len() > 0 {
             self.tcp_buffer_ts.clear();
         }
-        let v = Vec::new();
-        let consumed = self.filetracker_update(STREAM_TOSERVER, &v, gap_size);
+        let gap = vec![0; gap_size as usize];
+        let consumed = self.filetracker_update(STREAM_TOSERVER, &gap, gap_size);
         if consumed > gap_size {
             panic!("consumed more than GAP size: {} > {}", consumed, gap_size);
         }
@@ -1031,8 +1031,8 @@ impl NFS3State {
         if self.tcp_buffer_tc.len() > 0 {
             self.tcp_buffer_tc.clear();
         }
-        let v = Vec::new();
-        let consumed = self.filetracker_update(STREAM_TOCLIENT, &v, gap_size);
+        let gap = vec![0; gap_size as usize];
+        let consumed = self.filetracker_update(STREAM_TOCLIENT, &gap, gap_size);
         if consumed > gap_size {
             panic!("consumed more than GAP size: {} > {}", consumed, gap_size);
         }

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -499,7 +499,24 @@ impl NFS3State {
                 IResult::Incomplete(_) => { panic!("WEIRD"); },
                 IResult::Error(e) => { panic!("Parsing failed: {:?}",e);  },
             };
-
+        } else if r.procedure == NFSPROC3_MKDIR {
+            match parse_nfs3_request_mkdir(r.prog_data) {
+                IResult::Done(_, mr) => {
+                    xidmap.file_handle = mr.handle.value.to_vec();
+                    xidmap.file_name = mr.name_vec;
+                },
+                IResult::Incomplete(_) => { panic!("WEIRD"); },
+                IResult::Error(e) => { panic!("Parsing failed: {:?}",e);  },
+            };
+        } else if r.procedure == NFSPROC3_RMDIR {
+            match parse_nfs3_request_rmdir(r.prog_data) {
+                IResult::Done(_, rr) => {
+                    xidmap.file_handle = rr.handle.value.to_vec();
+                    xidmap.file_name = rr.name_vec;
+                },
+                IResult::Incomplete(_) => { panic!("WEIRD"); },
+                IResult::Error(e) => { panic!("Parsing failed: {:?}",e);  },
+            };
         } else if r.procedure == NFSPROC3_COMMIT {
             SCLogDebug!("COMMIT, closing shop");
 

--- a/rust/src/nfs/nfs3.rs
+++ b/rust/src/nfs/nfs3.rs
@@ -1645,31 +1645,25 @@ pub fn nfs3_probe(i: &[u8], direction: u8) -> i8 {
 
 /// TOSERVER probe function
 #[no_mangle]
-pub extern "C" fn rs_nfs_probe(input: *const libc::uint8_t, len: libc::uint32_t)
+pub extern "C" fn rs_nfs_probe_ts(input: *const libc::uint8_t, len: libc::uint32_t)
                                -> libc::int8_t
 {
     let slice: &[u8] = unsafe {
         std::slice::from_raw_parts(input as *mut u8, len as usize)
     };
     return nfs3_probe(slice, STREAM_TOSERVER);
-/*
-    match parse_rpc(slice) {
-        IResult::Done(_, ref rpc_hdr) => {
-            if rpc_hdr.progver == 3 && rpc_hdr.program == 100003 {
-                return 1;
-            } else {
-                return -1;
-            }
-        },
-        IResult::Incomplete(_) => {
-            return 0;
-        },
-        IResult::Error(_) => {
-            return -1;
-        },
-    }
-*/
 }
+/// TOCLIENT probe function
+#[no_mangle]
+pub extern "C" fn rs_nfs_probe_tc(input: *const libc::uint8_t, len: libc::uint32_t)
+                               -> libc::int8_t
+{
+    let slice: &[u8] = unsafe {
+        std::slice::from_raw_parts(input as *mut u8, len as usize)
+    };
+    return nfs3_probe(slice, STREAM_TOCLIENT);
+}
+
 
 #[no_mangle]
 pub extern "C" fn rs_nfs3_getfiles(direction: u8, ptr: *mut NFS3State) -> * mut FileContainer {

--- a/rust/src/nfs/parser.rs
+++ b/rust/src/nfs/parser.rs
@@ -160,6 +160,47 @@ named!(pub parse_nfs3_request_remove<Nfs3RequestRemove>,
 );
 
 #[derive(Debug,PartialEq)]
+pub struct Nfs3RequestRmdir<'a> {
+    pub handle: Nfs3Handle<'a>,
+    pub name_vec: Vec<u8>,
+}
+
+named!(pub parse_nfs3_request_rmdir<Nfs3RequestRmdir>,
+    do_parse!(
+            dir_handle: parse_nfs3_handle
+        >>  name_len: be_u32
+        >>  name: take!(name_len)
+        >>  fill_bytes: cond!(name_len % 4 != 0, take!(4 - name_len % 4))
+        >> (
+            Nfs3RequestRmdir {
+                handle:dir_handle,
+                name_vec:name.to_vec(),
+            }
+        ))
+);
+
+#[derive(Debug,PartialEq)]
+pub struct Nfs3RequestMkdir<'a> {
+    pub handle: Nfs3Handle<'a>,
+    pub name_vec: Vec<u8>,
+}
+
+named!(pub parse_nfs3_request_mkdir<Nfs3RequestMkdir>,
+    do_parse!(
+            dir_handle: parse_nfs3_handle
+        >>  name_len: be_u32
+        >>  name: take!(name_len)
+        >>  fill_bytes: cond!(name_len % 4 != 0, take!(4 - name_len % 4))
+        >>  attributes: rest
+        >> (
+            Nfs3RequestMkdir {
+                handle:dir_handle,
+                name_vec:name.to_vec(),
+            }
+        ))
+);
+
+#[derive(Debug,PartialEq)]
 pub struct Nfs3RequestRename<'a> {
     pub from_handle: Nfs3Handle<'a>,
     pub from_name_vec: Vec<u8>,

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,6 +40,7 @@ app-layer-smb2.c app-layer-smb2.h \
 app-layer-smb.c app-layer-smb.h \
 app-layer-smtp.c app-layer-smtp.h \
 app-layer-nfs3.c app-layer-nfs3.h \
+app-layer-nfs3-udp.c app-layer-nfs3-udp.h \
 app-layer-template.c app-layer-template.h \
 app-layer-ssh.c app-layer-ssh.h \
 app-layer-ssl.c app-layer-ssl.h \

--- a/src/app-layer-nfs3-udp.c
+++ b/src/app-layer-nfs3-udp.c
@@ -143,44 +143,44 @@ static int NFS3HasEvents(void *state)
 static AppProto NFS3ProbingParserTS(uint8_t *input, uint32_t input_len,
     uint32_t *offset)
 {
-    SCLogNotice("probing");
+    SCLogDebug("probing");
     if (input_len < NFS3_MIN_FRAME_LEN) {
-        SCLogNotice("unknown");
+        SCLogDebug("unknown");
         return ALPROTO_UNKNOWN;
     }
 
     int8_t r = rs_nfs_probe_udp_ts(input, input_len);
     if (r == 1) {
-        SCLogNotice("nfs3");
+        SCLogDebug("nfs3");
         return ALPROTO_NFS3;
     } else if (r == -1) {
-        SCLogNotice("failed");
+        SCLogDebug("failed");
         return ALPROTO_FAILED;
     }
 
-    SCLogNotice("Protocol not detected as ALPROTO_NFS3.");
+    SCLogDebug("Protocol not detected as ALPROTO_NFS3.");
     return ALPROTO_UNKNOWN;
 }
 
 static AppProto NFS3ProbingParserTC(uint8_t *input, uint32_t input_len,
     uint32_t *offset)
 {
-    SCLogNotice("probing");
+    SCLogDebug("probing");
     if (input_len < NFS3_MIN_FRAME_LEN) {
-        SCLogNotice("unknown");
+        SCLogDebug("unknown");
         return ALPROTO_UNKNOWN;
     }
 
     int8_t r = rs_nfs_probe_tc(input, input_len);
     if (r == 1) {
-        SCLogNotice("nfs3");
+        SCLogDebug("nfs3");
         return ALPROTO_NFS3;
     } else if (r == -1) {
-        SCLogNotice("failed");
+        SCLogDebug("failed");
         return ALPROTO_FAILED;
     }
 
-    SCLogNotice("Protocol not detected as ALPROTO_NFS3.");
+    SCLogDebug("Protocol not detected as ALPROTO_NFS3.");
     return ALPROTO_UNKNOWN;
 }
 
@@ -286,13 +286,13 @@ void RegisterNFS3UDPParsers(void)
 
         rs_nfs3_init(&sfc);
 
-        SCLogNotice("NFS3 UDP protocol detection enabled.");
+        SCLogDebug("NFS3 UDP protocol detection enabled.");
 
         AppLayerProtoDetectRegisterProtocol(ALPROTO_NFS3, proto_name);
 
         if (RunmodeIsUnittests()) {
 
-            SCLogNotice("Unittest mode, registering default configuration.");
+            SCLogDebug("Unittest mode, registering default configuration.");
             AppLayerProtoDetectPPRegister(IPPROTO_UDP, NFS3_DEFAULT_PORT,
                 ALPROTO_NFS3, 0, NFS3_MIN_FRAME_LEN, STREAM_TOSERVER,
                 NFS3ProbingParserTS, NFS3ProbingParserTC);
@@ -303,7 +303,7 @@ void RegisterNFS3UDPParsers(void)
             if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
                     proto_name, ALPROTO_NFS3, 0, NFS3_MIN_FRAME_LEN,
                     NFS3ProbingParserTS, NFS3ProbingParserTC)) {
-                SCLogNotice("No NFS3 app-layer configuration, enabling NFS3"
+                SCLogDebug("No NFS3 app-layer configuration, enabling NFS3"
                     " detection TCP detection on port %s.",
                     NFS3_DEFAULT_PORT);
                 AppLayerProtoDetectPPRegister(IPPROTO_UDP,
@@ -317,13 +317,13 @@ void RegisterNFS3UDPParsers(void)
     }
 
     else {
-        SCLogNotice("Protocol detecter and parser disabled for NFS3.");
+        SCLogDebug("Protocol detecter and parser disabled for NFS3.");
         return;
     }
 
     if (AppLayerParserConfParserEnabled("udp", proto_name))
     {
-        SCLogNotice("Registering NFS3 protocol parser.");
+        SCLogDebug("Registering NFS3 protocol parser.");
 
         /* Register functions for state allocation and freeing. A
          * state is allocated for every new NFS3 flow. */

--- a/src/app-layer-nfs3-udp.c
+++ b/src/app-layer-nfs3-udp.c
@@ -1,0 +1,395 @@
+/* Copyright (C) 2015 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ *
+ * NFS3 application layer detector and parser for learning and
+ * nfs3 pruposes.
+ *
+ * This nfs3 implements a simple application layer for something
+ * like the NFS3 protocol running on port 2049.
+ */
+
+#include "suricata-common.h"
+#include "stream.h"
+#include "conf.h"
+
+#include "util-unittest.h"
+
+#include "app-layer-detect-proto.h"
+#include "app-layer-parser.h"
+
+#include "app-layer-nfs3-udp.h"
+
+#ifndef HAVE_RUST
+void RegisterNFS3UDPParsers(void)
+{
+}
+
+#else
+
+#include "rust.h"
+#include "rust-nfs-nfs3-gen.h"
+
+/* The default port to probe for echo traffic if not provided in the
+ * configuration file. */
+#define NFS3_DEFAULT_PORT "2049"
+
+/* The minimum size for a RFC message. For some protocols this might
+ * be the size of a header. TODO actual min size is likely larger */
+#define NFS3_MIN_FRAME_LEN 32
+
+/* Enum of app-layer events for an echo protocol. Normally you might
+ * have events for errors in parsing data, like unexpected data being
+ * received. For echo we'll make something up, and log an app-layer
+ * level alert if an empty message is received.
+ *
+ * Example rule:
+ *
+ * alert nfs3 any any -> any any (msg:"SURICATA NFS3 empty message"; \
+ *    app-layer-event:nfs3.empty_message; sid:X; rev:Y;)
+ */
+enum {
+    NFS3_DECODER_EVENT_EMPTY_MESSAGE,
+};
+
+SCEnumCharMap nfs3_udp_decoder_event_table[] = {
+    {"EMPTY_MESSAGE", NFS3_DECODER_EVENT_EMPTY_MESSAGE},
+    { NULL, 0 }
+};
+
+static void *NFS3StateAlloc(void)
+{
+    return rs_nfs3_state_new();
+}
+
+static void NFS3StateFree(void *state)
+{
+    rs_nfs3_state_free(state);
+}
+
+/**
+ * \brief Callback from the application layer to have a transaction freed.
+ *
+ * \param state a void pointer to the NFS3State object.
+ * \param tx_id the transaction ID to free.
+ */
+static void NFS3StateTxFree(void *state, uint64_t tx_id)
+{
+    rs_nfs3_state_tx_free(state, tx_id);
+}
+
+#if 0
+static int NFS3StateGetEventInfo(const char *event_name, int *event_id,
+    AppLayerEventType *event_type)
+{
+    *event_id = SCMapEnumNameToValue(event_name, nfs3_decoder_event_table);
+    if (*event_id == -1) {
+        SCLogError(SC_ERR_INVALID_ENUM_MAP, "event \"%s\" not present in "
+                   "nfs3 enum map table.",  event_name);
+        /* This should be treated as fatal. */
+        return -1;
+    }
+
+    *event_type = APP_LAYER_EVENT_TYPE_TRANSACTION;
+
+    return 0;
+}
+
+static AppLayerDecoderEvents *NFS3GetEvents(void *state, uint64_t tx_id)
+{
+    NFS3State *nfs3_state = state;
+    NFS3Transaction *tx;
+
+    TAILQ_FOREACH(tx, &nfs3_state->tx_list, next) {
+        if (tx->tx_id == tx_id) {
+            return tx->decoder_events;
+        }
+    }
+
+    return NULL;
+}
+
+static int NFS3HasEvents(void *state)
+{
+    NFS3State *echo = state;
+    return echo->events;
+}
+#endif
+
+/**
+ * \brief Probe the input to see if it looks like echo.
+ *
+ * \retval ALPROTO_NFS3 if it looks like echo, otherwise
+ *     ALPROTO_UNKNOWN.
+ */
+static AppProto NFS3ProbingParserTS(uint8_t *input, uint32_t input_len,
+    uint32_t *offset)
+{
+    SCLogNotice("probing");
+    if (input_len < NFS3_MIN_FRAME_LEN) {
+        SCLogNotice("unknown");
+        return ALPROTO_UNKNOWN;
+    }
+
+    int8_t r = rs_nfs_probe_udp_ts(input, input_len);
+    if (r == 1) {
+        SCLogNotice("nfs3");
+        return ALPROTO_NFS3;
+    } else if (r == -1) {
+        SCLogNotice("failed");
+        return ALPROTO_FAILED;
+    }
+
+    SCLogNotice("Protocol not detected as ALPROTO_NFS3.");
+    return ALPROTO_UNKNOWN;
+}
+
+static AppProto NFS3ProbingParserTC(uint8_t *input, uint32_t input_len,
+    uint32_t *offset)
+{
+    SCLogNotice("probing");
+    if (input_len < NFS3_MIN_FRAME_LEN) {
+        SCLogNotice("unknown");
+        return ALPROTO_UNKNOWN;
+    }
+
+    int8_t r = rs_nfs_probe_tc(input, input_len);
+    if (r == 1) {
+        SCLogNotice("nfs3");
+        return ALPROTO_NFS3;
+    } else if (r == -1) {
+        SCLogNotice("failed");
+        return ALPROTO_FAILED;
+    }
+
+    SCLogNotice("Protocol not detected as ALPROTO_NFS3.");
+    return ALPROTO_UNKNOWN;
+}
+
+static int NFS3ParseRequest(Flow *f, void *state,
+    AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,
+    void *local_data)
+{
+    uint16_t file_flags = FileFlowToFlags(f, STREAM_TOSERVER);
+    rs_nfs3_setfileflags(0, state, file_flags);
+
+    return rs_nfs3_parse_request_udp(f, state, pstate, input, input_len, local_data);
+}
+
+static int NFS3ParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
+    uint8_t *input, uint32_t input_len, void *local_data)
+{
+    uint16_t file_flags = FileFlowToFlags(f, STREAM_TOCLIENT);
+    rs_nfs3_setfileflags(1, state, file_flags);
+
+    return rs_nfs3_parse_response_udp(f, state, pstate, input, input_len, local_data);
+}
+
+static uint64_t NFS3GetTxCnt(void *state)
+{
+    return rs_nfs3_state_get_tx_count(state);
+}
+
+static void *NFS3GetTx(void *state, uint64_t tx_id)
+{
+    return rs_nfs3_state_get_tx(state, tx_id);
+}
+
+static void NFS3SetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    rs_nfs3_tx_set_logged(state, vtx, logger);
+}
+
+static int NFS3GetTxLogged(void *state, void *vtx, uint32_t logger)
+{
+    return rs_nfs3_tx_get_logged(state, vtx, logger);
+}
+
+/**
+ * \brief Called by the application layer.
+ *
+ * In most cases 1 can be returned here.
+ */
+static int NFS3GetAlstateProgressCompletionStatus(uint8_t direction) {
+    return rs_nfs3_state_progress_completion_status(direction);
+}
+
+/**
+ * \brief Return the state of a transaction in a given direction.
+ *
+ * In the case of the echo protocol, the existence of a transaction
+ * means that the request is done. However, some protocols that may
+ * need multiple chunks of data to complete the request may need more
+ * than just the existence of a transaction for the request to be
+ * considered complete.
+ *
+ * For the response to be considered done, the response for a request
+ * needs to be seen.  The response_done flag is set on response for
+ * checking here.
+ */
+static int NFS3GetStateProgress(void *tx, uint8_t direction)
+{
+    return rs_nfs3_tx_get_alstate_progress(tx, direction);
+}
+
+/**
+ * \brief get stored tx detect state
+ */
+static DetectEngineState *NFS3GetTxDetectState(void *vtx)
+{
+    return rs_nfs3_state_get_tx_detect_state(vtx);
+}
+
+/**
+ * \brief set store tx detect state
+ */
+static int NFS3SetTxDetectState(void *state, void *vtx,
+    DetectEngineState *s)
+{
+    rs_nfs3_state_set_tx_detect_state(state, vtx, s);
+    return 0;
+}
+
+static FileContainer *NFS3GetFiles(void *state, uint8_t direction)
+{
+    return rs_nfs3_getfiles(direction, state);
+}
+
+static StreamingBufferConfig sbcfg = STREAMING_BUFFER_CONFIG_INITIALIZER;
+static SuricataFileContext sfc = { &sbcfg };
+
+void RegisterNFS3UDPParsers(void)
+{
+    const char *proto_name = "nfs3";
+
+    /* Check if NFS3 TCP detection is enabled. If it does not exist in
+     * the configuration file then it will be enabled by default. */
+    if (AppLayerProtoDetectConfProtoDetectionEnabled("udp", proto_name)) {
+
+        rs_nfs3_init(&sfc);
+
+        SCLogNotice("NFS3 UDP protocol detection enabled.");
+
+        AppLayerProtoDetectRegisterProtocol(ALPROTO_NFS3, proto_name);
+
+        if (RunmodeIsUnittests()) {
+
+            SCLogNotice("Unittest mode, registering default configuration.");
+            AppLayerProtoDetectPPRegister(IPPROTO_UDP, NFS3_DEFAULT_PORT,
+                ALPROTO_NFS3, 0, NFS3_MIN_FRAME_LEN, STREAM_TOSERVER,
+                NFS3ProbingParserTS, NFS3ProbingParserTC);
+
+        }
+        else {
+
+            if (!AppLayerProtoDetectPPParseConfPorts("udp", IPPROTO_UDP,
+                    proto_name, ALPROTO_NFS3, 0, NFS3_MIN_FRAME_LEN,
+                    NFS3ProbingParserTS, NFS3ProbingParserTC)) {
+                SCLogNotice("No NFS3 app-layer configuration, enabling NFS3"
+                    " detection TCP detection on port %s.",
+                    NFS3_DEFAULT_PORT);
+                AppLayerProtoDetectPPRegister(IPPROTO_UDP,
+                    NFS3_DEFAULT_PORT, ALPROTO_NFS3, 0,
+                    NFS3_MIN_FRAME_LEN, STREAM_TOSERVER,
+                    NFS3ProbingParserTS, NFS3ProbingParserTC);
+            }
+
+        }
+
+    }
+
+    else {
+        SCLogNotice("Protocol detecter and parser disabled for NFS3.");
+        return;
+    }
+
+    if (AppLayerParserConfParserEnabled("udp", proto_name))
+    {
+        SCLogNotice("Registering NFS3 protocol parser.");
+
+        /* Register functions for state allocation and freeing. A
+         * state is allocated for every new NFS3 flow. */
+        AppLayerParserRegisterStateFuncs(IPPROTO_UDP, ALPROTO_NFS3,
+            NFS3StateAlloc, NFS3StateFree);
+
+        /* Register request parser for parsing frame from server to client. */
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_NFS3,
+            STREAM_TOSERVER, NFS3ParseRequest);
+
+        /* Register response parser for parsing frames from server to client. */
+        AppLayerParserRegisterParser(IPPROTO_UDP, ALPROTO_NFS3,
+            STREAM_TOCLIENT, NFS3ParseResponse);
+
+        /* Register a function to be called by the application layer
+         * when a transaction is to be freed. */
+        AppLayerParserRegisterTxFreeFunc(IPPROTO_UDP, ALPROTO_NFS3,
+            NFS3StateTxFree);
+
+        AppLayerParserRegisterLoggerFuncs(IPPROTO_UDP, ALPROTO_NFS3,
+            NFS3GetTxLogged, NFS3SetTxLogged);
+
+        /* Register a function to return the current transaction count. */
+        AppLayerParserRegisterGetTxCnt(IPPROTO_UDP, ALPROTO_NFS3,
+            NFS3GetTxCnt);
+
+        /* Transaction handling. */
+        AppLayerParserRegisterGetStateProgressCompletionStatus(ALPROTO_NFS3,
+            NFS3GetAlstateProgressCompletionStatus);
+        AppLayerParserRegisterGetStateProgressFunc(IPPROTO_UDP,
+            ALPROTO_NFS3, NFS3GetStateProgress);
+        AppLayerParserRegisterGetTx(IPPROTO_UDP, ALPROTO_NFS3,
+            NFS3GetTx);
+
+        AppLayerParserRegisterGetFilesFunc(IPPROTO_UDP, ALPROTO_NFS3, NFS3GetFiles);
+
+        /* Application layer event handling. */
+//        AppLayerParserRegisterHasEventsFunc(IPPROTO_UDP, ALPROTO_NFS3,
+//            NFS3HasEvents);
+
+        /* What is this being registered for? */
+        AppLayerParserRegisterDetectStateFuncs(IPPROTO_UDP, ALPROTO_NFS3,
+            NULL, NFS3GetTxDetectState, NFS3SetTxDetectState);
+
+//        AppLayerParserRegisterGetEventInfo(IPPROTO_UDP, ALPROTO_NFS3,
+//            NFS3StateGetEventInfo);
+//        AppLayerParserRegisterGetEventsFunc(IPPROTO_UDP, ALPROTO_NFS3,
+//            NFS3GetEvents);
+    }
+    else {
+        SCLogNotice("NFS3 protocol parsing disabled.");
+    }
+
+#ifdef UNITTESTS
+    AppLayerParserRegisterProtocolUnittests(IPPROTO_UDP, ALPROTO_NFS3,
+        NFS3UDPParserRegisterTests);
+#endif
+}
+
+#ifdef UNITTESTS
+#endif
+
+void NFS3UDPParserRegisterTests(void)
+{
+#ifdef UNITTESTS
+#endif
+}
+
+#endif /* HAVE_RUST */

--- a/src/app-layer-nfs3-udp.h
+++ b/src/app-layer-nfs3-udp.h
@@ -27,8 +27,4 @@
 void RegisterNFS3UDPParsers(void);
 void NFS3UDPParserRegisterTests(void);
 
-/** Opaque Rust types. */
-typedef struct NFS3tate_ NFS3State;
-typedef struct NFS3Transaction_ NFS3Transaction;
-
 #endif /* __APP_LAYER_NFS3_H__ */

--- a/src/app-layer-nfs3-udp.h
+++ b/src/app-layer-nfs3-udp.h
@@ -1,0 +1,34 @@
+/* Copyright (C) 2017 Open Information Security Foundation
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/**
+ * \file
+ *
+ * \author Victor Julien <victor@inliniac.net>
+ */
+
+#ifndef __APP_LAYER_NFS3_UDP_H__
+#define __APP_LAYER_NFS3_UDP_H__
+
+void RegisterNFS3UDPParsers(void);
+void NFS3UDPParserRegisterTests(void);
+
+/** Opaque Rust types. */
+typedef struct NFS3tate_ NFS3State;
+typedef struct NFS3Transaction_ NFS3Transaction;
+
+#endif /* __APP_LAYER_NFS3_H__ */

--- a/src/app-layer-nfs3.c
+++ b/src/app-layer-nfs3.c
@@ -346,6 +346,10 @@ void RegisterNFS3Parsers(void)
 //            NFS3StateGetEventInfo);
 //        AppLayerParserRegisterGetEventsFunc(IPPROTO_TCP, ALPROTO_NFS3,
 //            NFS3GetEvents);
+
+        /* This parser accepts gaps. */
+        AppLayerParserRegisterOptionFlags(IPPROTO_TCP, ALPROTO_NFS3,
+                APP_LAYER_PARSER_OPT_ACCEPT_GAPS);
     }
     else {
         SCLogDebug("NFS3 protocol parsing disabled.");

--- a/src/app-layer-nfs3.h
+++ b/src/app-layer-nfs3.h
@@ -27,8 +27,4 @@
 void RegisterNFS3Parsers(void);
 void NFS3ParserRegisterTests(void);
 
-/** Opaque Rust types. */
-typedef struct NFS3tate_ NFS3State;
-typedef struct NFS3Transaction_ NFS3Transaction;
-
 #endif /* __APP_LAYER_NFS3_H__ */

--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -61,6 +61,7 @@
 #include "app-layer-enip.h"
 #include "app-layer-dnp3.h"
 #include "app-layer-nfs3.h"
+#include "app-layer-nfs3-udp.h"
 #include "app-layer-template.h"
 
 #include "conf.h"
@@ -1284,6 +1285,7 @@ void AppLayerParserRegisterProtocolParsers(void)
     RegisterENIPTCPParsers();
     RegisterDNP3Parsers();
     RegisterNFS3Parsers();
+    RegisterNFS3UDPParsers();
     RegisterTemplateParsers();
 
     /** IMAP */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -124,6 +124,7 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     if (ff->magic)
         json_object_set_new(fjs, "magic", json_string((char *)ff->magic));
 #endif
+    json_object_set_new(fjs, "gaps", json_boolean((ff->flags & FILE_HAS_GAPS)));
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             json_object_set_new(fjs, "state", json_string("CLOSED"));

--- a/src/output-json-nfs3.c
+++ b/src/output-json-nfs3.c
@@ -55,6 +55,7 @@
 
 #ifdef HAVE_RUST
 #ifdef HAVE_LIBJANSSON
+#include "rust.h"
 #include "rust-nfs-log-gen.h"
 
 typedef struct LogNFS3FileCtx_ {

--- a/src/output-json-nfs3.c
+++ b/src/output-json-nfs3.c
@@ -130,6 +130,7 @@ static OutputCtx *OutputNFS3LogInitSub(ConfNode *conf,
     SCLogDebug("NFS3 log sub-module initialized.");
 
     AppLayerParserRegisterLogger(IPPROTO_TCP, ALPROTO_NFS3);
+    AppLayerParserRegisterLogger(IPPROTO_UDP, ALPROTO_NFS3);
 
     return output_ctx;
 }

--- a/src/rust.h
+++ b/src/rust.h
@@ -33,6 +33,8 @@ typedef struct SuricataContext_ {
             const uint8_t *data, uint32_t data_len, uint16_t flags);
     int (*FileAppendDataById)(FileContainer *, uint32_t track_id,
             const uint8_t *data, uint32_t data_len);
+    int (*FileAppendGAPById)(FileContainer *, uint32_t track_id,
+            const uint8_t *data, uint32_t data_len);
     void (*FileContainerRecycle)(FileContainer *ffc);
     void (*FilePrune)(FileContainer *ffc);
     void (*FileSetTx)(FileContainer *, uint64_t);

--- a/src/rust.h
+++ b/src/rust.h
@@ -50,4 +50,8 @@ typedef struct SuricataFileContext_ {
 struct _Store;
 typedef struct _Store Store;
 
+/** Opaque Rust types. */
+typedef struct NFS3tate_ NFS3State;
+typedef struct NFS3Transaction_ NFS3Transaction;
+
 #endif /* !__RUST_H__ */

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2795,6 +2795,7 @@ int main(int argc, char **argv)
     context.FileOpenFileWithId = FileOpenFileWithId;
     context.FileCloseFileById = FileCloseFileById;
     context.FileAppendDataById = FileAppendDataById;
+    context.FileAppendGAPById = FileAppendGAPById;
     context.FileContainerRecycle = FileContainerRecycle;
     context.FilePrune = FilePrune;
     context.FileSetTx = FileContainerSetTx;

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -689,6 +689,41 @@ int FileAppendDataById(FileContainer *ffc, uint32_t track_id,
     SCReturnInt(-1);
 }
 
+/**
+ *  \brief Store/handle a chunk of file data in the File structure
+ *         The file with 'track_id' in the FileContainer will be used.
+ *
+ *  \param ffc FileContainer used to append to
+ *  \param track_id id to lookup the file
+ *  \param data data chunk
+ *  \param data_len data chunk len
+ *
+ *  \retval  0 ok
+ *  \retval -1 error
+ *  \retval -2 no store for this file
+ */
+int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
+        const uint8_t *data, uint32_t data_len)
+{
+    SCEnter();
+
+    if (ffc == NULL || ffc->tail == NULL || data == NULL || data_len == 0) {
+        SCReturnInt(-1);
+    }
+    File *ff = ffc->head;
+    for ( ; ff != NULL; ff = ff->next) {
+        if (track_id == ff->file_track_id) {
+            ff->flags |= FILE_HAS_GAPS;
+            ff->flags |= (FILE_NOMD5|FILE_NOSHA1|FILE_NOSHA256);
+            ff->flags &= ~(FILE_MD5|FILE_SHA1|FILE_SHA256);
+            SCLogDebug("FILE_HAS_GAPS set");
+
+            int r = FileAppendDataDo(ff, data, data_len);
+            SCReturnInt(r);
+        }
+    }
+    SCReturnInt(-1);
+}
 
 /**
  *  \brief Open a new File
@@ -837,7 +872,7 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
         }
     }
 
-    if (flags & FILE_TRUNCATED) {
+    if ((flags & FILE_TRUNCATED) || (ff->flags & FILE_HAS_GAPS)) {
         ff->state = FILE_STATE_TRUNCATED;
         SCLogDebug("flowfile state transitioned to FILE_STATE_TRUNCATED");
 

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -48,6 +48,7 @@
 #define FILE_NOTRACK    BIT_U16(12) /**< track size of file */
 #define FILE_USE_DETECT BIT_U16(13) /**< use content_inspected tracker */
 #define FILE_USE_TRACKID    BIT_U16(14) /**< File::file_track_id field is in use */
+#define FILE_HAS_GAPS   BIT_U16(15)
 
 typedef enum FileState_ {
     FILE_STATE_NONE = 0,    /**< no state */
@@ -158,6 +159,8 @@ int FileCloseFileById(FileContainer *, uint32_t track_id,
  */
 int FileAppendData(FileContainer *, const uint8_t *data, uint32_t data_len);
 int FileAppendDataById(FileContainer *, uint32_t track_id,
+        const uint8_t *data, uint32_t data_len);
+int FileAppendGAPById(FileContainer *ffc, uint32_t track_id,
         const uint8_t *data, uint32_t data_len);
 
 /**


### PR DESCRIPTION
Describe changes:
- different approach to GAP, now 0's are printed to the file. It is flagged as 'gapped'
- basic NFSv2 support
- NFSv3 UDP support

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/141
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/649
