### PR TITLE
python: use python path found during configure - v1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@
 
     AC_ARG_ENABLE(python,
            AS_HELP_STRING([--enable-python], [Enable python]),,[enable_python=yes])
-    AC_PATH_PROG(HAVE_PYTHON_CONFIG, python, "no")
+    AC_PATH_PROGS(HAVE_PYTHON, python python2 python2.7, "no")
     if test "x$enable_python" = "xno" ; then
         echo
         echo "   Warning! python disabled, you will not be      "
@@ -94,7 +94,7 @@
         echo
         enable_python="no"
     fi
-    if test "$HAVE_PYTHON_CONFIG" = "no"; then
+    if test "$HAVE_PYTHON" = "no"; then
         echo
         echo "   Warning! python not found, you will not be     "
         echo "   able to install suricatasc unix socket client   "

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -28,7 +28,7 @@ endif
 all-local:
 if HAVE_PYTHON
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		python ./gen-c-headers.py && \
+		$(HAVE_PYTHON) ./gen-c-headers.py && \
 		cargo build $(RELEASE) $(FROZEN) --features "$(FEATURES)"
 else
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
@@ -67,7 +67,7 @@ endif # HAVE_RUST
 if HAVE_PYTHON
 EXTRA_DIST +=	gen/c-headers
 gen/c-headers:
-	cd $(top_srcdir)/rust && python ./gen-c-headers.py
+	cd $(top_srcdir)/rust && $(HAVE_PYTHON) ./gen-c-headers.py
 else
 gen/c-headers:
 endif

--- a/scripts/suricatasc/Makefile.am
+++ b/scripts/suricatasc/Makefile.am
@@ -3,13 +3,13 @@ EXTRA_DIST = setup.py suricatasc.in src/__init__.py src/suricatasc.py
 if HAVE_PYTHON
 all-local:
 	mkdir -p $(top_builddir)/scripts/suricatasc/src
-	$(PYTHON) $(srcdir)/setup.py build;
+	$(HAVE_PYTHON) $(srcdir)/setup.py build;
 
 install-exec-local:
-	$(PYTHON) $(srcdir)/setup.py install --prefix $(DESTDIR)$(prefix)
+	$(HAVE_PYTHON) $(srcdir)/setup.py install --prefix $(DESTDIR)$(prefix)
 
 clean-local:
-	$(PYTHON) $(srcdir)/setup.py clean;
+	$(HAVE_PYTHON) $(srcdir)/setup.py clean;
 	rm -rf $(top_builddir)/scripts/suricatasc/build
 
 uninstall-local:


### PR DESCRIPTION
Also look for Python under more names. For example, on OpenBSD
if you just install Python 2, you will only get a python2.7
executable.

Also renames HAVE_PYTHON_CONFIG to simply HAVE_PYTHON for cosmetic reasons.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/186
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/539
