### PR TITLE
bypass: add explicit flag in stream engine

### DIFF
--- a/src/app-layer-parser.c
+++ b/src/app-layer-parser.c
@@ -141,7 +141,7 @@ typedef struct AppLayerParserCtx_ {
 } AppLayerParserCtx;
 
 struct AppLayerParserState_ {
-    uint8_t flags;
+    uint16_t flags;
 
     /* Indicates the current transaction that is being inspected.
      * We have a var per direction. */
@@ -1073,6 +1073,17 @@ int AppLayerParserParse(ThreadVars *tv, AppLayerParserThreadCtx *alp_tctx, Flow 
                     StreamTcpSetSessionNoReassemblyFlag(ssn,
                             flags & STREAM_TOCLIENT ? 1 : 0);
                     StreamTcpSetSessionNoReassemblyFlag(ssn,
+                            flags & STREAM_TOSERVER ? 1 : 0);
+                }
+            }
+            /* Set the bypass flag for both the stream in this TcpSession */
+            if (pstate->flags & APP_LAYER_PARSER_BYPASS_READY) {
+                /* Used only if it's TCP */
+                TcpSession *ssn = f->protoctx;
+                if (ssn != NULL) {
+                    StreamTcpSetSessionBypassFlag(ssn,
+                            flags & STREAM_TOCLIENT ? 1 : 0);
+                    StreamTcpSetSessionBypassFlag(ssn,
                             flags & STREAM_TOSERVER ? 1 : 0);
                 }
             }

--- a/src/app-layer-parser.h
+++ b/src/app-layer-parser.h
@@ -35,6 +35,7 @@
 #define APP_LAYER_PARSER_NO_INSPECTION          0x02
 #define APP_LAYER_PARSER_NO_REASSEMBLY          0x04
 #define APP_LAYER_PARSER_NO_INSPECTION_PAYLOAD  0x08
+#define APP_LAYER_PARSER_BYPASS_READY           0x10
 
 /* Flags for AppLayerParserProtoCtx. */
 #define APP_LAYER_PARSER_OPT_ACCEPT_GAPS        BIT_U64(0)

--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1136,9 +1136,10 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                         (ssl_state->flags & SSL_AL_FLAG_SSL_SERVER_SSN_ENCRYPTED)) {
                     AppLayerParserStateSetFlag(pstate,
                             APP_LAYER_PARSER_NO_INSPECTION);
-                    if (ssl_config.no_reassemble == 1)
-                        AppLayerParserStateSetFlag(pstate,
-                                APP_LAYER_PARSER_NO_REASSEMBLY);
+                    if (ssl_config.no_reassemble == 1) {
+                        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
+                        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
+                    }
                     SCLogDebug("SSLv2 No reassembly & inspection has been set");
                 }
             }
@@ -1257,6 +1258,7 @@ static int SSLv3Decode(uint8_t direction, SSLState *ssl_state,
             if (ssl_config.no_reassemble == 1) {
                 AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
                 AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
+                AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
             }
 
             break;

--- a/src/stream-tcp-private.h
+++ b/src/stream-tcp-private.h
@@ -183,6 +183,8 @@ enum
 #define STREAMTCP_STREAM_FLAG_NEW_RAW_DISABLED 0x0200
 /** Raw reassembly disabled completely */
 #define STREAMTCP_STREAM_FLAG_DISABLE_RAW 0x400
+/** Stream can be bypass */
+#define STREAMTCP_STREAM_FLAG_BYPASS 0x0800
 // vacancy 1x
 
 /** NOTE: flags field is 12 bits */

--- a/src/stream-tcp-reassemble.h
+++ b/src/stream-tcp-reassemble.h
@@ -94,6 +94,7 @@ int StreamTcpReassembleAppLayer (ThreadVars *tv, TcpReassemblyThreadCtx *ra_ctx,
 void StreamTcpCreateTestPacket(uint8_t *, uint8_t, uint8_t, uint8_t);
 
 void StreamTcpSetSessionNoReassemblyFlag (TcpSession *, char );
+void StreamTcpSetSessionBypassFlag (TcpSession *, char );
 void StreamTcpSetDisableRawReassemblyFlag (TcpSession *ssn, char direction);
 
 void StreamTcpSetOSPolicy(TcpStream *, Packet *);

--- a/src/stream-tcp.c
+++ b/src/stream-tcp.c
@@ -4653,8 +4653,8 @@ int StreamTcpPacket (ThreadVars *tv, Packet *p, StreamTcpThread *stt,
             p->flags |= PKT_STREAM_NOPCAPLOG;
         }
 
-        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY) &&
-            (ssn->server.flags & STREAMTCP_STREAM_FLAG_NOREASSEMBLY))
+        if ((ssn->client.flags & STREAMTCP_STREAM_FLAG_BYPASS) &&
+            (ssn->server.flags & STREAMTCP_STREAM_FLAG_BYPASS))
         {
             /* we can call bypass callback, if enabled */
             if (StreamTcpBypassEnabled()) {
@@ -5578,6 +5578,20 @@ void StreamTcpSetDisableRawReassemblyFlag (TcpSession *ssn, char direction)
 {
     direction ? (ssn->server.flags |= STREAMTCP_STREAM_FLAG_NEW_RAW_DISABLED) :
                 (ssn->client.flags |= STREAMTCP_STREAM_FLAG_NEW_RAW_DISABLED);
+}
+
+/** \brief enable bypass
+ *
+ * \param ssn TCP Session to set the flag in
+ * \param direction direction to set the flag in: 0 toserver, 1 toclient
+ */
+void StreamTcpSetSessionBypassFlag (TcpSession *ssn, char direction)
+{
+    if (direction) {
+        ssn->server.flags |= STREAMTCP_STREAM_FLAG_BYPASS;
+    } else {
+        ssn->client.flags |= STREAMTCP_STREAM_FLAG_BYPASS;
+    }
 }
 
 #define PSEUDO_PKT_SET_IPV4HDR(nipv4h,ipv4h) do { \


### PR DESCRIPTION
TCP reassembly is now deactivated more frequently and triggering a
bypass on it is resulting in missing some alerts due forgetting
about packet based signature.

So this patch is introducing a dedicated flag that can be set in
the app layer and transmitted in the streaming to trigger bypass.

It is currently used by the SSL app layer to trigger bypass when
the stream becomes encrypted.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [*] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [*] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [*] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Redmin issue: https://redmine.openinfosecfoundation.org/issues/2143

PRscript:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/293
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/77

