### PR TITLE
Rust dns string fixes 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: c
 

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -143,18 +143,6 @@ pub struct DNSQueryEntry {
     pub rrclass: u16,
 }
 
-impl DNSQueryEntry {
-
-    pub fn name(&self) -> &str {
-        let r = std::str::from_utf8(&self.name);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
-}
-
 #[derive(Debug,PartialEq)]
 pub struct DNSAnswerEntry {
     pub name: Vec<u8>,
@@ -163,26 +151,6 @@ pub struct DNSAnswerEntry {
     pub ttl: u32,
     pub data_len: u16,
     pub data: Vec<u8>,
-}
-
-impl DNSAnswerEntry {
-
-    pub fn name(&self) -> &str {
-        let r = std::str::from_utf8(&self.name);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
-    pub fn data_to_string(&self) -> &str {
-        let r = std::str::from_utf8(&self.data);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
 }
 
 #[derive(Debug)]

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -43,14 +43,14 @@ pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState,
 
     for request in &tx.request {
         for query in &request.queries {
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
     }
 
     for response in &tx.response {
         for query in &response.queries {
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
     }
@@ -88,7 +88,7 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             lua.settable(-3);
 
             lua.settable(-3);
@@ -133,7 +133,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(answer.name());
+            lua.pushstring(&String::from_utf8_lossy(&answer.name));
             lua.settable(-3);
 
             if answer.data.len() > 0 {
@@ -143,7 +143,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                         lua.pushstring(&dns_print_addr(&answer.data));
                     }
                     _ => {
-                        lua.pushstring(answer.data_to_string());
+                        lua.pushstring(&String::from_utf8_lossy(&answer.data));
                     }
                 }
                 lua.settable(-3);
@@ -190,7 +190,7 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(answer.name());
+            lua.pushstring(&String::from_utf8_lossy(&answer.name));
             lua.settable(-3);
 
             lua.settable(-3);

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use std::ffi::CString;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::os::raw::c_long;
@@ -26,7 +25,7 @@ pub enum CLuaState {}
 extern {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
-    fn lua_pushstring(lua: *mut CLuaState, s: *const c_char);
+    fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);
     fn lua_pushinteger(lua: *mut CLuaState, n: c_long);
 }
 
@@ -50,7 +49,7 @@ impl LuaState {
 
     pub fn pushstring(&self, val: &str) {
         unsafe {
-            lua_pushstring(self.lua, CString::new(val).unwrap().as_ptr());
+            lua_pushlstring(self.lua, val.as_ptr() as *const c_char, val.len());
         }
     }
 


### PR DESCRIPTION
More fixing of Rust to DNS string handling.

Move the safe string handling into the json module for now. It will replace non-printable characters with a hex code. Ubuntu 14.04 still doesn't have json_stringn, so we can't pass full unicode strings to it yet. So this might be a good middle ground for now without decoding unicode.  For example, we could pass through the unicode bytes, but a but like \xff will cause jansson not to log that field.

Likewise for Lua, use pushlstring so we don't have to worry about NULLs there.

Also updates Travis to use Ubuntu 14.04.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/192
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/545
