### PR TITLE
New option for logging hash of truncated files

### DIFF
--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -90,6 +90,9 @@ The most common way to use this is through 'EVE', which is a firehose approach w
             # force logging of checksums, available hash functions are md5,
             # sha1 and sha256
             #force-hash: [md5]
+            # force hash calculation for truncated files
+            #force-hash-truncated: yes
+
         #- drop:
         #    alerts: yes      # log alerts that caused drops
         #    flows: all       # start or all: 'start' logs only a single drop

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -125,13 +125,12 @@ static int CallLoggers(ThreadVars *tv, OutputLoggerThreadStore *store_list,
 }
 
 
-/* ALFREDO*/
+/* for hashing truncated files... */
 #ifdef HAVE_NSS
 static void end_hash_truncated( File *ff )
 {
     if ( ff != NULL )
     {
-        SCLogInfo( "ALFREDO **** **** FHASH ff[%p] state[%d] store_id[%d] sha1[%p]", ff, ff->state, ff->file_store_id,ff->sha1_ctx );
         if (ff->md5_ctx) {
             unsigned int len = 0;
             HASH_End(ff->md5_ctx, ff->md5, &len, sizeof(ff->md5));
@@ -214,7 +213,7 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
              * close the logger(s) */
             if (FileDataSize(ff) == ff->content_stored &&
                 (file_trunc || file_close)) {
-                /* ALFREDO */
+                /* for hashing truncated files... */
 #ifdef HAVE_NSS
                 if ( FileForceHashTruncated() )
                     end_hash_truncated( ff );
@@ -239,7 +238,7 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
              * loggers */
             if ((file_close || file_trunc) && ff->state < FILE_STATE_CLOSED) {
                 ff->state = FILE_STATE_TRUNCATED;
-                /* ALFREDO */
+                /* for hashing truncated files... */
 #ifdef HAVE_NSS
                 if ( FileForceHashTruncated() )
                     end_hash_truncated( ff );

--- a/src/output-filedata.c
+++ b/src/output-filedata.c
@@ -124,6 +124,34 @@ static int CallLoggers(ThreadVars *tv, OutputLoggerThreadStore *store_list,
     return file_logged;
 }
 
+
+/* ALFREDO*/
+#ifdef HAVE_NSS
+static void end_hash_truncated( File *ff )
+{
+    if ( ff != NULL )
+    {
+        SCLogInfo( "ALFREDO **** **** FHASH ff[%p] state[%d] store_id[%d] sha1[%p]", ff, ff->state, ff->file_store_id,ff->sha1_ctx );
+        if (ff->md5_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->md5_ctx, ff->md5, &len, sizeof(ff->md5));
+            ff->flags |= FILE_MD5;
+        }
+        if (ff->sha1_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->sha1_ctx, ff->sha1, &len, sizeof(ff->sha1));
+            ff->flags |= FILE_SHA1;
+        }
+        if (ff->sha256_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->sha256_ctx, ff->sha256, &len, sizeof(ff->sha256));
+            ff->flags |= FILE_SHA256;
+        }
+    }
+}
+#endif
+
+
 static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
 {
     BUG_ON(thread_data == NULL);
@@ -186,6 +214,11 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
              * close the logger(s) */
             if (FileDataSize(ff) == ff->content_stored &&
                 (file_trunc || file_close)) {
+                /* ALFREDO */
+#ifdef HAVE_NSS
+                if ( FileForceHashTruncated() )
+                    end_hash_truncated( ff );
+#endif
                 CallLoggers(tv, store, p, ff, NULL, 0, OUTPUT_FILEDATA_FLAG_CLOSE);
                 ff->flags |= FILE_STORED;
                 continue;
@@ -206,6 +239,11 @@ static TmEcode OutputFiledataLog(ThreadVars *tv, Packet *p, void *thread_data)
              * loggers */
             if ((file_close || file_trunc) && ff->state < FILE_STATE_CLOSED) {
                 ff->state = FILE_STATE_TRUNCATED;
+                /* ALFREDO */
+#ifdef HAVE_NSS
+                if ( FileForceHashTruncated() )
+                    end_hash_truncated( ff );
+#endif
             }
 
             /* tell the logger we're closing up */

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -78,6 +78,42 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
+/* ALFREDO */
+#ifdef HAVE_NSS
+static void FileWriteJsonHash( const File *ff, json_t *fjs )
+{
+    if (ff->flags & FILE_MD5) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->md5); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->md5[x]);
+        }
+        json_object_set_new(fjs, "md5", json_string(str));
+    }
+
+    if (ff->flags & FILE_SHA1) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->sha1); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->sha1[x]);
+        }
+        json_object_set_new(fjs, "sha1", json_string(str));
+    }
+
+    if (ff->flags & FILE_SHA256) {
+        size_t x;
+        int i;
+        char str[256];
+        for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
+            i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
+        }
+        json_object_set_new(fjs, "sha256", json_string(str));
+    }
+}
+#endif
+
 /**
  *  \internal
  *  \brief Write meta data on a single line json record
@@ -139,38 +175,18 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             json_object_set_new(fjs, "state", json_string("CLOSED"));
+            /* ALFREDO */
 #ifdef HAVE_NSS
-            if (ff->flags & FILE_MD5) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->md5); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->md5[x]);
-                }
-                json_object_set_new(fjs, "md5", json_string(str));
-            }
-            if (ff->flags & FILE_SHA1) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->sha1); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->sha1[x]);
-                }
-                json_object_set_new(fjs, "sha1", json_string(str));
-            }
-            if (ff->flags & FILE_SHA256) {
-                size_t x;
-                int i;
-                char str[256];
-                for (i = 0, x = 0; x < sizeof(ff->sha256); x++) {
-                    i += snprintf(&str[i], 255-i, "%02x", ff->sha256[x]);
-                }
-                json_object_set_new(fjs, "sha256", json_string(str));
-            }
+            FileWriteJsonHash( ff, fjs );
 #endif
             break;
         case FILE_STATE_TRUNCATED:
             json_object_set_new(fjs, "state", json_string("TRUNCATED"));
+            /* ALFREDO */
+#ifdef HAVE_NSS
+            if ( FileForceHashTruncated() )
+                FileWriteJsonHash( ff, fjs );
+#endif
             break;
         case FILE_STATE_ERROR:
             json_object_set_new(fjs, "state", json_string("ERROR"));
@@ -304,6 +320,9 @@ static OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
         }
 
         FileForceHashParseCfg(conf);
+
+        /* ALFREDO */
+        FileForceHashTruncatedCfg(conf);
     }
 
     output_ctx->data = output_file_ctx;

--- a/src/output-json-file.c
+++ b/src/output-json-file.c
@@ -78,7 +78,7 @@ typedef struct JsonFileLogThread_ {
     MemBuffer *buffer;
 } JsonFileLogThread;
 
-/* ALFREDO */
+/* for hashing truncated files... */
 #ifdef HAVE_NSS
 static void FileWriteJsonHash( const File *ff, json_t *fjs )
 {
@@ -175,14 +175,14 @@ static void FileWriteJsonRecord(JsonFileLogThread *aft, const Packet *p, const F
     switch (ff->state) {
         case FILE_STATE_CLOSED:
             json_object_set_new(fjs, "state", json_string("CLOSED"));
-            /* ALFREDO */
+            /* for hashing truncated files... */
 #ifdef HAVE_NSS
             FileWriteJsonHash( ff, fjs );
 #endif
             break;
         case FILE_STATE_TRUNCATED:
             json_object_set_new(fjs, "state", json_string("TRUNCATED"));
-            /* ALFREDO */
+            /* for hashing truncated files... */
 #ifdef HAVE_NSS
             if ( FileForceHashTruncated() )
                 FileWriteJsonHash( ff, fjs );
@@ -321,7 +321,7 @@ static OutputCtx *OutputFileLogInitSub(ConfNode *conf, OutputCtx *parent_ctx)
 
         FileForceHashParseCfg(conf);
 
-        /* ALFREDO */
+        /* for hashing truncated files... */
         FileForceHashTruncatedCfg(conf);
     }
 

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -67,7 +67,7 @@ static int g_file_force_sha256 = 0;
  */
 static int g_file_force_tracking = 0;
 
-/* ALFREDO */
+/* for hashing truncated files... */
 /** \brief switch to force hash calculation on
  *         truncated files.
  */
@@ -155,20 +155,20 @@ void FileForceTrackingEnable(void)
     g_file_force_tracking = 1;
 }
 
-/* ALFREDO */
+/* for hashing truncated files... */
 int FileForceHashTruncated(void)
 {
     return g_file_force_hash_truncated;
 }
 
-/* ALFREDO */
+/* for hashing truncated files... */
 void FileForceHashTruncatedEnable(void)
 {
     g_file_force_hash_truncated = 1;
 }
 
 /**
- * ALFREDO
+ * for hashing truncated files...
  * \brief Function to parse forced truncated file hashing configuration.
  */
 void FileForceHashTruncatedCfg(ConfNode *conf)
@@ -917,7 +917,7 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
     if ((flags & FILE_TRUNCATED) || (ff->flags & FILE_HAS_GAPS)) {
         ff->state = FILE_STATE_TRUNCATED;
         SCLogDebug("flowfile state transitioned to FILE_STATE_TRUNCATED");
-        /* ALFREDO */
+        /* for hashing truncated files... */
 #ifdef HAVE_NSS
         if (ff->md5_ctx) {
             unsigned int len = 0;

--- a/src/util-file.c
+++ b/src/util-file.c
@@ -67,6 +67,12 @@ static int g_file_force_sha256 = 0;
  */
 static int g_file_force_tracking = 0;
 
+/* ALFREDO */
+/** \brief switch to force hash calculation on
+ *         truncated files.
+ */
+static int g_file_force_hash_truncated = 0;
+
 /** \brief switch to use g_file_store_reassembly_depth
  *         to reassembly files
  */
@@ -147,6 +153,42 @@ int FileForceSha256(void)
 void FileForceTrackingEnable(void)
 {
     g_file_force_tracking = 1;
+}
+
+/* ALFREDO */
+int FileForceHashTruncated(void)
+{
+    return g_file_force_hash_truncated;
+}
+
+/* ALFREDO */
+void FileForceHashTruncatedEnable(void)
+{
+    g_file_force_hash_truncated = 1;
+}
+
+/**
+ * ALFREDO
+ * \brief Function to parse forced truncated file hashing configuration.
+ */
+void FileForceHashTruncatedCfg(ConfNode *conf)
+{
+    BUG_ON(conf == NULL);
+
+    const char *forcehash_truncated = ConfNodeLookupChildValue( conf, "force-hash-truncated" );
+
+    if ( forcehash_truncated != NULL )
+    {
+        if ( ConfValIsTrue( forcehash_truncated ) )
+        {
+#ifdef HAVE_NSS
+        FileForceHashTruncatedEnable();
+        SCLogConfig("forcing hash calculation for truncated files");
+#else
+        SCLogInfo("hash calculation for truncated files requires linking against libnss");
+#endif
+        }
+    }
 }
 
 /**
@@ -875,7 +917,24 @@ static int FileCloseFilePtr(File *ff, const uint8_t *data,
     if ((flags & FILE_TRUNCATED) || (ff->flags & FILE_HAS_GAPS)) {
         ff->state = FILE_STATE_TRUNCATED;
         SCLogDebug("flowfile state transitioned to FILE_STATE_TRUNCATED");
-
+        /* ALFREDO */
+#ifdef HAVE_NSS
+        if (ff->md5_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->md5_ctx, ff->md5, &len, sizeof(ff->md5));
+            ff->flags |= FILE_MD5;
+        }
+        if (ff->sha1_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->sha1_ctx, ff->sha1, &len, sizeof(ff->sha1));
+            ff->flags |= FILE_SHA1;
+        }
+        if (ff->sha256_ctx) {
+            unsigned int len = 0;
+            HASH_End(ff->sha256_ctx, ff->sha256, &len, sizeof(ff->sha256));
+            ff->flags |= FILE_SHA256;
+        }
+#endif
         if (flags & FILE_NOSTORE) {
             SCLogDebug("not storing this file");
             ff->flags |= FILE_NOSTORE;

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -235,4 +235,9 @@ uint64_t FileTrackedSize(const File *file);
 
 uint16_t FileFlowToFlags(const Flow *flow, uint8_t direction);
 
+/* ALFREDO */
+void FileForceHashTruncatedCfg(ConfNode *);
+void FileForceHashTruncatedEnable(void);
+int FileForceHashTruncated(void);
+
 #endif /* __UTIL_FILE_H__ */

--- a/src/util-file.h
+++ b/src/util-file.h
@@ -235,7 +235,7 @@ uint64_t FileTrackedSize(const File *file);
 
 uint16_t FileFlowToFlags(const Flow *flow, uint8_t direction);
 
-/* ALFREDO */
+/* for hashing truncated files... */
 void FileForceHashTruncatedCfg(ConfNode *);
 void FileForceHashTruncatedEnable(void);
 int FileForceHashTruncated(void);


### PR DESCRIPTION
Hi,

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2147

Describe changes:
- Added a new option for eve-log files type named 'force-hash-truncated', this way the user can log the hash for truncated files if needed, the option is disabled by default.

Regarding the documentation I've just changed one file because I don't see clearly what files to change
