### PR TITLE
eve/alert: include signature text in alert output

### DIFF
--- a/doc/userguide/configuration/suricata-yaml.rst
+++ b/doc/userguide/configuration/suricata-yaml.rst
@@ -305,6 +305,7 @@ integration with 3rd party tools like logstash.
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # signature-text: yes      # enable dumping of signature definition
             http: yes                # enable dumping of http fields
             tls: yes                 # enable dumping of tls fields
             ssh: yes                 # enable dumping of ssh fields

--- a/doc/userguide/output/eve/eve-json-output.rst
+++ b/doc/userguide/output/eve/eve-json-output.rst
@@ -42,6 +42,7 @@ The most common way to use this is through 'EVE', which is a firehose approach w
             # payload-buffer-size: 4kb # max size of payload buffer to output in eve-log
             # payload-printable: yes   # enable dumping payload in printable (lossy) format
             # packet: yes              # enable dumping of packet (without stream segments)
+            # signature-text: yes      # enable dumping of signature definition
             http: yes                # enable dumping of http fields
             tls: yes                 # enable dumping of tls fields
             ssh: yes                 # enable dumping of ssh fields
@@ -169,6 +170,7 @@ Metadata::
             # packet: yes              # enable dumping of packet (without stream segments)
             # http-body: yes           # enable dumping of http body in Base64
             # http-body-printable: yes # enable dumping of http body in printable format
+            # signature-text: yes      # enable dumping of signature definition
             metadata: yes              # add L7/applayer fields, flowbit and other vars to the alert
 
 Alternatively to the `metadata` key it is also possible to select the application

--- a/src/detect-parse.c
+++ b/src/detect-parse.c
@@ -1071,7 +1071,10 @@ int SigParse(DetectEngineCtx *de_ctx, Signature *s, const char *sigstr, uint8_t 
     SignatureParser parser;
     memset(&parser, 0x00, sizeof(parser));
 
-    s->sig_str = sigstr;
+    s->sig_str = SCStrdup(sigstr);
+    if (unlikely(s->sig_str == NULL)) {
+        SCReturnInt(-1);
+    }
 
     int ret = SigParseBasics(de_ctx, s, sigstr, &parser, addrs_direction);
     if (ret < 0) {
@@ -1099,8 +1102,6 @@ int SigParse(DetectEngineCtx *de_ctx, Signature *s, const char *sigstr, uint8_t 
 
         } while (ret == 1);
     }
-
-    s->sig_str = NULL;
 
     DetectIPProtoRemoveAllSMs(s);
 
@@ -1252,6 +1253,9 @@ void SigFree(Signature *s)
     }
     if (s->addr_dst_match6 != NULL) {
         SCFree(s->addr_dst_match6);
+    }
+    if (s->sig_str != NULL) {
+        SCFree(s->sig_str);
     }
 
     SigRefFree(s);

--- a/src/detect.h
+++ b/src/detect.h
@@ -466,9 +466,7 @@ typedef struct Signature_ {
     /** Reference */
     DetectReference *references;
 
-    /* Be careful, this pointer is only valid while parsing the sig,
-     * to warn the user about any possible problem */
-    const char *sig_str;
+    char *sig_str;
 
     SignatureInitData *init_data;
 

--- a/src/output-json-alert.c
+++ b/src/output-json-alert.c
@@ -90,6 +90,7 @@
 #define LOG_JSON_FLOW              BIT_U16(11)
 #define LOG_JSON_HTTP_BODY         BIT_U16(12)
 #define LOG_JSON_HTTP_BODY_BASE64  BIT_U16(13)
+#define LOG_JSON_SIGSTR            BIT_U16(14)
 
 #define LOG_JSON_METADATA_ALL  (LOG_JSON_APP_LAYER|LOG_JSON_HTTP|LOG_JSON_TLS|LOG_JSON_SSH|LOG_JSON_SMTP|LOG_JSON_DNP3|LOG_JSON_VARS|LOG_JSON_FLOW)
 
@@ -523,6 +524,13 @@ static int AlertJson(ThreadVars *tv, JsonAlertLogThread *aft, const Packet *p)
             AlertJsonPacket(p, js);
         }
 
+        /* signature text */
+        if (json_output_ctx->flags & LOG_JSON_SIGSTR) {
+            hjs = json_object_get(js, "alert");
+            BUG_ON(!json_is_object(hjs));
+            json_object_set_new(hjs, "signature_text", json_string(pa->s->sig_str));
+        }
+
         HttpXFFCfg *xff_cfg = json_output_ctx->xff_cfg;
 
         /* xff header */
@@ -794,6 +802,7 @@ static void XffSetup(AlertJsonOutputCtx *json_output_ctx, ConfNode *conf)
         SetFlag(conf, "payload-printable", LOG_JSON_PAYLOAD, &json_output_ctx->flags);
         SetFlag(conf, "http-body-printable", LOG_JSON_HTTP_BODY, &json_output_ctx->flags);
         SetFlag(conf, "http-body", LOG_JSON_HTTP_BODY_BASE64, &json_output_ctx->flags);
+        SetFlag(conf, "signature-text", LOG_JSON_SIGSTR, &json_output_ctx->flags);
 
         const char *payload_buffer_value = ConfNodeLookupChildValue(conf, "payload-buffer-size");
 

--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -171,6 +171,7 @@ outputs:
             # packet: yes              # enable dumping of packet (without stream segments)
             # http-body: yes           # enable dumping of http body in Base64
             # http-body-printable: yes # enable dumping of http body in printable format
+            # signature-text: yes      # enable dumping of signature definition
             metadata: yes              # add L7/applayer fields, flowbit and other vars to the alert
 
             # Enable the logging of tagged packets for rules using the


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2020

Describe changes:

For SIEM analysis it is often useful to refer to the actual rules to
find out why a specific alert has been triggered when the signature
message does not convey enough information.

Turn on the new signature-text flag to include the rule text in eve
alert output. The feature is turned off by default.

With a rule like this:

    alert dns $HOME_NET any -> 8.8.8.8 any (msg:"Google DNS server contacted"; sid:42;)

The eve alert output might look something like this (pretty-printed for
readability):

    {
      "timestamp": "2017-08-14T12:35:05.830812+0200",
      "flow_id": 1919856770919772,
      "in_iface": "eth0",
      "event_type": "alert",
      "src_ip": "10.20.30.40",
      "src_port": 50968,
      "dest_ip": "8.8.8.8",
      "dest_port": 53,
      "proto": "UDP",
      "alert": {
        "action": "allowed",
        "gid": 1,
        "signature_id": 42,
        "rev": 0,
        "signature": "Google DNS server contacted",
        "category": "",
        "severity": 3,
        "signature_text": "alert dns $HOME_NET any -> 8.8.8.8 any (msg:\"Google DNS server contacted\"; sid:43;)"
      },
      "app_proto": "dns",
      "flow": {
        "pkts_toserver": 1,
        "pkts_toclient": 0,
        "bytes_toserver": 81,
        "bytes_toclient": 0,
        "start": "2017-08-14T12:35:05.830812+0200"
      }
    }


