### PR TITLE
Rust/Lua: cast value to arch-dependant type (fix build on x86, #2197)

### DIFF
--- a/rust/src/lua.rs
+++ b/rust/src/lua.rs
@@ -43,7 +43,7 @@ impl LuaState {
 
     pub fn settable(&self, idx: i64) {
         unsafe {
-            lua_settable(self.lua, idx);
+            lua_settable(self.lua, idx as c_long);
         }
     }
 
@@ -55,7 +55,7 @@ impl LuaState {
 
     pub fn pushinteger(&self, val: i64) {
         unsafe {
-            lua_pushinteger(self.lua, val);
+            lua_pushinteger(self.lua, val as c_long);
         }
     }
 }


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
- [#2197](https://redmine.openinfosecfoundation.org/issues/2197)

Describe changes:
- Fix build on x86 : Lua functions expects a `long` value, and the Rust code was passing an `i64`, causing a type error. Fix: cast value as `c_long`.
