### PR TITLE
prscript: update docker code

### DIFF
--- a/qa/prscript.py
+++ b/qa/prscript.py
@@ -39,10 +39,22 @@ except:
     GOT_NOTIFY = False
 
 GOT_DOCKER = True
+GOT_DOCKERPY_API = 2
+
 try:
-    from docker import Client
-except:
+    import docker
+    try:
+        from docker import APIClient as Client
+        from docker import from_env as DockerClient
+    except ImportError:
+        GOT_DOCKERPY_API = 1
+        try:
+            from docker import Client
+        except ImportError:
+            GOT_DOCKER = FALSE
+except ImportError:
     GOT_DOCKER = False
+
 # variables
 #  - github user
 #  - buildbot user and password
@@ -80,7 +92,7 @@ username = args.username
 password = args.password
 cookie = None
 
-if args.create or args.start or args.stop:
+if args.create or args.start or args.stop or args.rm:
     if GOT_DOCKER:
         args.docker = True
         args.local = True
@@ -257,37 +269,57 @@ if not args.local:
             sys.exit(-1)
 
 def CreateContainer():
-    cli = Client()
     # FIXME check if existing
     print "Pulling docking image, first run should take long"
-    cli.pull('regit/suri-buildbot')
-    cli.create_container(name='suri-buildbot', image='regit/suri-buildbot', ports=[8010, 22], volumes=['/data/oisf', '/data/buildbot/master/master.cfg'])
+    if GOT_DOCKERPY_API < 2:
+        cli = Client()
+        cli.pull('regit/suri-buildbot')
+        cli.create_container(name='suri-buildbot', image='regit/suri-buildbot', ports=[8010, 22], volumes=['/data/oisf', '/data/buildbot/master/master.cfg'])
+    else:
+        cli = DockerClient()
+        cli.images.pull('regit/suri-buildbot')
+        suri_src_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
+        print "Using base src dir: " + suri_src_dir
+        cli.containers.create('regit/suri-buildbot', name='suri-buildbot', ports={'8010/tcp': 8010, '22/tcp': None} , volumes={suri_src_dir: { 'bind': '/data/oisf', 'mode': 'ro'}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'mode': 'ro'}}, detach = True)
     sys.exit(0)
 
 def StartContainer():
-    cli = Client()
     suri_src_dir = os.path.split(os.path.dirname(os.path.realpath(__file__)))[0]
     print "Using base src dir: " + suri_src_dir
-    cli.start('suri-buildbot', port_bindings={8010:8010, 22:None}, binds={suri_src_dir: { 'bind': '/data/oisf', 'ro': True}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'ro': True}} )
+    if GOT_DOCKERPY_API < 2:
+        cli = Client()
+        cli.start('suri-buildbot', port_bindings={8010:8010, 22:None}, binds={suri_src_dir: { 'bind': '/data/oisf', 'ro': True}, os.path.join(suri_src_dir,'qa','docker','buildbot.cfg'): { 'bind': '/data/buildbot/master/master.cfg', 'ro': True}} )
+    else:
+        cli = DockerClient()
+        cli.containers.get('suri-buildbot').start()
     sys.exit(0)
 
 def StopContainer():
-    cli = Client()
-    cli.stop('suri-buildbot')
+    if GOT_DOCKERPY_API < 2:
+        cli = Client()
+        cli.stop('suri-buildbot')
+    else:
+        cli = DockerClient()
+        cli.containers.get('suri-buildbot').stop()
     sys.exit(0)
 
 def RmContainer():
-    cli = Client()
-    try:
-        cli.remove_container('suri-buildbot')
-    except:
-        print "Unable to remove suri-buildbot container"
-        pass
-    try:
-        cli.remove_image('regit/suri-buildbot:latest')
-    except:
-        print "Unable to remove suri-buildbot images"
-        pass
+    if GOT_DOCKERPY_API < 2:
+        cli = Client()
+        try:
+            cli.remove_container('suri-buildbot')
+        except:
+            print "Unable to remove suri-buildbot container"
+            pass
+        try:
+            cli.remove_image('regit/suri-buildbot:latest')
+        except:
+            print "Unable to remove suri-buildbot images"
+            pass
+    else:
+        cli = DockerClient()
+        cli.containers.get('suri-buildbot').remove()
+        cli.images.remove('regit/suri-buildbot:latest')
     sys.exit(0)
 
 if GOT_DOCKER:


### PR DESCRIPTION
Update docker code to latest docker python API. This patch
preserves backwrd compatibility with older versions.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Describe changes:
- Fix backward compatibility that was not correct in #2889 

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/314
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/98

