### PR TITLE
Rust/nfs/gap/v10.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: c
 

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -14,3 +14,4 @@ lua = []
 [dependencies]
 nom = "~3.0"
 libc = "~0.2.0"
+crc = "~1.4.0"

--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -143,18 +143,6 @@ pub struct DNSQueryEntry {
     pub rrclass: u16,
 }
 
-impl DNSQueryEntry {
-
-    pub fn name(&self) -> &str {
-        let r = std::str::from_utf8(&self.name);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
-}
-
 #[derive(Debug,PartialEq)]
 pub struct DNSAnswerEntry {
     pub name: Vec<u8>,
@@ -163,26 +151,6 @@ pub struct DNSAnswerEntry {
     pub ttl: u32,
     pub data_len: u16,
     pub data: Vec<u8>,
-}
-
-impl DNSAnswerEntry {
-
-    pub fn name(&self) -> &str {
-        let r = std::str::from_utf8(&self.name);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
-    pub fn data_to_string(&self) -> &str {
-        let r = std::str::from_utf8(&self.data);
-        if r.is_err() {
-            return "";
-        }
-        return r.unwrap();
-    }
-
 }
 
 #[derive(Debug)]

--- a/rust/src/dns/lua.rs
+++ b/rust/src/dns/lua.rs
@@ -43,14 +43,14 @@ pub extern "C" fn rs_dns_lua_get_rrname(clua: &mut CLuaState,
 
     for request in &tx.request {
         for query in &request.queries {
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
     }
 
     for response in &tx.response {
         for query in &response.queries {
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             return 1;
         }
     }
@@ -88,7 +88,7 @@ pub extern "C" fn rs_dns_lua_get_query_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(query.name());
+            lua.pushstring(&String::from_utf8_lossy(&query.name));
             lua.settable(-3);
 
             lua.settable(-3);
@@ -133,7 +133,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(answer.name());
+            lua.pushstring(&String::from_utf8_lossy(&answer.name));
             lua.settable(-3);
 
             if answer.data.len() > 0 {
@@ -143,7 +143,7 @@ pub extern "C" fn rs_dns_lua_get_answer_table(clua: &mut CLuaState,
                         lua.pushstring(&dns_print_addr(&answer.data));
                     }
                     _ => {
-                        lua.pushstring(answer.data_to_string());
+                        lua.pushstring(&String::from_utf8_lossy(&answer.data));
                     }
                 }
                 lua.settable(-3);
@@ -190,7 +190,7 @@ pub extern "C" fn rs_dns_lua_get_authority_table(clua: &mut CLuaState,
             lua.settable(-3);
 
             lua.pushstring("rrname");
-            lua.pushstring(answer.name());
+            lua.pushstring(&String::from_utf8_lossy(&answer.name));
             lua.settable(-3);
 
             lua.settable(-3);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -20,6 +20,8 @@ extern crate libc;
 #[macro_use]
 extern crate nom;
 
+extern crate crc;
+
 #[macro_use]
 pub mod log;
 

--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -15,7 +15,6 @@
  * 02110-1301, USA.
  */
 
-use std::ffi::CString;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::os::raw::c_long;
@@ -26,7 +25,7 @@ pub enum CLuaState {}
 extern {
     fn lua_createtable(lua: *mut CLuaState, narr: c_int, nrec: c_int);
     fn lua_settable(lua: *mut CLuaState, idx: c_long);
-    fn lua_pushstring(lua: *mut CLuaState, s: *const c_char);
+    fn lua_pushlstring(lua: *mut CLuaState, s: *const c_char, len: usize);
     fn lua_pushinteger(lua: *mut CLuaState, n: c_long);
 }
 
@@ -50,7 +49,7 @@ impl LuaState {
 
     pub fn pushstring(&self, val: &str) {
         unsafe {
-            lua_pushstring(self.lua, CString::new(val).unwrap().as_ptr());
+            lua_pushlstring(self.lua, val.as_ptr() as *const c_char, val.len());
         }
     }
 

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -74,6 +74,7 @@ fn nfs_file_object(tx: &NFSTransaction) -> Json
     };
 
     js.set_integer("last_xid", tdf.file_last_xid as u64);
+    js.set_integer("chunks", tdf.chunk_count as u64);
     return js;
 }
 /*

--- a/rust/src/nfs/log.rs
+++ b/rust/src/nfs/log.rs
@@ -21,6 +21,7 @@ use std::string::String;
 use json::*;
 use nfs::types::*;
 use nfs::nfs::*;
+use crc::crc32;
 
 #[no_mangle]
 pub extern "C" fn rs_nfs_tx_logging_is_filtered(tx: &mut NFSTransaction)
@@ -75,6 +76,18 @@ fn nfs_file_object(tx: &NFSTransaction) -> Json
     js.set_integer("last_xid", tdf.file_last_xid as u64);
     return js;
 }
+/*
+fn nfs_handle2hex(bytes: &Vec<u8>) -> String {
+    let strings: Vec<String> = bytes.iter()
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    strings.join("")
+}
+*/
+fn nfs_handle2crc(bytes: &Vec<u8>) -> u32 {
+    let c = crc32::checksum_ieee(bytes);
+    c
+}
 
 fn nfs_common_header(state: &NFSState, tx: &NFSTransaction) -> Json
 {
@@ -83,6 +96,13 @@ fn nfs_common_header(state: &NFSState, tx: &NFSTransaction) -> Json
     js.set_string("procedure", &nfs3_procedure_string(tx.procedure));
     let file_name = String::from_utf8_lossy(&tx.file_name);
     js.set_string("filename", &file_name);
+
+    if tx.file_handle.len() > 0 {
+        //js.set_string("handle", &nfs_handle2hex(&tx.file_handle));
+        let c = nfs_handle2crc(&tx.file_handle);
+        let s = format!("{:x}", c);
+        js.set_string("hhash", &s);
+    }
     js.set_integer("id", tx.id as u64);
     js.set_boolean("file_tx", tx.is_file_tx);
     return js;

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -721,7 +721,7 @@ impl NFSState {
         tx.type_data = Some(NFSTransactionTypeData::FILE(NFSTransactionFile::new()));
         match tx.type_data {
             Some(NFSTransactionTypeData::FILE(ref mut d)) => {
-                d.file_tracker.tx_id = tx.id;
+                d.file_tracker.tx_id = tx.id - 1;
             },
             _ => { },
         }

--- a/rust/src/nfs/nfs.rs
+++ b/rust/src/nfs/nfs.rs
@@ -405,13 +405,16 @@ impl NFSState {
     }
 
     // TODO maybe not enough users to justify a func
-    fn mark_response_tx_done(&mut self, xid: u32, rpc_status: u32, nfs_status: u32)
+    fn mark_response_tx_done(&mut self, xid: u32, rpc_status: u32, nfs_status: u32, resp_handle: &Vec<u8>)
     {
         match self.get_tx_by_xid(xid) {
             Some(mut mytx) => {
                 mytx.response_done = true;
                 mytx.rpc_response_status = rpc_status;
                 mytx.nfs_response_status = nfs_status;
+                if mytx.file_handle.len() == 0 && resp_handle.len() > 0 {
+                    mytx.file_handle = resp_handle.to_vec();
+                }
 
                 SCLogDebug!("process_reply_record: tx ID {} XID {} REQUEST {} RESPONSE {}",
                         mytx.id, mytx.xid, mytx.request_done, mytx.response_done);
@@ -592,6 +595,7 @@ impl NFSState {
             tx.request_done = true;
             tx.file_name = xidmap.file_name.to_vec();
             tx.nfs_version = r.progver as u16;
+            tx.file_handle = xidmap.file_handle.to_vec();
             //self.ts_txs_updated = true;
 
             if r.procedure == NFSPROC3_RENAME {
@@ -678,6 +682,7 @@ impl NFSState {
             tx.procedure = r.procedure;
             tx.request_done = true;
             tx.file_name = xidmap.file_name.to_vec();
+            tx.file_handle = xidmap.file_handle.to_vec();
             tx.nfs_version = r.progver as u16;
             //self.ts_txs_updated = true;
 
@@ -829,6 +834,7 @@ impl NFSState {
 
     fn process_reply_record_v3<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &mut NFSRequestXidMap) -> u32 {
         let nfs_status;
+        let mut resp_handle = Vec::new();
 
         if xidmap.procedure == NFSPROC3_LOOKUP {
             match parse_nfs3_response_lookup(r.prog_data) {
@@ -840,6 +846,7 @@ impl NFSState {
 
                     SCLogDebug!("LOOKUP handle {:?}", lookup.handle);
                     self.namemap.insert(lookup.handle.value.to_vec(), xidmap.file_name.to_vec());
+                    resp_handle = lookup.handle.value.to_vec();
                 },
                 IResult::Incomplete(_) => { panic!("WEIRD"); },
                 IResult::Error(e) => { panic!("Parsing failed: {:?}",e);  },
@@ -856,6 +863,7 @@ impl NFSState {
                         Some(h) => {
                             SCLogDebug!("handle {:?}", h);
                             self.namemap.insert(h.value.to_vec(), xidmap.file_name.to_vec());
+                            resp_handle = h.value.to_vec();
                         },
                         _ => { },
                     }
@@ -927,7 +935,7 @@ impl NFSState {
                 r.hdr.xid, xidmap.procedure, r.prog_data.len());
 
         if xidmap.procedure != NFSPROC3_READ {
-            self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status);
+            self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status, &resp_handle);
         }
 
         0
@@ -935,6 +943,7 @@ impl NFSState {
 
     fn process_reply_record_v2<'b>(&mut self, r: &RpcReplyPacket<'b>, xidmap: &NFSRequestXidMap) -> u32 {
         let nfs_status;
+        let resp_handle = Vec::new();
 
         if xidmap.procedure == NFSPROC3_READ {
             match parse_nfs2_reply_read(r.prog_data) {
@@ -958,7 +967,7 @@ impl NFSState {
         SCLogDebug!("REPLY {} to procedure {} blob size {}",
                 r.hdr.xid, xidmap.procedure, r.prog_data.len());
 
-        self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status);
+        self.mark_response_tx_done(r.hdr.xid, r.reply_state, nfs_status, &resp_handle);
 
         0
     }

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -60,6 +60,7 @@
 #include "output-json-ssh.h"
 #include "output-json-smtp.h"
 #include "output-json-email-common.h"
+#include "output-json-nfs.h"
 
 #include "util-byte.h"
 #include "util-privs.h"
@@ -73,16 +74,19 @@
 
 #ifdef HAVE_LIBJANSSON
 
-#define LOG_JSON_PAYLOAD        0x001
-#define LOG_JSON_PACKET         0x002
-#define LOG_JSON_PAYLOAD_BASE64 0x004
-#define LOG_JSON_HTTP           0x008
-#define LOG_JSON_TLS            0x010
-#define LOG_JSON_SSH            0x020
-#define LOG_JSON_SMTP           0x040
-#define LOG_JSON_TAGGED_PACKETS 0x080
-#define LOG_JSON_DNP3           0x100
-#define LOG_JSON_VARS           0x200
+#define LOG_JSON_PAYLOAD        BIT_U16(0)
+#define LOG_JSON_PACKET         BIT_U16(1)
+#define LOG_JSON_PAYLOAD_BASE64 BIT_U16(2)
+#define LOG_JSON_HTTP           BIT_U16(3)
+#define LOG_JSON_TLS            BIT_U16(4)
+#define LOG_JSON_SSH            BIT_U16(5)
+#define LOG_JSON_SMTP           BIT_U16(6)
+#define LOG_JSON_TAGGED_PACKETS BIT_U16(7)
+#define LOG_JSON_DNP3           BIT_U16(8)
+#define LOG_JSON_VARS           BIT_U16(9)
+#define LOG_JSON_APP_LAYER      BIT_U16(10)
+
+#define LOG_JSON_APP_LAYER_ALL  (LOG_JSON_APP_LAYER|LOG_JSON_HTTP|LOG_JSON_TLS|LOG_JSON_SSH|LOG_JSON_SMTP|LOG_JSON_DNP3)
 
 #define JSON_STREAM_BUFFER_SIZE 4096
 
@@ -389,7 +393,19 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
                 }
             }
         }
-
+#ifdef HAVE_RUST
+        if ((json_output_ctx->flags & LOG_JSON_APP_LAYER) && p->flow != NULL) {
+            uint16_t alproto = FlowGetAppProtocol(p->flow);
+            if (alproto == ALPROTO_NFS) {
+                hjs = JsonNFSAddMetadataRPC(p->flow, pa->tx_id);
+                if (hjs)
+                    json_object_set_new(js, "rpc", hjs);
+                hjs = JsonNFSAddMetadata(p->flow, pa->tx_id);
+                if (hjs)
+                    json_object_set_new(js, "nfs", hjs);
+            }
+        }
+#endif
         if (json_output_ctx->flags & LOG_JSON_DNP3) {
             if (p->flow != NULL) {
                 uint16_t proto = FlowGetAppProtocol(p->flow);
@@ -724,11 +740,15 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         const char *tagged_packets = ConfNodeLookupChildValue(conf, "tagged-packets");
         const char *dnp3 = ConfNodeLookupChildValue(conf, "dnp3");
         const char *vars = ConfNodeLookupChildValue(conf, "vars");
+        const char *applayer = ConfNodeLookupChildValue(conf, "applayer");
 
         if (vars != NULL) {
             if (ConfValIsTrue(vars)) {
                 json_output_ctx->flags |= LOG_JSON_VARS;
             }
+        }
+        if (applayer != NULL && ConfValIsTrue(applayer)) {
+            json_output_ctx->flags |= LOG_JSON_APP_LAYER_ALL;
         }
         if (ssh != NULL) {
             if (ConfValIsTrue(ssh)) {

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -60,6 +60,7 @@
 #include "output-json-http.h"
 #include "output-json-smtp.h"
 #include "output-json-email-common.h"
+#include "output-json-nfs.h"
 
 #include "app-layer-htp.h"
 #include "util-memcmp.h"
@@ -105,6 +106,16 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
             if (hjs)
                 json_object_set_new(js, "email", hjs);
             break;
+#ifdef HAVE_RUST
+        case ALPROTO_NFS:
+            hjs = JsonNFSAddMetadataRPC(p->flow, ff->txid);
+            if (hjs)
+                json_object_set_new(js, "rpc", hjs);
+            hjs = JsonNFSAddMetadata(p->flow, ff->txid);
+            if (hjs)
+                json_object_set_new(js, "nfs", hjs);
+            break;
+#endif
     }
 
     json_object_set_new(js, "app_proto",

--- a/src/output-json-nfs.c
+++ b/src/output-json-nfs.c
@@ -62,6 +62,32 @@ typedef struct LogNFSLogThread_ {
     MemBuffer          *buffer;
 } LogNFSLogThread;
 
+json_t *JsonNFSAddMetadataRPC(const Flow *f, uint64_t tx_id)
+{
+    NFSState *state = FlowGetAppState(f);
+    if (state) {
+        NFSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_NFS, state, tx_id);
+        if (tx) {
+            return rs_rpc_log_json_response(tx);
+        }
+    }
+
+    return NULL;
+}
+
+json_t *JsonNFSAddMetadata(const Flow *f, uint64_t tx_id)
+{
+    NFSState *state = FlowGetAppState(f);
+    if (state) {
+        NFSTransaction *tx = AppLayerParserGetTx(f->proto, ALPROTO_NFS, state, tx_id);
+        if (tx) {
+            return rs_nfs_log_json_response(state, tx);
+        }
+    }
+
+    return NULL;
+}
+
 static int JsonNFSLogger(ThreadVars *tv, void *thread_data,
     const Packet *p, Flow *f, void *state, void *tx, uint64_t tx_id)
 {

--- a/src/output-json-nfs.h
+++ b/src/output-json-nfs.h
@@ -25,5 +25,8 @@
 #define __OUTPUT_JSON_NFS_H__
 
 void JsonNFSLogRegister(void);
-
+#ifdef HAVE_RUST
+json_t *JsonNFSAddMetadataRPC(const Flow *f, uint64_t tx_id);
+json_t *JsonNFSAddMetadata(const Flow *f, uint64_t tx_id);
+#endif /* HAVE_RUST */
 #endif /* __OUTPUT_JSON_NFS_H__ */

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -164,11 +164,7 @@ outputs:
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
-            http: yes                # enable dumping of http fields
-            tls: yes                 # enable dumping of tls fields
-            ssh: yes                 # enable dumping of ssh fields
-            smtp: yes                # enable dumping of smtp fields
-            dnp3: yes                # enable dumping of DNP3 fields
+            applayer: yes            # add L7/applayer fields to the alert
             vars: yes                # enable dumping of flowbits and other vars
 
             # Enable the logging of tagged packets for rules using the


### PR DESCRIPTION
Describe changes:
- #2791 
- Fixed a crash in alerts of non-NFS protocols that #2791 introduced.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/152
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/661

