### PR TITLE
rust - more fixups - 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,16 +64,16 @@ matrix:
         - NAME="linux,gcc,rust"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - ARGS="--enable-rust"
-    # Linux, gcc, Rust (1.7.0 - oldest supported).
+        - ARGS="--enable-rust --enable-rust-strict"
+    # Linux, gcc, Rust (1.15.0 - oldest supported).
     - os: linux
       compiler: gcc
       env:
-        - NAME="linux,gcc,rust-1.7.0"
+        - NAME="linux,gcc,rust-1.15.0"
         - *default-cflags
         - ENABLE_RUST="yes"
-        - RUST_VERSION="1.7.0"
-        - ARGS="--enable-rust"
+        - RUST_VERSION="1.15.0"
+        - ARGS="--enable-rust --enable-rust-strict"
     # Linux, gcc, -DNDEBUG.
     - os: linux
       compiler: gcc

--- a/configure.ac
+++ b/configure.ac
@@ -2055,6 +2055,13 @@
     fi
     AM_CONDITIONAL([HAVE_CARGO_VENDOR], [test "x$HAVE_CARGO_VENDOR" != "xno"])
 
+    AC_ARG_ENABLE(rust_strict,
+           AS_HELP_STRING([--enable-rust-strict], [Rust warnings as errors]),,[enable_rust_strict=no])
+    AS_IF([test "x$enable_rust_strict" = "xyes"], [
+        RUST_FEATURES="strict"
+    ])
+    AC_SUBST(RUST_FEATURES)
+
 # get revision
     if test -f ./revision; then
         REVISION=`cat ./revision`
@@ -2168,6 +2175,7 @@ SURICATA_BUILD_CONF="Suricata Configuration:
 
   Rust support (experimental):             ${enable_rust}
   Experimental Rust parsers:               ${enable_rust_experimental}
+  Rust strict mode:                        ${enable_rust_strict}
 
   Suricatasc install:                      ${enable_python}
 

--- a/configure.ac
+++ b/configure.ac
@@ -1977,6 +1977,14 @@
     if test "x$enable_rust" != "xyes"; then
       enable_rust="no"
     else
+      # Rust require jansson (json support).
+      if test "x$enable_jansson" = "xno"; then
+        echo ""
+        echo "   ERROR! Rust support requires jansson."
+        echo ""
+        exit 1
+      fi
+
       AC_PATH_PROG(HAVE_CARGO, cargo, "no")
       AC_PATH_PROG(HAVE_RUSTC, rustc, "no")
 

--- a/rust/Cargo.toml.in
+++ b/rust/Cargo.toml.in
@@ -11,6 +11,7 @@ debug = true
 [features]
 lua = []
 experimental = ["ntp-parser"]
+strict = []
 
 [dependencies]
 nom = "~3.0"

--- a/rust/Makefile.am
+++ b/rust/Makefile.am
@@ -19,14 +19,14 @@ if !DEBUG
 RELEASE = --release
 endif
 
-FEATURES =
+RUST_FEATURES =
 
 if HAVE_LUA
-FEATURES +=	lua
+RUST_FEATURES +=	lua
 endif
 
 if HAVE_RUST_EXTERNAL
-FEATURES +=	experimental
+RUST_FEATURES +=	experimental
 endif
 
 all-local:
@@ -35,11 +35,11 @@ if HAVE_PYTHON
 		$(HAVE_PYTHON) ./gen-c-headers.py && \
 		CARGO_TARGET_DIR=$(abs_builddir)/target \
 		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(FEATURES)"
+			--features "$(RUST_FEATURES)"
 else
 	cd $(top_srcdir)/rust && CARGO_TARGET_DIR=$(abs_builddir)/target \
 		CARGO_HOME=$(CARGO_HOME) $(CARGO) build $(RELEASE) $(FROZEN) \
-			--features "$(FEATURES)"
+			--features "$(RUST_FEATURES)"
 endif
 
 clean-local:

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,6 +15,8 @@
  * 02110-1301, USA.
  */
 
+#![cfg_attr(feature = "strict", deny(warnings))]
+
 extern crate libc;
 
 #[macro_use]


### PR DESCRIPTION
- New configure argument, --enable-rust-strict which simply turned Rust warnings into errors.
- Use --enable-rust-strict on Travis-CI.
- Update the minimum Rust version to 1.15.0 on Travis.
https://redmine.openinfosecfoundation.org/issues/2184
- Fail configure if --enable-rust is provided, but Jansson is not available.
https://redmine.openinfosecfoundation.org/issues/2185

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/202
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/555
