### PR TITLE
suricata: init storage before signature

### DIFF
--- a/src/suricata.c
+++ b/src/suricata.c
@@ -2687,10 +2687,10 @@ static int PostConfLoadedSetup(SCInstance *suri)
     }
 
     /* hardcoded initialization code */
+    StorageInit();
     SigTableSetup(); /* load the rule keywords */
     TmqhSetup();
 
-    StorageInit();
     CIDRInit();
     SigParsePrepare();
     SCProtoNameInit();


### PR DESCRIPTION
By doing initialization of storage before parsing registering
signature keywords we are able to declare a storage in the
register function of a signature.

If we are not doing that we have conflicting storage ID.

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [x] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

PRScript:
- PR regit: https://buildbot.openinfosecfoundation.org/builders/regit/builds/315
- PR regit-pcap: https://buildbot.openinfosecfoundation.org/builders/regit-pcap/builds/99

