### PR TITLE
app-layer-ssh: trigger bypass when done

### DIFF
--- a/src/app-layer-ssh.c
+++ b/src/app-layer-ssh.c
@@ -434,6 +434,7 @@ static int SSHParseRequest(Flow *f, void *state, AppLayerParserState *pstate,
         ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE) {
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
+        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
     }
 
     SCReturnInt(r);
@@ -458,6 +459,7 @@ static int SSHParseResponse(Flow *f, void *state, AppLayerParserState *pstate,
         ssh_state->srv_hdr.flags & SSH_FLAG_PARSER_DONE) {
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_INSPECTION);
         AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_NO_REASSEMBLY);
+        AppLayerParserStateSetFlag(pstate, APP_LAYER_PARSER_BYPASS_READY);
     }
 
     SCReturnInt(r);


### PR DESCRIPTION
Trigger bypass when application layer will not inspect anymore.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

PR builds:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/311
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/95

