### PR TITLE
samples: systemd unit file and logrotate configuration file - 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2152,7 +2152,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile contrib/suricata.logrotate suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile contrib/suricata.logrotate contrib/suricata.service suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/configure.ac
+++ b/configure.ac
@@ -2152,7 +2152,7 @@ AC_SUBST(CONFIGURE_SYSCONDIR)
 AC_SUBST(CONFIGURE_LOCALSTATEDIR)
 AC_SUBST(PACKAGE_VERSION)
 
-AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
+AC_OUTPUT(Makefile src/Makefile rust/Makefile rust/Cargo.toml rust/.cargo/config qa/Makefile qa/coccinelle/Makefile rules/Makefile doc/Makefile doc/userguide/Makefile contrib/Makefile contrib/file_processor/Makefile contrib/file_processor/Action/Makefile contrib/file_processor/Processor/Makefile contrib/tile_pcie_logd/Makefile contrib/suricata.logrotate suricata.yaml scripts/Makefile scripts/suricatasc/Makefile scripts/suricatasc/suricatasc)
 
 SURICATA_BUILD_CONF="Suricata Configuration:
   AF_PACKET support:                       ${enable_af_packet}

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,4 +1,5 @@
 SUBDIRS = file_processor tile_pcie_logd
 
 EXTRA_DIST = suri-graphite \
-             suricata.logrotate.in
+             suricata.logrotate.in \
+             suricata.service.in

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,3 +1,4 @@
 SUBDIRS = file_processor tile_pcie_logd
 
-EXTRA_DIST = suri-graphite
+EXTRA_DIST = suri-graphite \
+             suricata.logrotate.in

--- a/contrib/suricata.logrotate.in
+++ b/contrib/suricata.logrotate.in
@@ -1,0 +1,13 @@
+# Sample /etc/logrotate.d/suricata configuration file.
+@e_logdir@*.log @e_logdir@*.json {
+        daily
+        missingok
+        rotate 5
+        compress
+        delaycompress
+        minsize 500k
+	sharedscripts
+	postrotate
+	    /bin/kill -HUP `cat @e_rundir@suricata.pid 2> /dev/null` 2> /dev/null || true
+	endscript
+}

--- a/contrib/suricata.service.in
+++ b/contrib/suricata.service.in
@@ -1,0 +1,16 @@
+# Sample Suricata systemd unit file.
+[Unit]
+Description=Suricata Intrusion Detection Service
+After=syslog.target network-online.target
+
+[Service]
+# Environment file to pick up $OPTIONS. On Fedora/EL this would be
+# /etc/sysconfig/suricata, or on Debian/Ubuntu, /etc/default/suricata.
+#EnvironmentFile=-/etc/sysconfig/suricata
+#EnvironmentFile=-/etc/default/suricata
+ExecStartPre=/bin/rm -f @e_rundir@suricata.pid
+ExecStart=/sbin/suricata -c @e_sysconfdir@suricata.yaml --pidfile @e_rundir@suricata.pid $OPTIONS
+ExecReload=/bin/kill -USR2 $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a sample logrotate configuration file, and a systemd unit file.

These are in contrib, not sure if there was a better place. Perhaps creating an etc directory?

Prscript:
- PR jasonish-pcap: https://buildbot.openinfosecfoundation.org/builders/jasonish-pcap/builds/207
- PR jasonish: https://buildbot.openinfosecfoundation.org/builders/jasonish/builds/560
