### PR TITLE
Bug #2201: af_packet - treat BPF filter error as fatal

### DIFF
--- a/src/source-af-packet.c
+++ b/src/source-af-packet.c
@@ -2045,21 +2045,14 @@ static int AFPCreateSocket(AFPThreadVars *ptv, char *devname, int verbose)
     rc = AFPSetBPFFilter(ptv);
     if (rc == TM_ECODE_FAILED) {
         SCLogError(SC_ERR_AFP_CREATE, "Set AF_PACKET bpf filter \"%s\" failed.", ptv->bpf_filter);
-        goto frame_err;
+        ret = AFP_FATAL_ERROR;
+        goto socket_err;
     }
 
     /* Init is ok */
     AFPSwitchState(ptv, AFP_STATE_UP);
     return 0;
 
-frame_err:
-    if (ptv->flags & AFP_TPACKET_V3) {
-        if (ptv->ring_v3)
-            SCFree(ptv->ring_v3);
-    } else {
-        if (ptv->ring_v2)
-            SCFree(ptv->ring_v2);
-    }
 socket_err:
     close(ptv->socket);
     ptv->socket = -1;
@@ -2111,7 +2104,6 @@ TmEcode AFPSetBPFFilter(AFPThreadVars *ptv)
 
     return TM_ECODE_OK;
 }
-
 
 /**
  * \brief Init function for ReceiveAFP.


### PR DESCRIPTION
Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

https://redmine.openinfosecfoundation.org/issues/2201

Describe changes:

There is no need to try to set erroneous BPF filter again and again. Such attempts
lead to constant mmap() calls without corresponding munmap() when 'use-mmap' is enabled.