### PR TITLE
rust/dns: handle multiple txt strings - 1

### DIFF
--- a/rust/src/dns/dns.rs
+++ b/rust/src/dns/dns.rs
@@ -149,7 +149,6 @@ pub struct DNSAnswerEntry {
     pub rrtype: u16,
     pub rrclass: u16,
     pub ttl: u32,
-    pub data_len: u16,
     pub data: Vec<u8>,
 }
 

--- a/rust/src/dns/log.rs
+++ b/rust/src/dns/log.rs
@@ -330,7 +330,7 @@ pub fn dns_print_addr(addr: &Vec<u8>) -> std::string::String {
 fn dns_log_sshfp(js: &Json, answer: &DNSAnswerEntry)
 {
     // Need at least 3 bytes - TODO: log something if we don't?
-    if answer.data_len < 3 {
+    if answer.data.len() < 3 {
         return;
     }
 


### PR DESCRIPTION
Fix handling of TXT records when there are multiple strings
in a single TXT record. For now, conform to the C implementation
where an answer record is created for each string in a single
txt record.

Also removes the data_len field from the answer entry. In Rust,
the length is available from actual data, which after decoding
may actually be different than the encoded data length, so just
use the length from the actual data.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/200
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/553
