### PR TITLE
Rust/nfs/events/v7

### DIFF
--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -9,4 +9,5 @@ modbus-events.rules \
 app-layer-events.rules \
 files.rules \
 dnp3-events.rules \
-ntp-events.rules
+ntp-events.rules \
+nfs-events.rules

--- a/rules/nfs-events.rules
+++ b/rules/nfs-events.rules
@@ -1,0 +1,8 @@
+# NFS app layer event rules
+#
+# SID's fall in the 2223000+ range. See https://redmine.openinfosecfoundation.org/projects/suricata/wiki/AppLayer
+#
+# These sigs fire at most once per connection.
+#
+alert nfs any any -> any any (msg:"SURICATA NFS malformed request data"; flow:to_server; app-layer-event:nfs.malformed_data; classtype:protocol-command-decode; sid:2223000; rev:1;)
+alert nfs any any -> any any (msg:"SURICATA NFS malformed response data"; flow:to_client; app-layer-event:nfs.malformed_data; classtype:protocol-command-decode; sid:2223001; rev:1;)

--- a/rust/gen-c-headers.py
+++ b/rust/gen-c-headers.py
@@ -84,7 +84,9 @@ type_map = {
     "DetectEngineState": "DetectEngineState",
     "core::DetectEngineState": "DetectEngineState",
     "core::AppLayerDecoderEvents": "AppLayerDecoderEvents",
+    "AppLayerDecoderEvents": "AppLayerDecoderEvents",
     "core::AppLayerEventType": "AppLayerEventType",
+    "AppLayerEventType": "AppLayerEventType",
     "CLuaState": "lua_State",
     "Store": "Store",
 }

--- a/src/app-layer-nfs-tcp.h
+++ b/src/app-layer-nfs-tcp.h
@@ -24,6 +24,8 @@
 #ifndef __APP_LAYER_NFS_TCP_H__
 #define __APP_LAYER_NFS_TCP_H__
 
+#include "app-layer-events.h"
+
 void RegisterNFSTCPParsers(void);
 void NFSTCPParserRegisterTests(void);
 

--- a/src/detect-rpc.c
+++ b/src/detect-rpc.c
@@ -192,7 +192,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
     rd->procedure = 0;
 
     int i;
-    for (i = 0; i < (ret -1); i++) {
+    for (i = 0; i < (ret - 1); i++) {
         if (args[i]) {
             switch (i) {
                 case 0:
@@ -201,7 +201,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
                         goto error;
                     }
                     rd->flags |= DETECT_RPC_CHECK_PROGRAM;
-                break;
+                    break;
                 case 1:
                     if (args[i][0] != '*') {
                         if (ByteExtractStringUint32(&rd->program_version, 10, strlen(args[i]), args[i]) <= 0) {
@@ -210,7 +210,7 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
                         }
                         rd->flags |= DETECT_RPC_CHECK_VERSION;
                     }
-                break;
+                    break;
                 case 2:
                     if (args[i][0] != '*') {
                         if (ByteExtractStringUint32(&rd->procedure, 10, strlen(args[i]), args[i]) <= 0) {
@@ -220,11 +220,11 @@ static DetectRpcData *DetectRpcParse (const char *rpcstr)
                         rd->flags |= DETECT_RPC_CHECK_PROCEDURE;
                     }
                 break;
-                }
-            } else {
-                SCLogError(SC_ERR_INVALID_VALUE, "invalid rpc option %s",args[i]);
-                goto error;
             }
+        } else {
+            SCLogError(SC_ERR_INVALID_VALUE, "invalid rpc option %s",rpcstr);
+            goto error;
+        }
     }
     for (i = 0; i < (ret -1); i++){
         if (args[i] != NULL)

--- a/src/log-pcap.c
+++ b/src/log-pcap.c
@@ -1254,7 +1254,7 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
             ret = snprintf(filename, PATH_MAX, "%s/%s.%" PRIu32 ".%" PRIu32, pl->dir,
                     pl->prefix, (uint32_t)ts.tv_sec, (uint32_t)ts.tv_usec);
         }
-        if (ret < 0 || (size_t)ret >= sizeof(filename)) {
+        if (ret < 0 || (size_t)ret >= PATH_MAX) {
             SCLogError(SC_ERR_SPRINTF,"failed to construct path");
             goto error;
         }
@@ -1312,7 +1312,7 @@ static int PcapLogOpenFileCtx(PcapLogData *pl)
                 ret = snprintf(filename, PATH_MAX, "%s/%s.%u.%" PRIu32 ".%" PRIu32, pl->dir,
                         pl->prefix, pl->thread_number, (uint32_t)ts.tv_sec, (uint32_t)ts.tv_usec);
             }
-            if (ret < 0 || (size_t)ret >= sizeof(filename)) {
+            if (ret < 0 || (size_t)ret >= PATH_MAX) {
                 SCLogError(SC_ERR_SPRINTF,"failed to construct path");
                 goto error;
             }

--- a/src/runmode-erf-file.c
+++ b/src/runmode-erf-file.c
@@ -118,7 +118,7 @@ int RunModeErfFileAutoFp(void)
     char qname[TM_QUEUE_NAME_MAX];
     uint16_t cpu = 0;
     char *queues = NULL;
-    int thread;
+    uint16_t thread;
 
     RunModeInitialize();
 
@@ -145,6 +145,8 @@ int RunModeErfFileAutoFp(void)
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+    if (thread_max > 1024)
+        thread_max = 1024;
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -189,9 +191,9 @@ int RunModeErfFileAutoFp(void)
         exit(EXIT_FAILURE);
     }
 
-    for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_workers, thread+1);
-        snprintf(qname, sizeof(qname), "pickup%d", thread+1);
+    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
+        snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
+        snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
 

--- a/src/runmode-pcap-file.c
+++ b/src/runmode-pcap-file.c
@@ -151,7 +151,7 @@ int RunModeFilePcapAutoFp(void)
     char qname[TM_QUEUE_NAME_MAX];
     uint16_t cpu = 0;
     char *queues = NULL;
-    int thread;
+    uint16_t thread;
 
     RunModeInitialize();
 
@@ -180,6 +180,8 @@ int RunModeFilePcapAutoFp(void)
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+    if (thread_max > 1024)
+        thread_max = 1024;
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -222,9 +224,9 @@ int RunModeFilePcapAutoFp(void)
         exit(EXIT_FAILURE);
     }
 
-    for (thread = 0; thread < thread_max; thread++) {
+    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
         snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
-        snprintf(qname, sizeof(qname), "pickup%d", thread+1);
+        snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
         SCLogDebug("Assigning %s affinity to cpu %u", tname, cpu);

--- a/src/util-radix-tree.c
+++ b/src/util-radix-tree.c
@@ -746,21 +746,18 @@ static SCRadixNode *SCRadixAddKey(uint8_t *key_stream, uint16_t key_bitlen,
                     break;
             }
 
-            if ( (inter_node->netmasks = SCMalloc((node->netmask_cnt - i) *
-                                                sizeof(uint8_t))) == NULL) {
-                SCLogError(SC_ERR_MEM_ALLOC, "Fatal error encountered in SCRadixAddKey. Mem not allocated...");
-                return NULL;
-            }
+            if (i < node->netmask_cnt) {
+                if ( (inter_node->netmasks = SCMalloc((node->netmask_cnt - i) *
+                                sizeof(uint8_t))) == NULL) {
+                    SCLogError(SC_ERR_MEM_ALLOC, "Fatal error encountered in SCRadixAddKey. Mem not allocated...");
+                    return NULL;
+                }
 
-            for (j = 0; j < (node->netmask_cnt - i); j++)
-                inter_node->netmasks[j] = node->netmasks[i + j];
+                for (j = 0; j < (node->netmask_cnt - i); j++)
+                    inter_node->netmasks[j] = node->netmasks[i + j];
 
-            inter_node->netmask_cnt = (node->netmask_cnt - i);
-            node->netmask_cnt = i;
-
-            if (node->netmask_cnt == 0) {
-                SCFree(node->netmasks);
-                node->netmasks = NULL;
+                inter_node->netmask_cnt = (node->netmask_cnt - i);
+                node->netmask_cnt = i;
             }
         }
 

--- a/src/util-runmodes.c
+++ b/src/util-runmodes.c
@@ -95,7 +95,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
     char tname[TM_THREAD_NAME_MAX];
     char qname[TM_QUEUE_NAME_MAX];
     char *queues = NULL;
-    int thread = 0;
+    uint16_t thread = 0;
+
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
     int nlive = LiveGetDeviceCount();
@@ -105,6 +106,8 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+    if (thread_max > 1024)
+        thread_max = 1024;
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -224,9 +227,9 @@ int RunModeSetLiveCaptureAutoFp(ConfigIfaceParserFunc ConfigParser,
         }
     }
 
-    for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_workers, thread+1);
-        snprintf(qname, sizeof(qname), "pickup%d", thread+1);
+    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
+        snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
+        snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
 
@@ -429,7 +432,7 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
     TmModule *tm_module ;
     const char *cur_queue = NULL;
     char *queues = NULL;
-    int thread;
+    uint16_t thread;
 
     /* Available cpus */
     uint16_t ncpus = UtilCpuGetNumProcessorsOnline();
@@ -441,6 +444,8 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
         thread_max = ncpus * threading_detect_ratio;
     if (thread_max < 1)
         thread_max = 1;
+    if (thread_max > 1024)
+        thread_max = 1024;
 
     queues = RunmodeAutoFpCreatePickupQueuesString(thread_max);
     if (queues == NULL) {
@@ -488,9 +493,9 @@ int RunModeSetIPSAutoFp(ConfigIPSParserFunc ConfigParser,
         }
 
     }
-    for (thread = 0; thread < thread_max; thread++) {
-        snprintf(tname, sizeof(tname), "%s#%02d", thread_name_workers, thread+1);
-        snprintf(qname, sizeof(qname), "pickup%d", thread+1);
+    for (thread = 0; thread < (uint16_t)thread_max; thread++) {
+        snprintf(tname, sizeof(tname), "%s#%02u", thread_name_workers, thread+1);
+        snprintf(qname, sizeof(qname), "pickup%u", thread+1);
 
         SCLogDebug("tname %s, qname %s", tname, qname);
 


### PR DESCRIPTION
Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2175

Describe changes:
- reduce use of panics on exceptions in nfs parser in favor of using events

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- PR inliniac-pcap: https://buildbot.openinfosecfoundation.org/builders/inliniac-pcap/builds/170
- PR inliniac: https://buildbot.openinfosecfoundation.org/builders/inliniac/builds/679
