### PR TITLE
rust/dns - fix panics - v1

### DIFF
--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -19,6 +19,7 @@ extern crate libc;
 
 use std;
 use std::string::String;
+use std::ascii::AsciiExt;
 
 use json::*;
 use dns::dns::*;
@@ -286,6 +287,28 @@ pub fn dns_rrtype_string(rrtype: u16) -> String {
     }.to_string()
 }
 
+fn safe_bytes_to_string(input: &[u8]) -> String {
+    // First attempt to convert from UTF8.
+    match std::str::from_utf8(input) {
+        Ok(value) => {
+            return String::from(value);
+        },
+        _ => {}
+    }
+
+    // If that fails create a string from the printabe characters with
+    // the non-printable characters as hex.
+    let mut output: String = "".to_owned();
+    for c in input {
+        if (*c as char).is_ascii() {
+            output.push(*c as char);
+        } else {
+            output.push_str(&format!("\\x{:x}", c));
+        }
+    }
+    return output;
+}
+
 fn dns_rcode_string(flags: u16) -> String {
     match flags & 0x000f {
         DNS_RCODE_NOERROR => "NOERROR",
@@ -420,7 +443,7 @@ fn dns_log_json_failure(r: &DNSResponse, index: usize, flags: u64)
     js.set_string("type", "answer");
     js.set_integer("id", r.header.tx_id as u64);
     js.set_string("rcode", &dns_rcode_string(r.header.flags));
-    js.set_string("rrname", std::str::from_utf8(&query.name[..]).unwrap());
+    js.set_string("rrname", &safe_bytes_to_string(&query.name));
 
     return js.unwrap();
 }
@@ -469,4 +492,20 @@ pub extern "C" fn rs_dns_log_json_authority(tx: &mut DNSTransaction,
         }
     }
     return std::ptr::null_mut();
+}
+
+#[cfg(test)]
+mod tests {
+
+    use dns::log::*;
+
+    #[test]
+    fn test_safe_bytes_to_string() {
+        assert_eq!("suricata-ids.org",
+                   safe_bytes_to_string(
+                       &String::from("suricata-ids.org").into_bytes()));
+        assert_eq!("A\\xf0\\xf1\\xf2",
+                   safe_bytes_to_string(&[ 0x41, 0xf0, 0xf1, 0xf2 ]));
+    }
+
 }


### PR DESCRIPTION
First commit fixes a panic due to bad validation of the input length of TCP DNS frames. Unit tests were added to check for this condition.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/2144

The second commit addresses a panic in converting the rrname bytes to a printable string when the rrname contains bytes that don't convert to unicode. First we try to convert to unicode, if that fails the printable characters will be printed, with the unprintable ones printed like \xff.

Redmine ticket:
https://redmine.openinfosecfoundation.org/issues/2148

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/184
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/537
