### PR TITLE
rust - fixes - 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1965,9 +1965,6 @@
     AM_CONDITIONAL([HAVE_PDFLATEX], [test "x$enable_pdflatex" != "xno"])
 
 # Cargo/Rust.
-    dnl enable_rust="no"
-    dnl AC_ARG_ENABLE(rust, AS_HELP_STRING([--enable-rust], [Enable Rust]),
-    dnl     [enable_rust="$enableval"], [enable_rust=no])
     AC_ARG_ENABLE([rust], AS_HELP_STRING([--enable-rust], [Enable Experimental Rust support]))
 
     rust_vendor_comment="# "
@@ -2004,7 +2001,7 @@
             RUST_SURICATA_LIB="../rust/target/release/libsuricata.a"
           fi
           RUST_LDADD="${RUST_SURICATA_LIB} ${RUST_LDADD}"
-          CFLAGS="${CFLAGS} -I../rust/gen/c-headers"
+          CFLAGS="${CFLAGS} -I\${srcdir}/../rust/gen/c-headers"
           AC_SUBST(RUST_SURICATA_LIB)
           AC_SUBST(RUST_LDADD)
 	  AC_SUBST([CARGO], [$HAVE_CARGO])

--- a/configure.ac
+++ b/configure.ac
@@ -2007,9 +2007,15 @@
           CFLAGS="${CFLAGS} -I../rust/gen/c-headers"
           AC_SUBST(RUST_SURICATA_LIB)
           AC_SUBST(RUST_LDADD)
+	  AC_SUBST([CARGO], [$HAVE_CARGO])
+	  if test "x$CARGO_HOME" = "x"; then
+	    AC_SUBST([CARGO_HOME], [~/.cargo])
+	  else
+	    AC_SUBST([CARGO_HOME], [$CARGO_HOME])
+	  fi
           AC_CHECK_FILES([$srcdir/rust/vendor], [have_rust_vendor="yes"])
           if test "x$have_rust_vendor" = "xyes"; then
-	        rust_vendor_comment=""
+	    rust_vendor_comment=""
           fi
         fi
       fi

--- a/rust/.cargo/config.in
+++ b/rust/.cargo/config.in
@@ -5,4 +5,4 @@
 @rust_vendor_comment@replace-with = 'vendored-sources'
 @rust_vendor_comment@
 @rust_vendor_comment@[source.vendored-sources]
-@rust_vendor_comment@directory = './vendor'
+@rust_vendor_comment@directory = '@abs_top_srcdir@/rust/vendor'

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -29,15 +29,17 @@ all-local:
 if HAVE_PYTHON
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
 		$(HAVE_PYTHON) ./gen-c-headers.py && \
-		cargo build $(RELEASE) $(FROZEN) --features "$(FEATURES)"
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+			--features "$(FEATURES)"
 else
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo build $(RELEASE) $(FROZEN) --features "$(FEATURES)"
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
+			--features "$(FEATURES)"
 endif
 
 clean-local:
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo clean
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) clean
 
 distclean-local:
 	rm -rf vendor
@@ -45,14 +47,14 @@ distclean-local:
 
 check:
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
-		cargo test
+		CARGO_HOME=$(CARGO_HOME) $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	cargo update
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) update
 
 if HAVE_CARGO_VENDOR
 vendor:
-	cargo vendor > /dev/null
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) vendor > /dev/null
 else
 vendor:
 endif

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -27,8 +27,9 @@ endif
 
 all-local:
 if HAVE_PYTHON
-	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
+	cd $(top_srcdir)/rust && \
 		$(HAVE_PYTHON) ./gen-c-headers.py && \
+		CARGO_TARGET_DIR=$(abs_builddir)/target \
 		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
 			--features "$(FEATURES)"
 else
@@ -42,15 +43,14 @@ clean-local:
 		CARGO_HOME=$(CARGO_HOME) $(CARGO) clean
 
 distclean-local:
-	rm -rf vendor
-	rm -rf gen
+	rm -rf vendor gen Cargo.lock
 
 check:
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
 		CARGO_HOME=$(CARGO_HOME) $(CARGO) test
 
 Cargo.lock: Cargo.toml
-	CARGO_HOME=$(CARGO_HOME) $(CARGO) update
+	CARGO_HOME=$(CARGO_HOME) $(CARGO) generate-lockfile
 
 if HAVE_CARGO_VENDOR
 vendor:

--- a/rust/src/core.rs
+++ b/rust/src/core.rs
@@ -105,7 +105,7 @@ pub type SCFileSetTx = extern "C" fn (
 #[allow(non_snake_case)]
 #[repr(C)]
 pub struct SuricataContext {
-    SCLogMessage: SCLogMessageFunc,
+    pub SCLogMessage: SCLogMessageFunc,
     DetectEngineStateFree: DetectEngineStateFreeFunc,
     AppLayerDecoderEventsSetEventRaw: AppLayerDecoderEventsSetEventRawFunc,
     AppLayerDecoderEventsFreeEvents: AppLayerDecoderEventsFreeEventsFunc,
@@ -133,23 +133,6 @@ pub extern "C" fn rs_init(context: &'static mut SuricataContext)
     unsafe {
         SC = Some(context);
     }
-}
-
-/// SCLogMessage wrapper.
-pub fn sc_log_message(level: libc::c_int,
-                      filename: *const libc::c_char,
-                      line: libc::c_uint,
-                      function: *const libc::c_char,
-                      code: libc::c_int,
-                      message: *const libc::c_char) -> libc::c_int
-{
-    unsafe {
-        if let Some(c) = SC {
-            return (c.SCLogMessage)(level, filename, line, function,
-                                  code, message);
-        }
-    }
-    return 0;
 }
 
 /// DetectEngineStateFree wrapper.

--- a/src/app-layer-dns-tcp-rust.c
+++ b/src/app-layer-dns-tcp-rust.c
@@ -30,7 +30,9 @@
 #include "app-layer-dns-tcp-rust.h"
 #include "rust-dns-dns-gen.h"
 
+#ifdef UNITTESTS
 static void RustDNSTCPParserRegisterTests(void);
+#endif
 
 static int RustDNSTCPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,

--- a/src/app-layer-dns-udp-rust.c
+++ b/src/app-layer-dns-udp-rust.c
@@ -30,7 +30,9 @@
 #include "app-layer-dns-udp-rust.h"
 #include "rust-dns-dns-gen.h"
 
+#ifdef UNITTESTS
 static void RustDNSUDPParserRegisterTests(void);
+#endif
 
 static int RustDNSUDPParseRequest(Flow *f, void *state,
         AppLayerParserState *pstate, uint8_t *input, uint32_t input_len,


### PR DESCRIPTION
Previous PR: https://github.com/inliniac/suricata/pull/2795

- During configure, safe cargo path and CARGO_HOME so the same are used during "sudo make build" to prevent rebuilding as root.
- Safe string handling in Rust SCLog*.
- Make distcheck fixes.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/198
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/551
