### PR TITLE
gcc7: fixes for format string warnings

### DIFF
--- a/src/app-layer-ssl.c
+++ b/src/app-layer-ssl.c
@@ -1051,35 +1051,42 @@ static int SSLv2Decode(uint8_t direction, SSLState *ssl_state,
                                 break;
                         }
 
+                        /* fall through */
                     case 4:
                         input++;
                         ssl_state->curr_connp->bytes_processed++;
                         if (--input_len == 0)
                             break;
 
+                        /* fall through */
                     case 5:
                         input++;
                         ssl_state->curr_connp->bytes_processed++;
                         if (--input_len == 0)
                             break;
 
+                        /* fall through */
                     case 6:
                         input++;
                         ssl_state->curr_connp->bytes_processed++;
                         if (--input_len == 0)
                             break;
 
+                        /* fall through */
                     case 7:
                         ssl_state->curr_connp->session_id_length = *(input++) << 8;
                         ssl_state->curr_connp->bytes_processed++;
                         if (--input_len == 0)
                             break;
 
+                        /* fall through */
                     case 8:
                         ssl_state->curr_connp->session_id_length |= *(input++);
                         ssl_state->curr_connp->bytes_processed++;
                         if (--input_len == 0)
                             break;
+
+                        /* fall through */
                 }
             }
 

--- a/src/log-httplog.c
+++ b/src/log-httplog.c
@@ -161,9 +161,9 @@ static void LogHttpLogCustom(LogHttpLogThread *aft, htp_tx_t *tx, const struct t
                 break;
             case LOG_CF_TIMESTAMP_U:
             /* TIMESTAMP USECONDS */
-                snprintf(buf, 6, "%06u", (unsigned int) ts->tv_usec);
+                snprintf(buf, sizeof(buf), "%06u", (unsigned int) ts->tv_usec);
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                            aft->buffer->size, (uint8_t *)buf,strlen(buf));
+                            aft->buffer->size, (uint8_t *)buf, MIN(strlen(buf),6));
                 break;
             case LOG_CF_CLIENT_IP:
             /* CLIENT IP ADDRESS */

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1218,7 +1218,11 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
                 tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday);
 
         /* create the filename to use */
-        snprintf(dirfull, PATH_MAX, "%s/%s", pl->dir, dirname);
+        int ret = snprintf(dirfull, sizeof(dirfull), "%s/%s", pl->dir, dirname);
+        if (ret < 0 || (size_t)ret >= sizeof(dirfull)) {
+            SCLogError(SC_ERR_SPRINTF,"failed to construct path");
+            goto error;
+        }
 
         /* if mkdir fails file open will fail, so deal with errors there */
 #ifndef OS_WIN32
@@ -1241,13 +1245,18 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
         }
 
     } else if (pl->mode == LOGMODE_NORMAL) {
+        int ret;
         /* create the filename to use */
         if (pl->timestamp_format == TS_FORMAT_SEC) {
-            snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32, pl->dir,
-                     pl->prefix, (uint32_t)ts.tv_sec);
+            ret = snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32, pl->dir,
+                    pl->prefix, (uint32_t)ts.tv_sec);
         } else {
-            snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32 ".%" PRIu32, pl->dir,
-                     pl->prefix, (uint32_t)ts.tv_sec, (uint32_t)ts.tv_usec);
+            ret = snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32 ".%" PRIu32, pl->dir,
+                    pl->prefix, (uint32_t)ts.tv_sec, (uint32_t)ts.tv_usec);
+        }
+        if (ret < 0 || (size_t)ret >= sizeof(filename)) {
+            SCLogError(SC_ERR_SPRINTF,"failed to construct path");
+            goto error;
         }
     } else if (pl->mode == LOGMODE_MULTI) {
         if (pl->filename_part_cnt > 0) {
@@ -1294,13 +1303,18 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
                 }
             }
         } else {
+            int ret;
             /* create the filename to use */
             if (pl->timestamp_format == TS_FORMAT_SEC) {
-                snprintf(filename, PATH_MAX, "%s/%s.%u.%" PRIu32, pl->dir,
+                ret = snprintf(filename, PATH_MAX, "%s/%s.%u.%" PRIu32, pl->dir,
                         pl->prefix, pl->thread_number, (uint32_t)ts.tv_sec);
             } else {
-                snprintf(filename, PATH_MAX, "%s/%s.%u.%" PRIu32 ".%" PRIu32, pl->dir,
+                ret = snprintf(filename, PATH_MAX, "%s/%s.%u.%" PRIu32 ".%" PRIu32, pl->dir,
                         pl->prefix, pl->thread_number, (uint32_t)ts.tv_sec, (uint32_t)ts.tv_usec);
+            }
+            if (ret < 0 || (size_t)ret >= sizeof(filename)) {
+                SCLogError(SC_ERR_SPRINTF,"failed to construct path");
+                goto error;
             }
         }
         SCLogDebug("multi-mode: filename %s", filename);

--- a/src/log-tlslog.c
+++ b/src/log-tlslog.c
@@ -342,7 +342,7 @@ static void LogTlsLogCustom(LogTlsLogThread *aft, SSLState *ssl_state, const str
 {
     LogTlsFileCtx *tlslog_ctx = aft->tlslog_ctx;
     uint32_t i;
-    char buf[6];
+    char buf[64];
 
     for (i = 0; i < tlslog_ctx->cf->cf_n; i++) {
 
@@ -361,9 +361,9 @@ static void LogTlsLogCustom(LogTlsLogThread *aft, SSLState *ssl_state, const str
                 break;
             case LOG_CF_TIMESTAMP_U:
             /* TIMESTAMP USECONDS */
-                snprintf(buf, 6, "%06u", (unsigned int) ts->tv_usec);
+                snprintf(buf, sizeof(buf), "%06u", (unsigned int) ts->tv_usec);
                 PrintRawUriBuf((char *)aft->buffer->buffer, &aft->buffer->offset,
-                            aft->buffer->size, (uint8_t *)buf,strlen(buf));
+                            aft->buffer->size, (uint8_t *)buf, MIN(strlen(buf),6));
                 break;
             case LOG_CF_CLIENT_IP:
             /* CLIENT IP ADDRESS */

--- a/src/runmode-unittests.h
+++ b/src/runmode-unittests.h
@@ -24,6 +24,7 @@
 #ifndef __UTIL_RUNMODE_UNITTESTS_H__
 #define __UTIL_RUNMODE_UNITTESTS_H__
 
+__attribute__((noreturn))
 void RunUnittests(int list_unittests, const char *regex_arg);
 
 #endif /* __UTIL_RUNMODE_UNITTESTS_H__ */

--- a/src/util-debug.h
+++ b/src/util-debug.h
@@ -217,7 +217,9 @@ extern int sc_log_module_cleaned;
         {                                                                       \
             char _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN];                           \
                                                                                 \
-            snprintf(_sc_log_msg, SC_LOG_MAX_LOG_MSG_LEN, __VA_ARGS__);         \
+            int _sc_log_ret = snprintf(_sc_log_msg, SC_LOG_MAX_LOG_MSG_LEN, __VA_ARGS__);   \
+            if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
+                _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
             SCLogMessage(x, file, line, func, SC_OK, _sc_log_msg);              \
         }                                                                       \
@@ -234,7 +236,9 @@ extern int sc_log_module_cleaned;
         {                                                                       \
             char _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN];                           \
                                                                                 \
-            snprintf(_sc_log_msg, SC_LOG_MAX_LOG_MSG_LEN, __VA_ARGS__);         \
+            int _sc_log_ret = snprintf(_sc_log_msg, SC_LOG_MAX_LOG_MSG_LEN, __VA_ARGS__);   \
+            if (_sc_log_ret == SC_LOG_MAX_LOG_MSG_LEN)                          \
+                _sc_log_msg[SC_LOG_MAX_LOG_MSG_LEN - 1] = '\0';                 \
                                                                                 \
             SCLogMessage(x, file, line, func, err, _sc_log_msg);                \
         }                                                                       \

--- a/src/util-hash-lookup3.c
+++ b/src/util-hash-lookup3.c
@@ -195,10 +195,10 @@ uint32_t        initval)         /* the previous hash, or an arbitrary value */
   /*------------------------------------------- handle the last 3 uint32_t's */
   switch(length)                     /* all the case statements fall through */
   { 
-  case 3 : c+=k[2];
-  case 2 : b+=k[1];
+  case 3 : c+=k[2]; /* fall through */
+  case 2 : b+=k[1]; /* fall through */
   case 1 : a+=k[0];
-    final(a,b,c);
+    final(a,b,c);   /* fall through */
   case 0:     /* case 0: nothing left to add */
     break;
   }
@@ -241,10 +241,10 @@ uint32_t       *pb)               /* IN: more seed OUT: secondary hash value */
   /*------------------------------------------- handle the last 3 uint32_t's */
   switch(length)                     /* all the case statements fall through */
   { 
-  case 3 : c+=k[2];
-  case 2 : b+=k[1];
+  case 3 : c+=k[2]; /* fall through */
+  case 2 : b+=k[1]; /* fall through */
   case 1 : a+=k[0];
-    final(a,b,c);
+    final(a,b,c);   /* fall through */
   case 0:     /* case 0: nothing left to add */
     break;
   }
@@ -428,17 +428,17 @@ uint32_t hashlittle( const void *key, size_t length, uint32_t initval)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
+    case 12: c+=((uint32_t)k[11])<<24;  /* fall through */
+    case 11: c+=((uint32_t)k[10])<<16;  /* fall through */
+    case 10: c+=((uint32_t)k[9])<<8;    /* fall through */
+    case 9 : c+=k[8];                   /* fall through */
+    case 8 : b+=((uint32_t)k[7])<<24;   /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<16;   /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<8;    /* fall through */
+    case 5 : b+=k[4];                   /* fall through */
+    case 4 : a+=((uint32_t)k[3])<<24;   /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<16;   /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<8;    /* fall through */
     case 1 : a+=k[0];
              break;
     case 0 : return c;
@@ -602,17 +602,17 @@ uint32_t hashlittle_safe(const void *key, size_t length, uint32_t initval)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
+    case 12: c+=((uint32_t)k[11])<<24;  /* fall through */
+    case 11: c+=((uint32_t)k[10])<<16;  /* fall through */
+    case 10: c+=((uint32_t)k[9])<<8;    /* fall through */
+    case 9 : c+=k[8];                   /* fall through */
+    case 8 : b+=((uint32_t)k[7])<<24;   /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<16;   /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<8;    /* fall through */
+    case 5 : b+=k[4];                   /* fall through */
+    case 4 : a+=((uint32_t)k[3])<<24;   /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<16;   /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<8;    /* fall through */
     case 1 : a+=k[0];
              break;
     case 0 : return c;
@@ -786,17 +786,17 @@ void hashlittle2(
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=((uint32_t)k[11])<<24;
-    case 11: c+=((uint32_t)k[10])<<16;
-    case 10: c+=((uint32_t)k[9])<<8;
-    case 9 : c+=k[8];
-    case 8 : b+=((uint32_t)k[7])<<24;
-    case 7 : b+=((uint32_t)k[6])<<16;
-    case 6 : b+=((uint32_t)k[5])<<8;
-    case 5 : b+=k[4];
-    case 4 : a+=((uint32_t)k[3])<<24;
-    case 3 : a+=((uint32_t)k[2])<<16;
-    case 2 : a+=((uint32_t)k[1])<<8;
+    case 12: c+=((uint32_t)k[11])<<24; /* fall through */
+    case 11: c+=((uint32_t)k[10])<<16; /* fall through */
+    case 10: c+=((uint32_t)k[9])<<8;   /* fall through */
+    case 9 : c+=k[8];                  /* fall through */
+    case 8 : b+=((uint32_t)k[7])<<24;  /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<16;  /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<8;   /* fall through */
+    case 5 : b+=k[4];                  /* fall through */
+    case 4 : a+=((uint32_t)k[3])<<24;  /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<16;  /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<8;   /* fall through */
     case 1 : a+=k[0];
              break;
     case 0 : *pc=c; *pb=b; return;  /* zero length strings require no mixing */
@@ -915,17 +915,17 @@ uint32_t hashbig( const void *key, size_t length, uint32_t initval)
     /*-------------------------------- last block: affect all 32 bits of (c) */
     switch(length)                   /* all the case statements fall through */
     {
-    case 12: c+=k[11];
-    case 11: c+=((uint32_t)k[10])<<8;
-    case 10: c+=((uint32_t)k[9])<<16;
-    case 9 : c+=((uint32_t)k[8])<<24;
-    case 8 : b+=k[7];
-    case 7 : b+=((uint32_t)k[6])<<8;
-    case 6 : b+=((uint32_t)k[5])<<16;
-    case 5 : b+=((uint32_t)k[4])<<24;
-    case 4 : a+=k[3];
-    case 3 : a+=((uint32_t)k[2])<<8;
-    case 2 : a+=((uint32_t)k[1])<<16;
+    case 12: c+=k[11];                  /* fall through */
+    case 11: c+=((uint32_t)k[10])<<8;   /* fall through */
+    case 10: c+=((uint32_t)k[9])<<16;   /* fall through */
+    case 9 : c+=((uint32_t)k[8])<<24;   /* fall through */
+    case 8 : b+=k[7];                   /* fall through */
+    case 7 : b+=((uint32_t)k[6])<<8;    /* fall through */
+    case 6 : b+=((uint32_t)k[5])<<16;   /* fall through */
+    case 5 : b+=((uint32_t)k[4])<<24;   /* fall through */
+    case 4 : a+=k[3];				    /* fall through */
+    case 3 : a+=((uint32_t)k[2])<<8;    /* fall through */
+    case 2 : a+=((uint32_t)k[1])<<16;   /* fall through */
     case 1 : a+=((uint32_t)k[0])<<24;
              break;
     case 0 : return c;


### PR DESCRIPTION
GCC 7.1.1 on Fedora gave several warnings with -Wimplicit-fallthrough
and -Wformat-truncation

This patch addresses the warnings.

https://redmine.openinfosecfoundation.org/issues/2176

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/166
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/675

