### PR TITLE
rust - cargo home, logging fixups - 1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2007,9 +2007,15 @@
           CFLAGS="${CFLAGS} -I../rust/gen/c-headers"
           AC_SUBST(RUST_SURICATA_LIB)
           AC_SUBST(RUST_LDADD)
+	  AC_SUBST([CARGO], [$HAVE_CARGO])
+	  if test "x$CARGO_HOME" = "x"; then
+	    AC_SUBST([CARGO_HOME], [~/.cargo])
+	  else
+	    AC_SUBST([CARGO_HOME], [$CARGO_HOME])
+	  fi
           AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
           if test "x$have_rust_vendor" = "xyes"; then
-	        rust_vendor_comment=""
+	    rust_vendor_comment=""
           fi
         fi
       fi

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -29,15 +29,17 @@ all-local:
 if HAVE_PYTHON
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
 		$(HAVE_PYTHON) ./gen-c-headers.py && \
-		cargo build $(RELEASE) $(FROZEN) --features "$(FEATURES)"
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+			--features "$(FEATURES)"
 else
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo build $(RELEASE) $(FROZEN) --features "$(FEATURES)"
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+			--features "$(FEATURES)"
 endif
 
 clean-local:
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo clean
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) clean
 
 distclean-local:
 	rm -rf vendor
@@ -45,14 +47,14 @@ distclean-local:
 
 check:
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo test
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	cargo update
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) update
 
 if HAVE_CARGO_VENDOR
 vendor:
-	cargo vendor > /dev/null
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) vendor > /dev/null
 else
 vendor:
 endif

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -105,7 +105,7 @@ pub type SCFileSetTx = extern "C" fn (
 #[allow(non_snake_case)]
 #[repr(C)]
 pub struct SuricataContext {
-    SCLogMessage: SCLogMessageFunc,
+    pub SCLogMessage: SCLogMessageFunc,
     DetectEngineStateFree: DetectEngineStateFreeFunc,
     AppLayerDecoderEventsSetEventRaw: AppLayerDecoderEventsSetEventRawFunc,
     AppLayerDecoderEventsFreeEvents: AppLayerDecoderEventsFreeEventsFunc,
@@ -133,23 +133,6 @@ pub extern "C" fn rs_init(context: &'static mut SuricataContext)
     unsafe {
         SC = Some(context);
     }
-}
-
-/// SCLogMessage wrapper.
-pub fn sc_log_message(level: libc::c_int,
-                      filename: *const libc::c_char,
-                      line: libc::c_uint,
-                      function: *const libc::c_char,
-                      code: libc::c_int,
-                      message: *const libc::c_char) -> libc::c_int
-{
-    unsafe {
-        if let Some(c) = SC {
-            return (c.SCLogMessage)(level, filename, line, function,
-                                  code, message);
-        }
-    }
-    return 0;
 }
 
 /// DetectEngineStateFree wrapper.

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -30,7 +30,9 @@
 #include "app-layer-dns-tcp-rust.h"
 #include "rust-dns-dns-gen.h"
 
+#ifdef UNITTESTS
 static void RustDNSTCPParserRegisterTests(void);
+#endif
 
 static int RustDNSTCPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -30,7 +30,9 @@
 #include "app-layer-dns-udp-rust.h"
 #include "rust-dns-dns-gen.h"
 
+#ifdef UNITTESTS
 static void RustDNSUDPParserRegisterTests(void);
+#endif
 
 static int RustDNSUDPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,


### PR DESCRIPTION
When following the procedure of "make && sudo make install", Cargo will re-download and rebuild the Rust components as root $HOME/.cargo is used during the build. To fix this, save the path to cargo (for rustup users), and determine the path for CARGO_HOME at configure time and expose them as variables to the build so the "make" and "sudo make install" will see the same values preventing a rebuild.

Also do safe string handling in the SCLog routines and include a pure Rust logger for when not running as part of Suricata (unit tests).

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/196
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/549
