### PR TITLE
af-packet: optimize BPF

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2085,7 +2085,7 @@ TmEcode AFPSetBPFFilter(AFPThreadVars *ptv)
                 ptv->datalink,    /* linktype_arg */
                 &filter,       /* program */
                 ptv->bpf_filter, /* const char *buf */
-                0,             /* optimize */
+                1,             /* optimize */
                 0              /* mask */
                 ) == -1) {
         SCLogError(SC_ERR_AFP_CREATE, "Filter compilation failed.");


### PR DESCRIPTION
This patch turn on code optimization on BPF filter building by
libpcap. This allow to reduce the size of the BPF bytecode and
thus increase the size of BPF filter supported by Suricata.

Reported-by: Martijn van Oosterhout

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: https://redmine.openinfosecfoundation.org/issues/2170

PRscript:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/312
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/96

