### PR TITLE
NSM: provide filemane and MD5 for each attachment record within SMTP …

### DIFF
--- a/suricata.yaml.in
+++ b/suricata.yaml.in
@@ -232,10 +232,10 @@ outputs:
             #  x-originating-ip, in-reply-to, references, importance, priority,
             #  sensitivity, organization, content-md5, date
             #custom: [received, x-mailer, x-originating-ip, relays, reply-to, bcc]
-            # output md5 of fields: body, subject
+            # output md5 of fields: body, subject , attachments
             # for the body you need to set app-layer.protocols.smtp.mime.body-md5
             # to yes
-            #md5: [body, subject]
+            #md5: [body, subject, attachments]
 
         #- dnp3
         @rust_config_comment@- nfs


### PR DESCRIPTION
…flow

The goal is to add extra information for network security monitoring: so far it logs only MD5 body and subject.
I propose to log MD5 attached filename detected in SMTP protocol within json record.
This is proposed as an option.
It can be activated by using the attachments parameter (smtp:md5:attachments).

Make sure these boxes are signed before submitting your Pull Request -- thank you.

- [x ] I have read the contributing guide lines at https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Contributing
- [ x] I have signed the Open Information Security Foundation contribution agreement at https://suricata-ids.org/about/contribution-agreement/
- [ ] I have updated the user guide (in doc/userguide/) to reflect the changes made (if applicable)

Link to [redmine](https://redmine.openinfosecfoundation.org/projects/suricata/issues) ticket:

Describe changes:
- update output-json-email-common.c to log new json record (filename/md5) for any attachements
- apply to SMTP flow
- option drived by suricata.yaml.in (smtp:md5:attachments)

[PRScript](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/PRscript) output (if applicable):

