### PR TITLE
rule-parser: ignore duplicated msg keyword

### DIFF
--- a/src/detect-msg.c
+++ b/src/detect-msg.c
@@ -103,6 +103,10 @@ static int DetectMsgSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ms
         }
     }
 
+    if (s->msg != NULL) {
+        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "Duplicated 'msg:' keyword detected!");
+        goto error;
+    }
     s->msg = SCStrdup(str);
     if (s->msg == NULL)
         goto error;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/issues/2074) ticket:

Describe changes:

- This fixes the leak resulted by duplicated msg keyword
- This also fails with -T as requested by previous PR

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/49
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/51