### PR TITLE
verbosity: add more details for help command and manpage

### DIFF
--- a/doc/userguide/partials/options.rst
+++ b/doc/userguide/partials/options.rst
@@ -18,8 +18,9 @@
 
 .. option:: -v
 
-   The -v option enables more verbosity of Suricata's output. Supply
-   multiple times for more verbosity.
+   The -v option enables more verbosity of Suricata's output to include "Info"
+   output. Supply multiple times for more verbosity to add "Perf" (-vv) and
+   "Config" (-vvv) output.
 
 .. Basic input options.
 

--- a/src/suricata.c
+++ b/src/suricata.c
@@ -624,7 +624,9 @@ static void PrintUsage(const char *progname)
 #endif /* OS_WIN32 */
     printf("\t-k [all|none]                        : force checksum check (all) or disabled it (none)\n");
     printf("\t-V                                   : display Suricata version\n");
-    printf("\t-v[v]                                : increase default Suricata verbosity\n");
+    printf("\t-v                                   : increase default Suricata verbosity with \"Info\" output\n");
+    printf("\t-vv                                  : increase default Suricata verbosity even more with additonal \"Perf\" output\n");
+    printf("\t-vvv                                 : increase default Suricata verbosity also with additional \"Config\" output\n");
 #ifdef UNITTESTS
     printf("\t-u                                   : run the unittests and exit\n");
     printf("\t-U, --unittest-filter=REGEX          : filter unittests with a regex\n");


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/1851

Describe changes:

This adds the detailed information about the different verbosity output options level we offer (Info, Perf, Config) to the -h help command and the manpage.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/52
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/54