### PR TITLE
skip over double periods in JSON output tokenizing

### DIFF
--- a/src/counters.c
+++ b/src/counters.c
@@ -905,7 +905,7 @@ void StatsSpawnThreads(void)
 uint16_t StatsRegisterCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_NORMAL, NULL);
 
@@ -926,7 +926,7 @@ uint16_t StatsRegisterCounter(const char *name, struct ThreadVars_ *tv)
 uint16_t StatsRegisterAvgCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_AVERAGE, NULL);
 
@@ -947,7 +947,7 @@ uint16_t StatsRegisterAvgCounter(const char *name, struct ThreadVars_ *tv)
 uint16_t StatsRegisterMaxCounter(const char *name, struct ThreadVars_ *tv)
 {
     uint16_t id = StatsRegisterQualifiedCounter(name,
-                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->name,
+                                                 (tv->thread_group_name != NULL) ? tv->thread_group_name : tv->printable_name,
                                                  &tv->perf_public_ctx,
                                                  STATS_TYPE_MAXIMUM, NULL);
 
@@ -1168,7 +1168,8 @@ int StatsSetupPrivate(ThreadVars *tv)
 {
     StatsGetAllCountersArray(&(tv)->perf_public_ctx, &(tv)->perf_private_ctx);
 
-    StatsThreadRegister(tv->name, &(tv)->perf_public_ctx);
+    StatsThreadRegister(tv->printable_name ? tv->printable_name : tv->name,
+        &(tv)->perf_public_ctx);
     return 0;
 }
 

--- a/src/output-json-stats.c
+++ b/src/output-json-stats.c
@@ -68,6 +68,8 @@ static json_t *OutputStats2Json(json_t *js, const char *key)
     const char *dot = index(key, '.');
     if (dot == NULL)
         return NULL;
+    if (*(dot + 1) == '.' && *(dot + 2) != '\0')
+        dot = index(dot + 2, '.');
 
     size_t predot_len = (dot - key) + 1;
     char s[predot_len];

--- a/src/threadvars.h
+++ b/src/threadvars.h
@@ -57,6 +57,7 @@ struct TmSlot_;
 typedef struct ThreadVars_ {
     pthread_t t;
     char name[16];
+    char *printable_name;
     char *thread_group_name;
 
     SC_ATOMIC_DECLARE(unsigned int, flags);
@@ -117,4 +118,3 @@ typedef struct ThreadVars_ {
 #define THREAD_SET_AFFTYPE      0x04 /** Priority and affinity */
 
 #endif /* __THREADVARS_H__ */
-

--- a/src/tm-threads.c
+++ b/src/tm-threads.c
@@ -1833,6 +1833,10 @@ static void TmThreadFree(ThreadVars *tv)
         SCFree(tv->thread_group_name);
     }
 
+    if (tv->printable_name) {
+        SCFree(tv->printable_name);
+    }
+
     s = (TmSlot *)tv->tm_slots;
     while (s) {
         ps = s;


### PR DESCRIPTION
- [X] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [X] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [X] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket: [#2208](https://redmine.openinfosecfoundation.org/issues/2208)

Describe changes:
- Interface name shortening introduces double periods (`..`) as spacers, which cause issues during JSON stats serialization as there `.` characters are also used as separators to define nesting of the JSON output. This commit makes sure that `..` are skipped during tokenizing.

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):
- http://dropbox.tetrinetsucht.de/wf/gcc/
- http://dropbox.tetrinetsucht.de/wf/pcaps/

(from local dockerized run)