### PR TITLE
Creating New Section "5.4 Testing Rules" in the user guide documentation

### DIFF
--- a/doc/userguide/rule-management/index.rst
+++ b/doc/userguide/rule-management/index.rst
@@ -6,3 +6,4 @@ Rule Management
   oinkmaster
   adding-your-own-rules
   rule-reload
+  testing-rules

--- a/doc/userguide/rule-management/index.rst
+++ b/doc/userguide/rule-management/index.rst
@@ -6,4 +6,4 @@ Rule Management
   oinkmaster
   adding-your-own-rules
   rule-reload
-  testing-rules
+  test-rules

--- a/doc/userguide/rule-management/test-rules.rst
+++ b/doc/userguide/rule-management/test-rules.rst
@@ -1,5 +1,38 @@
-examples
+Testing Rules
+=============
 
-  one
-  two
-  three
+In this tutorial we will craft packets that can trigger suricata's rules, using scapy (a python module which can be ran in interactive mode as well), scapy is a great Network Packet Manipulation tool (it can forge/sniff packets) for more information on how to use it check out scapy's main website: http://www.secdev.org/projects/scapy/
+
+First lets create a simple/small rule in /etc/suricata/rules/local.rules
+say for example:
+::
+
+  alert udp any any -> any any (msg:"A Testing rule fired"; content:"Suricata"; nocase; sid:1; rev:1;)
+
+to create a packet that will trigger the rule above, run scapy in a terminal (it will need root Privileges to send packets):
+
+::
+
+  # scapy
+  WARNING: No route found for IPv6 destination :: (no default route?)
+  Welcome to Scapy (2.2.0)
+  >>>
+
+first we define a source/destination IP addresses, then source/destination ports, a payload and we send the packet we made:
+
+::
+
+  >>> ip=IP(src="192.168.2.1", dst="172.16.23.1")
+  >>> udp=UDP(dport=1542, sport=8415)
+  >>> payload="Suricata"
+  >>> send(ip/udp/payload)
+  .
+  Sent 1 packets.
+
+by now there should an alert in /var/log/suricata/fast.log that looks kind of like this:
+:: 
+  08/01/2017-16:15:52.731917  [**] [1:1] A Testing rule fired [**] ... {UDP} 192.168.2.1:1542 -> 172.16.23.1:8415
+
+
+
+ 

--- a/doc/userguide/rule-management/test-rules.rst
+++ b/doc/userguide/rule-management/test-rules.rst
@@ -31,7 +31,7 @@ first we define a source/destination IP addresses, then source/destination ports
 
 by now there should an alert in /var/log/suricata/fast.log that looks kind of like this:
 :: 
-  08/01/2017-16:15:52.731917  [**] [1:1] A Testing rule fired [**] ... {UDP} 192.168.2.1:1542 -> 172.16.23.1:8415
+  08/04/2017-04:34:32.668027  [**] [1:1:1] A Testing rule fired [**] [Classification: (null)] [Priority: 3] {UDP} 192.168.2.1:8415 -> 172.16.23.1:1542
 
 
 

--- a/doc/userguide/rule-management/test-rules.rst
+++ b/doc/userguide/rule-management/test-rules.rst
@@ -1,0 +1,5 @@
+examples
+
+  one
+  two
+  three


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- Added a new section "5.4 Testing Rules" 
- Included simple examples to trigger rules with scapy

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

