### PR TITLE
Fixes incorrect variable in ticket #2207

### DIFF
--- a/src/app-layer-dns-tcp.c
+++ b/src/app-layer-dns-tcp.c
@@ -628,7 +628,7 @@ next_record:
     }
 
     if (f != NULL) {
-        dns_state->last_req = f->lastts;
+        dns_state->last_resp = f->lastts;
     }
 
     SCReturnInt(1);


### PR DESCRIPTION
In app-layer-dns-tcp.c in the DNSTCPResponseParse function
a variable is set to last_req when it should be last_resp.
This makes it consistent with UDP DNS response parsing.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:
https://redmine.openinfosecfoundation.org/issues/2207

Describe changes:
- Changed the last_req variable in the DNSTCPResponseParse function in app-layer-dns-tcp.c to last_resp to properly reflect DNS UDP response parsing.

