### PR TITLE
log: wrap rotation and write in lock

### DIFF
--- a/src/util-debug.c
+++ b/src/util-debug.c
@@ -577,11 +577,13 @@ SCError SCLogMessage(const SCLogLevel log_level, const char *file,
                                           log_level, file, line, function,
                                           error_code, message) == 0)
                 {
+                    SCMutexLock(&op_iface_ctx->fp_mutex);
                     if (op_iface_ctx->rotation_flag) {
                         SCLogReopen(op_iface_ctx);
                         op_iface_ctx->rotation_flag = 0;
                     }
                     SCLogPrintToStream(op_iface_ctx->file_d, buffer);
+                    SCMutexUnlock(&op_iface_ctx->fp_mutex);
                 }
                 break;
             case SC_LOG_OP_IFACE_SYSLOG:
@@ -714,6 +716,7 @@ static inline SCLogOPIfaceCtx *SCLogInitFileOPIface(const char *file,
         goto error;
     }
 
+    SCMutexInit(&iface_ctx->fp_mutex, NULL);
     OutputRegisterFileRotationFlag(&iface_ctx->rotation_flag);
 
     iface_ctx->log_level = log_level;

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -139,6 +139,9 @@ typedef struct SCLogOPIfaceCtx_ {
     /* override for the global_log_format(currently not used) */
     const char *log_format;
 
+    /* Mutex used for locking around rotate/write to a file. */
+    SCMutex fp_mutex;
+
     struct SCLogOPIfaceCtx_ *next;
 } SCLogOPIfaceCtx;
 


### PR DESCRIPTION
The application log is subject to rotation, so the check for
rotation, the actual rotation and write needs to be done under
lock to ensure the file pointer is in a consisten state
at the time of write().

Fixes issue:
https://redmine.openinfosecfoundation.org/issues/2155

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/199
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/552
