### PR TITLE
dnp3: use BasicSearch instead of memmem

### DIFF
--- a/src/app-layer-dnp3.c
+++ b/src/app-layer-dnp3.c
@@ -258,7 +258,7 @@ static int DNP3CheckStartBytes(const DNP3LinkHeader *header)
  */
 static int DNP3ContainsBanner(const uint8_t *input, uint32_t len)
 {
-    return memmem(input, len, banner, strlen(banner)) != NULL;
+    return BasicSearch(input, len, (uint8_t *)banner, strlen(banner)) != NULL;
 }
 
 /**


### PR DESCRIPTION
Mingw doesn't support memmem.

Note, there is a unit test, DNP3ProbingParserTest that tests a probe with a banner, which uses this function.

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/203
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/556
