### PR TITLE
redis: support for rpush in list mode (Feature Request: #2114)

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -288,7 +288,9 @@ integration with 3rd party tools like logstash.
       #  server: 127.0.0.1
       #  port: 6379
       #  async: true ## if redis replies are read asynchronously
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -25,7 +25,9 @@ The most common way to use this is through 'EVE', which is a firehose approach w
       #  server: 127.0.0.1
       #  port: 6379
       #  async: true ## if redis replies are read asynchronously
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network
@@ -140,7 +142,9 @@ Output types::
       #  server: 127.0.0.1
       #  port: 6379
       #  async: true ## if redis replies are read asynchronously
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network

--- a/src/util-error.c
+++ b/src/util-error.c
@@ -341,6 +341,7 @@ const char * SCErrorToString(SCError err)
         CASE_CODE (SC_WARN_LOG_CF_TOO_MANY_NODES);
         CASE_CODE (SC_WARN_EVENT_DROPPED);
         CASE_CODE (SC_ERR_NO_REDIS_ASYNC);
+        CASE_CODE (SC_ERR_REDIS_CONFIG);
     }
 
     return "UNKNOWN_ERROR";

--- a/src/util-error.h
+++ b/src/util-error.h
@@ -330,7 +330,8 @@ typedef enum {
     SC_WARN_CHMOD,
     SC_WARN_LOG_CF_TOO_MANY_NODES,
     SC_WARN_EVENT_DROPPED,
-    SC_ERR_NO_REDIS_ASYNC
+    SC_ERR_NO_REDIS_ASYNC,
+    SC_ERR_REDIS_CONFIG
 } SCError;
 
 const char *SCErrorToString(SCError);

--- a/src/util-log-redis.c
+++ b/src/util-log-redis.c
@@ -33,7 +33,8 @@
 #include <event2/thread.h>
 #endif /* HAVE_LIBEVENT_PTHREADS */
 
-static const char * redis_push_cmd = "LPUSH";
+static const char * redis_lpush_cmd = "LPUSH";
+static const char * redis_rpush_cmd = "RPUSH";
 static const char * redis_publish_cmd = "PUBLISH";
 static const char * redis_default_key = "suricata";
 static const char * redis_default_server = "127.0.0.1";
@@ -497,11 +498,17 @@ int SCConfLogOpenRedis(ConfNode *redis_node, void *lf_ctx)
         log_ctx->redis_setup.batch_size = 0;
     }
 
-    if (!strcmp(redis_mode, "list")) {
-        log_ctx->redis_setup.command = redis_push_cmd;
-    } else {
+    if (!strcmp(redis_mode, "list") || !strcmp(redis_mode,"lpush")) {
+        log_ctx->redis_setup.command = redis_lpush_cmd;
+    } else if(!strcmp(redis_mode, "rpush")){
+        log_ctx->redis_setup.command = redis_rpush_cmd;
+    } else if(!strcmp(redis_mode,"channel") || !strcmp(redis_mode,"publish")) {
         log_ctx->redis_setup.command = redis_publish_cmd;
+    } else {
+        SCLogError(SC_ERR_REDIS_CONFIG,"Invalid redis mode");
+        exit(EXIT_FAILURE);
     }
+
     /* store server params for reconnection */
     if (!log_ctx->redis_setup.server) {
         SCLogError(SC_ERR_MEM_ALLOC, "Error allocating redis server string");

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -152,7 +152,9 @@ outputs:
       #  server: 127.0.0.1
       #  port: 6379
       #  async: true ## if redis replies are read asynchronously
-      #  mode: list ## possible values: list (default), channel
+      #  mode: list ## possible values: list|lpush (default), rpush, channel|publish
+      #             ## lpush and rpush are using a Redis list. "list" is an alias for lpush
+      #             ## publish is using a Redis channel. "channel" is an alias for publish
       #  key: suricata ## key or channel to use (default to suricata)
       # Redis pipelining set up. This will enable to only do a query every
       # 'batch-size' events. This should lower the latency induced by network


### PR DESCRIPTION
This adds a new redis mode rpush. Also more consistent config keywords orientated at the redis command: lpush and publish.
Keeping list and channel config keywords for backwards compatibility

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2114

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

