### PR TITLE
Fix dup keywords

### DIFF
--- a/src/detect-classtype.c
+++ b/src/detect-classtype.c
@@ -121,6 +121,12 @@ static int DetectClasstypeSetup(DetectEngineCtx *de_ctx, Signature *s, const cha
         goto error;
     }
 
+    if ((s->class > 0) || (s->class_msg != NULL))
+    {
+        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "duplicated 'classtype' keyword detected");
+        goto error;
+    }
+
     /* if we have retrieved the classtype, assign the message to be displayed
      * for this Signature by fast.log, if a Packet matches this Signature */
     s->class = ct->classtype_id;

--- a/src/detect-engine-siggroup.c
+++ b/src/detect-engine-siggroup.c
@@ -809,21 +809,12 @@ static int SigGroupHeadTest06(void)
 
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+                               "content:\"test2\"; content:\"test3\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
-
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
-    if (prev_sig->next == NULL) {
-        result = 0;
-        goto end;
-    }
-    prev_sig = prev_sig->next;
 
     prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
                              "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
@@ -852,6 +843,15 @@ static int SigGroupHeadTest06(void)
     }
     prev_sig = prev_sig->next;
 
+    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
+                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
+                             "content:\"test2\"; content:\"test3\"; sid:5;)");
+    if (prev_sig->next == NULL) {
+        result = 0;
+        goto end;
+    }
+    prev_sig = prev_sig->next;
+
     SigAddressPrepareStage1(de_ctx);
 
     SigGroupHeadAppendSig(de_ctx, &sh, de_ctx->sig_list);
@@ -861,11 +861,11 @@ static int SigGroupHeadTest06(void)
     SigGroupHeadSetSigCnt(sh, 4);
 
     result &= (sh->sig_cnt == 3);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 0) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 1) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 2) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 3) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 4) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 1) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 2) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 3) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 4) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 5) == 1);
 
     SigGroupHeadFree(sh);
 
@@ -893,21 +893,12 @@ static int SigGroupHeadTest07(void)
 
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+                               "content:\"test2\"; content:\"test3\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
-
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
-    if (prev_sig->next == NULL) {
-        result = 0;
-        goto end;
-    }
-    prev_sig = prev_sig->next;
 
     prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
                              "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
@@ -936,6 +927,15 @@ static int SigGroupHeadTest07(void)
     }
     prev_sig = prev_sig->next;
 
+    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
+                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
+                             "content:\"test2\"; content:\"test3\"; sid:5;)");
+    if (prev_sig->next == NULL) {
+        result = 0;
+        goto end;
+    }
+    prev_sig = prev_sig->next;
+
     SigAddressPrepareStage1(de_ctx);
 
     SigGroupHeadAppendSig(de_ctx, &sh, de_ctx->sig_list);
@@ -945,20 +945,20 @@ static int SigGroupHeadTest07(void)
     SigGroupHeadSetSigCnt(sh, 4);
 
     result &= (sh->sig_cnt == 3);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 0) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 1) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 2) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 3) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 4) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 1) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 2) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 3) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 4) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 5) == 1);
 
     SigGroupHeadClearSigs(sh);
 
     result &= (sh->sig_cnt == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 0) == 0);
     result &= (SigGroupHeadContainsSigId(de_ctx, sh, 1) == 0);
     result &= (SigGroupHeadContainsSigId(de_ctx, sh, 2) == 0);
     result &= (SigGroupHeadContainsSigId(de_ctx, sh, 3) == 0);
     result &= (SigGroupHeadContainsSigId(de_ctx, sh, 4) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, sh, 5) == 0);
 
     SigGroupHeadFree(sh);
 
@@ -985,21 +985,12 @@ static int SigGroupHeadTest08(void)
 
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+                               "content:\"test2\"; content:\"test3\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
-
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
-    if (prev_sig->next == NULL) {
-        result = 0;
-        goto end;
-    }
-    prev_sig = prev_sig->next;
 
     prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
                              "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
@@ -1028,6 +1019,15 @@ static int SigGroupHeadTest08(void)
     }
     prev_sig = prev_sig->next;
 
+    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
+                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
+                             "content:\"test2\"; content:\"test3\"; sid:5;)");
+    if (prev_sig->next == NULL) {
+        result = 0;
+        goto end;
+    }
+    prev_sig = prev_sig->next;
+
     SigAddressPrepareStage1(de_ctx);
 
     SigGroupHeadAppendSig(de_ctx, &src_sh, de_ctx->sig_list);
@@ -1037,22 +1037,22 @@ static int SigGroupHeadTest08(void)
     SigGroupHeadSetSigCnt(src_sh, 4);
 
     result &= (src_sh->sig_cnt == 3);
-    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 0) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 1) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 2) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 3) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 4) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 1) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 2) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 3) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 4) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, src_sh, 5) == 1);
 
     SigGroupHeadCopySigs(de_ctx, src_sh, &dst_sh);
 
     SigGroupHeadSetSigCnt(dst_sh, 4);
 
     result &= (dst_sh->sig_cnt == 3);
-    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 0) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 1) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 2) == 1);
-    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 3) == 0);
-    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 4) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 1) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 2) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 3) == 1);
+    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 4) == 0);
+    result &= (SigGroupHeadContainsSigId(de_ctx, dst_sh, 5) == 1);
 
     SigGroupHeadFree(src_sh);
     SigGroupHeadFree(dst_sh);
@@ -1079,21 +1079,12 @@ static int SigGroupHeadTest09(void)
 
     de_ctx->sig_list = SigInit(de_ctx, "alert tcp any any -> any any "
                                "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                               "content:\"test2\"; content:\"test3\"; sid:0;)");
+                               "content:\"test2\"; content:\"test3\"; sid:1;)");
     if (de_ctx->sig_list == NULL) {
         result = 0;
         goto end;
     }
     prev_sig = de_ctx->sig_list;
-
-    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
-                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
-                             "content:\"test2\"; content:\"test3\"; sid:1;)");
-    if (prev_sig->next == NULL) {
-        result = 0;
-        goto end;
-    }
-    prev_sig = prev_sig->next;
 
     prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
                              "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
@@ -1116,6 +1107,15 @@ static int SigGroupHeadTest09(void)
     prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
                              "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
                              "content:\"test2\"; content:\"test3\"; sid:4;)");
+    if (prev_sig->next == NULL) {
+        result = 0;
+        goto end;
+    }
+    prev_sig = prev_sig->next;
+
+    prev_sig->next = SigInit(de_ctx, "alert tcp any any -> any any "
+                             "(msg:\"SigGroupHead tests\"; content:\"test1\"; "
+                             "content:\"test2\"; content:\"test3\"; sid:5;)");
     if (prev_sig->next == NULL) {
         result = 0;
         goto end;

--- a/src/detect-rev.c
+++ b/src/detect-rev.c
@@ -56,6 +56,14 @@ static int DetectRevSetup (DetectEngineCtx *de_ctx, Signature *s, const char *ra
         SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "rev value to high, max %u", UINT_MAX);
         goto error;
     }
+    if (rev == 0) {
+        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "rev value 0 is invalid");
+        goto error;
+    }
+    if (s->rev > 0) {
+        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "duplicated 'rev' keyword detected");
+        goto error;
+    }
 
     s->rev = (uint32_t)rev;
 

--- a/src/detect-sid.c
+++ b/src/detect-sid.c
@@ -60,6 +60,14 @@ static int DetectSidSetup (DetectEngineCtx *de_ctx, Signature *s, const char *si
         SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "sid value to high, max %u", UINT_MAX);
         goto error;
     }
+    if (id == 0) {
+        SCLogError(SC_ERR_INVALID_NUMERIC_VALUE, "sid value 0 is invalid");
+        goto error;
+    }
+    if (s->id > 0) {
+        SCLogError(SC_ERR_INVALID_RULE_ARGUMENT, "duplicated 'sid' keyword detected");
+        goto error;
+    }
 
     s->id = (uint32_t)id;
     return 0;


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/2064
https://redmine.openinfosecfoundation.org/issues/2102
https://redmine.openinfosecfoundation.org/issues/2103

Describe changes:

This detects duplicated keywords (classtype, sid, rev) which aren't allowed. It also declines rev and sid being set to 0 which are also the initial value of the vars. This PR checks if one of those keywords was already set and prevents the overwrite of the values through a following second keyword that was already set.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

- PR norg-pcap: https://buildbot.openinfosecfoundation.org/builders/norg-pcap/builds/55
- PR norg: https://buildbot.openinfosecfoundation.org/builders/norg/builds/57